### PR TITLE
fixed dateParse for supporting complex formats parsing

### DIFF
--- a/lib/VM/JSLib/DateUtil.cpp
+++ b/lib/VM/JSLib/DateUtil.cpp
@@ -744,6 +744,7 @@ static double parseISODate(StringView u16str) {
 
   // See if need to adjust timezone
   bool adjustTZ = false;
+  bool onlyYear = false;
 
   auto consume = [&](char16_t ch) {
     if (it != end && *it == ch) {
@@ -764,6 +765,12 @@ static double parseISODate(StringView u16str) {
     return nan;
   }
   y *= sign;
+
+  if (it == end) {
+    onlyYear = true;
+  } else if (consume(' ')) {
+    onlyYear = false;
+  }
 
   // Assign separator character value, default '-'
   char16_t sepChr = u'-';
@@ -848,7 +855,7 @@ static double parseISODate(StringView u16str) {
     } else if (it == end) {
       adjustTZ = true;
     }
-  } else {
+  } else if (!onlyYear) {
     adjustTZ = true;
   }
 

--- a/lib/VM/JSLib/DateUtil.cpp
+++ b/lib/VM/JSLib/DateUtil.cpp
@@ -1066,7 +1066,7 @@ static double parseESDate(StringView str) {
       tzm *= sign;
     }
   } else {
-    // See if timezone didn't seperate by ':'
+    // If timezone adjustment isn't separated by ':'.
     if (it < end - 2) {
       // See if timezone is like '0700' or '070'
       if (!scanInt(it, it + 2, tzh)) {

--- a/lib/VM/JSLib/DateUtil.cpp
+++ b/lib/VM/JSLib/DateUtil.cpp
@@ -994,6 +994,10 @@ static double parseESDate(StringView str) {
     if (it == end) {
       goto complete;
     }
+  } else if (it == end) {
+    // Still paring, use local timezone
+    adjustTZ = true;
+    goto complete;
   }
 
   // Sign of the timezone adjustment.

--- a/lib/VM/JSLib/DateUtil.cpp
+++ b/lib/VM/JSLib/DateUtil.cpp
@@ -990,12 +990,10 @@ static double parseESDate(StringView str) {
       return nan;
     if (!tok.equals(llvm::arrayRefFromStringRef("GMT")))
       return nan;
-  }
-
-  // Support to parse no timezone date
-  if (it == end) {
-    adjustTZ = true;
-    goto complete;
+    // Still paring, use default value tzh=0 & tzm=0
+    if (it == end) {
+      goto complete;
+    }
   }
 
   // Sign of the timezone adjustment.

--- a/lib/VM/JSLib/DateUtil.cpp
+++ b/lib/VM/JSLib/DateUtil.cpp
@@ -1054,7 +1054,7 @@ static double parseESDate(StringView str) {
     // See if timezone is '-:' or '+:'
     adjustTZ = true;
   } else if ((it + 1 < end && *(it + 1) == u':') || (it + 2 < end && *(it + 2) == u':')) {
-    // See if timezone seperated by ':', is like '-07:00' or '-7:0' or '-7:00' or '-07:' or '-7:'
+    // See if timezone separated by ':', is like '-07:00' or '-7:0' or '-7:00' or '-07:' or '-7:'
     if (!scanInt(it, end, tzh)) {
       return nan;
     }

--- a/test/hermes/date-constructor.js
+++ b/test/hermes/date-constructor.js
@@ -243,6 +243,20 @@ print((new Date('2017/02/15 15:01:37.243-0700')).getSeconds());
 // CHECK-NEXT: 37
 print((new Date('2017/02/15/15/01:37.243-07:00')).getTime());
 // CHECK-NEXT: NaN
+print((new Date('2017/02/15 15:01:37.243-07')).getTime());
+// CHECK-NEXT: 1487196097243
+print((new Date('2017/02/15 15:01:37.243-7')).getTime());
+// CHECK-NEXT: 1487196097243
+print((new Date('2017/02/15 15:01:37.243-7:')).getTime());
+// CHECK-NEXT: 1487196097243
+print((new Date('2017/02/15 15:01:37.243-07:')).getTime());
+// CHECK-NEXT: 1487196097243
+print((new Date('2017/02/15 15:01:37.243-070')).getTime());
+// CHECK-NEXT: 1487175097243
+print((new Date('2017/02/15 15:01:37.243-07:01')).getTime());
+// CHECK-NEXT: 1487196157243
+print((new Date('2017/02/15 15:01:37.243-07:1')).getTime());
+// CHECK-NEXT: 1487196157243
 
 print(Date.parse('Tue Jul 16 2019 13:15:25 GMT-0700 (Pacific Daylight Time)'));
 // CHECK-NEXT: 1563308125000

--- a/test/hermes/date-constructor.js
+++ b/test/hermes/date-constructor.js
@@ -192,6 +192,8 @@ print(Date.parse('2016T12:30:00.000Z'));
 // CHECK-NEXT: 1451651400000
 print(Date.parse('2016'));
 // CHECK-NEXT: 1451606400000
+print(Date.parse('2016 '));
+// CHECK-NEXT: 1451631600000
 print(Date.parse('2016T12:30'));
 // CHECK-NEXT: 1451676600000
 print(Date.parse('2016T12:30:00.000-07:00'));

--- a/test/hermes/date-constructor.js
+++ b/test/hermes/date-constructor.js
@@ -186,6 +186,8 @@ print(Date.parse('2016-01T12:30Z'));
 // CHECK-NEXT: 1451651400000
 print(Date.parse('2016-01-01T12:30Z'));
 // CHECK-NEXT: 1451651400000
+print(Date.parse('2016-01-01-12:30:00'));
+// CHECK-NEXT: NaN
 print(Date.parse('2016T12:30:00Z'));
 // CHECK-NEXT: 1451651400000
 print(Date.parse('2016T12:30:00.000Z'));
@@ -193,6 +195,8 @@ print(Date.parse('2016T12:30:00.000Z'));
 print(Date.parse('2016'));
 // CHECK-NEXT: 1451606400000
 print(Date.parse('2016 '));
+// CHECK-NEXT: 1451631600000
+print(Date.parse('2016 00:00:00'));
 // CHECK-NEXT: 1451631600000
 print(Date.parse('2016T12:30'));
 // CHECK-NEXT: 1451676600000
@@ -228,6 +232,8 @@ print((new Date('2017/02/15T15:01:37.243')).getTime());
 print((new Date('2017/02/15 15:01:37.243-0700')).getTime());
 // CHECK-NEXT: 1487196097243
 print((new Date('2017/02/15 15:01:37.243-07:00')).getTime());
+// CHECK-NEXT: 1487196097243
+print((new Date('2017/02/15 15:01:37.243-7:0')).getTime());
 // CHECK-NEXT: 1487196097243
 print((new Date('2017/02/15 15:01:37.243-0700')).getHours());
 // CHECK-NEXT: 15

--- a/test/hermes/date-constructor.js
+++ b/test/hermes/date-constructor.js
@@ -69,7 +69,7 @@ print(new Date(-1, 2, 15, 15, 1, 37, 243).toString());
 print(new Date(NaN, 2, 15, 15, 1, 37, 243).toString());
 // CHECK-NEXT: Invalid Date
 print(new Date('2016T12:30').toString());
-// CHECK-NEXT: Fri Jan 01 2016 05:30:00 GMT-0700
+// CHECK-NEXT: Fri Jan 01 2016 12:30:00 GMT-0700
 
 print('@@toPrimitive');
 // CHECK-LABEL: @@toPrimitive
@@ -109,7 +109,7 @@ print(new Date(-1, 0, 0, 0, 0, 0).toUTCString());
 print('toJSON');
 // CHECK-LABEL: toJSON
 print(new Date('2016T12:30').toJSON());
-// CHECK-NEXT: 2016-01-01T12:30:00.000Z
+// CHECK-NEXT: 2016-01-01T19:30:00.000Z
 print(Date.prototype.toJSON.call({valueOf: function() {return Infinity;}}));
 // CHECK-NEXT: null
 try {
@@ -174,6 +174,8 @@ print(Date.parse('2016T12:30asdf'));
 // CHECK-NEXT: NaN
 print(Date.parse('2016T12:30Z-07:00'));
 // CHECK-NEXT: NaN
+print(Date.parse('2016T12:30Z-0700'));
+// CHECK-NEXT: NaN
 print(Date.parse('2016-+01T12:30Z'));
 // CHECK-NEXT: NaN
 print(Date.parse('2016T12:30:00.000-07:00asdf'));
@@ -191,7 +193,7 @@ print(Date.parse('2016T12:30:00.000Z'));
 print(Date.parse('2016'));
 // CHECK-NEXT: 1451606400000
 print(Date.parse('2016T12:30'));
-// CHECK-NEXT: 1451651400000
+// CHECK-NEXT: 1451676600000
 print(Date.parse('2016T12:30:00.000-07:00'));
 // CHECK-NEXT: 1451676600000
 print(Date.parse('2016T12:30:47.1-07:00'));
@@ -204,13 +206,43 @@ print(Date.parse('2016T12:30:47.1234-07:00'));
 // CHECK-NEXT: 1451676647123
 print(Date.parse('2016T12:30:47.760738998-07:00'));
 // CHECK-NEXT: 1451676647760
+print(Date.parse('2016T12:30:47.760738998-0700'));
+// CHECK-NEXT: 1451676647760
 print(Date.parse('2016T12:30:47.760-07:00') === Date.parse('2016T12:30:47.760738998-07:00'));
-+// CHECK-NEXT: true
+// CHECK-NEXT: true
+
+print(Date.parse('2016/01T12:30Z'));
+// CHECK-NEXT: 1451651400000
+print(Date.parse('2016/01/01T12:30Z'));
+// CHECK-NEXT: 1451651400000
+print((new Date('2017/02/15 15:01:37.243')).getTime());
+// CHECK-NEXT: 1487196097243
+print((new Date('2017/02/15 15:01:37.243')).getTime());
+// CHECK-NEXT: 1487196097243
+print((new Date('2017/02/15/15:01:37.243')).getTime());
+// CHECK-NEXT: 1487196097243
+print((new Date('2017/02/15T15:01:37.243')).getTime());
+// CHECK-NEXT: 1487196097243
+print((new Date('2017/02/15 15:01:37.243-0700')).getTime());
+// CHECK-NEXT: 1487196097243
+print((new Date('2017/02/15 15:01:37.243-07:00')).getTime());
+// CHECK-NEXT: 1487196097243
+print((new Date('2017/02/15 15:01:37.243-0700')).getHours());
+// CHECK-NEXT: 15
+print((new Date('2017/02/15 15:01:37.243-0700')).getMinutes());
+// CHECK-NEXT: 1
+print((new Date('2017/02/15 15:01:37.243-0700')).getSeconds());
+// CHECK-NEXT: 37
+print((new Date('2017/02/15/15/01:37.243-07:00')).getTime());
+// CHECK-NEXT: NaN
+
 print(Date.parse('Tue Jul 16 2019 13:15:25 GMT-0700 (Pacific Daylight Time)'));
 // CHECK-NEXT: 1563308125000
 print(Date.parse('Tue Jul 16 2019 13:15:25 GMT-0700'));
 // CHECK-NEXT: 1563308125000
 print(Date.parse('Tue Jul 16 2019 13:15:25 -0700'));
+// CHECK-NEXT: 1563308125000
+print(Date.parse('Tue Jul 16 2019 13:15:25 -07:00'));
 // CHECK-NEXT: 1563308125000
 print(Date.parse('Tue Jul 16 2019 13:15:25 GMT'));
 // CHECK-NEXT: 1563282925000
@@ -226,6 +258,8 @@ print(Date.parse('Mon Jul 16 2019 13:1525 GMT-0700'));
 // CHECK-NEXT: NaN
 print(Date.parse('Mon Jul 16 2019 13:1525 GMT'));
 // CHECK-NEXT: NaN
+print(Date.parse('Tue Jul 16 2019 13:15:25'));
+// CHECK-NEXT: 1563308125000
 
 // Quick check that getters work; internal functions are unit tested instead.
 print('getters');

--- a/test/hermes/date-constructor.js
+++ b/test/hermes/date-constructor.js
@@ -252,7 +252,7 @@ print((new Date('2017/02/15 15:01:37.243-7:')).getTime());
 print((new Date('2017/02/15 15:01:37.243-07:')).getTime());
 // CHECK-NEXT: 1487196097243
 print((new Date('2017/02/15 15:01:37.243-070')).getTime());
-// CHECK-NEXT: 1487175097243
+// CHECK-NEXT: 1487196097243
 print((new Date('2017/02/15 15:01:37.243-07:01')).getTime());
 // CHECK-NEXT: 1487196157243
 print((new Date('2017/02/15 15:01:37.243-07:1')).getTime());


### PR DESCRIPTION
fixed dateParse problem, linked issue [#136](https://github.com/facebook/hermes/issues/136)
for example:
2019-11-02 01:02:03+08:00
2019-11-02 01:02:03+0800
2019-11-02 01:02:03+08
2019-11-02 01:02:03
2019-11-02T01:02:03
2019/11/02 01:02:03+08:00
2019/11/02/01:02:03+08:00
Fri Oct 02 2019 01:02:03 +08:00
Fri Oct 02 2019 01:02:03 +0800
Fri Oct 02 2019 01:02:03
Fri Oct 02 2019
Fri Oct 02 2019 01:02:03 GMT+08
