### PR TITLE
Fix Error message when passing 'undefined' to the constructor

### DIFF
--- a/lib/VM/JSLib/Error.cpp
+++ b/lib/VM/JSLib/Error.cpp
@@ -107,7 +107,8 @@ static CallResult<HermesValue> constructErrorObject(
   JSError::setupStack(selfHandle, runtime);
 
   // new Error(message).
-  if (args.getArgCount() >= 1) {
+  // Only proceed when 'typeof message' isn't undefined.
+  if (!args.getArg(0).isUndefined()) {
     if (LLVM_UNLIKELY(
             JSError::setMessage(
                 selfHandle, runtime, runtime->makeHandle(args.getArg(0))) ==

--- a/test/hermes/error.js
+++ b/test/hermes/error.js
@@ -37,6 +37,14 @@ e = new Error('another-message');
 print(e);
 //CHECK: Error: another-message
 
+e = new Error(undefined);
+print(e);
+//CHECK: Error
+
+e = new Error('undefined');
+print(e);
+//CHECK: Error: undefined
+
 e = new TypeError();
 print(e);
 //CHECK: TypeError

--- a/test/hermes/stacktrace.js
+++ b/test/hermes/stacktrace.js
@@ -82,7 +82,7 @@ runAndPrint(function() {
 runAndPrint(function() {
   Math.abs({valueOf: thrower});
 })
-//CHECK-LABEL: Error: undefined
+//CHECK-LABEL: Error
 //CHECK-NEXT:     at thrower ({{.*}})
 //CHECK-NEXT:     at abs (native)
 //CHECK-NEXT:     at anonymous ({{.*}})
@@ -117,7 +117,7 @@ runAndPrint(func)
 
 Object.defineProperty(func, 'name', {writable:true, value:undefined})
 runAndPrint(func)
-//CHECK-LABEL: Error: undefined
+//CHECK-LABEL: Error
 //CHECK-NEXT:    at original ({{.*}})
 
 // Native functions can be renamed. Currently native functions with invalid


### PR DESCRIPTION
Fixes #252.
To solve this issue, this PR checks for the message in `JSError::setMessage()` function. 
If it's equal to `undefined`, it's changed to an empty string.