### PR TITLE
Enable building Hermes to x86:windows

### DIFF
--- a/external/zip/src/zip.h
+++ b/external/zip/src/zip.h
@@ -22,13 +22,19 @@ extern "C" {
 #if !defined(_SSIZE_T_DEFINED) && !defined(_SSIZE_T_DEFINED_) &&               \
     !defined(_SSIZE_T) && !defined(_SSIZE_T_) && !defined(__ssize_t_defined)
 #define _SSIZE_T
+
+#ifdef _MSC_VER
 // 64-bit Windows is the only mainstream platform
 // where sizeof(long) != sizeof(void*)
 #ifdef _WIN64
-typedef long long  ssize_t;  /* byte count or error */
-#else
-typedef long  ssize_t;  /* byte count or error */
+typedef long long ssize_t; /* byte count or error */
+#else // WIN32 etc
+typedef signed int ssize_t; // llvm\include\llvm-c\DataTypes.h
 #endif
+#else // _MSC_VER
+typedef long ssize_t; /* byte count or error */
+#endif // _MSC_VER
+
 #endif
 
 #ifndef MAX_PATH


### PR DESCRIPTION
Hermes build fails on x86-windows as there is a type definition conflict between LLVM and Hermes on ssize_t type.. Both <llvm>\include\llvm-c\DataTypes.h and <Hermes>\external\zip\src\zip.h tries to define it with conflicting types on non-win64 windows platforms. This change makes those two definitions in sync.