### PR TITLE
arm64 simulators & catalyst support

### DIFF
--- a/API/hermes/CMakeLists.txt
+++ b/API/hermes/CMakeLists.txt
@@ -119,6 +119,10 @@ if(APPLE AND HERMES_BUILD_APPLE_FRAMEWORK)
     add_custom_command(TARGET libhermes POST_BUILD
       COMMAND /usr/libexec/PlistBuddy -c "Add :MinimumOSVersion string ${CMAKE_OSX_DEPLOYMENT_TARGET}" $<TARGET_FILE_DIR:libhermes>/Info.plist
     )
+  elseif(HERMES_APPLE_TARGET_PLATFORM MATCHES "catalyst")
+    add_custom_command(TARGET libhermes POST_BUILD
+      COMMAND /usr/libexec/PlistBuddy -c "Add :LSMinimumSystemVersion string ${CMAKE_OSX_DEPLOYMENT_TARGET}" $<TARGET_FILE_DIR:libhermes>/Resources/Info.plist
+    )  
   elseif(HERMES_APPLE_TARGET_PLATFORM MATCHES "macos")
     add_custom_command(TARGET libhermes POST_BUILD
       COMMAND /usr/libexec/PlistBuddy -c "Add :LSMinimumSystemVersion string ${CMAKE_OSX_DEPLOYMENT_TARGET}" $<TARGET_FILE_DIR:libhermes>/Resources/Info.plist

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,16 @@ endif()
 # https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_SYSROOT.html
 set(CMAKE_OSX_SYSROOT ${HERMES_APPLE_TARGET_PLATFORM})
 
+if(HERMES_APPLE_CATALYST)
+  set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-target x86_64-arm64-apple-ios14.0-macabi -isystem ${CMAKE_OSX_SYSROOT}/System/iOSSupport/usr/include")
+  set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} "-target x86_64-arm64-apple-ios14.0-macabi -isystem ${CMAKE_OSX_SYSROOT}/System/iOSSupport/usr/include")
+  set(CMAKE_THREAD_LIBS_INIT "-lpthread")
+  set(CMAKE_HAVE_THREADS_LIBRARY 1)
+  set(CMAKE_USE_WIN32_THREADS_INIT 0)
+  set(CMAKE_USE_PTHREADS_INIT 1)
+  set(THREADS_PREFER_PTHREAD_FLAG ON)
+endif()
+
 # This must be consistent with the release_version in:
 # - android/build.gradle
 # - npm/package.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,8 @@ endif()
 # https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_SYSROOT.html
 set(CMAKE_OSX_SYSROOT ${HERMES_APPLE_TARGET_PLATFORM})
 
-if(HERMES_APPLE_CATALYST)
+if(HERMES_APPLE_TARGET_PLATFORM MATCHES "catalyst")
+  set(CMAKE_OSX_SYSROOT "macosx")
   set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-target x86_64-arm64-apple-ios14.0-macabi -isystem ${CMAKE_OSX_SYSROOT}/System/iOSSupport/usr/include")
   set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} "-target x86_64-arm64-apple-ios14.0-macabi -isystem ${CMAKE_OSX_SYSROOT}/System/iOSSupport/usr/include")
   set(CMAKE_THREAD_LIBS_INIT "-lpthread")

--- a/hermes-engine.podspec
+++ b/hermes-engine.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |spec|
   # The podspec would be serialized to JSON and people will download prebuilt binaries instead of the source.
   # TODO(use the hash field as a validation mechanism when the process is stable)
   spec.source      = ENV['hermes-artifact-url'] ? { http: ENV['hermes-artifact-url'] } : { git: "https://github.com/facebook/hermes.git", tag: "v#{spec.version}" }
-  spec.platforms   = { :osx => "11.0", :ios => "10.0" }
+  spec.platforms   = { :osx => "10.13", :ios => "10.0" }
 
   spec.preserve_paths      = ["destroot/bin/*"].concat(HermesHelper::BUILD_TYPE == :debug ? ["**/*.{h,c,cpp}"] : [])
   spec.source_files        = "destroot/include/**/*.h"

