### PR TITLE
[podspec] Build v0.4.x for macOS arm64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,7 +202,7 @@ jobs:
 
   macos:
     macos:
-      xcode: "10.0.0"
+      xcode: "12.0.0"
     environment:
       - HERMES_WS_DIR: /tmp/hermes
       - TERM: dumb
@@ -224,12 +224,12 @@ jobs:
           name: Build LLVM
           command: |
             cd "$HERMES_WS_DIR"
-            hermes/utils/build/build_llvm.py --distribute llvm llvm_build
+            hermes/utils/build/build_llvm.py --distribute --cmake-flags='-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.13 -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64;arm64' llvm llvm_build
       - run:
           name: Build Hermes for macOS
           command: |
             cd "$HERMES_WS_DIR"
-            hermes/utils/build/configure.py --distribute --cmake-flags='-DHERMES_BUILD_APPLE_FRAMEWORK:BOOLEAN=false'
+            hermes/utils/build/configure.py --distribute --cmake-flags='-DHERMES_BUILD_APPLE_FRAMEWORK:BOOLEAN=false -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.13 -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64;arm64'
             cmake --build ./build_release --target github-cli-release
       - run:
           name: Copy artifacts
@@ -253,7 +253,7 @@ jobs:
 
   build-macos-runtime:
     macos:
-      xcode: "10.3.0"
+      xcode: "12.0.0"
     environment:
       - HERMES_WS_DIR: /tmp/hermes
       - TERM: dumb
@@ -275,7 +275,7 @@ jobs:
           name: Build LLVM
           command: |
             cd "$HERMES_WS_DIR"
-            hermes/utils/build/build_llvm.py --distribute llvm llvm_build
+            hermes/utils/build/build_llvm.py --distribute --cmake-flags='-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.13 -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64;arm64' llvm llvm_build
       - run:
           name: Build Hermes for macOS as CocoaPods pod
           command: |
@@ -337,7 +337,7 @@ jobs:
 
   test-macos-runtime-build-and-cocoapods-integration:
     macos:
-      xcode: "10.3.0"
+      xcode: "12.0.0"
     environment:
       - TERM: dumb
       # Homebrew currently breaks while updating:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,7 +202,7 @@ jobs:
 
   macos:
     macos:
-      xcode: "12.0.0"
+      xcode: "12.0.0-beta"
     environment:
       - HERMES_WS_DIR: /tmp/hermes
       - TERM: dumb
@@ -253,7 +253,7 @@ jobs:
 
   build-macos-runtime:
     macos:
-      xcode: "12.0.0"
+      xcode: "12.0.0-beta"
     environment:
       - HERMES_WS_DIR: /tmp/hermes
       - TERM: dumb
@@ -338,7 +338,7 @@ jobs:
 
   test-macos-runtime-build-and-cocoapods-integration:
     macos:
-      xcode: "12.0.0"
+      xcode: "12.0.0-beta"
     environment:
       - TERM: dumb
       # Homebrew currently breaks while updating:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,6 +281,7 @@ jobs:
           command: |
             cd "$HERMES_WS_DIR"
             hermes/utils/build/configure.py --distribute --cmake-flags="$(ruby -rcocoapods-core -e 'load %{hermes/hermes.podspec}; puts HermesHelper.cmake_configuration') -DCMAKE_INSTALL_PREFIX:PATH=../destroot"
+            cd build_release && ninja && cd ..
             cmake --build ./build_release --target hermes-runtime-darwin-cocoapods-release
       - run:
           name: Copy artifacts

--- a/hermes.podspec
+++ b/hermes.podspec
@@ -12,11 +12,11 @@ module HermesHelper
   end
 
   def self.llvm_configure_command
-    "./utils/build/build_llvm.py #{"--distribute" if BUILD_TYPE == :release}"
+    "./utils/build/build_llvm.py #{"--distribute" if BUILD_TYPE == :release} --cmake-flags='-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.13 -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64;arm64'"
   end
 
   def self.cmake_configuration
-    "-DHERMES_ENABLE_DEBUGGER:BOOLEAN=true -DHERMES_ENABLE_TEST_SUITE:BOOLEAN=false -DHERMES_BUILD_APPLE_FRAMEWORK:BOOLEAN=true -DHERMES_BUILD_APPLE_DSYM:BOOLEAN=true"
+    "-DHERMES_ENABLE_DEBUGGER:BOOLEAN=true -DHERMES_ENABLE_TEST_SUITE:BOOLEAN=false -DHERMES_BUILD_APPLE_FRAMEWORK:BOOLEAN=true -DHERMES_BUILD_APPLE_DSYM:BOOLEAN=true -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.13 -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64;arm64"
   end
 
   def self.configure_command

