### PR TITLE
[cmake] Add install target

### DIFF
--- a/API/hermes/CMakeLists.txt
+++ b/API/hermes/CMakeLists.txt
@@ -95,3 +95,10 @@ set_target_properties(libhermes PROPERTIES
   OUTPUT_NAME hermes
   )
 hermes_link_icu(libhermes)
+
+install(TARGETS libhermes
+  LIBRARY DESTINATION lib
+)
+install(DIRECTORY "${PROJECT_SOURCE_DIR}/API/hermes" DESTINATION include
+  FILES_MATCHING PATTERN "*.h"
+  PATTERN "synthtest" EXCLUDE)

--- a/API/hermes/CMakeLists.txt
+++ b/API/hermes/CMakeLists.txt
@@ -97,7 +97,9 @@ set_target_properties(libhermes PROPERTIES
 hermes_link_icu(libhermes)
 
 install(TARGETS libhermes
+  RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
 )
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/API/hermes" DESTINATION include
   FILES_MATCHING PATTERN "*.h"

--- a/API/jsi/jsi/CMakeLists.txt
+++ b/API/jsi/jsi/CMakeLists.txt
@@ -22,3 +22,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
   list(APPEND jsi_compile_flags "/EHsc")
 endif()
 target_compile_options(jsi PUBLIC ${jsi_compile_flags})
+
+install(DIRECTORY "${PROJECT_SOURCE_DIR}/API/jsi/" DESTINATION include
+  FILES_MATCHING PATTERN "*.h"
+  PATTERN "test" EXCLUDE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -531,6 +531,7 @@ add_subdirectory(utils/hermes-lit)
 add_subdirectory(tools)
 add_subdirectory(include)
 add_subdirectory(lib)
+add_subdirectory(public)
 add_subdirectory(external)
 add_subdirectory(unittests)
 add_subdirectory(API)
@@ -544,21 +545,6 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ${save_CMAKE_POSITION_INDEPENDENT_CODE})
 if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/facebook)
     add_subdirectory(facebook)
 endif()
-
-# Configure install task
-#
-install(TARGETS libhermes hermes hermesc hdb hbcdump hvm
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-)
-install(DIRECTORY "${PROJECT_SOURCE_DIR}/API/hermes" DESTINATION include
-  FILES_MATCHING PATTERN "*.h"
-  PATTERN "synthtest" EXCLUDE)
-install(DIRECTORY "${PROJECT_SOURCE_DIR}/API/jsi/" DESTINATION include
-  FILES_MATCHING PATTERN "*.h"
-  PATTERN "test" EXCLUDE)
-install(DIRECTORY "${PROJECT_SOURCE_DIR}/public/hermes/Public" DESTINATION include/hermes
-  FILES_MATCHING PATTERN "*.h")
 
 # Configure the test suites
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -545,6 +545,21 @@ if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/facebook)
     add_subdirectory(facebook)
 endif()
 
