### PR TITLE
Use cmake --build instead of a separate build command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
           name: Build LLVM
           command: |
             cd "$HERMES_WS_DIR"
-            hermes/utils/build/build_llvm.py --cross-compile-only llvm llvm_build
+            hermes/utils/build/build_llvm.py --target llvm-tblgen llvm llvm_build
       - run:
           name: Crosscompile LLVM
           command: |

--- a/utils/build/build_llvm.py
+++ b/utils/build/build_llvm.py
@@ -23,37 +23,13 @@ _LLVM_REV_DATE = "2018-10-08"
 
 
 def parse_args():
-    def default_build_command(args):
-        # Choose a default based on the build system chosen
-        if args.build_system == "Ninja":
-            return "ninja"
-        elif args.build_system == "Unix Makefiles":
-            return "make"
-        elif "Visual Studio" in args.build_system:
-            return "MSBuild.exe LLVM.sln -target:build -maxcpucount -verbosity:normal"
-        else:
-            raise Exception("Unrecognized build system: {}".format(args.build_system))
-
     parser = get_parser()
     parser.add_argument("llvm_src_dir", type=str, nargs="?", default="llvm")
     parser.add_argument("llvm_build_dir", type=str, nargs="?", default="llvm_build")
-    parser.add_argument(
-        "--build-command",
-        type=str,
-        dest="build_command",
-        default=None,
-        help="Command to run once cmake finishes",
-    )
-    parser.add_argument(
-        "--cross-compile-only", dest="cross_compile_only", action="store_true"
-    )
+    parser.add_argument("--target", "-t", action="append", default=[])
     args = parser.parse_args()
     args.llvm_src_dir = os.path.realpath(args.llvm_src_dir)
     args.llvm_build_dir = os.path.realpath(args.llvm_build_dir)
-    if not args.build_command:
-        args.build_command = default_build_command(args)
-    if args.cross_compile_only:
-        args.build_command += " " + os.path.join("bin", "llvm-tblgen")
     args.build_type = args.build_type or ("MinSizeRel" if args.distribute else "Debug")
     args.llvm_build_dir += build_dir_suffix(args)
     return args
@@ -132,7 +108,6 @@ def main():
 
     print("Source Dir: {}".format(args.llvm_src_dir))
     print("Using Build system: {}".format(args.build_system))
-    print("Using Build command: {}".format(args.build_command))
     print("Build Dir: {}".format(args.llvm_build_dir))
     print("Build Type: {}".format(args.build_type))
 
@@ -192,15 +167,28 @@ def main():
 
     print("CMake flags: {}".format(" ".join(cmake_flags)))
     run_command(
-        [which("cmake"), "-G", args.build_system, args.llvm_src_dir] + cmake_flags,
+        [
+            which("cmake"),
+            "-G",
+            args.build_system,
+            "-S",
+            args.llvm_src_dir,
+            "-B",
+            args.llvm_build_dir,
+        ]
+        + cmake_flags,
         env=os.environ,
-        cwd=args.llvm_build_dir,
     )
     # MSBuild needs retries to handle an unexplainable linker error: LNK1000.
-    tries = 3 if "MSBuild" in args.build_command else 1
+    # Retry the build in case of failures.
+    tries = 3
     for i in range(tries):
         try:
-            run_command(args.build_command.split(), cwd=args.llvm_build_dir)
+            build_cmd = [which("cmake"), "--build", args.llvm_build_dir]
+            if args.target:
+                for target in args.target:
+                    build_cmd += ["--target", target]
+            run_command(build_cmd, env=os.environ)
             break
         except subprocess.CalledProcessError as e:
             if i == tries - 1:


### PR DESCRIPTION
Issue: https://github.com/facebook/hermes/issues/54

CMake already knows the correct build command based on the generator,
and can apply a consistent set of flags for things like parallelism.
CMake also presents a `--target` flag that makes it easy to select only one target,
so `--cross-compile-only` becomes unnecessary.