### PR TITLE
Remove any usage of FASTCOMP by default in builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -542,7 +542,6 @@ jobs:
                 -Bembuild \
                 -GNinja \
                 -DCMAKE_BUILD_TYPE=Release  \
-                -DEMSCRIPTEN_FASTCOMP=0 \
                 -DCMAKE_EXE_LINKER_FLAGS="-s NODERAWFS=1 -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s LLD_REPORT_UNDEFINED=1" \
                 -DCMAKE_TOOLCHAIN_FILE="$EMSDK/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake" \
                 -DIMPORT_HERMESC="$PWD/build_host_hermesc/ImportHermesc.cmake"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,7 +236,7 @@ set(ANDROID_LINUX_PERF_PATH ""
 set(HERMES_MSVC_MP ON CACHE STRING
   "Enable /MP in MSVC for parallel builds")
 
-set(EMSCRIPTEN_FASTCOMP ON CACHE BOOL
+set(EMSCRIPTEN_FASTCOMP OFF CACHE BOOL
   "Emscripten is using the fastcomp backend instead of the LLVM one")
 
 set(HERMES_ENABLE_INTL OFF CACHE BOOL

--- a/utils/build/configure.py
+++ b/utils/build/configure.py
@@ -96,9 +96,10 @@ def parse_args():
         "--emscripten-platform",
         dest="emscripten_platform",
         choices=("upstream", "fastcomp"),
-        default="fastcomp",
+        default="upstream",
         help="Use either the upstream emscripten backend based on LLVM or the "
-        "fastcomp backend",
+        "fastcomp backend. Note that the fastcomp backend is deprecated as of "
+        "emscripten v2 and above",
     )
     args = parser.parse_args()
     if args.icu_root:

--- a/website/build-hermes.sh
+++ b/website/build-hermes.sh
@@ -41,7 +41,6 @@ mkdir build_asmjs && cd build_asmjs
 cmake "$HERMES_PATH" \
     -DCMAKE_TOOLCHAIN_FILE="$EMS_PATH/emscripten/cmake/Modules/Platform/Emscripten.cmake" \
     -DCMAKE_BUILD_TYPE=MinSizeRel \
-    -DEMSCRIPTEN_FASTCOMP=1 \
     -DCMAKE_EXE_LINKER_FLAGS="$FLAGS"
 
 make -j hermes


### PR DESCRIPTION
Summary:
Since fastcomp was deprecated in emscripten v2 and above,
change the default in most places (configure.py and CMake) to be
"upstream".
This shouldn't have any effect on existing builds because they all
manually specified upstream anyways.
This change will prevent accidentally using fastcomp in the future,
although it's still possible to use it if you downgrade to emscripten v1.*

Reviewed By: neildhar

Differential Revision: D27128367

