### PR TITLE
Bump gradle version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,7 +47,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:4.0.0'
+    classpath 'com.android.tools.build:gradle:4.1.0'
     classpath("de.undercouch:gradle-download-task:4.0.2")
   }
 }

--- a/android/intltest/build.gradle
+++ b/android/intltest/build.gradle
@@ -84,6 +84,8 @@ android {
     }
   }
 
+  useLibrary 'android.test.base'
+
   dependencies {
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'


### PR DESCRIPTION
Summary:
This diff updates the minimum gradle plugin version for building the
Hermes OSS release in order to avoid problems in older versions of
the Android NDK.

Specifically, there was a bug
(https://github.com/android/ndk/issues/1166) in the Android NDK that
caused the exception handling functions in `libc++` to be incorrectly
exported. Depending on link order, this can lead to  `libhermes.so`
not statically linking in `_Unwind_resume`, and expecting it instead
to be resolved dynamically to the version in `libc++`. However, if
we're linking against an RN version that was built against the new
version of the NDK, those symbols may not be exported, and end up
unresolved (which crashes the app).

To allow Hermes to be built with newer versions of the NDK, we need
to bump up the gradle plugin version to 4.1. RN already uses 4.1.

Differential Revision: D28763472

