### PR TITLE
Avoid sorting SortModel if it's empty or contains one element

### DIFF
--- a/lib/VM/JSLib/Sorting.cpp
+++ b/lib/VM/JSLib/Sorting.cpp
@@ -268,7 +268,9 @@ quicksort_top:
 } // namespace
 
 ExecutionStatus quickSort(SortModel *sm, uint32_t begin, uint32_t end) {
-  if (end - begin > INSERTION_THRESHOLD) {
+  if (end - begin <= 1) {
+    return ExecutionStatus::RETURNED;
+  } else if (end - begin > INSERTION_THRESHOLD) {
     return doQuickSort(sm, llvh::Log2_32(end - begin) * 2, begin, end - 1);
   } else {
     return insertionSort(sm, begin, end);

--- a/test/hermes/array-functions.js
+++ b/test/hermes/array-functions.js
@@ -516,6 +516,8 @@ print('sort');
 // CHECK-LABEL: sort
 print('empty', [].sort());
 // CHECK-NEXT: empty
+print([1].sort());
+// CHECK-NEXT: 1
 print([1,2].sort());
 // CHECK-NEXT: 1,2
 print([2,1].sort());


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `master`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/master/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.
-->

## Summary
If the sorting model is empty or contains one element the sort function should return without going through the insertion Sort function.
<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
-->

## Test Plan

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes the user interface.
-->
