### PR TITLE
Re-sync with internal repository

### DIFF
--- a/external/dtoa/re_worker_requirements
+++ b/external/dtoa/re_worker_requirements
@@ -1,6 +1,0 @@
-{
-    "dtoa-locksAndroid#android-armv7,static": {
-        "workerSize": "MEDIUM",
-        "platformType": "LINUX"
-    }
-}


### PR DESCRIPTION
The internal and external repositories are out of sync. This attempts to brings them back in sync by patching the GitHub repository. Please carefully review this patch. You must disable ShipIt for your project in order to merge this pull request. DO NOT IMPORT this pull request. Instead, merge it directly on GitHub using the MERGE BUTTON. Re-enable ShipIt after merging.