### PR TITLE
Include android .aars in npm package

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -10,8 +10,8 @@
   },
   "files": [
     "README.md",
-    "android/hermes-debug.aar",
-    "android/hermes-release.aar",
+    "android/aar/hermes-debug.aar",
+    "android/aar/hermes-release.aar",
     "android/include/**/*.h",
     "osx-bin/hermes",
     "osx-bin/hermes-repl",


### PR DESCRIPTION
Update package filepaths for android aars so they are included in the
tarball generated by yarn pack.