### PR TITLE
Add Cross Compilation doc and Fix Emscripten doc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -526,10 +526,10 @@ jobs:
           name: Build Hermes Compiler
           command: |
             cd "$HERMES_WS_DIR"
-            hermes/utils/build/configure.py ./build
+            hermes/utils/build/configure.py ./build_host_hermesc
             # Build the Hermes compiler so that the cross compiler build can
             # access it to build the VM
-            cmake --build ./build --target hermesc
+            cmake --build ./build_host_hermesc --target hermesc
       - run:
           name: Build Hermes with Emscripten
           command: |
@@ -545,7 +545,7 @@ jobs:
                 -DEMSCRIPTEN_FASTCOMP=0 \
                 -DCMAKE_EXE_LINKER_FLAGS="-s NODERAWFS=1 -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s LLD_REPORT_UNDEFINED=1" \
                 -DCMAKE_TOOLCHAIN_FILE="$EMSDK/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake" \
-                -DIMPORT_HERMESC="$PWD/build/ImportHermesc.cmake"
+                -DIMPORT_HERMESC="$PWD/build_host_hermesc/ImportHermesc.cmake"
             cmake --build ./embuild --target hermes
             cmake --build ./embuild --target hermesc
             cmake --build ./embuild --target emhermesc

--- a/doc/CrossCompilation.md
+++ b/doc/CrossCompilation.md
@@ -1,0 +1,44 @@
+---
+id: cross-compilation
+title: Cross Compilation
+---
+
+This document describes how to build Hermes in a cross compilation setting, e.g.
+building for Android, WASM (with Emscripten), or any other platforms different 
+than the host development machines.
+
+## A Two-stage Build
+
+Hermes now requires a two stage build proecess because the VM now contains 
+Hermes bytecode which needs to be compiled by Hermes
+
+### Setting up the workspace
+
+We will use environment variable `$HERMES_WS_DIR` to indicate the root of your 
+workspace where the `hermes` git checkout directory is a subdirectory. 
+
+
+### 1st Stage: Building the Host Hermes Compiler
+
+```
+cd "$HERMES_WS_DIR"
+
+# Generate the build system at $HERMES_WS_DIR/build_host_hermesc
+hermes/utils/build/configure.py ./build_host_hermesc
+
+# Build the Hermes compiler
+cmake --build ./build_host_hermesc --target hermesc
+```
+
+### 2nd Stage: Building the target Hermes
+
+The key is that we need to pass a CMake flag `-DIMPORT_HERMESC:PATH=$HERMES_WS_DIR/build_host_hermesc/ImportHermesc.cmake` during the cross compilation build of 
+Hermes so it can access the host `hermesc` from the first stage to build the VM.
+
+This process is currently happened in different places for different platforms:
+
+1. For Android, this happened in `hermes/android/build.gradle`
+2. For Apple platforms, this happend in `hermes/utils/build-apple-framework.sh`
+3. For Emscripten, you can find an example from the `test-emscripte` job from `hermes/.circleci/config.yml`. Also see more details at [Building with Emscripten](../emscripten)
+
+

