### PR TITLE
Use the CircleCI Android orb for test-e2e

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -552,67 +552,38 @@ jobs:
             cmake --build ./embuild --target emhermesc
             EMHERMESC="$PWD/embuild/bin/emhermesc.js" node ./hermes/tools/emhermesc/test.js
   test-e2e:
-    # For now we run E2E tests on MacOS as running an Android emulator on Linux is
-    # not supported with Circle CI:
-    # https://support.circleci.com/hc/en-us/articles/360000028928-Testing-with-Android-emulator-on-CircleCI-2-0
-    # Windows is another option, but I came across a convenient Mac OS example first:
-    # https://gist.github.com/DoguD/58b4b86a5d892130af84074078581b87
-    macos:
-      xcode: "10.0.0"
-    environment:
-      - TERM: dumb
-      # Homebrew currently breaks while updating:
-      # https://discuss.circleci.com/t/brew-install-fails-while-updating/32992
-      - HOMEBREW_NO_AUTO_UPDATE: 1
-      - JVM_OPTS: -Xmx3200m
-      - ANDROID_HOME: /usr/local/share/android-sdk
-      - ANDROID_SDK_HOME: /usr/local/share/android-sdk
-      - ANDROID_SDK_ROOT: /usr/local/share/android-sdk
-      - ANDROID_NDK_HOME: /usr/local/share/android-ndk
-      - QEMU_AUDIO_DRV: none
-      - JAVA_HOME: /Library/Java/Home
+    executor:
+      name: android/android
+      sdk-version: '28'
+      variant: node
     steps:
+      - android/install-ndk
+      - android/create-avd:
+          avd-name: Pixel_2_API_25
+          install: true
+          # Use armeabi-v7a because x86 images can't be run without KVM and hardware
+          # acceleration, which docker jobs can't provide on CircleCI.
+          system-image: system-images;android-25;google_apis;armeabi-v7a
+      - android/start-emulator:
+          avd-name: Pixel_2_API_25
+          memory: 2048
+          # This argument's default tries to invoke ./gradlew assembleDebugAndroidTest which doesn't exist.
+          post-emulator-launch-assemble-command: ''
+          restore-gradle-cache-post-emulator-launch: false
+          wait-for-emulator: false
       - run:
           name: Setup dependencies
           command: |
             mkdir -p /tmp/hermes/output
-            # Node some version greater than 11 is needed by one of the app dependencies
-            curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.1/install.sh | bash
-            NVM_DIR="$HOME/.nvm"
-            . "$NVM_DIR/nvm.sh"
-            echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
-            echo '. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
-            nvm install 14
-            nvm use 14
-            # Reinstall the latest version of Yarn.
-            npm install --global yarn
-            brew install gnu-sed
-            brew install md5sha1sum
-            brew tap homebrew/cask
-            brew cask install android-sdk
-            brew cask install android-ndk
-            echo 'export PATH="/usr/local/share/android-sdk/platform-tools:/usr/local/share/android-sdk/tools/bin:$PATH"' >> $BASH_ENV
-            # At some point, adb ended up in platform-tools/platform-tools. Work around that.
-            echo 'export PATH="/usr/local/share/android-sdk/platform-tools/platform-tools:$PATH"' >> $BASH_ENV
       - run:
           name: Print versions
           command: |
             node --version
             yarn --version
-      - run:
-          name: Install emulator dependencies
-          command: (yes | sdkmanager "platform-tools" "platforms;android-26" "extras;intel;Hardware_Accelerated_Execution_Manager" "build-tools;26.0.0" "system-images;android-26;google_apis;x86" "emulator" --verbose) || true
-      - run:
-          name: Create emulator definition
-          command: |
-            avdmanager create avd -n Pixel_2_API_26 -k "system-images;android-26;google_apis;x86" -g google_apis -d "Nexus 5"
-      - run:
-          name: Run emulator in background
-          command: /usr/local/share/android-sdk/emulator/emulator @Pixel_2_API_26 -memory 2048 -noaudio
-          background: true
       - checkout
       - attach_workspace:
           at: /tmp/hermes/input
+      - android/wait-for-emulator
       - run:
           name: Run E2E test with master Hermes and Release React Native
           command: |


### PR DESCRIPTION
Summary:
Change the `test-e2e` job from running on a physical mac machine
to using a Linux docker container via the Android orb.
This has a few convenience functions, including:
* Pre-installed node.js
* Easy installation of ndk
* Creating AVDs and starting the emulator

Note that unfortunately due to KVM and hardware acceleration not being available
on CircleCI docker machines, ARMv7 needs to be used instead of x86, which
can slow down the test. Because of this, the API had to be downgraded to v25, which
was the most recent version with an armv7 system image available.

Differential Revision: D27302251

