### PR TITLE
Improve sanitizer support in CMake builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,14 @@ set(HERMESVM_API_TRACE OFF CACHE BOOL
 set(HERMESVM_SANITIZE_HANDLES OFF CACHE BOOL
   "Enable Handle sanitization")
 
+# Enable Address Sanitizer
+set(HERMES_ENABLE_ADDRESS_SANITIZER OFF CACHE BOOL
+  "Enable -fsanitize=address")
+
+# Enable Undefined Behavior Sanitizer
+set(HERMES_ENABLE_UNDEFINED_BEHAVIOR_SANITIZER OFF CACHE BOOL
+  "Enable -fsanitize=undefined")
+
 # Build with -DHERMES_SLOW_DEBUG for debug builds
 # This does not affect release builds
 set(HERMES_SLOW_DEBUG ON CACHE BOOL
@@ -280,6 +288,14 @@ if(HERMESVM_API_TRACE)
 endif()
 if(HERMESVM_SANITIZE_HANDLES)
     add_definitions(-DHERMESVM_SANITIZE_HANDLES)
+endif()
+if (HERMES_ENABLE_ADDRESS_SANITIZER)
+    append("-fsanitize=address" CMAKE_CXX_FLAGS CMAKE_C_FLAGS CMAKE_EXE_LINKER_FLAGS)
+endif()
+if (HERMES_ENABLE_UNDEFINED_BEHAVIOR_SANITIZER)
+    add_definitions(-DHERMES_UBSAN)
+    # Do not enable the vptr sanitizer, as it requires RTTI.
+    append("-fsanitize=undefined -fno-sanitize=vptr -fno-sanitize-recover=all" CMAKE_CXX_FLAGS CMAKE_C_FLAGS CMAKE_EXE_LINKER_FLAGS)
 endif()
 if(HERMES_FACEBOOK_BUILD)
     add_definitions(-DHERMES_FACEBOOK_BUILD)
@@ -561,8 +577,7 @@ set(HERMES_LIT_TEST_PARAMS
   profiler=${HERMES_PROFILER_MODE_IN_LIT_TEST}
   use_js_library_implementation=${HERMESVM_USE_JS_LIBRARY_IMPLEMENTATION}
   gc=${HERMESVM_GCKIND}
-  # TODO: Figure out how to tell if CMake is doing a UBSAN build.
-  ubsan=OFF
+  ubsan=${HERMES_ENABLE_UNDEFINED_BEHAVIOR_SANITIZER}
   )
 
 set(LLVH_LIT_ARGS "-sv")

--- a/external/zip/src/miniz.h
+++ b/external/zip/src/miniz.h
@@ -281,7 +281,7 @@
 #define MINIZ_LITTLE_ENDIAN 1
 #endif
 
-#if MINIZ_X86_OR_X64_CPU
+#if MINIZ_X86_OR_X64_CPU && !HERMES_UBSAN
 // Set MINIZ_USE_UNALIGNED_LOADS_AND_STORES to 1 on CPU's that permit efficient
 // integer loads and stores from unaligned addresses.
 #define MINIZ_USE_UNALIGNED_LOADS_AND_STORES 1

--- a/utils/build/common.py
+++ b/utils/build/common.py
@@ -65,6 +65,7 @@ def get_parser():
     parser.add_argument("--distribute", action="store_true")
     parser.add_argument("--32-bit", dest="is_32_bit", action="store_true")
     parser.add_argument("--enable-asan", dest="enable_asan", action="store_true")
+    parser.add_argument("--enable-ubsan", dest="enable_ubsan", action="store_true")
     return parser
 
 
@@ -121,6 +122,8 @@ def build_dir_suffix(args):
     suffices = []
     if args.enable_asan:
         suffices += ["asan"]
+    if args.enable_ubsan:
+        suffices += ["ubsan"]
     if args.distribute:
         suffices += ["release"]
     if args.is_32_bit:

--- a/utils/build/configure.py
+++ b/utils/build/configure.py
@@ -123,6 +123,10 @@ def main():
         cmake_flags += ["-DHERMES_ENABLE_WERROR=On"]
     if args.static_link:
         cmake_flags += ["-DHERMES_STATIC_LINK=On"]
+    if args.enable_asan:
+        cmake_flags += ["-DHERMES_ENABLE_ADDRESS_SANITIZER=ON"]
+    if args.enable_ubsan:
+        cmake_flags += ["-DHERMES_ENABLE_UNDEFINED_BEHAVIOR_SANITIZER=ON"]
     if args.fbsource_dir:
         cmake_flags += ["-DFBSOURCE_DIR=" + args.fbsource_dir]
     if args.wasm:


### PR DESCRIPTION
This makes the `--enable-asan` option to `configure.py` work again, and adds an analogous `--enable-ubsan`. It also disables misaligned reads in miniz when run under UBSan, which was the one test failure. With this change, the hermes tests pass with both ASan and UBSan (gcc-flavored).