### PR TITLE
Fix build break due to adb ending up in platform-tools/platform-tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -453,6 +453,8 @@ jobs:
             brew tap homebrew/cask
             brew cask install android-sdk
             echo 'export PATH="/usr/local/share/android-sdk/platform-tools:/usr/local/share/android-sdk/tools/bin:$PATH"' >> $BASH_ENV
+            # At some point, adb ended up in platform-tools/platform-tools. Work around that.
+            echo 'export PATH="/usr/local/share/android-sdk/platform-tools/platform-tools:$PATH"' >> $BASH_ENV
       - run:
           name: Install emulator dependencies
           command: (yes | sdkmanager "platform-tools" "platforms;android-26" "extras;intel;Hardware_Accelerated_Execution_Manager" "build-tools;26.0.0" "system-images;android-26;google_apis;x86" "emulator" --verbose) || true


### PR DESCRIPTION
Brew may have botched the path. This adds a workaround.