### PR TITLE
Fix CircleCI build failure (in progress)

### DIFF
--- a/include/hermes/VM/CallResult.h
+++ b/include/hermes/VM/CallResult.h
@@ -281,7 +281,7 @@ template <typename T>
 class CallResult<PseudoHandle<T>, detail::CallResultSpecialize::PseudoHandle> {
   PseudoHandle<T> valueOrStatus_;
 
-#ifdef NDEBUG
+#if defined(NDEBUG) && !defined(_WINDOWS)
   static_assert(
       hermes::IsTriviallyCopyable<PseudoHandle<T>, true>::value,
       "PseudoHandle<T> must be trivially copyable");

--- a/tools/repl/CMakeLists.txt
+++ b/tools/repl/CMakeLists.txt
@@ -4,10 +4,11 @@
 # LICENSE file in the root directory of this source tree.
 
 find_library(LIBREADLINE_FOUND readline)
+find_library(LIBTINFO_FOUND tinfo)
 
-if(LIBREADLINE_FOUND)
+if(LIBREADLINE_FOUND AND LIBTINFO_FOUND)
   set(HAVE_LIBREADLINE 1)
-  set(LIBREADLINE ${LIBREADLINE_FOUND})
+  set(LIBREADLINE ${LIBREADLINE_FOUND} ${LIBTINFO_FOUND})
 endif()
 
 configure_file(ReplConfig.h.in ${CMAKE_CURRENT_BINARY_DIR}/ReplConfig.h


### PR DESCRIPTION
Issues so far:

* `hermes-repl` requires `-ltinfo`
* `hermes::IsTriviallyCopyable<PseudoHandle<T>>` static_assert fails on Windows 