### PR TITLE
Use RNTester in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -523,12 +523,10 @@ jobs:
       - attach_workspace:
           at: /tmp/hermes/input
       - run:
-          # If RN master + Hermes becomes unstable we can remove
-          # --react-native-master in the run.sh invocation.
           name: Run E2E test with master Hermes and Release React Native
           command: |
             cd test/circleci-e2e
-            ./run.sh --react-native-master --hermes-npm-package /tmp/hermes/input/hermes-engine-v*.tgz
+            ./run.sh --hermes-npm-package /tmp/hermes/input/hermes-engine-v*.tgz
           # The react-native setup tool takes AGES "Installing CocoaPods dependencies"
           no_output_timeout: 45m
       - store_artifacts:

--- a/test/circleci-e2e/run.sh
+++ b/test/circleci-e2e/run.sh
@@ -5,16 +5,10 @@
 # LICENSE file in the root directory of this source tree.
 
 # Parse command-line arguments
-use_react_native_master=
 hermes_npm_package=
-project_dir=awesome1
 
 while (( "$#" )); do
   case $1 in
-    --react-native-master)
-      use_react_native_master=1
-      #project_dir=awesome2
-      ;;
     --hermes-npm-package)
       shift || (
         echo "Missing NPM package argument"
@@ -30,82 +24,24 @@ while (( "$#" )); do
    shift
 done
 
-# Use md5 instead of md5sum if the latter can't be found
-if ! command -v md5sum > /dev/null
-then
-  md5sum() {
-    md5 "$@"
-  }
-fi
+# Clone a fresh copy of RN master
+git clone --depth=1 https://github.com/facebook/react-native
 
-# Perform GNU sed operation confirming file changed
-function sed_op() {
-  local e=$1
-  local file=$2
-  # Use GNU version of sed if installed by Brew on MacOS
-  if [[ -x /usr/local/bin/gsed ]] ; then
-    sed_exec="/usr/local/bin/gsed"
-  else
-    sed_exec="sed"
-  fi
-  local hash_before
-  hash_before=$(md5sum "$file")
-  $sed_exec -i "$e" "$file"
-  # This will exit with failure if the file didn't change due to -e
-  [[ "$(md5sum "$file")" != "$hash_before" ]]
-}
-
-project_path="$PWD/$project_dir"
-commit() {
-  ( cd "$project_path" && git commit -a -m "$1" )
-}
-
-npx react-native init "$project_dir"
-
-# Install new NPM. This must be done before we start messing with
-# node_modules/react-native
-if [[ -n "$hermes_npm_package" ]]
-then
-  ( cd "$project_path" && npm install "$hermes_npm_package" )
-fi
-
-( cd "$project_path" && git init && git add . )
-commit "Initial project"
-
-# Enable Hermes
-# https://reactnative.dev/docs/hermes
-sed_op 's/enableHermes: false/enableHermes: true/' "$project_dir"/android/app/build.gradle
-commit "Enable hermes"
-
-# Patch in master React Native checkout.
-# https://github.com/facebook/react-native/wiki/Building-from-source
-if [[ -n "$use_react_native_master" ]] ; then
-  pushd "$project_dir"/node_modules/
-  mv react-native react-native-
-  git clone --depth=1 https://github.com/facebook/react-native
-  cd react-native
-  npm install
-  [[ -n "$hermes_npm_package" ]] && npm install "$hermes_npm_package"
-  popd
-  sed_op '/classpath("com.android.tools.build:gradle:.*")/aclasspath("de.undercouch:gradle-download-task:4.0.0")' "$project_dir"/android/build.gradle
-  cat >> "$project_dir"/android/settings.gradle <<EOT
-include ':ReactAndroid'
-project(':ReactAndroid').projectDir = new File(
-    rootProject.projectDir, '../node_modules/react-native/ReactAndroid')
-EOT
-  sed_op 's/implementation "com.facebook.react:react-native:.*/implementation project(":ReactAndroid")/' "$project_dir"/android/app/build.gradle
-fi
-commit "Run RN from source"
-
+cd react-native
+npm install
+# Install new Hermes NPM.
+npm install "$hermes_npm_package"
 
 # Modify RN Tester app to print a log message at start-up
-echo "console.log('Using Hermes: ' + (global.HermesInternal != null));" >> "$project_dir"/node_modules/react-native/RNTester/js/RNTesterApp.android.js
+echo "console.log('Using Hermes: ' + (global.HermesInternal != null));" >> RNTester/js/RNTesterApp.android.js
 
 # Wait for emulator to boot
 adb wait-for-device
 
 # Build and install release app
-( cd "$project_dir"/node_modules/react-native/ && ./gradlew :RNTester:android:app:installHermesRelease )
+./gradlew :RNTester:android:app:installHermesRelease
+
+cd ..
 
 # Start screen recording for debug
 adb shell screenrecord /sdcard/screencap.mp4 &
@@ -127,7 +63,7 @@ until grep 'Using Hermes: true' <(adb logcat -d -s ReactNativeJS:I) ; do
   if ((SECONDS > 30 )) ; then
     echo "Did not see correct log message within 30s"
     adb logcat -d > /tmp/hermes/output/adblog.txt
-    tar cfz /tmp/hermes/output/project.tar.gz "$project_path"
+    tar cfz /tmp/hermes/output/project.tar.gz react-native
     exit 1
   fi
   sleep 2


### PR DESCRIPTION
Using the upstream RN template is causing test flakiness, use
RNTester for e2e tests instead. RNTester generates the test app so
there is no need to create a new project. In addition, since RNTester
is only available when building from source, we no longer have the
option of using `react-native` from npm.