### PR TITLE
[circle] Build macOS CLI artefacts for arm64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,7 +196,7 @@ jobs:
 
   macos:
     macos:
-      xcode: "10.0.0"
+      xcode: "12.0.0"
     environment:
       - HERMES_WS_DIR: /tmp/hermes
       - TERM: dumb
@@ -219,7 +219,7 @@ jobs:
           name: Build Hermes for macOS
           command: |
             cd "$HERMES_WS_DIR"
-            hermes/utils/build/configure.py --distribute --cmake-flags='-DHERMES_BUILD_APPLE_FRAMEWORK:BOOLEAN=false'
+            hermes/utils/build/configure.py --distribute --cmake-flags='-DHERMES_BUILD_APPLE_FRAMEWORK:BOOLEAN=false -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64;arm64 -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.13'
             cmake --build ./build_release --target github-cli-release
       - run:
           name: Copy artifacts


### PR DESCRIPTION
## Summary

As noted on https://github.com/facebook/hermes/pull/345#issuecomment-692228581, that PR did not update the CLI artefacts to build for arm64.

I think there’s an opportunity to reduce the amount of separate builds and package both the runtime package and CLI from the same artefacts while also reducing build time, but for now I’d like to ensure the CLI tools at least also come with arm64 slices.

## Test Plan

Tested on a DTK machine:

```
$ ditto --arch arm64 package/osx-bin/hermes package/osx-bin/hermes-arm64                 
$ file package/osx-bin/hermes-arm64                                                      
package/osx-bin/hermes-arm64: Mach-O 64-bit executable arm64
$ echo "'use strict'; function hello() { print('Hello World'); } hello();" | ./package/osx-bin/hermes-arm64 
>> Hello World
undefined
>> 
```