### PR TITLE
fix: broken Hermes.podspec post-install in release

### DIFF
--- a/hermes.podspec
+++ b/hermes.podspec
@@ -38,7 +38,7 @@ Pod::Spec.new do |spec|
 
     # In a release package, there are no utilities and source files, we exit
     # early as there is nothing to build 
-    if [ ! -f /utils/build-apple-framework.sh ]; then
+    if [ ! -f ./utils/build-apple-framework.sh ]; then
       exit 0;
     fi
 

--- a/hermes.podspec
+++ b/hermes.podspec
@@ -36,6 +36,12 @@ Pod::Spec.new do |spec|
     # See `build-apple-framework.sh` for details
     DEBUG=#{HermesHelper::BUILD_TYPE == :debug}
 
+    # In a release package, there are no utilities and source files, we exit
+    # early as there is nothing to build 
+    if [ ! -f /utils/build-apple-framework.sh ]; then
+      exit 0;
+    fi
+
     # Source utilities into the scope
     . ./utils/build-apple-framework.sh
 


### PR DESCRIPTION
Utilities are not part of a final package. We need to check for their presence while Hermes is being installed, otherwise, this will throw an error and make installation impossible.