### PR TITLE
Fix a typo in RangeError exception

### DIFF
--- a/lib/VM/JSLib/Number.cpp
+++ b/lib/VM/JSLib/Number.cpp
@@ -564,7 +564,7 @@ numberPrototypeToExponential(void *, Runtime *runtime, NativeArgs args) {
   if (LLVM_UNLIKELY(
           !args.getArg(0).isUndefined() && (fDouble < 0 || fDouble > 100))) {
     return runtime->raiseRangeError(
-        "toExponential argument must be between 0 and 20");
+        "toExponential argument must be between 0 and 100");
   }
   /// Number of digits after the decimal point.
   /// Because we checked, 0 <= f <= 20.


### PR DESCRIPTION
The condition for toExponential checks the argument to be between 0 and
100, but if the argument does not fit to that condition then the runtime
will raise a RangeError expection. Thus, the error message in RangeError
expection should also be between 0 and 100.