### PR TITLE
Add project call to top-level CMakeLists.txt file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ else()
   cmake_minimum_required(VERSION 3.6.0)
 endif()
 
+project(Hermes)
+
 include(CheckCXXCompilerFlag)
 include(CheckCXXSourceCompiles)
 


### PR DESCRIPTION
Running cmake shows this warning:
```
CMake Warning (dev) in CMakeLists.txt:
  No project() command is present.  The top-level CMakeLists.txt file must
  contain a literal, direct call to the project() command.  Add a line of
  code such as

    project(ProjectName)

  near the top of the file, but after cmake_minimum_required().

  CMake is pretending there is a "project(Project)" command on the first
  line.
```

Add a `project(Hermes)` to silence the warning.