### PR TITLE
[Hermes] Remove unnecessary trailing semicolons

### DIFF
--- a/include/hermes/ADT/HalfPairIterator.h
+++ b/include/hermes/ADT/HalfPairIterator.h
@@ -60,6 +60,6 @@ HERMES_DECLARE_PARTIAL_ITERATOR(First, first);
 /// PairSecondIterator: iterate over pair::second.
 HERMES_DECLARE_PARTIAL_ITERATOR(Second, second);
 
-}; // namespace hermes
+} // namespace hermes
 
 #endif // HERMES_ADT_HALFPAIRITERATOR_H

--- a/include/hermes/AST/Context.h
+++ b/include/hermes/AST/Context.h
@@ -17,7 +17,7 @@ namespace hermes {
 
 namespace hbc {
 class BackendContext;
-};
+}
 
 /// Choices for bundling format, applicable to cross module opts
 enum class BundlerKind { none, metromin };
@@ -336,6 +336,6 @@ class Context {
   }
 };
 
-}; // namespace hermes
+} // namespace hermes
 
 #endif // HERMES_AST_CONTEXT_H

--- a/include/hermes/FrontEndDefs/Builtins.h
+++ b/include/hermes/FrontEndDefs/Builtins.h
@@ -21,7 +21,7 @@ enum Enum : unsigned char {
   _privateCount = _count - _firstPrivate,
 };
 
-}; // namespace BuiltinMethod
+} // namespace BuiltinMethod
 
 static_assert(BuiltinMethod::_count <= 256, "More than 256 builtin methods");
 

--- a/include/hermes/Parser/JSLexer.h
+++ b/include/hermes/Parser/JSLexer.h
@@ -644,7 +644,7 @@ inline bool JSLexer::isUnicodeIdentifierPart(uint32_t ch) {
       ch == UNICODE_ZWNJ || ch == UNICODE_ZWJ;
 }
 
-}; // namespace parser
-}; // namespace hermes
+} // namespace parser
+} // namespace hermes
 
 #endif // HERMES_PARSER_JSLEXER_H

--- a/include/hermes/Parser/JSONParser.h
+++ b/include/hermes/Parser/JSONParser.h
@@ -686,7 +686,7 @@ class JSONSharedValue {
   }
 };
 
-}; // namespace parser
-}; // namespace hermes
+} // namespace parser
+} // namespace hermes
 
 #endif // HERMES_PARSER_JSONPARSER_H

--- a/include/hermes/Parser/JSParser.h
+++ b/include/hermes/Parser/JSParser.h
@@ -88,7 +88,7 @@ class JSParser {
   std::unique_ptr<detail::JSParserImpl> const impl_;
 };
 
-}; // namespace parser
-}; // namespace hermes
+} // namespace parser
+} // namespace hermes
 
 #endif // HERMES_PARSER_JSPARSER_H

--- a/include/hermes/Parser/pack.h
+++ b/include/hermes/Parser/pack.h
@@ -50,7 +50,7 @@ struct Pack {
   }
 };
 
-}; // namespace parser
-}; // namespace hermes
+} // namespace parser
+} // namespace hermes
 
 #endif // HERMES_PARSER_PACK_H

--- a/include/hermes/Platform/Unicode/CharacterProperties.h
+++ b/include/hermes/Platform/Unicode/CharacterProperties.h
@@ -86,6 +86,6 @@ uint32_t canonicalize(uint32_t cp, bool unicode);
 class CodePointSet;
 CodePointSet makeCanonicallyEquivalent(const CodePointSet &set, bool unicode);
 
-}; // namespace hermes
+} // namespace hermes
 
 #endif // HERMES_PLATFORMUNICODE_CHARACTERPROPERTIES_H

--- a/include/hermes/Platform/Unicode/CodePointSet.h
+++ b/include/hermes/Platform/Unicode/CodePointSet.h
@@ -126,6 +126,6 @@ class CodePointSet {
   llvm::SmallVector<CodePointRange, 4> ranges_;
 };
 
-}; // namespace hermes
+} // namespace hermes
 
 #endif // HERMES_PLATFORMUNICODE_CODEPOINTSET_H

--- a/include/hermes/Support/JSONEmitter.h
+++ b/include/hermes/Support/JSONEmitter.h
@@ -202,6 +202,6 @@ class JSONEmitter {
   uint32_t indent_{0};
 };
 
