### PR TITLE
Cmake project integration

### DIFF
--- a/API/hermes/CMakeLists.txt
+++ b/API/hermes/CMakeLists.txt
@@ -82,6 +82,7 @@ hermes_link_icu(libhermes)
 
 # Export the required header directory
 target_include_directories(libhermes PUBLIC ..)
+target_include_directories(libhermes PUBLIC ../../public/)
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" OR
     "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")

--- a/API/hermes/CMakeLists.txt
+++ b/API/hermes/CMakeLists.txt
@@ -84,6 +84,11 @@ hermes_link_icu(libhermes)
 target_include_directories(libhermes PUBLIC ..)
 target_include_directories(libhermes PUBLIC ../../public/)
 
+target_compile_definitions(libhermes
+  PRIVATE
+  CREATE_SHARED_LIBRARY=1
+)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" OR
     "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
   # Export all API symbols

--- a/API/jsi/jsi/CMakeLists.txt
+++ b/API/jsi/jsi/CMakeLists.txt
@@ -6,10 +6,15 @@
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-add_library(jsi
-        jsi.cpp)
+add_library(jsi STATIC jsi.cpp)
 
 target_include_directories(jsi PUBLIC ..)
+
+set_target_properties(
+  jsi
+  PROPERTIES
+  POSITION_INDEPENDENT_CODE ON
+)
 
 
 set(jsi_compile_flags "")


### PR DESCRIPTION
## Summary

This PR resolves a set of cmake issues I've hit whilst integrating libhermes into a C++ project.
A discussion of the issues is available here: https://github.com/facebook/hermes/issues/326

## Test Plan

Build using the standard workflow below working:

```
hermes/utils/build/configure.py
cd build
ninja
```

Integrating libhermes in C++ project working here: https://github.com/nick-thompson/blueprint/pull/227/files