### PR TITLE
Adds fuzzilli_print function to fuzzilli harness, allowing for runtime type collection

### DIFF
--- a/tools/fuzzers/fuzzilli/fuzzilli.cpp
+++ b/tools/fuzzers/fuzzilli/fuzzilli.cpp
@@ -133,16 +133,40 @@ Value CrashFunction(
     const Value *args,
     size_t numArgs) {
   // crashes when calling FuzzilliCrash(1) and FuzzilliCrash(2)
-  if (numArgs != 1 || !args[0].isNumber())
+  if (numArgs != 2 || !args[0].isString())
     return Value();
-  auto crashCode = args[0].getNumber();
-  if (crashCode == 1) {
-    *((int *)0x1) = 2;
-    exit(-1);
-  } else if (crashCode == 2)
-    assert(0);
-  else
-    return Value();
+  String funcString = args[0].getString(rt);
+  if (String::strictEquals(
+          rt, funcString, String::createFromAscii(rt, "FUZZILLI_PRINT"))) {
+    // The Fuzzilli Print operation can take either a number or a string
+    static FILE *fzliout = fdopen(REPRL_DWFD, "w");
+    if (!fzliout) {
+      fprintf(
+          stderr,
+          "Fuzzer output channel not available, printing to stdout instead\n");
+      fzliout = stdout;
+    }
+    if (args[1].isNumber()) {
+      double num = args[1].asNumber();
+      fprintf(fzliout, "%.0f\n", num);
+    } else if (args[1].isString()) {
+      std::string outputString = args[1].getString(rt).utf8(rt);
+      fprintf(fzliout, "%s\n", outputString.c_str());
+    }
+    fflush(fzliout);
+  } else if (
+      String::strictEquals(
+          rt, funcString, String::createFromAscii(rt, "FUZZILLI_CRASH")) &&
+      args[1].isNumber()) {
+    double crashCode = args[1].getNumber();
+    if (crashCode == 0.0) {
+      *((int *)0x1) = 2;
+      exit(-1);
+    } else if (crashCode == 1.0) {
+      assert(1 == 0);
+    }
+  }
+  return Value();
 }
 
 class MemoryBuffer : public facebook::jsi::Buffer {
@@ -184,7 +208,7 @@ int main(int argc, char **argv) {
                                          .withEnableHermesInternal(true)
                                          .withEnableJIT(true)
                                          .build());
-    auto crashFunctionName = "FuzzilliCrash";
+    auto crashFunctionName = "fuzzilli";
     auto crashFunctionProp =
         facebook::jsi::PropNameID::forAscii(*runtime, crashFunctionName);
     auto crashFunctionDef = Function::createFromHostFunction(

--- a/tools/fuzzers/fuzzilli/profile/HermesProfile.swift
+++ b/tools/fuzzers/fuzzilli/profile/HermesProfile.swift
@@ -22,7 +22,7 @@ let hermesProfile = Profile(
 
     ecmaVersion: ECMAScriptVersion.es6,
 
-    crashTests: ["FuzzilliCrash(1)", "FuzzilliCrash(2)"],
+    crashTests: ["fuzzilli('FUZZILLI_CRASH', 0)", "fuzzilli('FUZZILLI_CRASH', 1)"],
 
     additionalCodeGenerators: WeightedList<CodeGenerator>([]),
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `master`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/master/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.
-->

## Summary

This implements the Fuzzilli_Print builtin, for use by the Fuzzilli fuzzer. This is needed for the collectRuntimeTypes flag, which improves fuzzer performance.

## Test Plan

Tested with `swift run -c release FuzzilliCli --profile=hermes --collectRuntimeTypes fuzzilli`, which executes successfully. Previously, the fuzzer would fail when attempting type collection.
