### PR TITLE
Build all targets in linux and macOS CircleCI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,6 +175,7 @@ jobs:
             cd "$HERMES_WS_DIR"
             hermes/utils/build/configure.py
             cd build
+            ninja
             ninja check-hermes
 
   macos:
@@ -249,6 +250,7 @@ jobs:
           command: |
             cd "$HERMES_WS_DIR"
             hermes/utils/build/configure.py
+            cmake --build ./build
             cmake --build ./build --target check-hermes
 
   windows:

--- a/tools/fuzzers/CMakeLists.txt
+++ b/tools/fuzzers/CMakeLists.txt
@@ -3,7 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+CHECK_CXX_COMPILER_FLAG("-fsanitize=fuzzer-no-link" HAVE_SANITIZE_FUZZER)
+if(HAVE_SANITIZE_FUZZER)
   set(CMAKE_CXX_STANDARD 14)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
   set(HERMES_ENABLE_EH ON)


### PR DESCRIPTION
Summary: Ensure that all targets can be built when running tests.

Differential Revision: D22339621

