### PR TITLE
Backport podspec and binary building to v0.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,15 +20,18 @@ workflows:
       - android
       - linux
       - macos
+      - build-macos-runtime
       - windows
       - npm:
           requires:
             - android
             - linux
             - macos
+            - build-macos-runtime
             - windows
       - test-linux
       - test-macos
+      - test-macos-runtime-build-and-cocoapods-integration
       - test-e2e:
           requires:
             - npm
@@ -224,13 +227,64 @@ jobs:
           name: Build Hermes for macOS
           command: |
             cd "$HERMES_WS_DIR"
-            hermes/utils/build/configure.py --distribute
+            hermes/utils/build/configure.py --distribute --cmake-flags='-DHERMES_BUILD_APPLE_FRAMEWORK:BOOLEAN=false'
             cmake --build ./build_release --target github-cli-release
       - run:
           name: Copy artifacts
           command: |
             cd "$HERMES_WS_DIR"
             cp "build_release/github"/hermes-cli-*.tar.gz "output"
+      - run:
+          name: Checksum artifacts
+          command: |
+            cd "$HERMES_WS_DIR/output"
+            for file in *
+            do
+              shasum -a 256 "$file" > "$file.sha256"
+            done
+      - store_artifacts:
+          path: /tmp/hermes/output/
+      - persist_to_workspace:
+          root: /tmp/hermes/output/
+          paths:
+            - .
+
+  build-macos-runtime:
+    macos:
+      xcode: "10.3.0"
+    environment:
+      - HERMES_WS_DIR: /tmp/hermes
+      - TERM: dumb
+      # Homebrew currently breaks while updating:
+      # https://discuss.circleci.com/t/brew-install-fails-while-updating/32992
+      - HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: |
+            brew install cmake ninja
+      - run:
+          name: Set up workspace
+          command: |
+            mkdir -p "$HERMES_WS_DIR" "$HERMES_WS_DIR/output" "$HERMES_WS_DIR/package-root"
+            ln -sf "$PWD" "$HERMES_WS_DIR/hermes"
+      - run:
+          name: Build LLVM
+          command: |
+            cd "$HERMES_WS_DIR"
+            hermes/utils/build/build_llvm.py --distribute llvm llvm_build
+      - run:
+          name: Build Hermes for macOS as CocoaPods pod
+          command: |
+            cd "$HERMES_WS_DIR"
+            hermes/utils/build/configure.py --distribute --cmake-flags="$(ruby -rcocoapods-core -e 'load %{hermes/hermes.podspec}; puts HermesHelper.cmake_configuration') -DCMAKE_INSTALL_PREFIX:PATH=../destroot"
+            cmake --build ./build_release --target hermes-runtime-darwin-cocoapods-release
+      - run:
+          name: Copy artifacts
+          command: |
+            cd "$HERMES_WS_DIR"
+            cp "build_release/github"/hermes-runtime-darwin-*.tar.gz "output"
       - run:
           name: Checksum artifacts
           command: |
@@ -279,13 +333,33 @@ jobs:
             hermes/utils/build/configure.py
             cmake --build ./build --target check-hermes
 
+  test-macos-runtime-build-and-cocoapods-integration:
+    macos:
+      xcode: "10.3.0"
+    environment:
+      - TERM: dumb
+      # Homebrew currently breaks while updating:
+      # https://discuss.circleci.com/t/brew-install-fails-while-updating/32992
+      - HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: |
+            brew install cmake ninja
+      - run:
+          name: Run CocoaPods installation and test framework
+          command: |
+            cd test/ApplePlatformsIntegrationTestApp
+            ./run.sh
+
   windows:
     executor:
       name: win/preview-default
       shell: powershell.exe
     environment:
       - HERMES_WS_DIR: 'C:\tmp\hermes'
-      - ICU_URL: 'https://github.com/unicode-org/icu/releases/download/release-64-2/icu4c-64_2-Win64-MSVC2017.zip'
+      - ICU_URL: "https://github.com/unicode-org/icu/releases/download/release-64-2/icu4c-64_2-Win64-MSVC2017.zip"
       - MSBUILD_DIR: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin'
       - CMAKE_DIR: 'C:\Program Files\CMake\bin'
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ jobs:
     environment:
       - HERMES_WS_DIR: /tmp/hermes
       - TERM: dumb
+      - DEBIAN_FRONTEND: noninteractive
     steps:
       - checkout
       - run:
@@ -110,6 +111,7 @@ jobs:
     environment:
       - HERMES_WS_DIR: /tmp/hermes
       - TERM: dumb
+      - DEBIAN_FRONTEND: noninteractive
     steps:
       - run:
           name: Install dependencies
@@ -168,6 +170,7 @@ jobs:
     environment:
       - HERMES_WS_DIR: /tmp/hermes
       - TERM: dumb
+      - DEBIAN_FRONTEND: noninteractive
     steps:
       - run:
           name: Install dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -472,6 +472,7 @@ jobs:
     environment:
       - yarn: yarnpkg
       - TERM: dumb
+      - DEBIAN_FRONTEND: noninteractive
     steps:
       - run:
           name: Install certificates required to attach workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,7 +468,7 @@ jobs:
 
   npm:
     docker:
-      - image: ubuntu:19.04
+      - image: ubuntu:rolling
     environment:
       - yarn: yarnpkg
       - TERM: dumb
@@ -478,13 +478,6 @@ jobs:
           command: |
             apt-get update
             apt-get install -y ca-certificates
-
-      - run:
-          name: Temporarily work around CircleCI workspace attachment bug
-          command: |
-            # As of 2019-09-10, CircleCI fails to attach Windows workspaces without this hack
-            cp /usr/bin/tar /usr/bin/tar.real
-            printf '%s\n' '#!/bin/sh' 'exec tar.real --no-same-owner "$@"' > /usr/bin/tar
 
       - attach_workspace:
           at: /tmp/hermes/input

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,6 @@ workflows:
             - android
             - linux
             - macos
-            - build-macos-runtime
             - windows
       - test-linux
       - test-macos

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,11 @@ buck-out
 
 # Mac
 .DS_Store
+
+# CocoaPods testing
+build
+destroot
+test/ApplePlatformsIntegrationTestApp/Podfile.lock
+test/ApplePlatformsIntegrationTestApp/Pods
+test/ApplePlatformsIntegrationTestApp/**/xcuserdata
+test/ApplePlatformsIntegrationTestApp/ApplePlatformsIntegrationTestApp.xcworkspace

--- a/API/hermes/CMakeLists.txt
+++ b/API/hermes/CMakeLists.txt
@@ -25,6 +25,9 @@ add_llvm_library(hermesapi
         ${api_sources}
         LINK_LIBS jsi hermesVMRuntime)
 
