### PR TITLE
Strip binaries on Linux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
           name: Build Hermes for Linux
           command: |
             cd "$HERMES_WS_DIR"
-            hermes/utils/build/configure.py --static-link --distribute
+            hermes/utils/build/configure.py --static-link --distribute --cmake-flags="-DCMAKE_CXX_FLAGS=-s"
             cd build_release
             ninja github-cli-release
       - run:


### PR DESCRIPTION
Our Linux binaries are currently not stripped, adding an unnecssary
~30MB to the NPM.