### PR TITLE
Delete HERMESVM_API_TRACE

### DIFF
--- a/API/hermes/CMakeLists.txt
+++ b/API/hermes/CMakeLists.txt
@@ -37,15 +37,18 @@ set_property(TARGET hermesapi APPEND_STRING PROPERTY
 add_hermes_library(synthTrace hermes_tracing.cpp SynthTrace.cpp TracingRuntime.cpp
   LINK_LIBS hermesapi)
 
-add_hermes_library(traceInterpreter SynthTraceParser.cpp TraceInterpreter.cpp
-  LINK_LIBS hermesapi hermesInstrumentation synthTrace)
+add_hermes_library(traceInterpreter TraceInterpreter.cpp
+  LINK_LIBS hermesapi hermesInstrumentation synthTrace synthTraceParser)
 
 set(HERMES_LINK_COMPONENTS LLVHSupport)
-
-# Disable EH and RTTI for compileJS
-set(HERMES_ENABLE_EH OFF)
 set(HERMES_ENABLE_RTTI OFF)
 
+# synthTraceParser uses exceptions but not rtti
+add_hermes_library(synthTraceParser SynthTraceParser.cpp LINK_LIBS hermesSupport hermesParser synthTrace)
+
+set(HERMES_ENABLE_EH OFF)
+
+# compileJS uses neither exceptions nor RTTI
 add_hermes_library(compileJS STATIC CompileJS.cpp)
 
 # Restore EH and RTTI (Note: At the time of writing, there is no usage of

--- a/API/hermes/SynthTrace.cpp
+++ b/API/hermes/SynthTrace.cpp
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#ifdef HERMESVM_API_TRACE
-
 #include "SynthTrace.h"
 
 #include "hermes/Support/Algorithms.h"
@@ -849,5 +847,3 @@ std::istream &operator>>(std::istream &is, SynthTrace::RecordType &type) {
 } // namespace tracing
 } // namespace hermes
 } // namespace facebook
-
-#endif

--- a/API/hermes/SynthTrace.h
+++ b/API/hermes/SynthTrace.h
@@ -8,8 +8,6 @@
 #ifndef HERMES_SYNTHTRACE_H
 #define HERMES_SYNTHTRACE_H
 
-#ifdef HERMESVM_API_TRACE
-
 #include "hermes/Public/RuntimeConfig.h"
 #include "hermes/Support/JSONEmitter.h"
 #include "hermes/Support/SHA1.h"
@@ -1085,7 +1083,5 @@ std::istream &operator>>(std::istream &is, SynthTrace::RecordType &type);
 } // namespace tracing
 } // namespace hermes
 } // namespace facebook
-
-#endif // HERMESVM_API_TRACE
 
 #endif // HERMES_SYNTHTRACE_H

--- a/API/hermes/SynthTraceParser.cpp
+++ b/API/hermes/SynthTraceParser.cpp
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#ifdef HERMESVM_API_TRACE
-
 #include "hermes/SynthTraceParser.h"
 
 #include "hermes/Parser/JSLexer.h"
@@ -593,5 +591,3 @@ parseSynthTrace(const std::string &tracefile) {
 } // namespace tracing
 } // namespace hermes
 } // namespace facebook
-
-#endif

--- a/API/hermes/SynthTraceParser.h
+++ b/API/hermes/SynthTraceParser.h
@@ -8,8 +8,6 @@
 #ifndef HERMES_SYNTHTRACEPARSER_H
 #define HERMES_SYNTHTRACEPARSER_H
 
-#ifdef HERMESVM_API_TRACE
-
 #include <tuple>
 
 #include "hermes/Public/RuntimeConfig.h"
@@ -41,7 +39,5 @@ parseSynthTrace(const std::string &tracefile);
 } // namespace tracing
 } // namespace hermes
 } // namespace facebook
