### PR TITLE
Include vcruntime140_1.dll as a dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -431,6 +431,7 @@ jobs:
             # Include MSVC++ 2015 redistributables
             Copy-Item -Path "c:\windows\system32\msvcp140.dll" -Destination "deps"
             Copy-Item -Path "c:\windows\system32\vcruntime140.dll" -Destination "deps"
+            Copy-Item -Path "c:\windows\system32\vcruntime140_1.dll" -Destination "deps"
 
       - run:
           name: Build Hermes for Windows


### PR DESCRIPTION
This dependency was left out of the 0.4 release: https://github.com/facebook/hermes/issues/210