### PR TITLE
[CI] add `emscripten-test` for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ workflows:
             - linux
             - package-apple-runtime
             - windows
+      - test-emscripten
       - test-linux
       - test-e2e:
           requires:
@@ -477,6 +478,75 @@ jobs:
           root: /tmp/hermes/output
           paths:
             - .
+
+  # test to build with emscripten, not run
+  test-emscripten:
+    docker:
+      # emcc requires Python 3.7+
+      - image: debian:buster
+    environment:
+      - HERMES_WS_DIR: /tmp/hermes
+      - EMSDK: /tmp/emsdk
+      - TERM: dumb
+      - DEBIAN_FRONTEND: noninteractive
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            apt-get update
+            apt-get install -y \
+                sudo git openssh-client cmake ninja-build python \
+                build-essential libreadline-dev libicu-dev zip python3 \
+                curl
+      - run:
+          name: Setup Emscripten
+          command: |
+            set -x
+            EMSDK_VERSION=2.0.9
+            curl -sfLO "https://github.com/emscripten-core/emsdk/archive/$EMSDK_VERSION.tar.gz"
+            tar -xf "$EMSDK_VERSION.tar.gz"
+            mv "emsdk-$EMSDK_VERSION" "$EMSDK"
+            rm "$EMSDK_VERSION.tar.gz"
+            "$EMSDK/emsdk" install latest
+            "$EMSDK/emsdk" activate latest
+      - checkout
+      - run:
+          name: Set up workspace
+          command: |
+            mkdir -p "$HERMES_WS_DIR"
+            ln -sf "$PWD" "$HERMES_WS_DIR/hermes"
+            sudo cp /usr/bin/ninja /usr/bin/ninja.real
+            # See top comment
+            printf '%s\n' '#!/bin/sh' 'ninja.real -j4 "$@" || ninja.real -j1 "$@"' | sudo tee /usr/bin/ninja
+      - run:
+          name: Build Hermes Compiler
+          command: |
+            cd "$HERMES_WS_DIR"
+            hermes/utils/build/configure.py ./build
+            cmake --build ./build --target hermesc
+            pwd
+            ls
+            ls build
+      - run:
+          name: Build Hermes with Emscripten
+          command: |
+            set -x
+            cd "$HERMES_WS_DIR"
+            source "$EMSDK/emsdk_env.sh"
+            "$EMSDK"/upstream/emscripten/emcc --version
+
+            cmake ./hermes \
+                -Bembuild \
+                -GNinja \
+                -DCMAKE_BUILD_TYPE=Release  \
+                -DEMSCRIPTEN_FASTCOMP=0 \
+                -DCMAKE_EXE_LINKER_FLAGS="-s NODERAWFS=1 -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s LLD_REPORT_UNDEFINED=1" \
+                -DCMAKE_TOOLCHAIN_FILE="$EMSDK/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake" \
+                -DIMPORT_HERMESC="$PWD/build/ImportHermesc.cmake"
+            cmake --build ./embuild --target hermes
+            cmake --build ./embuild --target hermesc
+            cmake --build ./embuild --target emhermesc
+            EMHERMESC="$PWD/embuild/bin/emhermesc.js" node ./hermes/tools/emhermesc/test.js
   test-e2e:
     # For now we run E2E tests on MacOS as running an Android emulator on Linux is
     # not supported with Circle CI:

--- a/tools/emhermesc/HermesCompiler.js
+++ b/tools/emhermesc/HermesCompiler.js
@@ -8,7 +8,7 @@
 // @flow
 // @format
 
-const hermesc = require("./emhermesc.js")({
+const hermesc = require(process.env.EMHERMESC || "./emhermesc.js")({
     noInitialRun: true,
     noExitRuntime: true,
 });
@@ -39,6 +39,9 @@ function strdup(str /*: string*/) /*: number*/ {
 }
 
 function compile(source /*: string | Buffer*/, options) /*: Buffer*/ {
+    if (typeof options === "undefined") {
+        options = {};
+    }
     const sourceURL = options.sourceURL || "";
     const sourceMap = options.sourceMap || "";
 
@@ -87,7 +90,7 @@ function compile(source /*: string | Buffer*/, options) /*: Buffer*/ {
 
 /// Check whether there is a valid bytecode module at the specified offset of
 /// the input buffer.
-/// \return the size of the module
+/// \return true if the module is valid.
 /// \throw an error if the module is not valid.
 function validateBytecodeModule(bc /*: Buffer*/, offset /*: number*/) /*: number*/ {
     // Check alignment.
@@ -118,7 +121,7 @@ function validateBytecodeModule(bc /*: Buffer*/, offset /*: number*/) /*: number
         throw Error("bytecode buffer is too small");
     }
 
-    return (fileLength + hermesProps.BYTECODE_ALIGNMENT - 1) % hermesProps.BYTECODE_ALIGNMENT;
+    return (fileLength + hermesProps.BYTECODE_ALIGNMENT - 1) % hermesProps.BYTECODE_ALIGNMENT === 0;
 }
 
 exports.compile = compile;

--- a/tools/emhermesc/test.js
+++ b/tools/emhermesc/test.js
@@ -7,16 +7,19 @@
 
 // @format
 
+// It requires EMHERMESC, the absolute path for emhermesc.js
+// see also HermesCompiler.js
+
 const hc = require("./HermesCompiler.js");
 const assert = require("assert");
 
 function compileOrError(str) {
     try {
-        let buffer = hc.compile(str, {});
-        console.log(JSON.stringify(buffer));
+        let buffer = hc.compile(str);
+        console.log("hc.compile:", buffer);
         console.log("bytecode buffer length", buffer.length)
     } catch (e) {
-        console.error("Hermes error:", e.message);
+        console.error("Hermes error:", e);
         return false;
     }
     return true;
@@ -46,3 +49,5 @@ badBuf = goodBuf.slice(0, 140);
 assert.equal(wrap(() => hc.validateBytecodeModule(badBuf, 0)), "bytecode buffer is too small");
 
 assert.notEqual(wrap(() => hc.validateBytecodeModule(goodBuf, 0)), 0);
+
+console.log("test.js: success");


### PR DESCRIPTION
## Summary

Related to #421, I'd like to add Emscripten builds to CI in order to make sure it works, or at least it compiles.

FWIW `configure.py` cannot be used to build Hermes with Emscripten, but I don't fix it in this PR. 

## Test Plan

See the CI status.

If you run it locally, use `circleci` CLI:

```
circleci local execute --job test-emscripten
```