### PR TITLE
Temporarily unblock test-e2e from broken apple jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,6 @@ workflows:
           requires:
             - android
             - linux
-            - package-apple-runtime
             - windows
       - test-linux
       - test-e2e:

--- a/npm/unpack-builds.js
+++ b/npm/unpack-builds.js
@@ -131,10 +131,10 @@ var inputs = [
     name: "hermes-cli-linux-v" + releaseVersion + ".tar.gz",
     dest: "linux64-bin"
   },
-  {
-    name: "hermes-cli-darwin-v" + releaseVersion + ".tar.gz",
-    dest: "osx-bin"
-  }
+  // {
+  //   name: "hermes-cli-darwin-v" + releaseVersion + ".tar.gz",
+  //   dest: "osx-bin"
+  // }
 ]
 
 unpackAll(inputs)


### PR DESCRIPTION
Summary:
`build-apple-runtime` is known to be broken by not setup internal
bytecode compilation yet, but that block all other changes being
tested by test-e2e.

This diff drop the requirement of `package-apple-runtime` of
`npm` job to temporarily unblock `test-e2e`

Differential Revision: D25132707

