### PR TITLE
(Ignore) Run regression tests and React Native tests on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,14 @@ workflows:
             - linux
             - macos
             - windows
+      - test-linux
+      - test-macos
+      - test-react-native-linux:
+          requires:
+            - npm
+      - test-react-native-windows:
+          requires:
+            - npm
 
 jobs:
   android:
@@ -137,6 +145,45 @@ jobs:
           paths:
             - .
 
+  test-linux:
+    # execution-time-limit.js and sampling-profiler.js segfault in statically
+    # linked release mode, so this job is just a duplicate of the Linux job
+    # that builds in dynamically linked debug mode
+    docker:
+      - image: debian:stretch
+    environment:
+      - HERMES_WS_DIR: /tmp/hermes
+      - TERM: dumb
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            apt-get update
+            apt-get install -y \
+                sudo git openssh-client cmake ninja-build python \
+                build-essential libreadline-dev libicu-dev zip python3
+      - checkout
+      - run:
+          name: Set up workspace
+          command: |
+            mkdir -p "$HERMES_WS_DIR"
+            ln -sf "$PWD" "$HERMES_WS_DIR/hermes"
+            sudo cp /usr/bin/ninja /usr/bin/ninja.real
+            # On failure, auto-retry serially to avoid OOMs and make output more readable
+            printf '%s\n' '#!/bin/sh' 'ninja.real -j4 "$@" || ninja.real -j1 "$@"' | sudo tee /usr/bin/ninja
+      - run:
+          name: Build LLVM in debug mode
+          command: |
+            cd "$HERMES_WS_DIR"
+            hermes/utils/build/build_llvm.py llvm llvm_build
+      - run:
+          name: Run Hermes regression tests
+          command: |
+            cd "$HERMES_WS_DIR"
+            hermes/utils/build/configure.py
+            cd build
+            ninja check-hermes
+
   macos:
     macos:
       xcode: "10.0.0"
@@ -185,6 +232,37 @@ jobs:
           root: /tmp/hermes/output/
           paths:
             - .
+
+  test-macos:
+    # CheckedMalloc.Death fails in release mode, so build a debug version
+    macos:
+      xcode: "10.0.0"
+    environment:
+      - HERMES_WS_DIR: /tmp/hermes
+      - TERM: dumb
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: |
+            brew install cmake ninja
+      - run:
+          name: Set up workspace
+          command: |
+            mkdir -p "$HERMES_WS_DIR"
+            ln -sf "$PWD" "$HERMES_WS_DIR/hermes"
+      - run:
+          name: Build LLVM in debug mode
+          command: |
+            cd "$HERMES_WS_DIR"
+            hermes/utils/build/build_llvm.py llvm llvm_build
+      - run:
+          name: Run MacOS regression tests in debug mode
+          command: |
+            cd "$HERMES_WS_DIR"
+            hermes/utils/build/configure.py
+            cd build
+            ninja check-hermes
 
   windows:
     executor:
@@ -235,7 +313,7 @@ jobs:
             $install = Start-Job {
               choco install visualstudio2019buildtools --package-parameters "--allWorkloads --includeRecommended --passive --locale en-US"
             }
-            $eta = 12
+            $eta = 15
             while ($install.State -eq "Running") {
                 Write-Host "Waiting for visualstudio2019buildtools. ETA $eta minutes..."
                 $install | Wait-Job -timeout 60
@@ -340,6 +418,9 @@ jobs:
           command: |
             cd npm
             cp hermes-engine-*.tgz /tmp/hermes/output
+            # Also copy the other packages for the sole purpose of not having
+            # to visit multiple jobs pages to download all release artifacts
+            cp hermes-cli-*.tar.gz /tmp/hermes/output
 
       - run:
           name: Checksum artifacts
@@ -357,3 +438,84 @@ jobs:
           root: /tmp/hermes/output
           paths:
             - .
+
+  test-react-native-linux:
+    docker:
+      - image: circleci/android:api-28-ndk
+    environment:
+      - TERM: dumb
+    steps:
+      - run:
+          name: Set up workspace and install dependencies
+          command: |
+            yes | sdkmanager "ndk-bundle"  &
+            sudo apt-get update
+            sudo apt-get install -y nodejs npm rsync
+            wait
+
+      - attach_workspace:
+          at: /tmp/hermes/input
+
+      - run:
+          name: Check out React Native tree
+          command: |
+            git clone https://github.com/facebook/react-native .
+
+      - run:
+          name: Install NPMs including new hermes-engine
+          command: |
+            npm install
+            npm install /tmp/hermes/input/hermes-engine-*.tgz
+
+      # Optimally we'd run the RN E2E tests, but they've been disabled for a
+      # while and have bitrotted. RNTester Release is the only thing that is
+      # continuously built for Android, so that's really the only thing we can
+      # reliably build at this time.
+      - run:
+          name: Build RNTester with Hermes in Release mode
+          command: |
+            ./gradlew -Pjobs=4 --max-workers=1 ":RNTester:android:app:assembleHermesRelease"
+
+
+  test-react-native-windows:
+    executor:
+      name: win/preview-default
+      shell: powershell.exe
+    environment:
+      - TERM: dumb
+    steps:
+      - run:
+          name: Set up workspace and install dependencies
+          command: |
+            # Install node 10 because 12.11.1 and triggers a regex bug in RN
+            choco install nodejs-lts
+            # The jdk11 choco package is broken as of 2019-10-02
+            choco install jdk8
+            choco install android-sdk
+            choco install python3
+            choco install vcredist2015
+            refreshenv
+            sdkmanager "ndk-bundle"
+
+      - attach_workspace:
+          at: c:\tmp\hermes\input
+
+      - run:
+          name: Check out React Native tree
+          command: |
+            git clone https://github.com/facebook/react-native .
+
+      - run:
+          name: Install NPMs including new hermes-engine
+          command: |
+            npm install
+            npm install (Get-Item c:\tmp\hermes\input\hermes-engine-*.tgz)
+
+      # RN e2e tests didn't run on Windows even when they worked, so just make
+      # sure we can build RNTester and invoke the Windows cli compiler.
+      - run:
+          name: Build RNTester with Hermes in Release mode
+          command: |
+            # Run without daemon, since it'll keep the job alive
+            .\gradlew --no-daemon ":RNTester:android:app:assembleHermesRelease"
+            if (-not $?) { throw "Failed to build RNTester" }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,9 @@ set(ANDROID_LINUX_PERF_PATH ""
   CACHE STRING
   "If buildling for Android, full path to <linux/perf_events.h>")
 
+set(HERMES_MSVC_MP ON CACHE STRING
+  "Enable /MP in MSVC for parallel builds")
+
 # On Android we need an ABI specific version of LLVM.
 # Unfortunately, the build system doesn't allow setting the
 # LLVM_BUILD_DIR per ABI, so we do it here instead.
@@ -313,6 +316,10 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -wd4068")
   # C4201 nonstandard extension used: nameless struct/union
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -wd4201")
+  # Parallelize build
+  if (HERMES_MSVC_MP)
+    add_definitions( /MP )
+  endif()
 endif()
 
 # Export a JSON file with the compilation commands that external tools can use


### PR DESCRIPTION
This PR is here to iterate on running integration tests for Hermes and RN on CircleCI