### PR TITLE
Length comparison incorrect for TypedArray.from

### DIFF
--- a/lib/VM/JSLib/TypedArray.cpp
+++ b/lib/VM/JSLib/TypedArray.cpp
@@ -46,9 +46,11 @@ T convertNegativeBoundsRelativeToLength(T value, T length) {
 CallResult<Handle<JSTypedArrayBase>> typedArrayCreate(
     Runtime *runtime,
     Handle<Callable> constructor,
-    HermesValue length) {
+    uint64_t length) {
   auto callRes = Callable::executeConstruct1(
-      constructor, runtime, runtime->makeHandle(length));
+      constructor,
+      runtime,
+      runtime->makeHandle(HermesValue::encodeNumberValue(length)));
   if (callRes == ExecutionStatus::EXCEPTION) {
     return ExecutionStatus::EXCEPTION;
   }
@@ -60,15 +62,11 @@ CallResult<Handle<JSTypedArrayBase>> typedArrayCreate(
   auto newTypedArray =
       Handle<JSTypedArrayBase>::vmcast(runtime->makeHandle(std::move(retval)));
   // If `argumentList` is a single number, then
-  if (LLVM_LIKELY(length.isNumber())) {
-    // If the value of newTypedArray's [[ArrayLength]] internal slot <
-    // argumentList[0], throw a TypeError exception.
-    if (LLVM_UNLIKELY(
-            newTypedArray->getLength() <
-            length.getNumberAs<JSTypedArrayBase::size_type>())) {
-      return runtime->raiseTypeError(
-          "TypedArray constructor created an array that was too small");
-    }
+  // If the value of newTypedArray's [[ArrayLength]] internal slot <
+  // argumentList[0], throw a TypeError exception.
+  if (LLVM_UNLIKELY(newTypedArray->getLength() < length)) {
+    return runtime->raiseTypeError(
+        "TypedArray constructor created an array that was too small");
   }
   return newTypedArray;
 }
@@ -552,7 +550,7 @@ typedArrayFrom(void *, Runtime *runtime, NativeArgs args) {
   if (intRes == ExecutionStatus::EXCEPTION) {
     return ExecutionStatus::EXCEPTION;
   }
-  auto len = intRes.getValue();
+  uint64_t len = intRes.getValue().getNumberAs<uint64_t>();
   // 8. Let targetObj be ? TypedArrayCreate(C, len).
   auto targetObj = typedArrayCreate(runtime, C, len);
   if (targetObj == ExecutionStatus::EXCEPTION) {
@@ -561,7 +559,7 @@ typedArrayFrom(void *, Runtime *runtime, NativeArgs args) {
   // 9. Let k be 0.
   MutableHandle<> k(runtime, HermesValue::encodeNumberValue(0));
   // 10. Repeat, while k < len.
-  for (; k->getNumberAs<uint64_t>() < len.getNumberAs<uint64_t>();
+  for (; k->getNumberAs<uint64_t>() < len;
        k = HermesValue::encodeNumberValue(k->getNumberAs<uint64_t>() + 1)) {
     GCScopeMarkerRAII marker{runtime};
     // a - b. Get the value of the property at k.
@@ -598,7 +596,7 @@ typedArrayFrom(void *, Runtime *runtime, NativeArgs args) {
 CallResult<HermesValue>
 typedArrayOf(void *, Runtime *runtime, NativeArgs args) {
   // 1. Let len be the actual number of arguments passed to this function.
-  auto len = args.getArgCount();
+  uint64_t len = args.getArgCount();
   // 2. Let items be the List of arguments passed to this function. (args is
   // items).
   // 3. Let C be the this value.
@@ -610,8 +608,7 @@ typedArrayOf(void *, Runtime *runtime, NativeArgs args) {
   }
   auto C = Handle<Callable>::vmcast(args.getThisHandle());
   // 5. Let newObj be ? TypedArrayCreate(C, len).
-  auto newObj =
-      typedArrayCreate(runtime, C, HermesValue::encodeNumberValue(len));
+  auto newObj = typedArrayCreate(runtime, C, len);
   if (newObj == ExecutionStatus::EXCEPTION) {
     return ExecutionStatus::EXCEPTION;
   }

--- a/test/hermes/TypedArray.js
+++ b/test/hermes/TypedArray.js
@@ -544,6 +544,20 @@ cons.forEach(function(c, i) {
   assert.throws(function() {
     from([]);
   }, TypeError);
+
+  // Test a TypedArray whose length is greater than 2 ^ 32 - 1
+  // NOTE: This behavior differs from v8 and JSC, because we use uint32_t as our
+  // indexing type. They also disagree with each other.
+  assert.throws(function() {
+    var ta = new c();
+    Object.defineProperty(ta, "length", {
+      get: function() {
+        // This number is 2 ^ 32 + 1.
+        return 4294967297;
+      }
+    });
+    return c.from(ta);
+  }, TypeError);
 });
 
 /// @}


### PR DESCRIPTION
Summary:
Fix #485.

The `length` can be any integer from 0 to 2 ^ 53 - 1, so it can't be cast to a uint32_t
safely. Doing so hits an assert in `getNumberAs<uint32_t>`.
Do the comparison using doubles so it will work correctly.
Alternatively it could be cast to uint64_t for the comparison, but since they're both
integers anyway there shouldn't be any double comparison issue.

After this change, the added unit test throws a TypeError instead of hitting an assert.

Differential Revision: D27683567

