### PR TITLE
hermes: set release version in soname

### DIFF
--- a/API/hermes/CMakeLists.txt
+++ b/API/hermes/CMakeLists.txt
@@ -73,6 +73,7 @@ target_link_libraries(libhermes
   ${CORE_FOUNDATION}
 )
 hermes_link_icu(libhermes)
+set_property(TARGET libhermes PROPERTY VERSION ${HERMES_RELEASE_VERSION})
 
 # Export the required header directory
 target_include_directories(libhermes PUBLIC ..)


### PR DESCRIPTION
Summary:
Ensure the release version is encoded in the soname to make it easier
to package Hermes in distributions.

Differential Revision: D25124152