+file(GLOB api_headers ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
+file(GLOB api_public_headers ${PROJECT_SOURCE_DIR}/public/hermes/Public/*.h)
+
 set(hermesapi_compile_flags "")
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" OR
     "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
@@ -55,7 +58,7 @@ add_llvm_library(compileJS STATIC CompileJS.cpp)
 set(LLVM_REQUIRES_EH ON)
 set(LLVM_REQUIRES_RTTI ON)
 
-add_library(libhermes SHARED ${api_sources})
+add_library(libhermes SHARED ${api_sources} ${api_headers} ${api_public_headers})
 target_link_libraries(libhermes
   jsi
   hermesVMRuntime
@@ -85,5 +88,63 @@ set_target_properties(libhermes PROPERTIES
   CXX_STANDARD_REQUIRED 14
   # Avoid becoming liblibhermes (and there's already a target called 'hermes')
   OUTPUT_NAME hermes
+)
+
+if(APPLE AND HERMES_BUILD_APPLE_FRAMEWORK)
+  set_target_properties(libhermes PROPERTIES
+    FRAMEWORK TRUE
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION}
+    FRAMEWORK_VERSION ${PROJECT_VERSION_MAJOR}
+    MACOSX_FRAMEWORK_SHORT_VERSION_STRING ${PROJECT_VERSION}
+    MACOSX_FRAMEWORK_BUNDLE_VERSION ${PROJECT_VERSION}
+    MACOSX_FRAMEWORK_IDENTIFIER dev.hermesengine.${CMAKE_SYSTEM_NAME}
   )
-hermes_link_icu(libhermes)
+  # Install headers into `Headers` while keeping required directory structure
+  set_source_files_properties(${api_headers} PROPERTIES
+    MACOSX_PACKAGE_LOCATION Headers
+  )
+  set_source_files_properties(${api_public_headers} PROPERTIES
+    MACOSX_PACKAGE_LOCATION Headers/Public
+  )
+endif()
+
+install(TARGETS libhermes
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  FRAMEWORK DESTINATION Library/Frameworks
+)
+# Install headers into `include` while keeping required directory structure
+install(DIRECTORY "${PROJECT_SOURCE_DIR}/API/hermes" DESTINATION include
+  FILES_MATCHING PATTERN "*.h"
+  PATTERN "synthtest" EXCLUDE)
+
+# Create debug symbols (dSYM) bundle for Apple platform dylibs/frameworks
+# Largely inspired by https://github.com/llvm/llvm-project/blob/6701993027f8af172d7ba697884459261b00e3c6/llvm/cmake/modules/AddLLVM.cmake#L1934-L1986
+if(HERMES_BUILD_APPLE_DSYM)
+  if(CMAKE_CXX_FLAGS MATCHES "-flto")
+    set(lto_object ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/libhermes-lto.o)
+    set_property(TARGET libhermes APPEND_STRING PROPERTY LINK_FLAGS " -Wl,-object_path_lto,${lto_object}")
+  endif()
+
+  get_target_property(DSYM_PATH libhermes LOCATION)
+  if(HERMES_BUILD_APPLE_FRAMEWORK)
+    get_filename_component(DSYM_PATH ${DSYM_PATH} DIRECTORY)
+  endif()
+  set(DSYM_PATH "${DSYM_PATH}.dSYM")
+
+  if(NOT CMAKE_DSYMUTIL)
+    set(CMAKE_DSYMUTIL xcrun dsymutil)
+  endif()
+  add_custom_command(TARGET libhermes POST_BUILD
+    COMMAND ${CMAKE_DSYMUTIL} $<TARGET_FILE:libhermes> --out ${DSYM_PATH}
+    BYPRODUCTS ${DSYM_PATH}
+  )
+
+  if(HERMES_BUILD_APPLE_FRAMEWORK)
+    install(DIRECTORY ${DSYM_PATH} DESTINATION Library/Frameworks)
+  else()
+    install(DIRECTORY ${DSYM_PATH} DESTINATION lib)
+  endif()
+endif()

--- a/API/jsi/jsi/CMakeLists.txt
+++ b/API/jsi/jsi/CMakeLists.txt
@@ -22,3 +22,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
   list(APPEND jsi_compile_flags "/EHsc")
 endif()
 target_compile_options(jsi PUBLIC ${jsi_compile_flags})
+
+install(DIRECTORY "${PROJECT_SOURCE_DIR}/API/jsi/" DESTINATION include
+  FILES_MATCHING PATTERN "*.h"
+  PATTERN "test" EXCLUDE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,15 +25,13 @@ endif()
 # This must be consistent with the release_version in
 # android/build.gradle and npm/package.json
 project(Hermes
-        VERSION 0.4.2
+        VERSION 0.4.1
         LANGUAGES C CXX)
-# Optional suffix like "-rc3"
-set(VERSION_SUFFIX "-rc1")
 
 include(CheckCXXCompilerFlag)
 include(CheckCXXSourceCompiles)
 
-set(HERMES_RELEASE_VERSION ${PROJECT_VERSION}${VERSION_SUFFIX})
+set(HERMES_RELEASE_VERSION ${PROJECT_VERSION})
 
 # Project options.
 set(HERMESVM_GCKIND NONCONTIG_GENERATIONAL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -639,11 +639,13 @@ add_custom_target(
   COMMAND
     ${CMAKE_COMMAND} --build . --target install/strip
   COMMAND
-    mkdir -p ${HERMES_PKG_ROOT}
+    mkdir -p ${HERMES_PKG_ROOT}/destroot/bin
   COMMAND
-    cp -R -f ${CMAKE_INSTALL_PREFIX} ${HERMES_PKG_ROOT}/destroot
+    cp ${CMAKE_INSTALL_PREFIX}/bin/hermesc ${HERMES_PKG_ROOT}/destroot/bin/
   COMMAND
-    find ${HERMES_PKG_ROOT}/destroot/bin -type f ! -name 'hermesc' -delete
+    cp -R ${CMAKE_INSTALL_PREFIX}/Library ${HERMES_PKG_ROOT}/destroot/
+  COMMAND
+    cp -R ${CMAKE_INSTALL_PREFIX}/include ${HERMES_PKG_ROOT}/destroot/
   COMMAND
     cp ${CMAKE_CURRENT_SOURCE_DIR}/hermes.podspec ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE ${HERMES_PKG_ROOT}
   COMMAND

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -643,9 +643,9 @@ add_custom_target(
   COMMAND
     cp -R -f ${CMAKE_INSTALL_PREFIX} ${HERMES_PKG_ROOT}/destroot
   COMMAND
-    rm -r ${HERMES_PKG_FRAMEWORK}/{Headers,Resources,hermes} && mv ${HERMES_PKG_FRAMEWORK}/Versions/0/* ${HERMES_PKG_FRAMEWORK}/ && rm -r ${HERMES_PKG_FRAMEWORK}/Versions && install_name_tool -id @rpath/hermes.framework/hermes ${HERMES_PKG_FRAMEWORK}/hermes
+    find ${HERMES_PKG_ROOT}/destroot/bin -type f ! -name 'hermesc' -delete
   COMMAND
-    cp ${CMAKE_CURRENT_SOURCE_DIR}/hermes.podspec ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE ${CMAKE_CURRENT_SOURCE_DIR}/README.md ${HERMES_PKG_ROOT}
+    cp ${CMAKE_CURRENT_SOURCE_DIR}/hermes.podspec ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE ${HERMES_PKG_ROOT}
   COMMAND
-    tar -C ${HERMES_PKG_ROOT}/ -czhf ${HERMES_GITHUB_DIR}/hermes-runtime-${HERMES_GITHUB_SYSTEM_NAME}-v${HERMES_RELEASE_VERSION}.tar.gz .
+    tar -C ${HERMES_PKG_ROOT}/ -czvf ${HERMES_GITHUB_DIR}/hermes-runtime-${HERMES_GITHUB_SYSTEM_NAME}-v${HERMES_RELEASE_VERSION}.tar.gz .
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,17 @@ if (POLICY CMP0075)
   cmake_policy(SET CMP0075 NEW)
 endif()
 
-# This must be consistent with the release_version in
-# android/build.gradle and npm/package.json
+# Allow reading the LOCATION property of a target to determine the eventual
+# location of build targets. This is needed when building the debugging symbols
+# bundles for Apple platforms.
+if (POLICY CMP0026)
+  cmake_policy(SET CMP0026 OLD)
+endif()
+
+# This must be consistent with the release_version in:
+# - android/build.gradle
+# - npm/package.json
+# - hermes.podspec
 project(Hermes
         VERSION 0.4.1
         LANGUAGES C CXX)
@@ -126,11 +135,21 @@ set(ANDROID_LINUX_PERF_PATH ""
 set(HERMES_MSVC_MP ON CACHE STRING
   "Enable /MP in MSVC for parallel builds")
 
-# On Android we need an ABI specific version of LLVM.
-# Unfortunately, the build system doesn't allow setting the
-# LLVM_BUILD_DIR per ABI, so we do it here instead.
+set(HERMES_ENABLE_TEST_SUITE ON CACHE BOOL
+  "Enable the test suite")
+
+set(HERMES_BUILD_APPLE_FRAMEWORK ON CACHE BOOL
+  "Whether to build the libhermes target as a framework bundle or dylib on Apple platforms")
+
+set(HERMES_BUILD_APPLE_DSYM OFF CACHE BOOL
+  "Whether to build a DWARF debugging symbols bundle")
+
 if (HERMES_IS_ANDROID)
+  # On Android we need an ABI specific version of LLVM.
+  # Unfortunately, the build system doesn't allow setting the
+  # LLVM_BUILD_DIR per ABI, so we do it here instead.
   set(LLVM_BUILD_DIR "${LLVM_BUILD_BASE}-${ANDROID_ABI}")
+
   add_definitions(-DHERMES_PLATFORM_UNICODE=HERMES_PLATFORM_UNICODE_JAVA)
 
   # The toolchain passes -Wa,--noexecstack which is valid for compiling
@@ -149,6 +168,10 @@ if (HERMES_IS_ANDROID)
     # https://github.com/android-ndk/ndk/issues/242
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fuse-ld=gold")
   endif()
+endif()
+
+if(HERMES_BUILD_APPLE_DSYM)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -gdwarf")
 endif()
 
 # The hermes project is built using CMake and the LLVM's build system.
@@ -346,6 +369,8 @@ endif()
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 set(LLVM_MAIN_SRC_DIR ${LLVM_SRC_DIR})
+# Do not install llvm artefacts.
+set(LLVM_INSTALL_TOOLCHAIN_ONLY ON)
 include(LLVMConfig)
 include(AddLLVM)
 include(HandleLLVMOptions)
@@ -499,68 +524,72 @@ endif()
 add_subdirectory(tools)
 add_subdirectory(include)
 add_subdirectory(lib)
+add_subdirectory(public)
 add_subdirectory(external)
-add_subdirectory(unittests)
 add_subdirectory(${HERMES_JSI_DIR}/jsi ${CMAKE_CURRENT_BINARY_DIR}/jsi)
 add_subdirectory(API)
 
 # Configure the test suites
 #
-list(APPEND HERMES_TEST_DEPS
-  HermesUnitTests
-  hermes
-  hermesc
-  hvm
-  interp-dispatch-bench
-  hdb
-  hbcdump
-  hermes-repl
-  hbc-attribute
-  hbc-deltaprep
-  hbc-diff
-  llvm-config
-  )
+if(HERMES_ENABLE_TEST_SUITE)
+  add_subdirectory(unittests)
 
-set(HERMES_LIT_TEST_PARAMS
-  test_exec_root=${HERMES_BINARY_DIR}/test
-  unittests_dir=${HERMES_BINARY_DIR}/unittests
-  debugger_enabled=${HERMES_ENABLE_DEBUGGER}
-  use_flowparser=${HERMES_USE_FLOWPARSER}
-  jit_enabled=${HERMESVM_JIT}
-  jit_disassembler_enabled=${HERMESVM_JIT_DISASSEMBLER}
-  hbc_deltaprep=${HERMES_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin/hbc-deltaprep
-  FileCheck=${LLVM_BUILD_DIR}/${CMAKE_CFG_INTDIR}/bin/FileCheck
-  hermes=${HERMES_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin/hermes
-  hermesc=${HERMES_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin/hermesc
-  hdb=${HERMES_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin/hdb
-  hbcdump=${HERMES_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin/hbcdump
-  repl=${HERMES_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin/hermes-repl
-  hbc-deltaprep=${HERMES_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin/hbc-deltaprep
-  hbc_diff=${HERMES_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin/hbc-diff
-  build_mode=${HERMES_ASSUMED_BUILD_MODE_IN_LIT_TEST}
-  exception_on_oom_enabled=${HERMESVM_EXCEPTION_ON_OOM}
-  serialize_enabled=${HERMESVM_SERIALIZE}
-  profiler=${HERMES_PROFILER_MODE_IN_LIT_TEST}
-  use_js_library_implementation=${HERMESVM_USE_JS_LIBRARY_IMPLEMENTATION}
-  gc=${HERMESVM_GCKIND}
-  # TODO: Figure out how to tell if CMake is doing a UBSAN build.
-  ubsan=OFF
-  )
+  list(APPEND HERMES_TEST_DEPS
+    HermesUnitTests
+    hermes
+    hermesc
+    hvm
+    interp-dispatch-bench
+    hdb
+    hbcdump
+    hermes-repl
+    hbc-attribute
+    hbc-deltaprep
+    hbc-diff
+    llvm-config
+    )
 
-set(LLVM_LIT_ARGS "-sv")
+  set(HERMES_LIT_TEST_PARAMS
+    test_exec_root=${HERMES_BINARY_DIR}/test
+    unittests_dir=${HERMES_BINARY_DIR}/unittests
+    debugger_enabled=${HERMES_ENABLE_DEBUGGER}
+    use_flowparser=${HERMES_USE_FLOWPARSER}
+    jit_enabled=${HERMESVM_JIT}
+    jit_disassembler_enabled=${HERMESVM_JIT_DISASSEMBLER}
+    hbc_deltaprep=${HERMES_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin/hbc-deltaprep
+    FileCheck=${LLVM_BUILD_DIR}/${CMAKE_CFG_INTDIR}/bin/FileCheck
+    hermes=${HERMES_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin/hermes
+    hermesc=${HERMES_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin/hermesc
+    hdb=${HERMES_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin/hdb
+    hbcdump=${HERMES_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin/hbcdump
+    repl=${HERMES_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin/hermes-repl
+    hbc-deltaprep=${HERMES_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin/hbc-deltaprep
+    hbc_diff=${HERMES_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin/hbc-diff
+    build_mode=${HERMES_ASSUMED_BUILD_MODE_IN_LIT_TEST}
+    exception_on_oom_enabled=${HERMESVM_EXCEPTION_ON_OOM}
+    serialize_enabled=${HERMESVM_SERIALIZE}
+    profiler=${HERMES_PROFILER_MODE_IN_LIT_TEST}
+    use_js_library_implementation=${HERMESVM_USE_JS_LIBRARY_IMPLEMENTATION}
+    gc=${HERMESVM_GCKIND}
+    # TODO: Figure out how to tell if CMake is doing a UBSAN build.
+    ubsan=OFF
+    )
 
-# This is a hack to help LLVM find its own llvm-lit tool, since we had to set
-# LLVM_RUNTIME_OUTPUT_INTDIR to our own build dir.
-set(LLVM_LIT_OUTPUT_DIR ${LLVM_BUILD_DIR}/${CMAKE_CFG_INTDIR}/bin)
+  set(LLVM_LIT_ARGS "-sv")
 
-add_lit_testsuite(check-hermes "Running the Hermes regression tests"
-  ${HERMES_SOURCE_DIR}/test
-  ${HERMES_SOURCE_DIR}/unittests
-  PARAMS ${HERMES_LIT_TEST_PARAMS}
-  DEPENDS ${HERMES_TEST_DEPS}
-  ARGS ${HERMES_TEST_EXTRA_ARGS}
-  )
-set_target_properties(check-hermes PROPERTIES FOLDER "Hermes regression tests")
+  # This is a hack to help LLVM find its own llvm-lit tool, since we had to set
+  # LLVM_RUNTIME_OUTPUT_INTDIR to our own build dir.
+  set(LLVM_LIT_OUTPUT_DIR ${LLVM_BUILD_DIR}/${CMAKE_CFG_INTDIR}/bin)
+
+  add_lit_testsuite(check-hermes "Running the Hermes regression tests"
+    ${HERMES_SOURCE_DIR}/test
+    ${HERMES_SOURCE_DIR}/unittests
+    PARAMS ${HERMES_LIT_TEST_PARAMS}
+    DEPENDS ${HERMES_TEST_DEPS}
+    ARGS ${HERMES_TEST_EXTRA_ARGS}
+    )
+  set_target_properties(check-hermes PROPERTIES FOLDER "Hermes regression tests")
+endif()
 
 # This is how github release files are built.
 
@@ -601,3 +630,22 @@ add_custom_command(
 add_custom_target(
   github-cli-release
   DEPENDS ${HERMES_GITHUB_DIR}/${HERMES_CLI_GITHUB_FILE})
+
+set(HERMES_PKG_ROOT ${HERMES_GITHUB_DIR}/package-root)
+set(HERMES_PKG_FRAMEWORK ${HERMES_PKG_ROOT}/destroot/Library/Frameworks/hermes.framework)
+
+add_custom_target(
+  hermes-runtime-darwin-cocoapods-release
+  COMMAND
+    ${CMAKE_COMMAND} --build . --target install/strip
+  COMMAND
+    mkdir -p ${HERMES_PKG_ROOT}
+  COMMAND
+    cp -R -f ${CMAKE_INSTALL_PREFIX} ${HERMES_PKG_ROOT}/destroot
+  COMMAND
+    rm -r ${HERMES_PKG_FRAMEWORK}/{Headers,Resources,hermes} && mv ${HERMES_PKG_FRAMEWORK}/Versions/0/* ${HERMES_PKG_FRAMEWORK}/ && rm -r ${HERMES_PKG_FRAMEWORK}/Versions && install_name_tool -id @rpath/hermes.framework/hermes ${HERMES_PKG_FRAMEWORK}/hermes
+  COMMAND
+    cp ${CMAKE_CURRENT_SOURCE_DIR}/hermes.podspec ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE ${CMAKE_CURRENT_SOURCE_DIR}/README.md ${HERMES_PKG_ROOT}
+  COMMAND
+    tar -C ${HERMES_PKG_ROOT}/ -czhf ${HERMES_GITHUB_DIR}/hermes-runtime-${HERMES_GITHUB_SYSTEM_NAME}-v${HERMES_RELEASE_VERSION}.tar.gz .
+)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@
 
 // This must be consistent with the release_version in npm/package.json
 // and the HERMES_RELEASE_VERSION in CMakeLists.txt
-def release_version = "0.4.2-rc1"
+def release_version = "0.4.1"
 
 buildscript {
   ext {

--- a/hermes.podspec
+++ b/hermes.podspec
@@ -1,0 +1,63 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+module HermesHelper
+  # BUILD_TYPE = :debug
+  BUILD_TYPE = :release
+
+  def self.command_exists?(bin)
+    "command -v #{bin} > /dev/null 2>&1"
+  end
+
+  def self.llvm_configure_command
+    "./utils/build/build_llvm.py #{"--distribute" if BUILD_TYPE == :release}"
+  end
+
+  def self.cmake_configuration
+    "-DHERMES_ENABLE_DEBUGGER:BOOLEAN=true -DHERMES_ENABLE_TEST_SUITE:BOOLEAN=false -DHERMES_BUILD_APPLE_FRAMEWORK:BOOLEAN=true -DHERMES_BUILD_APPLE_DSYM:BOOLEAN=true"
+  end
+
+  def self.configure_command
+    "./utils/build/configure.py #{BUILD_TYPE == :release ? "--distribute" : "--build-type=Debug"} --cmake-flags='#{HermesHelper.cmake_configuration} -DCMAKE_INSTALL_PREFIX:PATH=../destroot' build"
+  end
+
+  def self.build_dir
+    BUILD_TYPE == :release ? "build_release" : "build"
+  end
+end
+
+Pod::Spec.new do |spec|
+  spec.name        = "hermes"
+  spec.version     = "0.4.1"
+  spec.summary     = "Hermes is a small and lightweight JavaScript engine optimized for running React Native."
+  spec.description = "Hermes is a JavaScript engine optimized for fast start-up of React Native apps. It features ahead-of-time static optimization and compact bytecode."
+  spec.homepage    = "https://hermesengine.dev"
+  spec.license     = { type: "MIT", file: "LICENSE" }
+  spec.author      = "Facebook"
+  spec.source      = { git: "https://github.com/facebook/hermes.git", tag: "v#{spec.version}" }
+  spec.platforms   = { :osx => "10.14" }
+
+  spec.preserve_paths      = ["destroot/bin/*"].concat(HermesHelper::BUILD_TYPE == :debug ? ["**/*.{h,c,cpp}"] : [])
+  spec.source_files        = "destroot/include/**/*.h"
+  spec.header_mappings_dir = "destroot/include"
+  spec.vendored_frameworks = "destroot/Library/Frameworks/hermes.framework"
+  spec.xcconfig            = { "CLANG_CXX_LANGUAGE_STANDARD" => "c++14", "CLANG_CXX_LIBRARY" => "compiler-default", "GCC_PREPROCESSOR_DEFINITIONS" => "HERMES_ENABLE_DEBUGGER=1" }
+
+  spec.prepare_command = <<-EOS
+    if [ ! -d destroot/Library/Frameworks/hermes.framework ]; then
+      #{HermesHelper.llvm_configure_command}
+      if #{HermesHelper.command_exists?("cmake")}; then
+        if #{HermesHelper.command_exists?("ninja")}; then
+          #{HermesHelper.configure_command} --build-system='Ninja' && cd #{HermesHelper.build_dir} && ninja install/strip
+        else
+          #{HermesHelper.configure_command} --build-system='Unix Makefiles' && cd #{HermesHelper.build_dir} && make install/strip
+        fi
+      else
+        echo >&2 'CMake is required to install Hermes, install it with: brew install cmake'
+        exit 1
+      fi
+    fi
+  EOS
+end

--- a/lib/VM/Runtime.cpp
+++ b/lib/VM/Runtime.cpp
@@ -172,7 +172,7 @@ Runtime::Runtime(StorageProvider *provider, const RuntimeConfig &runtimeConfig)
           runtimeConfig.getCrashMgr(),
           provider),
       jitContext_(runtimeConfig.getEnableJIT(), (1 << 20) * 8, (1 << 20) * 32),
-      hasES6Proxy_(true),
+      hasES6Proxy_(runtimeConfig.getES6Proxy()),
       hasES6Symbol_(runtimeConfig.getES6Symbol()),
       shouldRandomizeMemoryLayout_(runtimeConfig.getRandomizeMemoryLayout()),
       bytecodeWarmupPercent_(runtimeConfig.getBytecodeWarmupPercent()),

--- a/npm/.gitignore
+++ b/npm/.gitignore
@@ -1,6 +1,11 @@
 *.tar.gz
 *.tgz
+*.sha256
 android
 node_modules
 osx-bin
 package-lock.json
+destroot
+LICENSE
+README.md
+hermes.podspec

--- a/npm/fetch.js
+++ b/npm/fetch.js
@@ -148,6 +148,10 @@ var inputs = [
   {
     name: "hermes-cli-darwin-v" + releaseVersion + ".tar.gz",
     dest: "osx-bin"
+  },
+  {
+    name: "hermes-runtime-darwin-v" + releaseVersion + ".tar.gz",
+    dest: ".",
   }
 ]
 

--- a/npm/fetch.js
+++ b/npm/fetch.js
@@ -148,10 +148,6 @@ var inputs = [
   {
     name: "hermes-cli-darwin-v" + releaseVersion + ".tar.gz",
     dest: "osx-bin"
-  },
-  {
-    name: "hermes-runtime-darwin-v" + releaseVersion + ".tar.gz",
-    dest: ".",
   }
 ]
 

--- a/npm/hermes-engine-darwin/BUILD.md
+++ b/npm/hermes-engine-darwin/BUILD.md
@@ -1,0 +1,27 @@
+# NPM instructions
+
+## When building artefacts locally
+
+```bash
+./src/utils/build/build_llvm.py --distribute
+./src/utils/build/configure.py --distribute --cmake-flags='-DHERMES_ENABLE_DEBUGGER:BOOLEAN=true -DHERMES_ENABLE_FUZZING:BOOLEAN=false -DHERMES_ENABLE_TEST_SUITE:BOOLEAN=false -DHERMES_BUILD_APPLE_FRAMEWORK:BOOLEAN=true -DHERMES_BUILD_APPLE_DSYM:BOOLEAN=true  -DCMAKE_INSTALL_PREFIX:PATH=../destroot' build
+cd build_release
+ninja hermes-runtime-darwin-cocoapods-release
+mv github/hermes-runtime-darwin-v*.tar.gz ../src/npm/hermes-engine-darwin/
+```
+
+## Or when fetching artefacts from CI
+
+Get the URL of the `hermes-runtime-darwin-v*.tar.gz` tarball from the `build-macos-runtime` CI job.
+
+```bash
+curl -L -O [ARTEFACT_URL]
+mv hermes-runtime-darwin-v*.tar.gz /path/to/src/npm/hermes-engine-darwin/
+```
+
+## Pack package
+
+```bash
+cd npm/hermes-engine-darwin
+yarn pack
+```

--- a/npm/hermes-engine-darwin/README.md
+++ b/npm/hermes-engine-darwin/README.md
@@ -1,12 +1,6 @@
 ## Hermes
 
-Hermes is a small and lightweight JavaScript VM optimized for running React
-Native apps on macOS.
+Hermes is a small and lightweight JavaScript VM optimized for running
+React Native apps on macOS.
 
 See [hermesengine.dev](https://hermesengine.dev) for more information.
-
-This package contains a Hermes bytecode compiler for macOS, plus macOS runtime
-framework.
-
-Additional tools are available in
-[hermes-engine-cli](https://www.npmjs.com/package/hermes-engine-cli).

--- a/npm/hermes-engine-darwin/README.md
+++ b/npm/hermes-engine-darwin/README.md
@@ -1,0 +1,12 @@
+## Hermes
+
+Hermes is a small and lightweight JavaScript VM optimized for running React
+Native apps on macOS.
+
+See [hermesengine.dev](https://hermesengine.dev) for more information.
+
+This package contains a Hermes bytecode compiler for macOS, plus macOS runtime
+framework.
+
+Additional tools are available in
+[hermes-engine-cli](https://www.npmjs.com/package/hermes-engine-cli).

--- a/npm/hermes-engine-darwin/package.json
+++ b/npm/hermes-engine-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-engine-darwin",
-  "version": "%VERSION%",
+  "version": "0.4.1",
   "private": false,
   "description": "A JavaScript engine optimized for running React Native on macOS",
   "license": "MIT",
@@ -8,12 +8,12 @@
     "type": "git",
     "url": "git@github.com:facebook/hermes.git"
   },
+  "scripts": {
+    "postinstall": "node unpack-tarball.js"
+  },
   "files": [
-    "LICENSE",
     "README.md",
-    "hermes.podspec",
-    "destroot/bin/hermesc",
-    "destroot/include/**/*",
-    "destroot/Library/**/*"
+    "unpack-tarball.js",
+    "hermes-runtime-darwin-v*.tar.gz"
   ]
 }

--- a/npm/hermes-engine-darwin/package.json
+++ b/npm/hermes-engine-darwin/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "hermes-engine-darwin",
+  "version": "%VERSION%",
+  "private": false,
+  "description": "A JavaScript engine optimized for running React Native on macOS",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:facebook/hermes.git"
+  },
+  "files": [
+    "LICENSE",
+    "README.md",
+    "hermes.podspec",
+    "destroot/bin/hermesc",
+    "destroot/include/**/*",
+    "destroot/Library/**/*"
+  ]
+}

--- a/npm/hermes-engine-darwin/unpack-tarball.js
+++ b/npm/hermes-engine-darwin/unpack-tarball.js
@@ -12,8 +12,5 @@ if (
   if (!tarball) {
     throw new Error("Could not locate tarball");
   }
-  child_process.execFileSync("/usr/bin/tar", [
-    "-xzvf",
-    path.join(__dirname, tarball),
-  ]);
+  child_process.execFileSync("tar", ["-xzvf", path.join(__dirname, tarball)]);
 }

--- a/npm/hermes-engine-darwin/unpack-tarball.js
+++ b/npm/hermes-engine-darwin/unpack-tarball.js
@@ -7,7 +7,7 @@ if (
   !fs.existsSync(path.join(__dirname, "destroot"))
 ) {
   const tarball = fs.readdirSync(__dirname).find(function (entry) {
-    return entry.endsWith(".tar.gz");
+    return /^hermes-runtime-darwin-v[\d\.]+\.tar\.gz$/.test(entry);
   });
   if (!tarball) {
     throw new Error("Could not locate tarball");

--- a/npm/hermes-engine-darwin/unpack-tarball.js
+++ b/npm/hermes-engine-darwin/unpack-tarball.js
@@ -1,0 +1,19 @@
+const path = require("path");
+const fs = require("fs");
+const child_process = require("child_process");
+
+if (
+  process.platform === "darwin" &&
+  !fs.existsSync(path.join(__dirname, "destroot"))
+) {
+  const tarball = fs.readdirSync(__dirname).find(function (entry) {
+    return entry.endsWith(".tar.gz");
+  });
+  if (!tarball) {
+    throw new Error("Could not locate tarball");
+  }
+  child_process.execFileSync("/usr/bin/tar", [
+    "-xzvf",
+    path.join(__dirname, tarball),
+  ]);
+}

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-engine",
-  "version": "0.4.2-rc1",
+  "version": "0.4.1",
   "private": false,
   "description": "A JavaScript engine optimized for running React Native on Android",
   "license": "MIT",

--- a/public/hermes/Public/CMakeLists.txt
+++ b/public/hermes/Public/CMakeLists.txt
@@ -3,4 +3,5 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-add_subdirectory(hermes/Public)
+install(DIRECTORY "${PROJECT_SOURCE_DIR}/public/hermes/Public" DESTINATION include/hermes
+  FILES_MATCHING PATTERN "*.h")

--- a/test/ApplePlatformsIntegrationTestApp/ApplePlatformsIntegrationTestApp.xcodeproj/project.pbxproj
+++ b/test/ApplePlatformsIntegrationTestApp/ApplePlatformsIntegrationTestApp.xcodeproj/project.pbxproj
@@ -1,0 +1,391 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 51;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		13FD1E23BAD24B7D00FF22CB /* Pods_ApplePlatformsIntegrationTestApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C07B9F4D127D4B52FF9015AB /* Pods_ApplePlatformsIntegrationTestApp.framework */; };
+		51387F3D24B4D93100BDA32A /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51387F3C24B4D93100BDA32A /* AppDelegate.mm */; };
+		51387F4824B4D93300BDA32A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 51387F4724B4D93300BDA32A /* main.m */; };
+		51387F5124B4E4B900BDA32A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 51387F4F24B4E4B900BDA32A /* Main.storyboard */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		51387F3824B4D93100BDA32A /* ApplePlatformsIntegrationTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ApplePlatformsIntegrationTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		51387F3B24B4D93100BDA32A /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		51387F3C24B4D93100BDA32A /* AppDelegate.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AppDelegate.mm; sourceTree = "<group>"; };
+		51387F4624B4D93300BDA32A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		51387F4724B4D93300BDA32A /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		51387F4924B4D93300BDA32A /* ApplePlatformsIntegrationTestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ApplePlatformsIntegrationTestApp.entitlements; sourceTree = "<group>"; };
+		51387F5024B4E4B900BDA32A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		7185E82510338F98E6D5ABAE /* Pods-ApplePlatformsIntegrationTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ApplePlatformsIntegrationTestApp.release.xcconfig"; path = "Target Support Files/Pods-ApplePlatformsIntegrationTestApp/Pods-ApplePlatformsIntegrationTestApp.release.xcconfig"; sourceTree = "<group>"; };
+		A1B2AE6857A1A970726F1351 /* Pods-ApplePlatformsIntegrationTestApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ApplePlatformsIntegrationTestApp.debug.xcconfig"; path = "Target Support Files/Pods-ApplePlatformsIntegrationTestApp/Pods-ApplePlatformsIntegrationTestApp.debug.xcconfig"; sourceTree = "<group>"; };
+		C07B9F4D127D4B52FF9015AB /* Pods_ApplePlatformsIntegrationTestApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ApplePlatformsIntegrationTestApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		51387F3524B4D93100BDA32A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				13FD1E23BAD24B7D00FF22CB /* Pods_ApplePlatformsIntegrationTestApp.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		51387F2F24B4D93100BDA32A = {
+			isa = PBXGroup;
+			children = (
+				51387F3A24B4D93100BDA32A /* ApplePlatformsIntegrationTestApp */,
+				51387F3924B4D93100BDA32A /* Products */,
+				5B15161F422A44367877CB3E /* Pods */,
+				95D715CE5183719D082A4A7B /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		51387F3924B4D93100BDA32A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				51387F3824B4D93100BDA32A /* ApplePlatformsIntegrationTestApp.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		51387F3A24B4D93100BDA32A /* ApplePlatformsIntegrationTestApp */ = {
+			isa = PBXGroup;
+			children = (
+				51387F3B24B4D93100BDA32A /* AppDelegate.h */,
+				51387F3C24B4D93100BDA32A /* AppDelegate.mm */,
+				51387F4624B4D93300BDA32A /* Info.plist */,
+				51387F4724B4D93300BDA32A /* main.m */,
+				51387F4924B4D93300BDA32A /* ApplePlatformsIntegrationTestApp.entitlements */,
+				51387F4F24B4E4B900BDA32A /* Main.storyboard */,
+			);
+			path = ApplePlatformsIntegrationTestApp;
+			sourceTree = "<group>";
+		};
+		5B15161F422A44367877CB3E /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				A1B2AE6857A1A970726F1351 /* Pods-ApplePlatformsIntegrationTestApp.debug.xcconfig */,
+				7185E82510338F98E6D5ABAE /* Pods-ApplePlatformsIntegrationTestApp.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
+		95D715CE5183719D082A4A7B /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				C07B9F4D127D4B52FF9015AB /* Pods_ApplePlatformsIntegrationTestApp.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		51387F3724B4D93100BDA32A /* ApplePlatformsIntegrationTestApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 51387F4C24B4D93300BDA32A /* Build configuration list for PBXNativeTarget "ApplePlatformsIntegrationTestApp" */;
+			buildPhases = (
+				54731B4A78B0349CFCF73729 /* [CP] Check Pods Manifest.lock */,
+				51387F3424B4D93100BDA32A /* Sources */,
+				51387F3524B4D93100BDA32A /* Frameworks */,
+				51387F3624B4D93100BDA32A /* Resources */,
+				23A2AA98BD411224E4C9BBCA /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ApplePlatformsIntegrationTestApp;
+			productName = ApplePlatformsIntegrationTestApp;
+			productReference = 51387F3824B4D93100BDA32A /* ApplePlatformsIntegrationTestApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		51387F3024B4D93100BDA32A /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1150;
+				ORGANIZATIONNAME = "";
+				TargetAttributes = {
+					51387F3724B4D93100BDA32A = {
+						CreatedOnToolsVersion = 11.5;
+					};
+				};
+			};
+			buildConfigurationList = 51387F3324B4D93100BDA32A /* Build configuration list for PBXProject "ApplePlatformsIntegrationTestApp" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 51387F2F24B4D93100BDA32A;
+			productRefGroup = 51387F3924B4D93100BDA32A /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				51387F3724B4D93100BDA32A /* ApplePlatformsIntegrationTestApp */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		51387F3624B4D93100BDA32A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				51387F5124B4E4B900BDA32A /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		23A2AA98BD411224E4C9BBCA /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ApplePlatformsIntegrationTestApp/Pods-ApplePlatformsIntegrationTestApp-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ApplePlatformsIntegrationTestApp/Pods-ApplePlatformsIntegrationTestApp-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ApplePlatformsIntegrationTestApp/Pods-ApplePlatformsIntegrationTestApp-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		54731B4A78B0349CFCF73729 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-ApplePlatformsIntegrationTestApp-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		51387F3424B4D93100BDA32A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				51387F4824B4D93300BDA32A /* main.m in Sources */,
+				51387F3D24B4D93100BDA32A /* AppDelegate.mm in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		51387F4F24B4E4B900BDA32A /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				51387F5024B4E4B900BDA32A /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		51387F4A24B4D93300BDA32A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		51387F4B24B4D93300BDA32A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		51387F4D24B4D93300BDA32A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A1B2AE6857A1A970726F1351 /* Pods-ApplePlatformsIntegrationTestApp.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = ApplePlatformsIntegrationTestApp/ApplePlatformsIntegrationTestApp.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = ApplePlatformsIntegrationTestApp/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.hermesengine.ApplePlatformsIntegrationTestApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		51387F4E24B4D93300BDA32A /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7185E82510338F98E6D5ABAE /* Pods-ApplePlatformsIntegrationTestApp.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = ApplePlatformsIntegrationTestApp/ApplePlatformsIntegrationTestApp.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = ApplePlatformsIntegrationTestApp/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.hermesengine.ApplePlatformsIntegrationTestApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		51387F3324B4D93100BDA32A /* Build configuration list for PBXProject "ApplePlatformsIntegrationTestApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				51387F4A24B4D93300BDA32A /* Debug */,
+				51387F4B24B4D93300BDA32A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		51387F4C24B4D93300BDA32A /* Build configuration list for PBXNativeTarget "ApplePlatformsIntegrationTestApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				51387F4D24B4D93300BDA32A /* Debug */,
+				51387F4E24B4D93300BDA32A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 51387F3024B4D93100BDA32A /* Project object */;
+}

