### PR TITLE
Update CircleCI npm job to use latest Ubuntu image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,9 @@ workflows:
             - linux
             - macos
             - windows
+          matrix:
+            parameters:
+              ubuntu-version: ["latest", "rolling"]
       - test-linux
       - test-macos
       - test-e2e:
@@ -355,7 +358,7 @@ jobs:
 
   npm:
     docker:
-      - image: ubuntu:19.10
+      - image: ubuntu:<< ubuntu-version >>
     environment:
       - YARN: yarnpkg
       - TERM: dumb
@@ -365,13 +368,6 @@ jobs:
           command: |
             apt-get update
             apt-get install -y ca-certificates
-
-      - run:
-          name: Temporarily work around CircleCI workspace attachment bug
-          command: |
-            # As of 2019-09-10, CircleCI fails to attach Windows workspaces without this hack
-            cp /usr/bin/tar /usr/bin/tar.real
-            printf '%s\n' '#!/bin/sh' 'exec tar.real --no-same-owner "$@"' > /usr/bin/tar
 
       - attach_workspace:
           at: /tmp/hermes/input

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,7 +358,7 @@ jobs:
 
   npm:
     docker:
-      - image: ubuntu:<< ubuntu-version >>
+      - image: ubuntu:<< matrix.ubuntu-version >>
     environment:
       - YARN: yarnpkg
       - TERM: dumb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,7 +355,7 @@ jobs:
 
   npm:
     docker:
-      - image: ubuntu:latest
+      - image: ubuntu:19.10
     environment:
       - YARN: yarnpkg
       - TERM: dumb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,9 +27,6 @@ workflows:
             - linux
             - macos
             - windows
-          matrix:
-            parameters:
-              ubuntu-version: ["latest", "rolling"]
       - test-linux
       - test-macos
       - test-e2e:
@@ -357,11 +354,8 @@ jobs:
             - .
 
   npm:
-    parameters:
-      ubuntu-version:
-        type: string
     docker:
-      - image: ubuntu:<< parameters.ubuntu-version >>
+      - image: ubuntu:rolling
     environment:
       - YARN: yarnpkg
       - TERM: dumb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,7 +355,7 @@ jobs:
 
   npm:
     docker:
-      - image: ubuntu:19.04
+      - image: ubuntu:latest
     environment:
       - YARN: yarnpkg
       - TERM: dumb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,8 +357,11 @@ jobs:
             - .
 
   npm:
+    parameters:
+      ubuntu-version:
+        type: string
     docker:
-      - image: ubuntu:<< matrix.ubuntu-version >>
+      - image: ubuntu:<< parameters.ubuntu-version >>
     environment:
       - YARN: yarnpkg
       - TERM: dumb


### PR DESCRIPTION
The build is currently failing (possibly because 19.04 is EOL). This updates it to just use the latest Ubuntu.