+# Configure install task
+#
+install(TARGETS libhermes hermes hermesc hdb hbcdump hvm
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+)
+install(DIRECTORY "${PROJECT_SOURCE_DIR}/API/hermes" DESTINATION include
+  FILES_MATCHING PATTERN "*.h"
+  PATTERN "synthtest" EXCLUDE)
+install(DIRECTORY "${PROJECT_SOURCE_DIR}/API/jsi/" DESTINATION include
+  FILES_MATCHING PATTERN "*.h"
+  PATTERN "test" EXCLUDE)
+install(DIRECTORY "${PROJECT_SOURCE_DIR}/public/hermes/Public" DESTINATION include/hermes
+  FILES_MATCHING PATTERN "*.h")
+
 # Configure the test suites
 #
 list(APPEND HERMES_TEST_DEPS

--- a/public/hermes/Public/CMakeLists.txt
+++ b/public/hermes/Public/CMakeLists.txt
@@ -3,4 +3,5 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-add_subdirectory(hermes/Public)
+install(DIRECTORY "${PROJECT_SOURCE_DIR}/public/hermes/Public" DESTINATION include/hermes
+  FILES_MATCHING PATTERN "*.h")

--- a/tools/hbcdump/CMakeLists.txt
+++ b/tools/hbcdump/CMakeLists.txt
@@ -18,3 +18,7 @@ target_link_libraries(hbcdump
 )
 
 hermes_link_icu(hbcdump)
+
+install(TARGETS hbcdump
+  RUNTIME DESTINATION bin
+)

--- a/tools/hdb/CMakeLists.txt
+++ b/tools/hdb/CMakeLists.txt
@@ -20,3 +20,7 @@ set_target_properties(hdb PROPERTIES
 target_link_libraries(hdb
   hermesapi
 )
+
+install(TARGETS hdb
+  RUNTIME DESTINATION bin
+)

--- a/tools/hermes/CMakeLists.txt
+++ b/tools/hermes/CMakeLists.txt
@@ -43,3 +43,7 @@ target_link_libraries(hermes
 )
 
 hermes_link_icu(hermes)
+
+install(TARGETS hermes
+  RUNTIME DESTINATION bin
+)

--- a/tools/hermesc/CMakeLists.txt
+++ b/tools/hermesc/CMakeLists.txt
@@ -31,3 +31,7 @@ if(NOT CMAKE_CROSSCOMPILING)
   # Namespace added to avoid clashing the host binary with the target binary.
   export(TARGETS hermesc FILE ${CMAKE_BINARY_DIR}/ImportHermesc.cmake NAMESPACE native-)
 endif()
+
+install(TARGETS hermesc
+  RUNTIME DESTINATION bin
+)

--- a/tools/hvm/CMakeLists.txt
+++ b/tools/hvm/CMakeLists.txt
@@ -26,3 +26,6 @@ target_link_libraries(hvm
 
 hermes_link_icu(hvm)
 
+install(TARGETS hvm
+  RUNTIME DESTINATION bin
+)


### PR DESCRIPTION
This adds a CMake install target, which makes it a little easier to collect the files needed for a distribution.

_I have not updated the Android build yet to make use of this yet, because I don’t currently have the correct setup and figured it could be done in a next iteration, either on my end or your end._

```
$ ./src/utils/build/configure.py --build-type=Debug --cmake-flags='-DCMAKE_INSTALL_PREFIX:PATH=../destroot'
$ cd build
$ ninja install -v
[…]
[430/431] cd /Users/eloy/Code/ReactNative/Hermes/build && /usr/local/Cellar/cmake/3.15.3/bin/cmake -P cmake_install.cmake
-- Install configuration: "Debug"
-- Installing: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/lib/libhermes.dylib
-- Installing: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/bin/hermes
-- Installing: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/bin/hermesc
-- Installing: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/bin/hdb
-- Installing: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/bin/hbcdump
-- Installing: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/bin/hvm
-- Up-to-date: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/include/hermes
-- Up-to-date: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/include/hermes/TraceInterpreter.h
-- Up-to-date: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/include/hermes/SynthTrace.h
-- Up-to-date: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/include/hermes/TracingRuntime.h
-- Up-to-date: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/include/hermes/DebuggerAPI.h
-- Up-to-date: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/include/hermes/SynthTraceParser.h
-- Up-to-date: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/include/hermes/CompileJS.h
-- Up-to-date: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/include/hermes/hermes.h
-- Up-to-date: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/include/hermes/hermes_tracing.h
-- Up-to-date: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/include
-- Up-to-date: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/include/jsi
-- Up-to-date: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/include/jsi/jsi-inl.h
-- Up-to-date: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/include/jsi/JSIDynamic.h
-- Up-to-date: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/include/jsi/instrumentation.h
-- Up-to-date: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/include/jsi/jsi.h
-- Up-to-date: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/include/jsi/decorator.h
-- Up-to-date: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/include/jsi/threadsafe.h
-- Up-to-date: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/include/jsi/jsilib.h
-- Up-to-date: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/include/hermes/Public
-- Up-to-date: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/include/hermes/Public/RuntimeConfig.h
-- Up-to-date: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/include/hermes/Public/GCConfig.h
-- Up-to-date: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/include/hermes/Public/GCTripwireContext.h
-- Up-to-date: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/include/hermes/Public/Buffer.h
-- Up-to-date: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/include/hermes/Public/DebuggerTypes.h
-- Up-to-date: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/include/hermes/Public/CtorConfig.h
-- Up-to-date: /Users/eloy/Code/ReactNative/Hermes/build/../destroot/include/hermes/Public/CrashManager.h
```

This ends up creating:

```
$ tree ../destroot/
../destroot/
├── bin
│   ├── hbcdump
│   ├── hdb
│   ├── hermes
│   ├── hermesc
│   └── hvm
├── include
│   ├── hermes
│   │   ├── CompileJS.h
│   │   ├── DebuggerAPI.h
│   │   ├── Public
│   │   │   ├── Buffer.h
│   │   │   ├── CrashManager.h
│   │   │   ├── CtorConfig.h
│   │   │   ├── DebuggerTypes.h
│   │   │   ├── GCConfig.h
│   │   │   ├── GCTripwireContext.h
│   │   │   └── RuntimeConfig.h
│   │   ├── SynthTrace.h
│   │   ├── SynthTraceParser.h
│   │   ├── TraceInterpreter.h
│   │   ├── TracingRuntime.h
│   │   ├── hermes.h
│   │   └── hermes_tracing.h
│   └── jsi
│       ├── JSIDynamic.h
│       ├── decorator.h
│       ├── instrumentation.h
│       ├── jsi-inl.h
│       ├── jsi.h
│       ├── jsilib.h
│       └── threadsafe.h
└── lib
    └── libhermes.dylib
```

…as opposed to what the current `include` dir looks like in the npm package:

```
$ tree ../npm-releases/0.5.0/android/include
../npm-releases/0.5.0/android/include
└── hermes
    ├── CompileJS.h
    ├── DebuggerAPI.h
    ├── Public
    │   ├── Buffer.h
    │   ├── CrashManager.h
    │   ├── CtorConfig.h
    │   ├── DebuggerTypes.h
    │   ├── GCConfig.h
    │   ├── GCTripwireContext.h
    │   ├── MemoryEventTracker.h
    │   └── RuntimeConfig.h
    ├── SynthTrace.h
    ├── SynthTraceParser.h
    ├── TraceInterpreter.h
    ├── TracingRuntime.h
    ├── hermes.h
    ├── hermes_tracing.h
    └── synthtest
        └── tests
            └── TestFunctions.h
```

(I assume that `TestFunctions.h` header didn’t need to be included?)