### PR TITLE
Add macOS arm64 support to 0.5.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,7 @@ jobs:
 
   macos:
     macos:
-      xcode: "10.0.0"
+      xcode: "12.0.0-beta"
     environment:
       - HERMES_WS_DIR: /tmp/hermes
       - TERM: dumb
@@ -204,7 +204,7 @@ jobs:
           name: Build Hermes for macOS
           command: |
             cd "$HERMES_WS_DIR"
-            hermes/utils/build/configure.py --distribute --cmake-flags='-DHERMES_BUILD_APPLE_FRAMEWORK:BOOLEAN=false'
+            hermes/utils/build/configure.py --distribute --cmake-flags='-DHERMES_BUILD_APPLE_FRAMEWORK:BOOLEAN=false -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.13 -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64;arm64'
             cmake --build ./build_release --target github-cli-release
       - run:
           name: Copy artifacts
@@ -228,7 +228,7 @@ jobs:
 
   build-macos-runtime:
     macos:
-      xcode: "10.3.0"
+      xcode: "12.0.0-beta"
     environment:
       - HERMES_WS_DIR: /tmp/hermes
       - TERM: dumb
@@ -302,7 +302,7 @@ jobs:
 
   test-macos-runtime-build-and-cocoapods-integration:
     macos:
-      xcode: "10.3.0"
+      xcode: "12.0.0-beta"
     environment:
       - TERM: dumb
       # Homebrew currently breaks while updating:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,6 +251,7 @@ jobs:
           command: |
             cd "$HERMES_WS_DIR"
             hermes/utils/build/configure.py --distribute --cmake-flags="$(ruby -rcocoapods-core -e 'load %{hermes/hermes.podspec}; puts HermesHelper.cmake_configuration') -DCMAKE_INSTALL_PREFIX:PATH=../destroot"
+            cmake --build ./build_release
             cmake --build ./build_release --target hermes-runtime-darwin-cocoapods-release
       - run:
           name: Copy artifacts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,10 +63,10 @@ endif()
 # - npm/package.json
 # - hermes.podspec
 project(Hermes
-        VERSION 0.5.2
+        VERSION 0.5.3
         LANGUAGES C CXX)
 # Optional suffix like "-rc3"
-set(VERSION_SUFFIX "-rc1")
+set(VERSION_SUFFIX "")
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/")
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@
 
 // This must be consistent with the release_version in npm/package.json
 // and the HERMES_RELEASE_VERSION in CMakeLists.txt
-def release_version = "0.5.2-rc1"
+def release_version = "0.5.3"
 
 buildscript {
   ext {

--- a/hermes.podspec
+++ b/hermes.podspec
@@ -7,12 +7,14 @@ module HermesHelper
   # BUILD_TYPE = :debug
   BUILD_TYPE = :release
 
+  DEPLOYMENT_TARGET = "10.13"
+
   def self.command_exists?(bin)
     "command -v #{bin} > /dev/null 2>&1"
   end
 
   def self.cmake_configuration
-    "-DHERMES_ENABLE_DEBUGGER:BOOLEAN=true -DHERMES_ENABLE_FUZZING:BOOLEAN=false -DHERMES_ENABLE_TEST_SUITE:BOOLEAN=false -DHERMES_BUILD_APPLE_FRAMEWORK:BOOLEAN=true -DHERMES_BUILD_APPLE_DSYM:BOOLEAN=true"
+    "-DHERMES_ENABLE_DEBUGGER:BOOLEAN=true -DHERMES_ENABLE_FUZZING:BOOLEAN=false -DHERMES_ENABLE_TEST_SUITE:BOOLEAN=false -DHERMES_BUILD_APPLE_FRAMEWORK:BOOLEAN=true -DHERMES_BUILD_APPLE_DSYM:BOOLEAN=true -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=#{DEPLOYMENT_TARGET} -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64;arm64"
   end
 
   def self.configure_command
@@ -22,14 +24,14 @@ end
 
 Pod::Spec.new do |spec|
   spec.name        = "hermes"
-  spec.version     = "0.5.1"
+  spec.version     = "0.5.2-rc.1"
   spec.summary     = "Hermes is a small and lightweight JavaScript engine optimized for running React Native."
   spec.description = "Hermes is a JavaScript engine optimized for fast start-up of React Native apps. It features ahead-of-time static optimization and compact bytecode."
   spec.homepage    = "https://hermesengine.dev"
   spec.license     = { type: "MIT", file: "LICENSE" }
   spec.author      = "Facebook"
   spec.source      = { git: "https://github.com/facebook/hermes.git", tag: "v#{spec.version}" }
-  spec.platforms   = { :osx => "10.14" }
+  spec.platforms   = { :osx => HermesHelper::DEPLOYMENT_TARGET }
 
   spec.preserve_paths      = ["destroot/bin/*"].concat(HermesHelper::BUILD_TYPE == :debug ? ["**/*.{h,c,cpp}"] : [])
   spec.source_files        = "destroot/include/**/*.h"

--- a/hermes.podspec
+++ b/hermes.podspec
@@ -24,7 +24,7 @@ end
 
 Pod::Spec.new do |spec|
   spec.name        = "hermes"
-  spec.version     = "0.5.2-rc.1"
+  spec.version     = "0.5.3"
   spec.summary     = "Hermes is a small and lightweight JavaScript engine optimized for running React Native."
   spec.description = "Hermes is a JavaScript engine optimized for fast start-up of React Native apps. It features ahead-of-time static optimization and compact bytecode."
   spec.homepage    = "https://hermesengine.dev"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.2-rc1",
+  "version": "0.5.3",
   "scripts": {
     "unpack-builds": "node unpack-builds.js",
     "unpack-builds-dev": "node unpack-builds.js --dev",


### PR DESCRIPTION
## Summary

Build macOS artefacts for macOS 10.13 and with arm64 slices.

## Test Plan

<img width="999" alt="Screenshot 2020-10-22 at 19 27 07" src="https://user-images.githubusercontent.com/2320/96908392-dff8a480-149c-11eb-82a6-a7dccc5f8dd6.png">