--- a/test/ApplePlatformsIntegrationTestApp/ApplePlatformsIntegrationTestApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/test/ApplePlatformsIntegrationTestApp/ApplePlatformsIntegrationTestApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:ApplePlatformsIntegrationTestApp.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/test/ApplePlatformsIntegrationTestApp/ApplePlatformsIntegrationTestApp.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/test/ApplePlatformsIntegrationTestApp/ApplePlatformsIntegrationTestApp.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/test/ApplePlatformsIntegrationTestApp/ApplePlatformsIntegrationTestApp/AppDelegate.h
+++ b/test/ApplePlatformsIntegrationTestApp/ApplePlatformsIntegrationTestApp/AppDelegate.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Cocoa/Cocoa.h>
+
+@interface AppDelegate : NSObject<NSApplicationDelegate>
+@end

--- a/test/ApplePlatformsIntegrationTestApp/ApplePlatformsIntegrationTestApp/AppDelegate.mm
+++ b/test/ApplePlatformsIntegrationTestApp/ApplePlatformsIntegrationTestApp/AppDelegate.mm
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "AppDelegate.h"
+
+#import <hermes/hermes.h>
+#import <jsi/jsi.h>
+
+@interface AppDelegate ()
+@end
+
+@implementation AppDelegate
+
+- (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
+  std::string s = "print('Hello world -- son of Maia and Zeus');";
+  std::string url = "http://example/js";
+  facebook::hermes::HermesRuntime::DebugFlags flags;
+  auto runtime = facebook::hermes::makeHermesRuntime();
+  runtime->debugJavaScript(s, url, flags);
+  exit(0);
+}
+
+@end

