### PR TITLE
fix build_llvm.py not to regard a dir as an executable file in which()

### DIFF
--- a/utils/build_llvm.py
+++ b/utils/build_llvm.py
@@ -122,7 +122,7 @@ def which(cmd):
                     ):
                         return os.path.realpath(p_and_extension)
             else:
-                if os.path.exists(p) and os.access(p, os.X_OK):
+                if os.path.isfile(p) and os.access(p, os.X_OK):
                     return os.path.realpath(p)
         raise Exception("{} not found on PATH".format(cmd))
 


### PR DESCRIPTION
In my environment, there's `cmake` directory in the PATH and `which()` found it as an executable file and the build script fails.