### PR TITLE
Update XCode in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ workflows:
 # Default settings for Apple jobs (apple-runtime, test-apple-runtime)
 apple_defaults: &apple_defaults
   macos:
-    xcode: "12.0.0-beta"
+    xcode: 12.2.0
   working_directory: ~/hermes
   environment:
     - TERM: dumb


### PR DESCRIPTION
Summary:
XCode 12.0.0-beta has been deprecated on CircleCI. Use 12.2.0
instead.

Details at:
https://discuss.circleci.com/t/xcode-12-2-released/38156

Differential Revision: D25112899

