### PR TITLE
Update CircleCI npm job to use latest Ubuntu image (#215)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,6 +359,7 @@ jobs:
     environment:
       - YARN: yarnpkg
       - TERM: dumb
+      - DEBIAN_FRONTEND: noninteractive
     steps:
       - run:
           name: Install certificates required to attach workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,7 +355,7 @@ jobs:
 
   npm:
     docker:
-      - image: ubuntu:19.04
+      - image: ubuntu:rolling
     environment:
       - YARN: yarnpkg
       - TERM: dumb
@@ -365,13 +365,6 @@ jobs:
           command: |
             apt-get update
             apt-get install -y ca-certificates
-
-      - run:
-          name: Temporarily work around CircleCI workspace attachment bug
-          command: |
-            # As of 2019-09-10, CircleCI fails to attach Windows workspaces without this hack
-            cp /usr/bin/tar /usr/bin/tar.real
-            printf '%s\n' '#!/bin/sh' 'exec tar.real --no-same-owner "$@"' > /usr/bin/tar
 
       - attach_workspace:
           at: /tmp/hermes/input

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ jobs:
     environment:
       - HERMES_WS_DIR: /tmp/hermes
       - TERM: dumb
+      - DEBIAN_FRONTEND: noninteractive
     steps:
       - checkout
       - run:
@@ -96,6 +97,7 @@ jobs:
     environment:
       - HERMES_WS_DIR: /tmp/hermes
       - TERM: dumb
+      - DEBIAN_FRONTEND: noninteractive
     steps:
       - run:
           name: Install dependencies
@@ -149,6 +151,7 @@ jobs:
     environment:
       - HERMES_WS_DIR: /tmp/hermes
       - TERM: dumb
+      - DEBIAN_FRONTEND: noninteractive
     steps:
       - run:
           name: Install dependencies


### PR DESCRIPTION
Summary:
The build is currently failing (possibly because 19.04 is EOL). This updates it to just use the latest Ubuntu.
Pull Request resolved: https://github.com/facebook/hermes/pull/215

Reviewed By: willholen

Differential Revision: D21026727

Pulled By: neildhar

fbshipit-source-id: 3b0bd7e286e8d2b21d3b7122e495c3fa31f9e41a