### PR TITLE
Swap the set order of name and length for Callable

### DIFF
--- a/lib/VM/Callable.cpp
+++ b/lib/VM/Callable.cpp
@@ -175,15 +175,17 @@ ExecutionStatus Callable::defineNameLengthAndPrototype(
 
   assert(name.isValid() && "A name must always be provided");
 
-  // Define the name.
-  auto nameHandle =
-      runtime->makeHandle(runtime->getStringPrimFromSymbolID(name));
-  DEFINE_PROP(selfHandle, P::name, nameHandle);
-
   // Length is the number of formal arguments.
+  // 10.2.9 SetFunctionLength is performed during 10.2.3 OrdinaryFunctionCreate.
   auto lengthHandle =
       runtime->makeHandle(HermesValue::encodeDoubleValue(paramCount));
   DEFINE_PROP(selfHandle, P::length, lengthHandle);
+
+  // Define the name.
+  // 10.2.8 SetFunctionName is performed after 10.2.3 OrdinaryFunctionCreate.
+  auto nameHandle =
+      runtime->makeHandle(runtime->getStringPrimFromSymbolID(name));
+  DEFINE_PROP(selfHandle, P::name, nameHandle);
 
   if (strictMode) {
     // Define .callee and .arguments properties: throw always in strict mode.

--- a/test/hermes/async-function-builtin.js
+++ b/test/hermes/async-function-builtin.js
@@ -13,7 +13,7 @@ print('AsyncFunction instance');
 
 async function af(){};
 print(Reflect.ownKeys(af));
-// CHECK-NEXT: name,length
+// CHECK-NEXT: length,name
 print(af.prototype);
 // CHECK-NEXT: undefined
 try {
@@ -36,7 +36,7 @@ print('AsyncFunction constructor');
 
 var AF = af.__proto__.constructor;
 print(Reflect.ownKeys(AF));
-// CHECK-NEXT: name,length,prototype
+// CHECK-NEXT: length,name,prototype
 print(AF.name);
 // CHECK-NEXT: AsyncFunction
 print(AF.length);


### PR DESCRIPTION
Summary:
Accroding to the spec, `length` is set during the
`OrdinaryFunctionCreate` and `name` is set later.

Also according to the spec, enumeration order should follow
the insertion order. Hence `Reflect.ownKeys(function(){})`
should print `length,name`.

This break one of the tc39 Intl tests that is newly added,
which break the CircleCI e2e-intl test.

Differential Revision: D26335344

