### PR TITLE
Detect host platform instead of target for InternalBytecode Cmake

### DIFF
--- a/lib/InternalBytecode/CMakeLists.txt
+++ b/lib/InternalBytecode/CMakeLists.txt
@@ -34,7 +34,7 @@ set(JS_COMPILER_FLAGS "-O" "-Wno-undefined-variable")
 
 # Concatenate all JS files into one source file for compilation.
 # This way there is only one RuntimeModule made for them.
-if(NOT WIN32)
+if(NOT CMAKE_HOST_WIN32)
   set(concatenate "cat")
 else()
   set(concatenate "type")


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `master`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/master/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.
-->

## Summary
There is a switch for choosing the right concatinator for concating js file together
in `lib/InternalBytecode/CMakeLists.txt`. When crosscompiling (eg compiling Android on Windows)
it chooses the target platform (not WIN32) despite being launched on Windows.
CMAKE_HOST_WIN32 var is suggested to be used instead to make the proper detection.
<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
-->

## Test Plan
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes the user interface.
-->
Environment: Win10, Powershell
1. cd one folder up from hermes repo
2. Configure host build `python3 hermes/utils/build/configure.py --build-system='Visual Studio 15 2017' ./build`
3. Run the host build `MSBuild.exe ALL_BUILD.vcxproj /p:Configuration=Debug`
4. Set HERMES_WS_DIR:  `$env:HERMES_WS_DIR=<path to build foder>`
5. `cd hermes\android; ./gradlew assembleNoIntl`
6. Actual result: the following error
```
FAILED: cmd.exe /C "cd /D [..]hermes\lib\InternalBytecode && cat [..]\hermes\lib\InternalBytecode\00-header.js [..]hermes\lib\InternalBytecode\01-Promise.js [..]hermes\lib\InternalBytecode\02-AsyncFn.js [..]hermes\lib\InternalBytecode\99-footer.js > [..]staging/hermes/cmake/nointlDebug/armeabi-v7a/lib/InternalBytecode/InternalBytecode.js"
  'cat' is not recognized as an internal or external command,
  ```
7. Expected result: BUILD SUCCESSFUL 