--- a/doc/Emscripten.md
+++ b/doc/Emscripten.md
@@ -11,43 +11,52 @@ Follow the directions on the
 [Emscripten website for `emsdk`](https://emscripten.org/docs/getting_started/downloads.html)
 to download the SDK.
 
-We recommend using `latest-fastcomp` to build Hermes, but `latest` works as well.
 ```
-emsdk install latest-fastcomp
-emsdk activate latest-fastcomp
+emsdk install latest
+emsdk activate latest
+source ./emsdk_env.sh
 ```
 
-If you install `emsdk` at `~/emsdk` and activate `latest-fastcomp`,
+If you install `emsdk` at `~/emsdk` and activate `latest`,
 then you should use this shell variable for the rest of these instructions:
+
 ```
-$EmscriptenRoot = ~/emsdk/fastcomp/emscripten
+$EmscriptenRoot = ~/emsdk/upstream/emscripten
 ```
 
-If you use `latest` instead, replace `fastcomp` in the above instruction with
-`upstream`.
+If you are using the old `fastcomp` instead, replace `upstream` in the above instruction with `fastcomp`.
+
+WARNING: The old `fastcomp` backend was [removed in `2.0.0` (August 2020)](https://emscripten.org/docs/compiling/WebAssembly.html?highlight=fastcomp#backends)
+
+
+## Setting up Workspace and Host Hermesc
+
+Hermes now requires a two stage build proecess because the VM now contains 
+Hermes bytecode which needs to be compiled by Herme.
+
+Please follow the [Cross Compilation](../CrossCompilation) to set up a workplace 
+and build a host hermesc at `$HERMES_WS_DIR/build_host_hermesc`.
+
 
 ## Building Hermes With configure.py
 
 ```
 # Configure the build. Here the build is output to a
 # directory starting with the prefix "embuild".
-python3 ${HermesSourcePath?}/utils/build/configure.py \
+python3 ${HERMES_WS_DIR}/hermes/utils/build/configure.py \
+    --cmake-flags " -DIMPORT_HERMESC:PATH=${HERMES_WS_DIR}/build_host_hermesc/ImportHermesc.cmake " \
     --distribute \
     --wasm \
     --emscripten-platform=fastcomp \
-    --emscripten-root="${EmscriptenRoot?}" \
+    --emscripten-root="${EmscriptenRoot}" \
     /tmp/embuild
 
 # Build Hermes. The build directory name will depend on the flags passed to
 # configure.py.
-cmake --build /tmp/embuild_release_wasm_fastcomp --target hermes
+cmake --build /tmp/embuild --target hermes
 # Execute hermes
-node /tmp/embuild_release_wasm_fastcomp/bin/hermes.js --help
+node /tmp/embuild/bin/hermes.js --help
 ```
-
-In the commands above, replace `${HermesSourcePath?}` with the path where you
-cloned Hermes, and `${EmscriptenRoot?}` with the path to your Emscripten
-install.
 
 Make sure that the `--emscripten-platform` option matches the directory given
 to `--emscripten-root`, and is also the current activated Emscripten toolchain
@@ -62,12 +71,13 @@ project. If you want to customize your build, you can take this command as a
 base.
 
 ```
-mkdir embuild && cd embuild
-cmake ${HermesSourcePath?} \
-        -DCMAKE_TOOLCHAIN_FILE=${EmscriptenRoot?}/cmake/Modules/Platform/Emscripten.cmake \
+cmake ${HERMES_WS_DIR}/hermes \
+        -B embuild \
+        -DCMAKE_TOOLCHAIN_FILE=${EmscriptenRoot}/cmake/Modules/Platform/Emscripten.cmake \
         -DCMAKE_BUILD_TYPE=Release \
-        -DEMSCRIPTEN_FASTCOMP=1 \
-        -DCMAKE_EXE_LINKER_FLAGS="-s NODERAWFS=1 -s WASM=1 -s ALLOW_MEMORY_GROWTH=1"
+        -DEMSCRIPTEN_FASTCOMP=0 \
+        -DCMAKE_EXE_LINKER_FLAGS="-s NODERAWFS=1 -s WASM=1 -s ALLOW_MEMORY_GROWTH=1" \
+        -DIMPORT_HERMESC:PATH="${HERMES_WS_DIR}/build_host_hermesc/ImportHermesc.cmake"
 ```
 
 Each option is explained below:


### PR DESCRIPTION
Summary:
This diff add document to resolve the recent question regarding
building Hermes from issue #326 and #421:

1. add instructions on how to set up the two stage build
required to cross build Hermes.
2. fix the instructions of Building with Emscripten and updated the
recommended toolchain to upstream (fastcomp is removed in 2.0.0).

Differential Revision: D26615012

