### PR TITLE
Pin CMake version in builds to 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,8 +194,9 @@ jobs:
       - checkout
       - run:
           name: Install dependencies
+          # Force homebrew to install cmake 3.7
           command: |
-            brew install cmake ninja
+            brew install ninja https://raw.githubusercontent.com/Homebrew/homebrew-core/d25c628ff2510f68c89f4660fc93e86377ae61dc/Formula/cmake.rb
       - run:
           name: Set up workspace
           command: |
@@ -356,7 +357,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            choco install --no-progress cmake
+            choco install --no-progress cmake --version 3.14.7
             if (-not $?) { throw "Failed to install CMake" }
             choco install --no-progress python3
             if (-not $?) { throw "Failed to install Python" }

--- a/utils/build/configure.py
+++ b/utils/build/configure.py
@@ -214,7 +214,7 @@ def main():
         and platform.machine().endswith("64")
         and "Visual Studio" in args.build_system
     ):
-        cmake_flags += ["-Thost=x64"]
+        cmake_flags += ["-Ax64"]
     if args.opcode_stats:
         cmake_flags += ["-DHERMESVM_PROFILER_OPCODE=ON"]
     if args.basic_block_profiler:


### PR DESCRIPTION
This PR forces choco and brew in CircleCI builds to use CMake 3.7.
This brings them in line with the specified CMake minimum version
of 3.7.

For macOS, this meant pinning the cmake version installed by brew
to 3.7.2.

For Windows, this required multiple changes. First, since CMake 3.7
does not support Visual Studio 2019, I changed the script to install
Visual Studio 2017 instead.

I then had to accommodate some differences between Visual Studio 2019
and Visual Studio 2017:
1. Visual Studio 2017 (at least the one installed via choco) does not
come with a 64 bit toolset whereas VS2019 does. It can still build for
64 bit but the toolset itself is 32 bit.
2. VS2017 targets 32 bit platforms by default whereas VS2019 targets
whatever the host is running by default.

The current `configure.py` script sets the toolset to be used to x64
(on 64 bit systems) which did not work with VS2017 since the 64 bit
toolset could not be found. I therefore removed the line from
`configure.py` that sets this requirement (this shouldn't really
matter because VS2019 will use a 64 bit toolset on 64 bit platforms
anyway).

However, in order to ensure that a 64 bit binary would be built on 64
bit platforms even when using VS2017, I added a flag in `configure.py`
to set the target platform to x64.

I think this behaviour may be better since the configuration now
defines the architecture of the binary rather than the architecture of
the toolset.