### PR TITLE
Add TypedArray support to jsi

### DIFF
--- a/API/jsi/jsi/TypedArrays.def
+++ b/API/jsi/jsi/TypedArrays.def
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the LICENSE
+ * file in the root directory of this source tree.
+ */
+// The TypedArray objects, see ES6 22.2 (Table 49)
+
+#ifndef TYPED_ARRAY
+#error "TYPED_ARRAY must exist before including this file"
+#endif
+
+TYPED_ARRAY(Int8, int8_t)
+TYPED_ARRAY(Int16, int16_t)
+TYPED_ARRAY(Int32, int32_t)
+TYPED_ARRAY(Uint8, uint8_t)
+TYPED_ARRAY(Uint8Clamped, uint8_t)
+TYPED_ARRAY(Uint16, uint16_t)
+TYPED_ARRAY(Uint32, uint32_t)
+TYPED_ARRAY(Float32, float)
+TYPED_ARRAY(Float64, double)
+
+#undef TYPED_ARRAY

--- a/API/jsi/jsi/decorator.h
+++ b/API/jsi/jsi/decorator.h
@@ -240,6 +240,9 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   bool isArrayBuffer(const Object& o) const override {
     return plain_.isArrayBuffer(o);
   };
+  bool isTypedArray(const Object& o) const override {
+    return plain_.isTypedArray(o);
+  };
   bool isFunction(const Object& o) const override {
     return plain_.isFunction(o);
   };
@@ -249,6 +252,9 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   bool isHostFunction(const jsi::Function& f) const override {
     return plain_.isHostFunction(f);
   };
+  TypedArrayKind getTypedArrayKind(const TypedArrayBase& a) const override {
+    return plain_.getTypedArrayKind(a);
+  }
   Array getPropertyNames(const Object& o) override {
     return plain_.getPropertyNames(o);
   };
@@ -263,15 +269,30 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   Array createArray(size_t length) override {
     return plain_.createArray(length);
   };
+  TypedArrayBase createTypedArray(size_t length, TypedArrayKind kind) override {
+    return plain_.createTypedArray(length, kind);
+  }
   size_t size(const Array& a) override {
     return plain_.size(a);
   };
   size_t size(const ArrayBuffer& ab) override {
     return plain_.size(ab);
   };
+  size_t size(const TypedArrayBase& ta) override {
+    return plain_.size(ta);
+  }
+  size_t byteOffset(const TypedArrayBase& ta) override {
+    return plain_.byteOffset(ta);
+  }
   uint8_t* data(const ArrayBuffer& ab) override {
     return plain_.data(ab);
   };
+  bool hasBuffer(const TypedArrayBase& ta) override {
+    return plain_.hasBuffer(ta);
+  }
+  ArrayBuffer getBuffer(const TypedArrayBase& ta) override {
+    return plain_.getBuffer(ta);
+  }
   Value getValueAtIndex(const Array& a, size_t i) override {
     return plain_.getValueAtIndex(a, i);
   };
@@ -612,6 +633,10 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
     Around around{with_};
     return RD::isArrayBuffer(o);
   };
+  bool isTypedArray(const Object& o) const override {
+    Around around{with_};
+    return RD::isTypedArray(o);
+  };
   bool isFunction(const Object& o) const override {
     Around around{with_};
     return RD::isFunction(o);
@@ -624,6 +649,10 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
     Around around{with_};
     return RD::isHostFunction(f);
   };
+  TypedArrayKind getTypedArrayKind(const TypedArrayBase& a) const override {
+    Around around{with_};
+    return RD::getTypedArrayKind(a);
+  }
   Array getPropertyNames(const Object& o) override {
     Around around{with_};
     return RD::getPropertyNames(o);
@@ -642,6 +671,10 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
     Around around{with_};
     return RD::createArray(length);
   };
+  TypedArrayBase createTypedArray(size_t length, TypedArrayKind kind) override {
+    Around around{with_};
+    return RD::createTypedArray(length, kind);
+  }
   size_t size(const Array& a) override {
     Around around{with_};
     return RD::size(a);
@@ -650,10 +683,26 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
     Around around{with_};
     return RD::size(ab);
   };
