### PR TITLE
[ci] Create hermes-engine-darwin npm package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ workflows:
             - android
             - linux
             - macos
+            - build-macos-runtime
             - windows
       - test-linux
       - test-macos

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -712,9 +712,9 @@ add_custom_target(
   COMMAND
     cp -R -f ${CMAKE_INSTALL_PREFIX} ${HERMES_PKG_ROOT}/destroot
   COMMAND
-    rm -r ${HERMES_PKG_FRAMEWORK}/{Headers,Resources,hermes} && mv ${HERMES_PKG_FRAMEWORK}/Versions/0/* ${HERMES_PKG_FRAMEWORK}/ && rm -r ${HERMES_PKG_FRAMEWORK}/Versions && install_name_tool -id @rpath/hermes.framework/hermes ${HERMES_PKG_FRAMEWORK}/hermes
+    find ${HERMES_PKG_ROOT}/destroot/bin -type f ! -name 'hermesc' -delete
   COMMAND
-    cp ${CMAKE_CURRENT_SOURCE_DIR}/hermes.podspec ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE ${CMAKE_CURRENT_SOURCE_DIR}/README.md ${HERMES_PKG_ROOT}
+    cp ${CMAKE_CURRENT_SOURCE_DIR}/hermes.podspec ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE ${HERMES_PKG_ROOT}
   COMMAND
-    tar -C ${HERMES_PKG_ROOT}/ -czhf ${HERMES_GITHUB_DIR}/hermes-runtime-${HERMES_GITHUB_SYSTEM_NAME}-v${HERMES_RELEASE_VERSION}.tar.gz .
+    tar -C ${HERMES_PKG_ROOT}/ -czvf ${HERMES_GITHUB_DIR}/hermes-runtime-${HERMES_GITHUB_SYSTEM_NAME}-v${HERMES_RELEASE_VERSION}.tar.gz .
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -700,16 +700,21 @@ add_custom_target(
   github-cli-release
   DEPENDS ${HERMES_GITHUB_DIR}/${HERMES_CLI_GITHUB_FILE})
 
+set(HERMES_PKG_ROOT ${HERMES_GITHUB_DIR}/package-root)
+set(HERMES_PKG_FRAMEWORK ${HERMES_PKG_ROOT}/destroot/Library/Frameworks/hermes.framework)
+
 add_custom_target(
   hermes-runtime-darwin-cocoapods-release
   COMMAND
     ${CMAKE_COMMAND} --build . --target install/strip
   COMMAND
-    mkdir -p ${HERMES_GITHUB_DIR}/package-root
+    mkdir -p ${HERMES_PKG_ROOT}
   COMMAND
-    cp -R -f ${CMAKE_INSTALL_PREFIX} ${HERMES_GITHUB_DIR}/package-root/destroot
+    cp -R -f ${CMAKE_INSTALL_PREFIX} ${HERMES_PKG_ROOT}/destroot
   COMMAND
-    cp ${CMAKE_CURRENT_SOURCE_DIR}/hermes.podspec ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE ${CMAKE_CURRENT_SOURCE_DIR}/README.md ${HERMES_GITHUB_DIR}/package-root/
+    rm -r ${HERMES_PKG_FRAMEWORK}/{Headers,Resources,hermes} && mv ${HERMES_PKG_FRAMEWORK}/Versions/0/* ${HERMES_PKG_FRAMEWORK}/ && rm -r ${HERMES_PKG_FRAMEWORK}/Versions && install_name_tool -id @rpath/hermes.framework/hermes ${HERMES_PKG_FRAMEWORK}/hermes
   COMMAND
-    tar -C ${HERMES_GITHUB_DIR}/package-root/ -czhf ${HERMES_GITHUB_DIR}/hermes-runtime-${HERMES_GITHUB_SYSTEM_NAME}-v${HERMES_RELEASE_VERSION}.tar.gz .
+    cp ${CMAKE_CURRENT_SOURCE_DIR}/hermes.podspec ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE ${CMAKE_CURRENT_SOURCE_DIR}/README.md ${HERMES_PKG_ROOT}
+  COMMAND
+    tar -C ${HERMES_PKG_ROOT}/ -czhf ${HERMES_GITHUB_DIR}/hermes-runtime-${HERMES_GITHUB_SYSTEM_NAME}-v${HERMES_RELEASE_VERSION}.tar.gz .
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -708,11 +708,13 @@ add_custom_target(
   COMMAND
     ${CMAKE_COMMAND} --build . --target install/strip
   COMMAND
-    mkdir -p ${HERMES_PKG_ROOT}
+    mkdir -p ${HERMES_PKG_ROOT}/destroot/bin
   COMMAND
-    cp -R -f ${CMAKE_INSTALL_PREFIX} ${HERMES_PKG_ROOT}/destroot
+    cp ${CMAKE_INSTALL_PREFIX}/bin/hermesc ${HERMES_PKG_ROOT}/destroot/bin/
   COMMAND
-    find ${HERMES_PKG_ROOT}/destroot/bin -type f ! -name 'hermesc' -delete
+    cp -R ${CMAKE_INSTALL_PREFIX}/Library ${HERMES_PKG_ROOT}/destroot/
+  COMMAND
+    cp -R ${CMAKE_INSTALL_PREFIX}/include ${HERMES_PKG_ROOT}/destroot/
   COMMAND
     cp ${CMAKE_CURRENT_SOURCE_DIR}/hermes.podspec ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE ${HERMES_PKG_ROOT}
   COMMAND

--- a/npm/.gitignore
+++ b/npm/.gitignore
@@ -1,6 +1,11 @@
 *.tar.gz
 *.tgz
+*.sha256
 android
 node_modules
 osx-bin
 package-lock.json
+destroot
+LICENSE
+README.md
+hermes.podspec

--- a/npm/hermes-engine-darwin/README.md
+++ b/npm/hermes-engine-darwin/README.md
@@ -1,12 +1,6 @@
 ## Hermes
 
-Hermes is a small and lightweight JavaScript VM optimized for running React
-Native apps on macOS.
+Hermes is a small and lightweight JavaScript VM optimized for running
+React Native apps on macOS.
 
 See [hermesengine.dev](https://hermesengine.dev) for more information.
-
-This package contains a Hermes bytecode compiler for macOS, plus macOS runtime
-framework.
-
-Additional tools are available in
-[hermes-engine-cli](https://www.npmjs.com/package/hermes-engine-cli).

--- a/npm/hermes-engine-darwin/README.md
+++ b/npm/hermes-engine-darwin/README.md
@@ -1,0 +1,12 @@
+## Hermes
+
+Hermes is a small and lightweight JavaScript VM optimized for running React
+Native apps on macOS.
+
+See [hermesengine.dev](https://hermesengine.dev) for more information.
+
+This package contains a Hermes bytecode compiler for macOS, plus macOS runtime
+framework.
+
+Additional tools are available in
+[hermes-engine-cli](https://www.npmjs.com/package/hermes-engine-cli).

--- a/npm/hermes-engine-darwin/package.json
+++ b/npm/hermes-engine-darwin/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "hermes-engine-darwin",
+  "version": "%VERSION%",
+  "private": false,
+  "description": "A JavaScript engine optimized for running React Native on macOS",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:facebook/hermes.git"
+  },
+  "files": [
+    "LICENSE",
+    "README.md",
+    "hermes.podspec",
+    "destroot/bin/hermesc",
+    "destroot/include/**/*",
+    "destroot/Library/**/*"
+  ]
+}

