### PR TITLE
Use non-interactive option with apt-get

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,6 +359,7 @@ jobs:
     environment:
       - YARN: yarnpkg
       - TERM: dumb
+      - DEBIAN_FRONTEND: noninteractive
     steps:
       - run:
           name: Install certificates required to attach workspace


### PR DESCRIPTION
Builds are currently failing because the tzdata package requires user input while being installed via apt-get. Setting the environment variable `DEBIAN_FRONTEND` to `noninteractive` forces apt-get to bypass the requirement.