--- a/test/ApplePlatformsIntegrationTestApp/ApplePlatformsIntegrationTestApp/ApplePlatformsIntegrationTestApp.entitlements
+++ b/test/ApplePlatformsIntegrationTestApp/ApplePlatformsIntegrationTestApp/ApplePlatformsIntegrationTestApp.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-only</key>
+    <true/>
+</dict>
+</plist>

--- a/test/ApplePlatformsIntegrationTestApp/ApplePlatformsIntegrationTestApp/Base.lproj/Main.storyboard
+++ b/test/ApplePlatformsIntegrationTestApp/ApplePlatformsIntegrationTestApp/Base.lproj/Main.storyboard
@@ -1,0 +1,701 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097"/>
+    </dependencies>
+    <scenes>
+        <!--Application-->
+        <scene sceneID="JPo-4y-FX3">
+            <objects>
+                <application id="hnw-xV-0zn" sceneMemberID="viewController">
+                    <menu key="mainMenu" title="Main Menu" systemMenu="main" id="AYu-sK-qS6">
+                        <items>
+                            <menuItem title="ApplePlatformsIntegrationTestApp" id="1Xt-HY-uBw">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="ApplePlatformsIntegrationTestApp" systemMenu="apple" id="uQy-DD-JDr">
+                                    <items>
+                                        <menuItem title="About ApplePlatformsIntegrationTestApp" id="5kV-Vb-QxS">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="orderFrontStandardAboutPanel:" target="Ady-hI-5gd" id="Exp-CZ-Vem"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
+                                        <menuItem title="Preferences…" keyEquivalent="," id="BOF-NM-1cW"/>
+                                        <menuItem isSeparatorItem="YES" id="wFC-TO-SCJ"/>
+                                        <menuItem title="Services" id="NMo-om-nkz">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Services" systemMenu="services" id="hz9-B4-Xy5"/>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="4je-JR-u6R"/>
+                                        <menuItem title="Hide ApplePlatformsIntegrationTestApp" keyEquivalent="h" id="Olw-nP-bQN">
+                                            <connections>
+                                                <action selector="hide:" target="Ady-hI-5gd" id="PnN-Uc-m68"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Hide Others" keyEquivalent="h" id="Vdr-fp-XzO">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="hideOtherApplications:" target="Ady-hI-5gd" id="VT4-aY-XCT"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Show All" id="Kd2-mp-pUS">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="unhideAllApplications:" target="Ady-hI-5gd" id="Dhg-Le-xox"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="kCx-OE-vgT"/>
+                                        <menuItem title="Quit ApplePlatformsIntegrationTestApp" keyEquivalent="q" id="4sb-4s-VLi">
+                                            <connections>
+                                                <action selector="terminate:" target="Ady-hI-5gd" id="Te7-pn-YzF"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="File" id="dMs-cI-mzQ">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="File" id="bib-Uj-vzu">
+                                    <items>
+                                        <menuItem title="New" keyEquivalent="n" id="Was-JA-tGl">
+                                            <connections>
+                                                <action selector="newDocument:" target="Ady-hI-5gd" id="4Si-XN-c54"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Open…" keyEquivalent="o" id="IAo-SY-fd9">
+                                            <connections>
+                                                <action selector="openDocument:" target="Ady-hI-5gd" id="bVn-NM-KNZ"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Open Recent" id="tXI-mr-wws">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Open Recent" systemMenu="recentDocuments" id="oas-Oc-fiZ">
+                                                <items>
+                                                    <menuItem title="Clear Menu" id="vNY-rz-j42">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="clearRecentDocuments:" target="Ady-hI-5gd" id="Daa-9d-B3U"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="m54-Is-iLE"/>
+                                        <menuItem title="Close" keyEquivalent="w" id="DVo-aG-piG">
+                                            <connections>
+                                                <action selector="performClose:" target="Ady-hI-5gd" id="HmO-Ls-i7Q"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Save…" keyEquivalent="s" id="pxx-59-PXV">
+                                            <connections>
+                                                <action selector="saveDocument:" target="Ady-hI-5gd" id="teZ-XB-qJY"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Save As…" keyEquivalent="S" id="Bw7-FT-i3A">
+                                            <connections>
+                                                <action selector="saveDocumentAs:" target="Ady-hI-5gd" id="mDf-zr-I0C"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Revert to Saved" keyEquivalent="r" id="KaW-ft-85H">
+                                            <connections>
+                                                <action selector="revertDocumentToSaved:" target="Ady-hI-5gd" id="iJ3-Pv-kwq"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="aJh-i4-bef"/>
+                                        <menuItem title="Page Setup…" keyEquivalent="P" id="qIS-W8-SiK">
+                                            <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="runPageLayout:" target="Ady-hI-5gd" id="Din-rz-gC5"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Print…" keyEquivalent="p" id="aTl-1u-JFS">
+                                            <connections>
+                                                <action selector="print:" target="Ady-hI-5gd" id="qaZ-4w-aoO"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Edit" id="5QF-Oa-p0T">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Edit" id="W48-6f-4Dl">
+                                    <items>
+                                        <menuItem title="Undo" keyEquivalent="z" id="dRJ-4n-Yzg">
+                                            <connections>
+                                                <action selector="undo:" target="Ady-hI-5gd" id="M6e-cu-g7V"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Redo" keyEquivalent="Z" id="6dh-zS-Vam">
+                                            <connections>
+                                                <action selector="redo:" target="Ady-hI-5gd" id="oIA-Rs-6OD"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="WRV-NI-Exz"/>
+                                        <menuItem title="Cut" keyEquivalent="x" id="uRl-iY-unG">
+                                            <connections>
+                                                <action selector="cut:" target="Ady-hI-5gd" id="YJe-68-I9s"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Copy" keyEquivalent="c" id="x3v-GG-iWU">
+                                            <connections>
+                                                <action selector="copy:" target="Ady-hI-5gd" id="G1f-GL-Joy"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Paste" keyEquivalent="v" id="gVA-U4-sdL">
+                                            <connections>
+                                                <action selector="paste:" target="Ady-hI-5gd" id="UvS-8e-Qdg"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Paste and Match Style" keyEquivalent="V" id="WeT-3V-zwk">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="pasteAsPlainText:" target="Ady-hI-5gd" id="cEh-KX-wJQ"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Delete" id="pa3-QI-u2k">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="delete:" target="Ady-hI-5gd" id="0Mk-Ml-PaM"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Select All" keyEquivalent="a" id="Ruw-6m-B2m">
+                                            <connections>
+                                                <action selector="selectAll:" target="Ady-hI-5gd" id="VNm-Mi-diN"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="uyl-h8-XO2"/>
+                                        <menuItem title="Find" id="4EN-yA-p0u">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Find" id="1b7-l0-nxx">
+                                                <items>
+                                                    <menuItem title="Find…" tag="1" keyEquivalent="f" id="Xz5-n4-O0W">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="cD7-Qs-BN4"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Find and Replace…" tag="12" keyEquivalent="f" id="YEy-JH-Tfz">
+                                                        <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="WD3-Gg-5AJ"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Find Next" tag="2" keyEquivalent="g" id="q09-fT-Sye">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="NDo-RZ-v9R"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Find Previous" tag="3" keyEquivalent="G" id="OwM-mh-QMV">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="HOh-sY-3ay"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Use Selection for Find" tag="7" keyEquivalent="e" id="buJ-ug-pKt">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="U76-nv-p5D"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Jump to Selection" keyEquivalent="j" id="S0p-oC-mLd">
+                                                        <connections>
+                                                            <action selector="centerSelectionInVisibleArea:" target="Ady-hI-5gd" id="IOG-6D-g5B"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Spelling and Grammar" id="Dv1-io-Yv7">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Spelling" id="3IN-sU-3Bg">
+                                                <items>
+                                                    <menuItem title="Show Spelling and Grammar" keyEquivalent=":" id="HFo-cy-zxI">
+                                                        <connections>
+                                                            <action selector="showGuessPanel:" target="Ady-hI-5gd" id="vFj-Ks-hy3"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Check Document Now" keyEquivalent=";" id="hz2-CU-CR7">
+                                                        <connections>
+                                                            <action selector="checkSpelling:" target="Ady-hI-5gd" id="fz7-VC-reM"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="bNw-od-mp5"/>
+                                                    <menuItem title="Check Spelling While Typing" id="rbD-Rh-wIN">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleContinuousSpellChecking:" target="Ady-hI-5gd" id="7w6-Qz-0kB"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Check Grammar With Spelling" id="mK6-2p-4JG">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleGrammarChecking:" target="Ady-hI-5gd" id="muD-Qn-j4w"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Correct Spelling Automatically" id="78Y-hA-62v">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticSpellingCorrection:" target="Ady-hI-5gd" id="2lM-Qi-WAP"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Substitutions" id="9ic-FL-obx">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Substitutions" id="FeM-D8-WVr">
+                                                <items>
+                                                    <menuItem title="Show Substitutions" id="z6F-FW-3nz">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="orderFrontSubstitutionsPanel:" target="Ady-hI-5gd" id="oku-mr-iSq"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="gPx-C9-uUO"/>
+                                                    <menuItem title="Smart Copy/Paste" id="9yt-4B-nSM">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleSmartInsertDelete:" target="Ady-hI-5gd" id="3IJ-Se-DZD"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smart Quotes" id="hQb-2v-fYv">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticQuoteSubstitution:" target="Ady-hI-5gd" id="ptq-xd-QOA"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smart Dashes" id="rgM-f4-ycn">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticDashSubstitution:" target="Ady-hI-5gd" id="oCt-pO-9gS"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smart Links" id="cwL-P1-jid">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticLinkDetection:" target="Ady-hI-5gd" id="Gip-E3-Fov"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Data Detectors" id="tRr-pd-1PS">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticDataDetection:" target="Ady-hI-5gd" id="R1I-Nq-Kbl"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Text Replacement" id="HFQ-gK-NFA">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticTextReplacement:" target="Ady-hI-5gd" id="DvP-Fe-Py6"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Transformations" id="2oI-Rn-ZJC">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Transformations" id="c8a-y6-VQd">
+                                                <items>
+                                                    <menuItem title="Make Upper Case" id="vmV-6d-7jI">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="uppercaseWord:" target="Ady-hI-5gd" id="sPh-Tk-edu"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Make Lower Case" id="d9M-CD-aMd">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="lowercaseWord:" target="Ady-hI-5gd" id="iUZ-b5-hil"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Capitalize" id="UEZ-Bs-lqG">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="capitalizeWord:" target="Ady-hI-5gd" id="26H-TL-nsh"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Speech" id="xrE-MZ-jX0">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Speech" id="3rS-ZA-NoH">
+                                                <items>
+                                                    <menuItem title="Start Speaking" id="Ynk-f8-cLZ">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="startSpeaking:" target="Ady-hI-5gd" id="654-Ng-kyl"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Stop Speaking" id="Oyz-dy-DGm">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="stopSpeaking:" target="Ady-hI-5gd" id="dX8-6p-jy9"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Format" id="jxT-CU-nIS">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Format" id="GEO-Iw-cKr">
+                                    <items>
+                                        <menuItem title="Font" id="Gi5-1S-RQB">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Font" systemMenu="font" id="aXa-aM-Jaq">
+                                                <items>
+                                                    <menuItem title="Show Fonts" keyEquivalent="t" id="Q5e-8K-NDq">
+                                                        <connections>
+                                                            <action selector="orderFrontFontPanel:" target="YLy-65-1bz" id="WHr-nq-2xA"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Bold" tag="2" keyEquivalent="b" id="GB9-OM-e27">
+                                                        <connections>
+                                                            <action selector="addFontTrait:" target="YLy-65-1bz" id="hqk-hr-sYV"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Italic" tag="1" keyEquivalent="i" id="Vjx-xi-njq">
+                                                        <connections>
+                                                            <action selector="addFontTrait:" target="YLy-65-1bz" id="IHV-OB-c03"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Underline" keyEquivalent="u" id="WRG-CD-K1S">
+                                                        <connections>
+                                                            <action selector="underline:" target="Ady-hI-5gd" id="FYS-2b-JAY"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="5gT-KC-WSO"/>
+                                                    <menuItem title="Bigger" tag="3" keyEquivalent="+" id="Ptp-SP-VEL">
+                                                        <connections>
+                                                            <action selector="modifyFont:" target="YLy-65-1bz" id="Uc7-di-UnL"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smaller" tag="4" keyEquivalent="-" id="i1d-Er-qST">
+                                                        <connections>
+                                                            <action selector="modifyFont:" target="YLy-65-1bz" id="HcX-Lf-eNd"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="kx3-Dk-x3B"/>
+                                                    <menuItem title="Kern" id="jBQ-r6-VK2">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Kern" id="tlD-Oa-oAM">
+                                                            <items>
+                                                                <menuItem title="Use Default" id="GUa-eO-cwY">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="useStandardKerning:" target="Ady-hI-5gd" id="6dk-9l-Ckg"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Use None" id="cDB-IK-hbR">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="turnOffKerning:" target="Ady-hI-5gd" id="U8a-gz-Maa"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Tighten" id="46P-cB-AYj">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="tightenKerning:" target="Ady-hI-5gd" id="hr7-Nz-8ro"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Loosen" id="ogc-rX-tC1">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="loosenKerning:" target="Ady-hI-5gd" id="8i4-f9-FKE"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem title="Ligatures" id="o6e-r0-MWq">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Ligatures" id="w0m-vy-SC9">
+                                                            <items>
+                                                                <menuItem title="Use Default" id="agt-UL-0e3">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="useStandardLigatures:" target="Ady-hI-5gd" id="7uR-wd-Dx6"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Use None" id="J7y-lM-qPV">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="turnOffLigatures:" target="Ady-hI-5gd" id="iX2-gA-Ilz"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Use All" id="xQD-1f-W4t">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="useAllLigatures:" target="Ady-hI-5gd" id="KcB-kA-TuK"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem title="Baseline" id="OaQ-X3-Vso">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Baseline" id="ijk-EB-dga">
+                                                            <items>
+                                                                <menuItem title="Use Default" id="3Om-Ey-2VK">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="unscript:" target="Ady-hI-5gd" id="0vZ-95-Ywn"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Superscript" id="Rqc-34-cIF">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="superscript:" target="Ady-hI-5gd" id="3qV-fo-wpU"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Subscript" id="I0S-gh-46l">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="subscript:" target="Ady-hI-5gd" id="Q6W-4W-IGz"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Raise" id="2h7-ER-AoG">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="raiseBaseline:" target="Ady-hI-5gd" id="4sk-31-7Q9"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Lower" id="1tx-W0-xDw">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="lowerBaseline:" target="Ady-hI-5gd" id="OF1-bc-KW4"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="Ndw-q3-faq"/>
+                                                    <menuItem title="Show Colors" keyEquivalent="C" id="bgn-CT-cEk">
+                                                        <connections>
+                                                            <action selector="orderFrontColorPanel:" target="Ady-hI-5gd" id="mSX-Xz-DV3"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="iMs-zA-UFJ"/>
+                                                    <menuItem title="Copy Style" keyEquivalent="c" id="5Vv-lz-BsD">
+                                                        <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="copyFont:" target="Ady-hI-5gd" id="GJO-xA-L4q"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Paste Style" keyEquivalent="v" id="vKC-jM-MkH">
+                                                        <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="pasteFont:" target="Ady-hI-5gd" id="JfD-CL-leO"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Text" id="Fal-I4-PZk">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Text" id="d9c-me-L2H">
+                                                <items>
+                                                    <menuItem title="Align Left" keyEquivalent="{" id="ZM1-6Q-yy1">
+                                                        <connections>
+                                                            <action selector="alignLeft:" target="Ady-hI-5gd" id="zUv-R1-uAa"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Center" keyEquivalent="|" id="VIY-Ag-zcb">
+                                                        <connections>
+                                                            <action selector="alignCenter:" target="Ady-hI-5gd" id="spX-mk-kcS"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Justify" id="J5U-5w-g23">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="alignJustified:" target="Ady-hI-5gd" id="ljL-7U-jND"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Align Right" keyEquivalent="}" id="wb2-vD-lq4">
+                                                        <connections>
+                                                            <action selector="alignRight:" target="Ady-hI-5gd" id="r48-bG-YeY"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="4s2-GY-VfK"/>
+                                                    <menuItem title="Writing Direction" id="H1b-Si-o9J">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Writing Direction" id="8mr-sm-Yjd">
+                                                            <items>
+                                                                <menuItem title="Paragraph" enabled="NO" id="ZvO-Gk-QUH">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                </menuItem>
+                                                                <menuItem id="YGs-j5-SAR">
+                                                                    <string key="title">	Default</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeBaseWritingDirectionNatural:" target="Ady-hI-5gd" id="qtV-5e-UBP"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="Lbh-J2-qVU">
+                                                                    <string key="title">	Left to Right</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeBaseWritingDirectionLeftToRight:" target="Ady-hI-5gd" id="S0X-9S-QSf"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="jFq-tB-4Kx">
+                                                                    <string key="title">	Right to Left</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeBaseWritingDirectionRightToLeft:" target="Ady-hI-5gd" id="5fk-qB-AqJ"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem isSeparatorItem="YES" id="swp-gr-a21"/>
+                                                                <menuItem title="Selection" enabled="NO" id="cqv-fj-IhA">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                </menuItem>
+                                                                <menuItem id="Nop-cj-93Q">
+                                                                    <string key="title">	Default</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeTextWritingDirectionNatural:" target="Ady-hI-5gd" id="lPI-Se-ZHp"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="BgM-ve-c93">
+                                                                    <string key="title">	Left to Right</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeTextWritingDirectionLeftToRight:" target="Ady-hI-5gd" id="caW-Bv-w94"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="RB4-Sm-HuC">
+                                                                    <string key="title">	Right to Left</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeTextWritingDirectionRightToLeft:" target="Ady-hI-5gd" id="EXD-6r-ZUu"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="fKy-g9-1gm"/>
+                                                    <menuItem title="Show Ruler" id="vLm-3I-IUL">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleRuler:" target="Ady-hI-5gd" id="FOx-HJ-KwY"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Copy Ruler" keyEquivalent="c" id="MkV-Pr-PK5">
+                                                        <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="copyRuler:" target="Ady-hI-5gd" id="71i-fW-3W2"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Paste Ruler" keyEquivalent="v" id="LVM-kO-fVI">
+                                                        <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="pasteRuler:" target="Ady-hI-5gd" id="cSh-wd-qM2"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="View" id="H8h-7b-M4v">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="View" id="HyV-fh-RgO">
+                                    <items>
+                                        <menuItem title="Show Toolbar" keyEquivalent="t" id="snW-S8-Cw5">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="toggleToolbarShown:" target="Ady-hI-5gd" id="BXY-wc-z0C"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Customize Toolbar…" id="1UK-8n-QPP">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="runToolbarCustomizationPalette:" target="Ady-hI-5gd" id="pQI-g3-MTW"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="hB3-LF-h0Y"/>
+                                        <menuItem title="Show Sidebar" keyEquivalent="s" id="kIP-vf-haE">
+                                            <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="toggleSidebar:" target="Ady-hI-5gd" id="iwa-gc-5KM"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Enter Full Screen" keyEquivalent="f" id="4J7-dP-txa">
+                                            <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="toggleFullScreen:" target="Ady-hI-5gd" id="dU3-MA-1Rq"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Window" id="aUF-d1-5bR">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Window" systemMenu="window" id="Td7-aD-5lo">
+                                    <items>
+                                        <menuItem title="Minimize" keyEquivalent="m" id="OY7-WF-poV">
+                                            <connections>
+                                                <action selector="performMiniaturize:" target="Ady-hI-5gd" id="VwT-WD-YPe"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Zoom" id="R4o-n2-Eq4">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="performZoom:" target="Ady-hI-5gd" id="DIl-cC-cCs"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="eu3-7i-yIM"/>
+                                        <menuItem title="Bring All to Front" id="LE2-aR-0XJ">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="arrangeInFront:" target="Ady-hI-5gd" id="DRN-fu-gQh"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Help" id="wpr-3q-Mcd">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Help" systemMenu="help" id="F2S-fz-NVQ">
+                                    <items>
+                                        <menuItem title="ApplePlatformsIntegrationTestApp Help" keyEquivalent="?" id="FKE-Sm-Kum">
+                                            <connections>
+                                                <action selector="showHelp:" target="Ady-hI-5gd" id="y7X-2Q-9no"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                        </items>
+                    </menu>
+                    <connections>
+                        <outlet property="delegate" destination="Voe-Tx-rLC" id="PrD-fu-P6m"/>
+                    </connections>
+                </application>
+                <customObject id="Voe-Tx-rLC" customClass="AppDelegate"/>
+                <customObject id="YLy-65-1bz" customClass="NSFontManager"/>
+                <customObject id="Ady-hI-5gd" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="75" y="0.0"/>
+        </scene>
+        <!--Window Controller-->
+        <scene sceneID="R2V-B0-nI4">
+            <objects>
+                <windowController id="B8D-0N-5wS" sceneMemberID="viewController">
+                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
+                        <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+                        <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+                        <rect key="contentRect" x="196" y="240" width="480" height="270"/>
+                        <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
+                        <connections>
+                            <outlet property="delegate" destination="B8D-0N-5wS" id="98r-iN-zZc"/>
+                        </connections>
+                    </window>
+                </windowController>
+                <customObject id="Oky-zY-oP4" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="75" y="250"/>
+        </scene>
+    </scenes>
+</document>

