### PR TITLE
Fix gcc9 warnings and error

### DIFF
--- a/API/hermes/hermes.cpp
+++ b/API/hermes/hermes.cpp
@@ -2015,7 +2015,7 @@ std::unique_ptr<HermesRuntime> makeHermesRuntime(
       new debugger::Debugger(ret.get(), &(ret->runtime_.getDebugger()))));
 #endif
 
-  return std::move(ret);
+  return ret;
 }
 
 std::unique_ptr<jsi::ThreadSafeRuntime> makeThreadSafeHermesRuntime(
@@ -2045,7 +2045,7 @@ std::unique_ptr<jsi::ThreadSafeRuntime> makeThreadSafeHermesRuntime(
       new debugger::Debugger(&hermesRt, &(hermesRt.runtime_.getDebugger()))));
 #endif
 
-  return std::move(ret);
+  return ret;
 }
 
 #ifdef HERMES_ENABLE_DEBUGGER

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,10 +320,12 @@ endif()
 
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" OR
     "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
-  # Superss warnings about unknown warnings
+  # Supress warnings about unknown warnings
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-warning-option")
   # Suppress an uninteresting warning about C++17 name mangling changes.
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-noexcept-type")
+  # Suppress uninteresting warnings about initializing ArrayRef from initializer lists.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-init-list-lifetime")
   # Don't export symbols unless we explicitly say so
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden")
 elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")

--- a/include/hermes/Regex/Compiler.h
+++ b/include/hermes/Regex/Compiler.h
@@ -1373,8 +1373,8 @@ void Node::reverseNodeList(NodeList &nodes) {
 #ifndef NDEBUG
   for (const auto &node : nodes) {
     assert(
-        !node->isGoal() ||
-        (node == nodes.back()) && "Goal node should only be at end");
+        (!node->isGoal() || (node == nodes.back())) &&
+        "Goal node should only be at end");
   }
 #endif
 

--- a/include/hermes/VM/SegmentedArray.h
+++ b/include/hermes/VM/SegmentedArray.h
@@ -169,6 +169,8 @@ class SegmentedArray final
           "Cannot make an iterator that points outside of the storage");
     }
 
+    iterator(const iterator &) = default;
+
     iterator &operator=(const iterator &that) {
       assert(
           owner_ == that.owner_ &&

--- a/lib/VM/Callable.cpp
+++ b/lib/VM/Callable.cpp
@@ -1474,11 +1474,11 @@ void GeneratorInnerFunction::restoreStack(Runtime *runtime) {
       ? runtime->getCurrentFrame().ptr()
       : runtime->getCurrentFrame().ptr() - frameSize;
   assert(
-      (StackFrameLayout::StackIncrement > 0 &&
-       dst + frameSize <= runtime->getStackPointer()) ||
-      (StackFrameLayout::StackIncrement < 0 &&
-       dst >= runtime->getStackPointer()) &&
-          "reading off the end of the stack");
+      ((StackFrameLayout::StackIncrement > 0 &&
+        dst + frameSize <= runtime->getStackPointer()) ||
+       (StackFrameLayout::StackIncrement < 0 &&
+        dst >= runtime->getStackPointer())) &&
+      "reading off the end of the stack");
   const GCHermesValue *src = &savedContext_.get(runtime)->at(frameOffset);
   std::memcpy(dst, src, frameSize * sizeof(PinnedHermesValue));
 }
@@ -1491,11 +1491,11 @@ void GeneratorInnerFunction::saveStack(Runtime *runtime) {
       ? runtime->getCurrentFrame().ptr()
       : runtime->getCurrentFrame().ptr() - frameSize;
   assert(
-      (StackFrameLayout::StackIncrement > 0 &&
-       first + frameSize <= runtime->getStackPointer()) ||
-      (StackFrameLayout::StackIncrement < 0 &&
-       first >= runtime->getStackPointer()) &&
-          "reading off the end of the stack");
+      ((StackFrameLayout::StackIncrement > 0 &&
+        first + frameSize <= runtime->getStackPointer()) ||
+       (StackFrameLayout::StackIncrement < 0 &&
+        first >= runtime->getStackPointer())) &&
+      "reading off the end of the stack");
   // Use GCHermesValue::copy to ensure write barriers are executed.
   GCHermesValue::copy(
       first,

--- a/lib/VM/IdentifierTable.cpp
+++ b/lib/VM/IdentifierTable.cpp
@@ -292,7 +292,7 @@ IdentifierTable::allocateDynamicString(
     result = createPseudoHandle<StringPrimitive>(tmp);
   }
 
-  return std::move(result);
+  return result;
 }
 
 uint32_t IdentifierTable::allocIDAndInsert(

--- a/lib/VM/JSLib/Math.cpp
+++ b/lib/VM/JSLib/Math.cpp
@@ -226,7 +226,9 @@ CallResult<HermesValue> mathRandom(void *, Runtime *runtime, NativeArgs) {
 }
 
 CallResult<HermesValue> mathFround(void *, Runtime *runtime, NativeArgs args)
-    LLVM_NO_SANITIZE("float-cast-overflow") {
+    LLVM_NO_SANITIZE("float-cast-overflow");
+
+CallResult<HermesValue> mathFround(void *, Runtime *runtime, NativeArgs args) {
   auto res = toNumber_RJS(runtime, args.getArgHandle(0));
   if (LLVM_UNLIKELY(res == ExecutionStatus::EXCEPTION)) {
     return ExecutionStatus::EXCEPTION;


### PR DESCRIPTION
Hermes currently has a number of warnings and one error when building in gcc9.
This fixes most of the warnings and the error.