### PR TITLE
Add some missing entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@ hermes/facebook/llvm/llvm_build*
 buck-out
 .buckd
 .buckconfig.local
+
+# Python
+*.pyc
+
+# Mac
+.DS_Store


### PR DESCRIPTION
When running the configure.py script, Python will emit a common.pyc
file into the utils/build/ directory. This file contains compiled
bytecode. Teach git to ignore it.

Also ignore .DS_Store, which the Mac sprinkles around.