### PR TITLE
DeclareGlobalVar to not overwrite existing properties

### DIFF
--- a/lib/VM/Interpreter.cpp
+++ b/lib/VM/Interpreter.cpp
@@ -2221,6 +2221,8 @@ tailCall:
         DefinePropertyFlags dpf =
             DefinePropertyFlags::getDefaultNewPropertyFlags();
         dpf.configurable = 0;
+        // Do not overwrite existing globals with undefined.
+        dpf.setValue = 0;
 
         CAPTURE_IP_ASSIGN(
             auto res,

--- a/test/hermes/global-var-no-clear.js
+++ b/test/hermes/global-var-no-clear.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -target=HBC -O %s | %FileCheck --match-full-lines %s
+// RUN: %hermes -target=HBC -O -emit-binary -out %t.hbc %s && %hermes %t.hbc | %FileCheck --match-full-lines %s
+
+var globalEval = eval;
+
+var q = true;
+globalEval('var q;');
+print(q);
+// CHECK: true
+
+var s = 'if (x === undefined) { var x; x = 0; }; x += 1;';
+globalEval(s);
+globalEval(s);
+globalEval(s);
+print(x);
+// CHECK: 3


### PR DESCRIPTION
Ha ha, this is a doozy.

Prior to this change, DeclareGlobalVariable would unconditionally store
undefined as a property on global. With this change, only do so if there is
not already such an own-property.

The reason for the fix is that eval() can otherwise overwrite existing
global variables. For example:

var q = true;
eval('var q;');

it is wrong for 'q' to result in undefined (and in practice, v8 and jsc do not).

Test Plan: Added a new test