### PR TITLE
Add missing quote in the Windows build command

### DIFF
--- a/doc/BuildingAndRunning.md
+++ b/doc/BuildingAndRunning.md
@@ -42,7 +42,7 @@ The build system has now been generated in the `build` directory. To perform the
 The Windows build depends on which particular combination of GitBash/Cygwin/WSL and Visual Studio is used.
 
     git -c core.autocrlf=false clone https://github.com/facebook/hermes.git
-    hermes/utils/build/configure.py --build-system='Visual Studio 16 2019' --cmake-flags='-A x64 --distribute
+    hermes/utils/build/configure.py --build-system='Visual Studio 16 2019' --cmake-flags='-A x64' --distribute
     cd build_release && MSBuild.exe ALL_BUILD.vcxproj /p:Configuration=Release
 
 ## Running Hermes


### PR DESCRIPTION
This PR adds the missing quote at the end of the `--cmake-flags` argument when building Hermes for Windows.