### PR TITLE
Don't include VM header in public API.

### DIFF
--- a/API/hermes/hermes.cpp
+++ b/API/hermes/hermes.cpp
@@ -1164,10 +1164,12 @@ void HermesRuntime::setMockedEnvironment(
   static_cast<HermesRuntimeImpl *>(this)->runtime_.setMockedEnvironment(env);
 }
 
+#ifdef HERMESVM_API_TRACE
 const ::hermes::vm::GCExecTrace &HermesRuntime::getGCExecTrace() const {
   return static_cast<const HermesRuntimeImpl *>(this)
       ->runtime_.getGCExecTrace();
 }
+#endif
 
 std::string HermesRuntime::getIOTrackingInfoJSON() {
   std::string buf;

--- a/API/hermes/hermes.h
+++ b/API/hermes/hermes.h
@@ -14,8 +14,11 @@
 #include <string>
 
 #include <hermes/Public/RuntimeConfig.h>
-#include <hermes/VM/GCExecTrace.h>
 #include <jsi/jsi.h>
+
+#ifdef HERMESVM_API_TRACE
+#include <hermes/VM/GCExecTrace.h>
+#endif
 
 struct HermesTestHelper;
 
@@ -121,10 +124,12 @@ class HermesRuntime : public jsi::Runtime {
   /// it can be written into the trace for later replay.
   const ::hermes::vm::MockedEnvironment &getMockedEnvironment() const;
 
+#ifdef HERMESVM_API_TRACE
   /// Get a structure representing the execution history (currently just of
   /// GC, but will be generalized as necessary), to aid in debugging
   /// non-deterministic execution.
   const ::hermes::vm::GCExecTrace &getGCExecTrace() const;
+#endif
 
   /// Make the runtime read from \p env to replay its environment-dependent
   /// behavior.


### PR DESCRIPTION
As per [this comment](https://github.com/microsoft/react-native/issues/319#issuecomment-621389883), removing this inclusion to keep VM header requirement out of distributions.