### PR TITLE
Fix RNTester test

### DIFF
--- a/test/circleci-e2e/run.sh
+++ b/test/circleci-e2e/run.sh
@@ -33,13 +33,13 @@ npm install
 npm install "$hermes_npm_package"
 
 # Modify RN Tester app to print a log message at start-up
-echo "console.log('Using Hermes: ' + (global.HermesInternal != null));" >> RNTester/js/RNTesterApp.android.js
+echo "console.log('Using Hermes: ' + (global.HermesInternal != null));" >> packages/rn-tester/js/RNTesterApp.android.js
 
 # Wait for emulator to boot
 adb wait-for-device
 
 # Build and install release app
-./gradlew :RNTester:android:app:installHermesRelease
+./gradlew :packages:rn-tester:android:app:installHermesRelease
 
 cd ..
 


### PR DESCRIPTION
RNTester e2e test is currently broken because RNTester was moved to a different directory. Update the directory and commands.
