### PR TITLE
Add arm64 slice to macOS framework

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ workflows:
 # Default settings for Apple jobs (apple-runtime, test-apple-runtime)
 apple_defaults: &apple_defaults
   macos:
-    xcode: "10.3.0"
+    xcode: "12.0.0"
   working_directory: ~/hermes
   environment:
     - TERM: dumb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,7 +274,7 @@ jobs:
             xcodebuild test \
               -workspace ApplePlatformsIntegrationTests.xcworkspace \
               -configuration Debug \
-              -destination 'platform=iOS Simulator,name=iPhone X' \
+              -destination 'platform=iOS Simulator,name=iPhone 11' \
               -scheme ApplePlatformsIntegrationMobileTests
           working_directory: test/ApplePlatformsIntegrationTestApp
       - save_cache:

--- a/hermes.podspec
+++ b/hermes.podspec
@@ -49,7 +49,7 @@ Pod::Spec.new do |spec|
 
     # If MacOS framework does not exist, build one
     if [ ! -d destroot/Library/Frameworks/macosx/hermes.framework ]; then
-      build_apple_framework "macosx" "x86_64" "#{HermesHelper::OSX_DEPLOYMENT_TARGET}"
+      build_apple_framework "macosx" "x86_64;arm64" "#{HermesHelper::OSX_DEPLOYMENT_TARGET}"
     fi
   EOS
 end


### PR DESCRIPTION
## Summary

This adds a arm64 slice to the macOS framework artefact for the upcoming ARM based Macs.

## Test Plan

As tested on a DTK machine:

<img width="1052" alt="Screenshot 2020-09-14 at 17 45 06" src="https://user-images.githubusercontent.com/2320/93107811-60640280-f6b2-11ea-9d11-957e7a6f73de.png">