-
-#endif // HERMESVM_API_TRACE
 
 #endif // HERMES_SYNTHTRACEPARSER_H

--- a/API/hermes/TraceInterpreter.cpp
+++ b/API/hermes/TraceInterpreter.cpp
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#ifdef HERMESVM_API_TRACE
-
 #include <hermes/TraceInterpreter.h>
 
 #include <hermes/BCGen/HBC/BytecodeDataProvider.h>
@@ -1675,5 +1673,3 @@ LLVM_ATTRIBUTE_NORETURN void TraceInterpreter::crashOnException(
 } // namespace tracing
 } // namespace hermes
 } // namespace facebook
-
-#endif

--- a/API/hermes/TraceInterpreter.h
+++ b/API/hermes/TraceInterpreter.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#ifdef HERMESVM_API_TRACE
-
 #include <hermes/Public/RuntimeConfig.h>
 #include <hermes/Support/OptValue.h>
 #include <hermes/Support/SHA1.h>
@@ -426,5 +424,3 @@ class TraceInterpreter final {
 } // namespace tracing
 } // namespace hermes
 } // namespace facebook
-
-#endif

--- a/API/hermes/TracingRuntime.cpp
+++ b/API/hermes/TracingRuntime.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#ifdef HERMESVM_API_TRACE
 #include "TracingRuntime.h"
 
 #include <hermes/BCGen/HBC/BytecodeDataProvider.h>
@@ -749,5 +748,3 @@ std::unique_ptr<TracingHermesRuntime> makeTracingHermesRuntime(
 } // namespace tracing
 } // namespace hermes
 } // namespace facebook
-
-#endif

--- a/API/hermes/TracingRuntime.h
+++ b/API/hermes/TracingRuntime.h
@@ -8,8 +8,6 @@
 #ifndef HERMES_TRACINGRUNTIME_H
 #define HERMES_TRACINGRUNTIME_H
 
-#ifdef HERMESVM_API_TRACE
-
 #include "SynthTrace.h"
 
 #include <hermes/hermes.h>
@@ -241,7 +239,5 @@ std::unique_ptr<TracingHermesRuntime> makeTracingHermesRuntime(
 } // namespace tracing
 } // namespace hermes
 } // namespace facebook
-
-#endif // HERMESVM_API_TRACE
 
 #endif // HERMES_TRACINGRUNTIME_H

--- a/API/hermes/hermes_tracing.cpp
+++ b/API/hermes/hermes_tracing.cpp
@@ -7,10 +7,8 @@
 
 #include "hermes_tracing.h"
 
-#ifdef HERMESVM_API_TRACE
 #include <hermes/Support/Algorithms.h>
 #include <hermes/TracingRuntime.h>
-#endif
 
 namespace facebook {
 namespace hermes {
@@ -19,14 +17,12 @@ std::unique_ptr<jsi::Runtime> makeTracingHermesRuntime(
     std::unique_ptr<HermesRuntime> hermesRuntime,
     const ::hermes::vm::RuntimeConfig &runtimeConfig) {
   if (runtimeConfig.getTraceEnabled()) {
-#ifdef HERMESVM_API_TRACE
     return tracing::makeTracingHermesRuntime(
         std::move(hermesRuntime),
         runtimeConfig,
         runtimeConfig.getTraceScratchPath(),
         runtimeConfig.getTraceResultPath(),
         runtimeConfig.getTraceRegisterCallback());
-#endif
   }
   return hermesRuntime;
 }

--- a/API/hermes/synthtest/Driver.cpp
+++ b/API/hermes/synthtest/Driver.cpp
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#ifdef HERMESVM_API_TRACE
-
 #include <hermes/TraceInterpreter.h>
 #include <hermes/hermes.h>
 
@@ -175,5 +173,3 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::ValuesIn(testGenerator()));
 
 } // namespace
