### PR TITLE
Fix handing of minutes in time zone offset parsing

### DIFF
--- a/lib/VM/JSLib/DateUtil.cpp
+++ b/lib/VM/JSLib/DateUtil.cpp
@@ -840,6 +840,7 @@ static double parseISODate(StringView u16str) {
       if (!scanInt(it, end, tzm)) {
         return nan;
       }
+      tzm *= sign;
     }
   }
 

--- a/test/hermes/date-constructor.js
+++ b/test/hermes/date-constructor.js
@@ -244,6 +244,8 @@ print(Date.parse('Mon Jul 16 2019 13:1525 GMT-0700'));
 // CHECK-NEXT: NaN
 print(Date.parse('Mon Jul 16 2019 13:1525 GMT'));
 // CHECK-NEXT: NaN
+print(Date.parse('2021-04-10T01:00:00.000-01:30'));
+// CHECK-NEXT: 1618021800000
 
 // Fault tolerance on garbages (marked as "G"s).
 // TODO(T66628172) adapt to local timezone.


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `master`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/master/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.
-->

## Summary

When a time zone with an offset that includes negative minutes (e.g.
-2:30) is given the `new Date` or `Date.parse`, dates were parsed
incorrectly.

This resolves the issue by correctly negating the minutes offset, and
adds a test case that will catch any future regressions.

## Test Plan

Added a test case that used a -1:30 offset, and ran the test suite. It failed, showing a 1 hour difference in the unix timestamp.

Applied fix, and re-ran with all tests passing.

Before:

```
test/hermes/date-constructor.js:248:16: error: CHECK-NEXT: expected string not found in input
// CHECK-NEXT: 1618021800000
               ^
<stdin>:101:1: note: scanning from here
1618018200000
^
```

After:
```
[11/12] Running the Hermes regression tests
Testing Time: 31.64s
  Expected Passes    : 1353
  Unsupported Tests  : 55
```