-}; // namespace hermes
+} // namespace hermes
 
 #endif // HERMES_SUPPORT_JSONEMITTER_H

--- a/include/hermes/Support/JenkinsHash.h
+++ b/include/hermes/Support/JenkinsHash.h
@@ -27,7 +27,7 @@ constexpr JenkinsHash jenkinsMix1(JenkinsHash hash) {
 constexpr JenkinsHash jenkinsMix2(JenkinsHash hash) {
   return hash ^ (hash >> 6);
 }
-}; // namespace jenkins_details
+} // namespace jenkins_details
 
 /// Incorporates the character \p c to the given \p hash, using the classic
 /// Jenkins algorithm.

--- a/include/hermes/Support/OptValue.h
+++ b/include/hermes/Support/OptValue.h
@@ -117,7 +117,7 @@ template <typename T, typename U>
 bool operator!=(const OptValue<T> &a, const OptValue<U> &b) {
   return !(a == b);
 }
-}; // namespace hermes
+} // namespace hermes
 
 namespace llvm {
 template <typename T>

--- a/include/hermes/Support/SourceErrorManager.h
+++ b/include/hermes/Support/SourceErrorManager.h
@@ -475,6 +475,6 @@ class SourceErrorManager {
   void doPrintMessage(DiagKind dk, SMLoc loc, SMRange sm, const Twine &msg);
 };
 
-}; // namespace hermes
+} // namespace hermes
 
 #endif // HERMES_SUPPORT_SOURCEERRORMANAGER_H

--- a/include/hermes/Support/UTF16Stream.h
+++ b/include/hermes/Support/UTF16Stream.h
@@ -76,6 +76,6 @@ class UTF16Stream {
   OwningArray<char16_t> storage_;
 };
 
-}; // namespace hermes
+} // namespace hermes
 
 #endif // HERMES_SUPPORT_UTF16STREAM_H

--- a/include/hermes/Support/UTF8.h
+++ b/include/hermes/Support/UTF8.h
@@ -234,6 +234,6 @@ bool convertUTF16ToUTF8WithReplacements(
     llvm::ArrayRef<char16_t> input,
     size_t maxCharacters = 0);
 
-}; // namespace hermes
+} // namespace hermes
 
 #endif // HERMES_SUPPORT_UTF8_H

--- a/include/hermes/VM/CellKind.h
+++ b/include/hermes/VM/CellKind.h
@@ -43,7 +43,7 @@ cellKindsContiguousAscending(CellKind v1, CellKind v2, T... rest) {
 
 const char *cellKindStr(CellKind kind);
 
-}; // namespace vm
+} // namespace vm
 } // namespace hermes
 
 #endif // HERMES_VM_CELLKIND_H

--- a/include/hermes/VM/Handle.h
+++ b/include/hermes/VM/Handle.h
@@ -211,7 +211,7 @@ class Handle : public HandleBase {
   Handle<T> &operator=(const Handle<U> &other) {
     HandleBase::operator=(other);
     return *this;
-  };
+  }
 
 #ifndef NDEBUG
   Handle<T> &operator=(const Handle<T> &other) {

--- a/include/hermes/VM/StringRefUtils.h
+++ b/include/hermes/VM/StringRefUtils.h
@@ -41,7 +41,7 @@ bool stringRefEquals(llvm::ArrayRef<T1> str1, llvm::ArrayRef<T2> str2) {
     return false;
   }
   return std::equal(str1.begin(), str1.end(), str2.begin());
-};
+}
 
 /// Compare two ArrayRef, \return +1 if str1 > str2, -1 if str1 < str2, 0
 /// otherwise.
@@ -72,7 +72,7 @@ int stringRefCompare(llvm::ArrayRef<T1> str1, llvm::ArrayRef<T2> str2) {
   }
   // Found a different character, return based on which is bigger.
   return *pos.first > *pos.second ? +1 : -1;
-};
+}
 
 } // namespace vm
 } // namespace hermes

--- a/lib/Parser/JSLexer.cpp
+++ b/lib/Parser/JSLexer.cpp
@@ -1759,5 +1759,5 @@ bool JSLexer::error(
   return false;
 }
 
-}; // namespace parser
-}; // namespace hermes
+} // namespace parser
+} // namespace hermes