--- a/hermes-engine.podspec
+++ b/hermes-engine.podspec
@@ -20,13 +20,13 @@ Pod::Spec.new do |spec|
   # The podspec would be serialized to JSON and people will download prebuilt binaries instead of the source.
   # TODO(use the hash field as a validation mechanism when the process is stable)
   spec.source      = ENV['hermes-artifact-url'] ? { http: ENV['hermes-artifact-url'] } : { git: "https://github.com/facebook/hermes.git", tag: "v#{spec.version}" }
-  spec.platforms   = { :osx => "10.13", :ios => "10.0" }
+  spec.platforms   = { :osx => "11.0", :ios => "10.0" }
 
   spec.preserve_paths      = ["destroot/bin/*"].concat(HermesHelper::BUILD_TYPE == :debug ? ["**/*.{h,c,cpp}"] : [])
   spec.source_files        = "destroot/include/**/*.h"
   spec.header_mappings_dir = "destroot/include"
 
-  spec.ios.vendored_frameworks = "destroot/Library/Frameworks/iphoneos/hermes.framework"
+  spec.ios.vendored_frameworks = "destroot/Library/Frameworks/iphoneos/hermes.xcframework"
   spec.osx.vendored_frameworks = "destroot/Library/Frameworks/macosx/hermes.framework"
 
   spec.xcconfig            = { "CLANG_CXX_LANGUAGE_STANDARD" => "c++14", "CLANG_CXX_LIBRARY" => "compiler-default", "GCC_PREPROCESSOR_DEFINITIONS" => "HERMES_ENABLE_DEBUGGER=1" }

--- a/utils/build-apple-framework.sh
+++ b/utils/build-apple-framework.sh
@@ -109,5 +109,11 @@ function create_universal_framework {
 
   xcodebuild -create-xcframework $args -output "${platforms[0]}/hermes.xcframework"
 
+  # Once all was linked into a single framework, clean destroot
+  # from unused frameworks
+  for platform in "${@:2}"; do
+    rm -r "$platform"
+  done
+
   cd - || exit 1
 }

--- a/utils/build-ios-framework.sh
+++ b/utils/build-ios-framework.sh
@@ -10,9 +10,10 @@ if [ ! -d destroot/Library/Frameworks/iphoneos/hermes.framework ]; then
     ios_deployment_target=$(get_ios_deployment_target)
 
     build_apple_framework "iphoneos" "armv7;armv7s;arm64" "$ios_deployment_target"
-    build_apple_framework "iphonesimulator" "x86_64;i386" "$ios_deployment_target"
+    build_apple_framework "iphonesimulator" "x86_64;arm64" "$ios_deployment_target"
+    build_apple_framework "catalyst" "x86_64;arm64" "$ios_deployment_target"
 
-    create_universal_framework "iphoneos" "iphonesimulator"
+    create_universal_framework
 else
     echo "Skipping; Clean \"destroot\" to rebuild".
 fi

--- a/utils/build-ios-framework.sh
+++ b/utils/build-ios-framework.sh
@@ -13,7 +13,7 @@ if [ ! -d destroot/Library/Frameworks/iphoneos/hermes.framework ]; then
     build_apple_framework "iphonesimulator" "x86_64;arm64" "$ios_deployment_target"
     build_apple_framework "catalyst" "x86_64;arm64" "$ios_deployment_target"
 
-    create_universal_framework
+    create_universal_framework "iphoneos" "iphonesimulator" "catalyst"
 else
     echo "Skipping; Clean \"destroot\" to rebuild".
 fi


### PR DESCRIPTION
## Summary

Edits build scripts to allow merging architectures into .xcframework instead of using lipo for building fat framework.
Adds compatibility with arm64 iOS Simulators on Apple M1 Macs and allows using Hermes with RN apps built for Mac Catalyst.

Fixes #460 and #468