### PR TITLE
[apple] Define the deployment target in the frameworks metadata

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ workflows:
 # Default settings for Apple jobs (apple-runtime, test-apple-runtime)
 apple_defaults: &apple_defaults
   macos:
-    xcode: "12.0.0-beta"
+    xcode: "12.2.0"
   working_directory: ~/hermes
   environment:
     - TERM: dumb

--- a/API/hermes/CMakeLists.txt
+++ b/API/hermes/CMakeLists.txt
@@ -123,6 +123,16 @@ if(APPLE AND HERMES_BUILD_APPLE_FRAMEWORK)
     target_compile_options(libhermes PUBLIC "-fembed-bitcode")
     target_link_libraries(libhermes PUBLIC "-fembed-bitcode")
   endif()
+  # Define the deployment target in the frameworks metadata
+  if(HERMES_APPLE_TARGET_PLATFORM MATCHES "iphone")
+    add_custom_command(TARGET libhermes POST_BUILD
+      COMMAND /usr/libexec/PlistBuddy -c "Add :MinimumOSVersion string ${CMAKE_OSX_DEPLOYMENT_TARGET}" $<TARGET_FILE_DIR:libhermes>/Info.plist
+    )
+  elseif(HERMES_APPLE_TARGET_PLATFORM MATCHES "macos")
+    add_custom_command(TARGET libhermes POST_BUILD
+      COMMAND /usr/libexec/PlistBuddy -c "Add :LSMinimumSystemVersion string ${CMAKE_OSX_DEPLOYMENT_TARGET}" $<TARGET_FILE_DIR:libhermes>/Resources/Info.plist
+    )
+  endif()
 endif()
 
 install(TARGETS libhermes


### PR DESCRIPTION
Fixes #420

## Summary

Apple App Store submission, at least the iOS one, requires this metadata to be specified when only targeting a subset of possible archs.

## Test Plan

```
~/tmp » curl -L -O https://12725-154201259-gh.circle-artifacts.com/0/tmp/hermes/output/hermes-engine-darwin-v0.7.1.tgz
~/tmp » tar -zvxf hermes-engine-darwin-v0.7.1.tgz
~/tmp » cd package/
~/t/package » node unpack-tarball.js
~/t/package » /usr/libexec/PlistBuddy -c 'Print :MinimumOSVersion' destroot/Library/Frameworks/iphoneos/hermes.framework/Info.plist
10.0
~/t/package » /usr/libexec/PlistBuddy -c 'Print :LSMinimumSystemVersion' destroot/Library/Frameworks/macosx/hermes.framework/Resources/Info.plist
10.13
```