--- a/npm/hermes-engine-darwin/package.json
+++ b/npm/hermes-engine-darwin/package.json
@@ -8,12 +8,12 @@
     "type": "git",
     "url": "git@github.com:facebook/hermes.git"
   },
+  "scripts": {
+    "postinstall": "node unpack-tarball.js"
+  },
   "files": [
-    "LICENSE",
     "README.md",
-    "hermes.podspec",
-    "destroot/bin/hermesc",
-    "destroot/include/**/*",
-    "destroot/Library/**/*"
+    "unpack-tarball.js",
+    "hermes-runtime-darwin-v*.tar.gz"
   ]
 }

--- a/npm/hermes-engine-darwin/unpack-tarball.js
+++ b/npm/hermes-engine-darwin/unpack-tarball.js
@@ -12,8 +12,5 @@ if (
   if (!tarball) {
     throw new Error("Could not locate tarball");
   }
-  child_process.execFileSync("/usr/bin/tar", [
-    "-xzvf",
-    path.join(__dirname, tarball),
-  ]);
+  child_process.execFileSync("tar", ["-xzvf", path.join(__dirname, tarball)]);
 }

--- a/npm/hermes-engine-darwin/unpack-tarball.js
+++ b/npm/hermes-engine-darwin/unpack-tarball.js
@@ -7,7 +7,7 @@ if (
   !fs.existsSync(path.join(__dirname, "destroot"))
 ) {
   const tarball = fs.readdirSync(__dirname).find(function (entry) {
-    return entry.endsWith(".tar.gz");
+    return /^hermes-runtime-darwin-v[\d\.]+\.tar\.gz$/.test(entry);
   });
   if (!tarball) {
     throw new Error("Could not locate tarball");

--- a/npm/hermes-engine-darwin/unpack-tarball.js
+++ b/npm/hermes-engine-darwin/unpack-tarball.js
@@ -1,0 +1,19 @@
+const path = require("path");
+const fs = require("fs");
+const child_process = require("child_process");
+
+if (
+  process.platform === "darwin" &&
+  !fs.existsSync(path.join(__dirname, "destroot"))
+) {
+  const tarball = fs.readdirSync(__dirname).find(function (entry) {
+    return entry.endsWith(".tar.gz");
+  });
+  if (!tarball) {
+    throw new Error("Could not locate tarball");
+  }
+  child_process.execFileSync("/usr/bin/tar", [
+    "-xzvf",
+    path.join(__dirname, tarball),
+  ]);
+}

--- a/npm/unpack-builds.js
+++ b/npm/unpack-builds.js
@@ -134,6 +134,10 @@ var inputs = [
   {
     name: "hermes-cli-darwin-v" + releaseVersion + ".tar.gz",
     dest: "osx-bin"
+  },
+  {
+    name: "hermes-runtime-darwin-v" + releaseVersion + ".tar.gz",
+    dest: ".",
   }
 ]
 

--- a/npm/unpack-builds.js
+++ b/npm/unpack-builds.js
@@ -134,10 +134,6 @@ var inputs = [
   {
     name: "hermes-cli-darwin-v" + releaseVersion + ".tar.gz",
     dest: "osx-bin"
-  },
-  {
-    name: "hermes-runtime-darwin-v" + releaseVersion + ".tar.gz",
-    dest: ".",
   }
 ]
 


### PR DESCRIPTION
⚠️ _This includes the changes of #296, so I’ll have to rebase this PR once that lands. The changes that pertain to this PR are in https://github.com/facebook/hermes/commit/9da61f7a9da01b5bd49e95dca0b98a5204210790_

## Summary

Adds hermes-engine-darwin to the npm CI job.

Notably the symbolic links need to be stripped from the framework bundle, as npm by design does not support symbolic links to exist in packages. However, seeing as we already package distinct versions of the framework in distinct npm packages, there isn't any need to support multiple versions of Hermes in a single framework bundle; so this should be fine.

## Test Plan

TODO: I’ll need to backport all changes to Hermes v0.4.1 in order to pull it into RN macOS v0.62. In the meantime I want to see if CI is correctly cutting this package.