### PR TITLE
Use the CircleCI Android orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ version: 2.1
 
 orbs:
   win: circleci/windows@2.4.0
+  android: circleci/android@1.0.3
 
 workflows:
   version: 2
@@ -56,8 +57,10 @@ apple_defaults: &apple_defaults
 
 jobs:
   android:
-    docker:
-      - image: circleci/android:api-28-ndk
+    executor:
+      name: android/android
+      sdk-version: '28'
+      variant: ndk
     environment:
       - HERMES_WS_DIR: /tmp/hermes
       - TERM: dumb
@@ -67,7 +70,6 @@ jobs:
       - run:
           name: Set up workspace and install dependencies
           command: |
-            yes | sdkmanager "ndk-bundle"  &
             yes | sdkmanager "cmake;3.6.4111459" &
             mkdir -p "$HERMES_WS_DIR" "$HERMES_WS_DIR/output"
             ln -sf "$PWD" "$HERMES_WS_DIR/hermes"


### PR DESCRIPTION
Summary:
CircleCI defines a convenience "orb" that has a lot of stuff built in:
* A system image with Android SDK and NDK pre-installed
* Common steps for creating an AVD, starting it, and waiting for it
* Comes with node.js preinstalled

The preinstalls means there's no lengthy download step, that often
fails flakily.
This orb also has commands for persisting a build and gradle cache,
which I haven't added yet. It might be good to add those in the future
to speed up the jobs.

I think some other things in this script can be simplified as well, such
as downloading and pinning cmake and ninja to specific versions, but
I don't want to mess with them yet.

Differential Revision: D25786818

