### PR TITLE
[Hermes] Decrement the shallow-since date in build_llvm

### DIFF
--- a/utils/build/build_llvm.py
+++ b/utils/build/build_llvm.py
@@ -23,10 +23,10 @@ from common import (
 
 # It references the commit day so we can shallow clone
 # and still manage to checkout this specific revision.
-# NOTE: The revision date must be the day before the
-# actual commit date.
+# NOTE: The revision date must be before the actual
+# commit date.
 _LLVM_REV = "c179d7b006348005d2da228aed4c3c251590baa3"
-_LLVM_REV_DATE = "2018-10-08"
+_LLVM_REV_DATE = "2018-10-07"
 
 
 def parse_args():


### PR DESCRIPTION
build_llvm.py tries to avoid cloning unnecessary commits, via --shallow-since.
For some reason this date no longer picks up the necessary commit, so
the build_llvm.py script fails - very mysterious.

Pushing the date back one more day solves the issue. ¯\_(ツ)_/¯