### PR TITLE
[cmake] Add explicit option to build Apple dSYM

### DIFF
--- a/API/hermes/CMakeLists.txt
+++ b/API/hermes/CMakeLists.txt
@@ -134,7 +134,7 @@ install(DIRECTORY "${PROJECT_SOURCE_DIR}/API/hermes" DESTINATION include
 
 # Create debug symbols (dSYM) bundle for Apple platform dylibs/frameworks
 # Largely inspired by https://github.com/llvm/llvm-project/blob/6701993027f8af172d7ba697884459261b00e3c6/llvm/cmake/modules/AddLLVM.cmake#L1934-L1986
-if(APPLE AND CMAKE_CXX_FLAGS MATCHES "-gdwarf")
+if(HERMES_BUILD_APPLE_DSYM)
   if(CMAKE_CXX_FLAGS MATCHES "-flto")
     set(lto_object ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/libhermes-lto.o)
     set_property(TARGET libhermes APPEND_STRING PROPERTY LINK_FLAGS " -Wl,-object_path_lto,${lto_object}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,6 +214,9 @@ set(HERMES_ENABLE_TEST_SUITE ON CACHE BOOL
 set(HERMES_BUILD_APPLE_FRAMEWORK ON CACHE BOOL
   "Whether to build the libhermes target as a framework bundle or dylib on Apple platforms")
 
+set(HERMES_BUILD_APPLE_DSYM OFF CACHE BOOL
+  "Whether to build a DWARF debugging symbols bundle")
+
 if (HERMES_IS_ANDROID)
   set(HERMES_IS_MOBILE_BUILD TRUE)
 
@@ -235,6 +238,10 @@ if (HERMES_IS_ANDROID)
     # https://github.com/android-ndk/ndk/issues/242
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fuse-ld=gold")
   endif()
+endif()
+
+if(HERMES_BUILD_APPLE_DSYM)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -gdwarf")
 endif()
 
 if (HERMES_IS_MOBILE_BUILD)
@@ -695,7 +702,8 @@ add_custom_target(
 
 add_custom_target(
   hermes-runtime-darwin-cocoapods-release
-  DEPENDS install
+  COMMAND
+    ${CMAKE_COMMAND} --build . --target install/strip
   COMMAND
     mkdir -p ${HERMES_GITHUB_DIR}/package-root
   COMMAND

--- a/hermes.podspec
+++ b/hermes.podspec
@@ -12,7 +12,7 @@ module HermesHelper
   end
 
   def self.cmake_configuration
-    "-DHERMES_ENABLE_DEBUGGER:BOOLEAN=true -DHERMES_ENABLE_FUZZING:BOOLEAN=false -DHERMES_ENABLE_TEST_SUITE:BOOLEAN=false"
+    "-DHERMES_ENABLE_DEBUGGER:BOOLEAN=true -DHERMES_ENABLE_FUZZING:BOOLEAN=false -DHERMES_ENABLE_TEST_SUITE:BOOLEAN=false -DHERMES_BUILD_APPLE_FRAMEWORK:BOOLEAN=true -DHERMES_BUILD_APPLE_DSYM:BOOLEAN=true"
   end
 
   def self.configure_command
@@ -41,9 +41,9 @@ Pod::Spec.new do |spec|
     if [ ! -d destroot/Library/Frameworks/hermes.framework ]; then
       if #{HermesHelper.command_exists?("cmake")}; then
         if #{HermesHelper.command_exists?("ninja")}; then
-          #{HermesHelper.configure_command} --build-system='Ninja' && cd build && ninja install
+          #{HermesHelper.configure_command} --build-system='Ninja' && cd build && ninja install/strip
         else
-          #{HermesHelper.configure_command} --build-system='Unix Makefiles' && cd build && make install
+          #{HermesHelper.configure_command} --build-system='Unix Makefiles' && cd build && make install/strip
         fi
       else
         echo >&2 'CMake is required to install Hermes, install it with: brew install cmake'


### PR DESCRIPTION
## Summary

Add `HERMES_BUILD_APPLE_DSYM` option to build a dSYM bundle for the libhermes target on Apple platforms.

This will work with any of the build types and is off by default.

Installing the tools with the install/strip target will ensure all tools and the runtime lib are stripped of debug symbols, but leaving the dSYM bundle in tact.

## Test Plan

### Build

```bash
./src/utils/build/configure.py --distribute --cmake-flags='-DHERMES_BUILD_APPLE_DSYM:BOOLEAN=true -DCMAKE_INSTALL_PREFIX:PATH=../destroot_release' build_release
cmake --build ./build_release
```

### Install without stripping

```bash
cmake --build ./build_release --target install
nm -a destroot_release/bin/hermesc | wc -l
   27943
```

### Install with stripping

```bash
cmake --build ./build_release --target install/strip
nm -a destroot_release/bin/hermesc | wc -l
     250
```

…and dSYM DWARF metadata is maintained:

```bash
dwarfdump --statistics destroot_release/Library/Frameworks/hermes.framework.dSYM
{"version":3,"file":"destroot_release/Library/Frameworks/hermes.framework.dSYM/Contents/Resources/DWARF/hermes","format":"Mach-O 64-bit x86-64","source functions":30305,"source functions with location":30302,"inlined functions":172725,"inlined funcs with abstract origins":172725,"unique source variables":79276,"source variables":353690,"variables with location":232195,"call site entries":186409,"scope bytes total":19161949,"scope bytes covered":10500176,"total function size":1763513,"total inlined function size":998375,"total formal params":300264,"formal params with source location":166067,"formal params with type":300264,"formal params with binary location":200407,"total vars":38809,"vars with source location":38385,"vars with type":38809,"vars with binary location":22161}
```