--- a/test/ApplePlatformsIntegrationTestApp/ApplePlatformsIntegrationTestApp/Info.plist
+++ b/test/ApplePlatformsIntegrationTestApp/ApplePlatformsIntegrationTestApp/Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSMainStoryboardFile</key>
+	<string>Main</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSSupportsAutomaticTermination</key>
+	<true/>
+	<key>NSSupportsSuddenTermination</key>
+	<true/>
+</dict>
+</plist>

--- a/test/ApplePlatformsIntegrationTestApp/ApplePlatformsIntegrationTestApp/main.m
+++ b/test/ApplePlatformsIntegrationTestApp/ApplePlatformsIntegrationTestApp/main.m
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Cocoa/Cocoa.h>
+
+int main(int argc, const char *argv[]) {
+  return NSApplicationMain(argc, argv);
+}

--- a/test/ApplePlatformsIntegrationTestApp/Podfile
+++ b/test/ApplePlatformsIntegrationTestApp/Podfile
@@ -1,0 +1,7 @@
+source 'https://cdn.cocoapods.org/'
+
+target 'ApplePlatformsIntegrationTestApp' do
+  use_frameworks!
+  platform :osx, '10.14'
+  pod 'hermes', :path => '../../'
+end

--- a/test/ApplePlatformsIntegrationTestApp/run.sh
+++ b/test/ApplePlatformsIntegrationTestApp/run.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+XCODEBUILD="xcodebuild -workspace ApplePlatformsIntegrationTestApp.xcworkspace -configuration Debug -scheme ApplePlatformsIntegrationTestApp"
+
+# Build
+pod install
+$XCODEBUILD
+# Get path to product
+PRODUCT=$($XCODEBUILD -showBuildSettings | grep -m 1 "BUILT_PRODUCTS_DIR" | grep -oEi "\/.*")
+# Launch
+OUTPUT=$($PRODUCT/ApplePlatformsIntegrationTestApp.app/Contents/MacOS/ApplePlatformsIntegrationTestApp)
+# Test
+EXPECTED_OUTPUT="Hello world -- son of Maia and Zeus"
+if [[ $OUTPUT != $EXPECTED_OUTPUT ]]; then
+  echo "Expected output to be '$EXPECTED_OUTPUT', but got '$OUTPUT'"
+  echo "** TEST FAILED **"
+  exit 1
+else
+  echo $OUTPUT
+  echo "** TEST SUCCEEDED **"
+  exit 0
+fi

