### PR TITLE
Fix call to JSDate::getPrimitiveValue in Intl

### DIFF
--- a/lib/VM/JSLib/Intl.cpp
+++ b/lib/VM/JSLib/Intl.cpp
@@ -1397,7 +1397,7 @@ CallResult<HermesValue> intlDatePrototypeToSomeLocaleString(
     const NativeArgs &args,
     JSDate *date,
     int dtoFlags) {
-  double x = JSDate::getPrimitiveValue(date).getNumber(runtime);
+  double x = date->getPrimitiveValue();
   std::u16string str;
   if (isnan(x)) {
     str = u"Invalid Date";


### PR DESCRIPTION
Summary:
My previous change to make this method non-static missed the usage in
Intl.cpp. Update it to use the new non-static method.

Differential Revision: D28765667

