### PR TITLE
Use apt-get in non-interactive mode for all jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ jobs:
     environment:
       - HERMES_WS_DIR: /tmp/hermes
       - TERM: dumb
+      - DEBIAN_FRONTEND: noninteractive
     steps:
       - checkout
       - run:
@@ -96,6 +97,7 @@ jobs:
     environment:
       - HERMES_WS_DIR: /tmp/hermes
       - TERM: dumb
+      - DEBIAN_FRONTEND: noninteractive
     steps:
       - run:
           name: Install dependencies
@@ -149,6 +151,7 @@ jobs:
     environment:
       - HERMES_WS_DIR: /tmp/hermes
       - TERM: dumb
+      - DEBIAN_FRONTEND: noninteractive
     steps:
       - run:
           name: Install dependencies


### PR DESCRIPTION
This change avoids future build failures due to user input
requirements when installing packages via apt-get.