+  size_t size(const TypedArrayBase& ta) override {
+    Around around{with_};
+    return RD::size(ta);
+  };
+  size_t byteOffset(const TypedArrayBase& ta) override {
+    Around around{with_};
+    return RD::byteOffset(ta);
+  };
   uint8_t* data(const ArrayBuffer& ab) override {
     Around around{with_};
     return RD::data(ab);
   };
+  bool hasBuffer(const TypedArrayBase& ta) override {
+    Around around{with_};
+    return RD::hasBuffer(ta);
+  }
+  ArrayBuffer getBuffer(const TypedArrayBase& ta) override {
+    Around around{with_};
+    return RD::getBuffer(ta);
+  }
   Value getValueAtIndex(const Array& a, size_t i) override {
     Around around{with_};
     return RD::getValueAtIndex(a, i);

--- a/API/jsi/jsi/jsi-inl.h
+++ b/API/jsi/jsi/jsi-inl.h
@@ -147,6 +147,52 @@ inline ArrayBuffer Object::getArrayBuffer(Runtime& runtime) && {
   return ArrayBuffer(value);
 }
 
+inline TypedArrayBase Object::getTypedArray(Runtime& runtime) const& {
+  assert(runtime.isTypedArray(*this));
+  (void)runtime; // when assert is disabled we need to mark this as used
+  return TypedArrayBase(runtime.cloneObject(ptr_));
+}
+
+inline TypedArrayBase Object::getTypedArray(Runtime& runtime) && {
+  assert(runtime.isTypedArray(*this));
+  (void)runtime; // when assert is disabled we need to mark this as used
+  Runtime::PointerValue* value = ptr_;
+  ptr_ = nullptr;
+  return TypedArrayBase(value);
+}
+
+template <TypedArrayKind T>
+inline TypedArray<T> TypedArrayBase::get(Runtime& runtime) const& {
+  assert(getKind(runtime) == T);
+  (void)runtime; // when assert is disabled we need to mark this as used
+  return TypedArray<T>(runtime.cloneObject(ptr_));
+}
+
+template <TypedArrayKind T>
+inline TypedArray<T> TypedArrayBase::get(Runtime& runtime) && {
+  assert(getKind(runtime) == T);
+  (void)runtime; // when assert is disabled we need to mark this as used
+  Runtime::PointerValue* value = ptr_;
+  ptr_ = nullptr;
+  return TypedArray<T>(value);
+}
+
+template <TypedArrayKind T>
+inline TypedArray<T> TypedArrayBase::as(Runtime& runtime) const& {
+  if (getKind(runtime) != T) {
+    throw JSError(runtime, "Object is not a TypedArray");
+  }
+  return get<T>(runtime);
+}
+
+template <TypedArrayKind T>
+inline TypedArray<T> TypedArrayBase::as(Runtime& runtime) && {
+  if (getKind(runtime) != T) {
+    throw JSError(runtime, "Object is not a TypedArray");
+  }
+  return std::move(*this).get<T>(runtime);
+}
+
 inline Function Object::getFunction(Runtime& runtime) const& {
   assert(runtime.isFunction(*this));
   return Function(runtime.cloneObject(ptr_));

--- a/API/jsi/jsi/jsi.cpp
+++ b/API/jsi/jsi/jsi.cpp
@@ -191,6 +191,82 @@ Array Object::asArray(Runtime& runtime) && {
   return std::move(*this).getArray(runtime);
 }
 
+std::vector<uint8_t> ArrayBuffer::toVector(Runtime& runtime) const {
+  uint8_t *dataBlock = runtime.data(*this);
+  size_t blockSize = byteLength(runtime);
+  return std::vector<uint8_t>(dataBlock, dataBlock + blockSize);
+}
+
+void ArrayBuffer::update(Runtime& runtime, const std::vector<uint8_t>& data, size_t offset) {
+  uint8_t *dataBlock = runtime.data(*this);
+  size_t blockSize = byteLength(runtime);
+  if (data.size() > blockSize) {
+    throw JSError(runtime, "ArrayBuffer is to small to fit data");
+  }
+  std::copy(data.begin(), data.end(), dataBlock + offset);
+}
+
+template <TypedArrayKind T>
+std::vector<TypedArrayBase::ContentType<T>> TypedArray<T>::toVector(Runtime& runtime) {
+  auto start = reinterpret_cast<ContentType<T>*>(runtime.data(getBuffer(runtime)) + byteOffset(runtime));
+  auto end = start + size(runtime);
+  return std::vector<ContentType<T>>(start, end);
+}
+
+template <TypedArrayKind T>
+void TypedArray<T>::update(Runtime& runtime, const std::vector<ContentType<T>>& data) {
+  if (data.size() != size(runtime)) {
+    throw JSError(runtime, "TypedArray can only be updated with a vector of the same size");
+  }
+  uint8_t *rawData = runtime.data(getBuffer(runtime)) + byteOffset(runtime);
+  std::copy(data.begin(), data.end(), reinterpret_cast<ContentType<T>*>(rawData));
+}
+
+#define TYPED_ARRAY(name, content) \
+    template class TypedArray<TypedArrayKind::name##Array>;
+#include "TypedArrays.def"
+#undef TYPED_ARRAY
+
+TypedArrayBase Object::asTypedArray(Runtime& runtime) const& {
+  if (!isTypedArray(runtime)) {
+    throw JSError(
+        runtime,
+        "Object is " + kindToString(Value(runtime, *this), &runtime) +
+            ", expected a TypedArray");
+  }
+  return getTypedArray(runtime);
+}
+
+TypedArrayBase Object::asTypedArray(Runtime& runtime) && {
+  if (!isTypedArray(runtime)) {
+    throw JSError(
+        runtime,
+        "Object is " + kindToString(Value(runtime, *this), &runtime) +
+            ", expected a TypedArray");
+  }
+  return std::move(*this).getTypedArray(runtime);
+}
+
+ArrayBuffer Object::asArrayBuffer(Runtime& runtime) const& {
+  if (!isArrayBuffer(runtime)) {
+    throw JSError(
+        runtime,
+        "Object is " + kindToString(Value(runtime, *this), &runtime) +
+            ", expected an ArrayBuffer");
+  }
+  return getArrayBuffer(runtime);
+}
+
+ArrayBuffer Object::asArrayBuffer(Runtime& runtime) && {
+  if (!isArrayBuffer(runtime)) {
+    throw JSError(
+        runtime,
+        "Object is " + kindToString(Value(runtime, *this), &runtime) +
+            ", expected an ArrayBuffer");
+  }
+  return std::move(*this).getArrayBuffer(runtime);
+}
+
 Function Object::asFunction(Runtime& runtime) const& {
   if (!isFunction(runtime)) {
     throw JSError(


### PR DESCRIPTION
Closes #182 

Current API allows us to work with TypedArrays and ArrayBuffers, but there are cases where it's either inefficient or very cumbersome.

The main use case for me is WebGl implementation, which uses a lot of per frame calls that are passing typed arrays between js and c++. In a lot of cases, those are very small typed arrays (3 or 4 elements).

Few examples with current API
- to detect TypedArray kind I would need to 
```
    auto constructorName = this->getProperty(runtime, "__proto__")
                               .asObject(runtime)
                               .getProperty(runtime, "constructor")
                               .asObject(runtime)
                               .getProperty(runtime, "name")
                               .asString(runtime)
                               .utf8(runtime);
```
- to create TypedArray
```
runtime.global()
        .getProperty(
            runtime, jsi::String::createFromUtf8(runtime, getTypedArrayConstructorName(kind)))
        .asObject(runtime)
        .asFunction(runtime)
        .callAsConstructor(runtime, {static_cast<double>(size)})
        .asObject(runtime);
```
- to access data I would need to do all operations regarding offsets and sizes manually