### PR TITLE
REPL: Load and write history to file

### DIFF
--- a/tools/repl/repl.cpp
+++ b/tools/repl/repl.cpp
@@ -325,7 +325,7 @@ int main(int argc, char **argv) {
   runtime->getHeap().runtimeWillExecute();
 
 #if HAVE_LIBREADLINE
-  llvm::SmallString<128> historyFile = llvm::SmallString<128>();
+  llvm::SmallString<128> historyFile{};
   auto historyErr = loadOrCreateHistoryFile(historyFile);
   if (historyErr) {
     llvm::errs() << "Could not load history file: " << historyErr.message() << '\n';

--- a/tools/repl/repl.cpp
+++ b/tools/repl/repl.cpp
@@ -46,6 +46,7 @@
 #define C_STRING(x) #x
 
 #define HISTORY_FILE ".hermes_history"
+#define HISTORY_MAX_ENTRIES 500
 
 using namespace hermes;
 
@@ -346,6 +347,7 @@ int main(int argc, char **argv) {
       // EOF or user exit on non-continuation line.
       llvm::outs() << '\n';
 #if HAVE_LIBREADLINE
+      ::stifle_history(HISTORY_MAX_ENTRIES);
       ::write_history(historyFile.c_str());
 #endif
       return 0;

--- a/tools/repl/repl.cpp
+++ b/tools/repl/repl.cpp
@@ -45,8 +45,8 @@
 
 #define C_STRING(x) #x
 
-#define HISTORY_FILE ".hermes_history"
-#define HISTORY_MAX_ENTRIES 500
+static const std::string historyFileBaseName = ".hermes_history";
+static const int historyMaxEntries = 500;
 
 using namespace hermes;
 
@@ -231,14 +231,12 @@ static bool needsAnotherLine(llvm::StringRef input) {
 #if HAVE_LIBREADLINE
 // Load history file or create it
 std::error_code loadOrCreateHistoryFile(llvm::SmallString<128>& historyFile) {
-  llvm::Twine baseHistoryFile = llvm::Twine(HISTORY_FILE);
-
   if (!llvm::sys::path::home_directory(historyFile)) {
     // Use ENOENT here since it could not found a home directory
     return std::error_code(ENOENT, std::system_category());
   }
 
-  llvm::sys::path::append(historyFile, baseHistoryFile);
+  llvm::sys::path::append(historyFile, historyFileBaseName);
 
   if (!llvm::sys::fs::exists(historyFile)) {
     int fd;
@@ -347,7 +345,7 @@ int main(int argc, char **argv) {
       // EOF or user exit on non-continuation line.
       llvm::outs() << '\n';
 #if HAVE_LIBREADLINE
-      ::stifle_history(HISTORY_MAX_ENTRIES);
+      ::stifle_history(historyMaxEntries);
       ::write_history(historyFile.c_str());
 #endif
       return 0;

--- a/tools/repl/repl.cpp
+++ b/tools/repl/repl.cpp
@@ -233,30 +233,30 @@ static bool needsAnotherLine(llvm::StringRef input) {
 std::error_code loadOrCreateHistoryFile(llvm::SmallString<128>& historyFile) {
   llvm::Twine baseHistoryFile = llvm::Twine(HISTORY_FILE);
 
-  if (llvm::sys::path::home_directory(historyFile)) {
-    llvm::sys::path::append(historyFile, baseHistoryFile);
-
-    if (!llvm::sys::fs::exists(historyFile)) {
-      int fd;
-      auto err = llvm::sys::fs::openFileForWrite(llvm::Twine(historyFile), fd);
-      if (err) {
-	return err;
-      }
-
-      llvm::sys::fs::closeFile(fd);
-    }
-
-    auto err = ::read_history(historyFile.c_str());
-    if (err != 0) {
-      // Return a error_code object from a errno enum
-      return std::error_code(err, std::system_category());
-    }
-
-    return std::error_code();
+  if (!llvm::sys::path::home_directory(historyFile)) {
+    // Use ENOENT here since it could not found a home directory
+    return std::error_code(ENOENT, std::system_category());
   }
 
-  // Use ENOENT here since it could not found a home directory
-  return std::error_code(ENOENT, std::system_category());
+  llvm::sys::path::append(historyFile, baseHistoryFile);
+
+  if (!llvm::sys::fs::exists(historyFile)) {
+    int fd;
+    auto err = llvm::sys::fs::openFileForWrite(llvm::Twine(historyFile), fd);
+    if (err) {
+      return err;
+    }
+
+    llvm::sys::fs::closeFile(fd);
+  }
+
+  auto err = ::read_history(historyFile.c_str());
+  if (err != 0) {
+    // Return a error_code object from a errno enum
+    return std::error_code(err, std::system_category());
+  }
+
+  return std::error_code();
 }
 #endif
 


### PR DESCRIPTION
Use libreadline to load and write command history to file. By default the history is written to `~/.hermes_history' and is created when does not exists.

I was not able to resolve the full path, so I had to check the home directory and append to `.hermes_history`.