-
-#endif

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,9 +136,6 @@ set(HERMESVM_HEAP_SEGMENT_SIZE_KB 4096
 set(HERMESVM_ALLOW_CONCURRENT_GC ON CACHE BOOL
         "Enable concurrency in the GC for 64-bit builds.")
 
-set(HERMESVM_API_TRACE OFF CACHE BOOL
-  "Enable tracing interactions via the API")
-
 set(HERMESVM_API_TRACE_ANDROID_REPLAY OFF CACHE BOOL
   "Simulate Android config on Linux in API tracing.")
 
@@ -355,9 +352,6 @@ endif()
 add_definitions(-DHERMESVM_HEAP_SEGMENT_SIZE_KB=${HERMESVM_HEAP_SEGMENT_SIZE_KB})
 if(HERMESVM_ALLOW_CONCURRENT_GC)
     add_definitions(-DHERMESVM_ALLOW_CONCURRENT_GC)
-endif()
-if(HERMESVM_API_TRACE)
-    add_definitions(-DHERMESVM_API_TRACE)
 endif()
 if(HERMESVM_API_TRACE_ANDROID_REPLAY)
     add_definitions(-DHERMESVM_API_TRACE_ANDROID_REPLAY)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -17,7 +17,4 @@ add_subdirectory(emhermesc)
 add_subdirectory(fuzzers)
 add_subdirectory(dependency-extractor)
 add_subdirectory(hermes-parser)
-
-if (HERMESVM_API_TRACE)
-  add_subdirectory(synth)
-endif()
+add_subdirectory(synth)

--- a/unittests/API/CMakeLists.txt
+++ b/unittests/API/CMakeLists.txt
@@ -12,15 +12,9 @@ set(APISources
   APILeanTest.cpp
   DebuggerTest.cpp
   SegmentTest.cpp
-  TrackIOTest.cpp
   )
 set(APISegmentTestCompileSources
   SegmentTestCompile.cpp
-  )
-set(APITraceSources
-  SynthTraceTest.cpp
-  SynthTraceParserTest.cpp
-  TrackIOTest.cpp
   )
 
 set(HERMES_LINK_COMPONENTS LLVHSupport)
@@ -40,4 +34,6 @@ add_hermes_unittest(APITests ${APITestsSources})
 
 include_directories(${HERMES_SOURCE_DIR}/API)
 include_directories(${HERMES_JSI_DIR})
-target_link_libraries(APITests hermesapi compileJS SegmentTestCompile traceInterpreter)
+# TODO: The synth trace and heap snapshot tests are currently disabled
+# because of build issues. We should find a way to re-enable them.
+target_link_libraries(APITests hermesapi compileJS SegmentTestCompile)

--- a/unittests/API/SynthTraceParserTest.cpp
+++ b/unittests/API/SynthTraceParserTest.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#ifdef HERMESVM_API_TRACE
 #include <hermes/SynthTraceParser.h>
 
 #include <gtest/gtest.h>
@@ -178,5 +177,3 @@ TEST_F(SynthTraceParserTest, SynthMissingVersion) {
 }
 
 } // namespace
-
-#endif

--- a/unittests/API/SynthTraceTest.cpp
+++ b/unittests/API/SynthTraceTest.cpp
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#ifdef HERMESVM_API_TRACE
-
 #include <hermes/SynthTrace.h>
 
 #include <hermes/Parser/JSONParser.h>
@@ -1446,5 +1444,3 @@ function f(s) {
 /// @}
 
 } // namespace
-
-#endif


### PR DESCRIPTION
Summary:
For buck, this change makes no difference, since the flag is set to
true by default.

For CMake, this means that we will be able to build the synth tool or
create synth traces without needing to specifically set this build
flag. More importantly, it ensures that the CMake build doesn't break
because it will be continuously built through CI.

There should be no effect on the binary size of hermesapi or
libhermes because the synth trace targets are not linked into them.

Reviewed By: dulinriley

Differential Revision: D26771883