--- a/hermes.podspec
+++ b/hermes.podspec
@@ -7,16 +7,18 @@ module HermesHelper
   # BUILD_TYPE = :debug
   BUILD_TYPE = :release
 
+  DEPLOYMENT_TARGET = "10.13"
+
   def self.command_exists?(bin)
     "command -v #{bin} > /dev/null 2>&1"
   end
 
   def self.llvm_configure_command
-    "./utils/build/build_llvm.py #{"--distribute" if BUILD_TYPE == :release} --cmake-flags='-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.13 -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64;arm64'"
+    "./utils/build/build_llvm.py #{"--distribute" if BUILD_TYPE == :release} --cmake-flags='-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=#{DEPLOYMENT_TARGET} -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64;arm64'"
   end
 
   def self.cmake_configuration
-    "-DHERMES_ENABLE_DEBUGGER:BOOLEAN=true -DHERMES_ENABLE_TEST_SUITE:BOOLEAN=false -DHERMES_BUILD_APPLE_FRAMEWORK:BOOLEAN=true -DHERMES_BUILD_APPLE_DSYM:BOOLEAN=true -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.13 -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64;arm64"
+    "-DHERMES_ENABLE_DEBUGGER:BOOLEAN=true -DHERMES_ENABLE_TEST_SUITE:BOOLEAN=false -DHERMES_BUILD_APPLE_FRAMEWORK:BOOLEAN=true -DHERMES_BUILD_APPLE_DSYM:BOOLEAN=true -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=#{DEPLOYMENT_TARGET} -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64;arm64"
   end
 
   def self.configure_command
@@ -37,7 +39,7 @@ Pod::Spec.new do |spec|
   spec.license     = { type: "MIT", file: "LICENSE" }
   spec.author      = "Facebook"
   spec.source      = { git: "https://github.com/facebook/hermes.git", tag: "v#{spec.version}" }
-  spec.platforms   = { :osx => "10.14" }
+  spec.platforms   = { :osx => HermesHelper::DEPLOYMENT_TARGET }
 
   spec.preserve_paths      = ["destroot/bin/*"].concat(HermesHelper::BUILD_TYPE == :debug ? ["**/*.{h,c,cpp}"] : [])
   spec.source_files        = "destroot/include/**/*.h"

--- a/npm/hermes-engine-darwin/BUILD.md
+++ b/npm/hermes-engine-darwin/BUILD.md
@@ -3,8 +3,8 @@
 ## When building artefacts locally
 
 ```bash
-./src/utils/build/build_llvm.py --distribute
-./src/utils/build/configure.py --distribute --cmake-flags='-DHERMES_ENABLE_DEBUGGER:BOOLEAN=true -DHERMES_ENABLE_FUZZING:BOOLEAN=false -DHERMES_ENABLE_TEST_SUITE:BOOLEAN=false -DHERMES_BUILD_APPLE_FRAMEWORK:BOOLEAN=true -DHERMES_BUILD_APPLE_DSYM:BOOLEAN=true  -DCMAKE_INSTALL_PREFIX:PATH=../destroot' build
+./src/utils/build/build_llvm.py --distribute --cmake-flags='-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.13 -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64;arm64'
+./src/utils/build/configure.py --distribute --cmake-flags='-DHERMES_ENABLE_DEBUGGER:BOOLEAN=true -DHERMES_ENABLE_FUZZING:BOOLEAN=false -DHERMES_ENABLE_TEST_SUITE:BOOLEAN=false -DHERMES_BUILD_APPLE_FRAMEWORK:BOOLEAN=true -DHERMES_BUILD_APPLE_DSYM:BOOLEAN=true -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.13 -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64;arm64 -DCMAKE_INSTALL_PREFIX:PATH=../destroot' build
 cd build_release
 ninja hermes-runtime-darwin-cocoapods-release
 mv github/hermes-runtime-darwin-v*.tar.gz ../src/npm/hermes-engine-darwin/


### PR DESCRIPTION
## Summary

Backports https://github.com/facebook/hermes/pull/345 to v0.4.x

## Test Plan

<img width="1404" alt="Screenshot 2020-09-16 at 15 36 36" src="https://user-images.githubusercontent.com/2320/93344844-73054580-f832-11ea-8e1a-35d5fee84360.png">

```
$ ditto --arch arm64 ./destroot/bin/hermesc ./destroot/bin/hermesc-arm64
$ file ./destroot/bin/hermesc-arm64 
./destroot/bin/hermesc-arm64: Mach-O 64-bit executable arm64
$ ./destroot/bin/hermesc-arm64 -version
LLVM (http://llvm.org/):
  LLVM version 8.0.0svn
  Optimized build

Hermes JavaScript compiler.
  Hermes release version: 0.4.3
  HBC bytecode version: 74
```