--- a/lib/Parser/JSONParser.cpp
+++ b/lib/Parser/JSONParser.cpp
@@ -312,5 +312,5 @@ llvm::Optional<JSONValue *> JSONParser::parseObject() {
   return factory_.newObject(pairs.begin(), pairs.end(), true);
 }
 
-}; // namespace parser
-}; // namespace hermes
+} // namespace parser
+} // namespace hermes

--- a/lib/Parser/JSParser.cpp
+++ b/lib/Parser/JSParser.cpp
@@ -62,5 +62,5 @@ llvm::Optional<ESTree::NodePtr> JSParser::parseLazyFunction(
   return impl_->parseLazyFunction(kind, start);
 }
 
-}; // namespace parser
-}; // namespace hermes
+} // namespace parser
+} // namespace hermes

--- a/lib/Parser/JSParserImpl.cpp
+++ b/lib/Parser/JSParserImpl.cpp
@@ -4522,6 +4522,6 @@ Optional<ESTree::NodePtr> JSParserImpl::parseLazyFunction(
       llvm_unreachable("Asked to parse unexpected node type");
   }
 }
-}; // namespace detail
-}; // namespace parser
-}; // namespace hermes
+} // namespace detail
+} // namespace parser
+} // namespace hermes

--- a/lib/Parser/JSParserImpl.h
+++ b/lib/Parser/JSParserImpl.h
@@ -772,8 +772,8 @@ class JSParserImpl {
   };
 };
 
-}; // namespace detail
-}; // namespace parser
-}; // namespace hermes
+} // namespace detail
+} // namespace parser
+} // namespace hermes
 
 #endif // HERMES_PARSER_JSPARSERIMPL_H

--- a/lib/Platform/Unicode/CharacterProperties.cpp
+++ b/lib/Platform/Unicode/CharacterProperties.cpp
@@ -210,4 +210,4 @@ uint32_t canonicalize(uint32_t cp, bool unicode) {
   }
 }
 
-}; // namespace hermes
+} // namespace hermes

--- a/lib/Support/UTF8.cpp
+++ b/lib/Support/UTF8.cpp
@@ -169,4 +169,4 @@ bool isAllASCII(const uint8_t *start, const uint8_t *end) {
   return true;
 }
 
-}; // namespace hermes
+} // namespace hermes

--- a/lib/VM/CellKind.cpp
+++ b/lib/VM/CellKind.cpp
@@ -25,5 +25,5 @@ const char *cellKindStr(CellKind kind) {
   return cellKinds[static_cast<size_t>(kind)];
 }
 
-}; // namespace vm
+} // namespace vm
 } // namespace hermes

--- a/lib/VM/JSLib/JSONLexer.cpp
+++ b/lib/VM/JSLib/JSONLexer.cpp
@@ -219,5 +219,5 @@ ExecutionStatus JSONLexer::scanWord(const char *word, JSONTokenKind kind) {
   return ExecutionStatus::RETURNED;
 }
 
-}; // namespace vm
-}; // namespace hermes
+} // namespace vm
+} // namespace hermes

--- a/lib/VM/JSLib/JSONLexer.h
+++ b/lib/VM/JSLib/JSONLexer.h
@@ -153,7 +153,7 @@ class JSONLexer {
   CallResult<char16_t> consumeUnicode();
 };
 
-}; // namespace vm
-}; // namespace hermes
+} // namespace vm
+} // namespace hermes
 
 #endif // HERMES_PARSER_JSONLEXER_H

--- a/tools/hbcdump/StructuredPrinter.h
+++ b/tools/hbcdump/StructuredPrinter.h
@@ -100,6 +100,6 @@ class StructuredPrinter {
   void operator=(StructuredPrinter &&) = delete;
 };
 
-}; // namespace hermes
+} // namespace hermes
 
 #endif // HERMES_TOOLS_HBCDUMP_STRUCTUREDPRINTER_H

--- a/unittests/Parser/DiagContext.h
+++ b/unittests/Parser/DiagContext.h
@@ -55,7 +55,7 @@ class DiagContext {
   }
 };
 
-}; // namespace parser
-}; // namespace hermes
+} // namespace parser
+} // namespace hermes
 
 #endif // HERMES_TEST_PARSER_DIAGCONTEXT_H


### PR DESCRIPTION
gcc9 is salty about useless semicolons, particularly those that come after
brackets which close namespaces. Remove them.