### PR TITLE
Fix error attaching CircleCI workspace from Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,6 +309,13 @@ jobs:
             apt-get update
             apt-get install -y ca-certificates
 
+      - run:
+          name: Temporarily work around CircleCI workspace attachment bug
+          command: |
+            # As of 2019-09-10, CircleCI fails to attach Windows workspaces without this hack
+            cp /usr/bin/tar /usr/bin/tar.real
+            printf '%s\n' '#!/bin/sh' 'exec tar.real --no-same-owner "$@"' > /usr/bin/tar
+
       - attach_workspace:
           at: /tmp/hermes/input
 


### PR DESCRIPTION
The `npm` job is failing with the following error:

```
Error applying workspace layer for job
a05f76fe-c7a5-44f0-a024-48a99a8a7013: Error extracting tarball
/tmp/workspace-layer-a05f76fe-c7a5-44f0-a024-48a99a8a7013325397731 :
tar: ./hermes-cli-windows-v0.1.1.tar.gz: Cannot change ownership to uid
197610, gid 197121
```

This workaround is suggested by https://stackoverflow.com/questions/57828037