### PR TITLE
[docs] Rename package 'Python' to 'python'

### DIFF
--- a/doc/BuildingAndRunning.md
+++ b/doc/BuildingAndRunning.md
@@ -13,7 +13,7 @@ The Hermes REPL will also use libreadline, if available.
 
 To install dependencies on Ubuntu:
 
-    apt install cmake git ninja-build libicu-dev Python zip libreadline-dev
+    apt install cmake git ninja-build libicu-dev python zip libreadline-dev
 
 On Mac via Homebrew:
 


### PR DESCRIPTION
`apt` throws `E: Unable to locate package Python` since deb package names are case-sensitive.