### PR TITLE
Remove 'hermesc' step from Android CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,14 +72,6 @@ jobs:
             export ANDROID_NDK="$ANDROID_HOME/ndk-bundle"
             cd "$HERMES_WS_DIR" && hermes/utils/crosscompile_llvm.sh
       - run:
-          name: Build Hermes Compiler
-          command: |
-            cd "$HERMES_WS_DIR"
-            hermes/utils/build/configure.py ./build ./llvm_build ./llvm
-            # Build the Hermes compiler so that the cross compiler build can
-            # access it to build the VM
-            cmake --build ./build --target hermesc
-      - run:
           name: Build Hermes for Android
           command: |
             export ANDROID_SDK="$ANDROID_HOME"


### PR DESCRIPTION
We don't need a compiler to build Hermes by default, so remove the failing build step.