--- a/tools/hbcdump/CMakeLists.txt
+++ b/tools/hbcdump/CMakeLists.txt
@@ -23,3 +23,7 @@ target_link_libraries(hbcdump
 )
 
 hermes_link_icu(hbcdump)
+
+install(TARGETS hbcdump
+  RUNTIME DESTINATION bin
+)

--- a/tools/hdb/CMakeLists.txt
+++ b/tools/hdb/CMakeLists.txt
@@ -20,3 +20,9 @@ set_target_properties(hdb PROPERTIES
 target_link_libraries(hdb
   hermesapi
 )
+
+hermes_link_icu(hdb)
+
+install(TARGETS hdb
+  RUNTIME DESTINATION bin
+)

--- a/tools/hermes/CMakeLists.txt
+++ b/tools/hermes/CMakeLists.txt
@@ -32,3 +32,7 @@ target_link_libraries(hermes
 )
 
 hermes_link_icu(hermes)
+
+install(TARGETS hermes
+  RUNTIME DESTINATION bin
+)

--- a/tools/hermesc/CMakeLists.txt
+++ b/tools/hermesc/CMakeLists.txt
@@ -35,3 +35,7 @@ if(NOT CMAKE_CROSSCOMPILING)
   # Namespace added to avoid clashing the host binary with the target binary.
   export(TARGETS hermesc FILE ${CMAKE_BINARY_DIR}/ImportHermesc.cmake NAMESPACE native-)
 endif()
+
+install(TARGETS hermesc
+  RUNTIME DESTINATION bin
+)

--- a/tools/hvm/CMakeLists.txt
+++ b/tools/hvm/CMakeLists.txt
@@ -30,3 +30,6 @@ target_link_libraries(hvm
 
 hermes_link_icu(hvm)
 
+install(TARGETS hvm
+  RUNTIME DESTINATION bin
+)

--- a/tools/jsi/CMakeLists.txt
+++ b/tools/jsi/CMakeLists.txt
@@ -23,3 +23,4 @@ set_property(TARGET hermes-jsi APPEND_STRING PROPERTY
 target_link_libraries(hermes-jsi
   hermesapi
   )
+


### PR DESCRIPTION
## Summary

Backport podspec and binary building to v0.4.1. Note that this reverts the 0.4.2-rc1 changes!


## Test Plan

See [steps to create a NPM package](https://github.com/facebook/hermes/blob/45177faae0252da470ca49d67499b4c913806adf/npm/hermes-engine-darwin/BUILD.md) and use it with [this RN macOS change](https://github.com/facebook/react-native/commit/d4d07b96d62e2d40b24bd908551850772855f2a6).
