### PR TITLE
Manually tweak minSdkVersion in lieu of using template from RN master

### DIFF
--- a/test/circleci-e2e/run.sh
+++ b/test/circleci-e2e/run.sh
@@ -72,6 +72,15 @@ fi
 ( cd "$project_path" && git init && git add . )
 commit "Initial project"
 
+# The template project from RN 0.63 is no longer compatible with RN master.  We
+# should really be using the RN master template, but the CLI functionality for
+# this is currently broken. Meanwhile, we'll just kludge the required changes.
+#
+# https://github.com/react-native-community/cli/pull/1110
+#
+sed_op 's/minSdkVersion = .*/minSdkVersion = 19/' "$project_dir"/android/build.gradle
+commit "Kludge minSdkVersion until we can use an updated RN project"
+
 # Enable Hermes
 # https://reactnative.dev/docs/hermes
 sed_op 's/enableHermes: false/enableHermes: true/' "$project_dir"/android/app/build.gradle


### PR DESCRIPTION
Due to a recent change in minSdk requirements, RN master is no longer compatible with the RN stable template project.

Unfortunately the `--template` switch for `npx react-native` currently ignores the template, so we can't easily use the latest version.

This diff makes the required changes to the latest stable template instead. 

## Test Plan

See if the test-e2e circleCI test works again