### PR TITLE
arm64 simulators & catalyst support (#475)

### DIFF
--- a/API/hermes/CMakeLists.txt
+++ b/API/hermes/CMakeLists.txt
@@ -113,6 +113,10 @@ if(APPLE AND HERMES_BUILD_APPLE_FRAMEWORK)
     add_custom_command(TARGET libhermes POST_BUILD
       COMMAND /usr/libexec/PlistBuddy -c "Add :MinimumOSVersion string ${CMAKE_OSX_DEPLOYMENT_TARGET}" $<TARGET_FILE_DIR:libhermes>/Info.plist
     )
+  elseif(HERMES_APPLE_TARGET_PLATFORM MATCHES "catalyst")
+    add_custom_command(TARGET libhermes POST_BUILD
+      COMMAND /usr/libexec/PlistBuddy -c "Add :LSMinimumSystemVersion string ${CMAKE_OSX_DEPLOYMENT_TARGET}" $<TARGET_FILE_DIR:libhermes>/Resources/Info.plist
+    )  
   elseif(HERMES_APPLE_TARGET_PLATFORM MATCHES "macos")
     add_custom_command(TARGET libhermes POST_BUILD
       COMMAND /usr/libexec/PlistBuddy -c "Add :LSMinimumSystemVersion string ${CMAKE_OSX_DEPLOYMENT_TARGET}" $<TARGET_FILE_DIR:libhermes>/Resources/Info.plist

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,17 @@ endif()
 # https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_SYSROOT.html
 set(CMAKE_OSX_SYSROOT ${HERMES_APPLE_TARGET_PLATFORM})
 
+if(HERMES_APPLE_TARGET_PLATFORM MATCHES "catalyst")
+  set(CMAKE_OSX_SYSROOT "macosx")
+  set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-target x86_64-arm64-apple-ios14.0-macabi -isystem ${CMAKE_OSX_SYSROOT}/System/iOSSupport/usr/include")
+  set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} "-target x86_64-arm64-apple-ios14.0-macabi -isystem ${CMAKE_OSX_SYSROOT}/System/iOSSupport/usr/include")
+  set(CMAKE_THREAD_LIBS_INIT "-lpthread")
+  set(CMAKE_HAVE_THREADS_LIBRARY 1)
+  set(CMAKE_USE_WIN32_THREADS_INIT 0)
+  set(CMAKE_USE_PTHREADS_INIT 1)
+  set(THREADS_PREFER_PTHREAD_FLAG ON)
+endif()
+
 # This must be consistent with the release_version in:
 # - android/build.gradle
 # - npm/package.json

--- a/hermes-engine.podspec
+++ b/hermes-engine.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |spec|
   spec.source_files        = "destroot/include/**/*.h"
   spec.header_mappings_dir = "destroot/include"
 
-  spec.ios.vendored_frameworks = "destroot/Library/Frameworks/iphoneos/hermes.framework"
+  spec.ios.vendored_frameworks = "destroot/Library/Frameworks/iphoneos/hermes.xcframework"
   spec.osx.vendored_frameworks = "destroot/Library/Frameworks/macosx/hermes.framework"
 
   spec.xcconfig            = { "CLANG_CXX_LANGUAGE_STANDARD" => "c++14", "CLANG_CXX_LIBRARY" => "compiler-default", "GCC_PREPROCESSOR_DEFINITIONS" => "HERMES_ENABLE_DEBUGGER=1" }

--- a/utils/build-apple-framework.sh
+++ b/utils/build-apple-framework.sh
@@ -46,7 +46,8 @@ function build_host_hermesc {
 # Utility function to configure an Apple framework
 function configure_apple_framework {
   local build_cli_tools enable_bitcode
-  if [[ $1 == iphoneos ]]; then
+
+  if [[ $1 == iphoneos || $1 == catalyst ]]; then
     enable_bitcode="true"
   else
     enable_bitcode="false"
@@ -98,22 +99,21 @@ function create_universal_framework {
   cd ./destroot/Library/Frameworks || exit 1
 
   local platforms=("$@")
+  local args=""
 
   echo "Creating universal framework for platforms: ${platforms[*]}"
 
   for i in "${!platforms[@]}"; do
-    platforms[$i]="${platforms[$i]}/hermes.framework/hermes"
+    args+="-framework ${platforms[$i]}/hermes.framework "
   done
 
-  lipo -create -output "${platforms[0]}" "${platforms[@]}"
+  xcodebuild -create-xcframework $args -output "${platforms[0]}/hermes.xcframework"
 
   # Once all was linked into a single framework, clean destroot
   # from unused frameworks
   for platform in "${@:2}"; do
     rm -r "$platform"
   done
-
-  lipo -info "${platforms[0]}"
 
   cd - || exit 1
 }

--- a/utils/build-ios-framework.sh
+++ b/utils/build-ios-framework.sh
@@ -10,9 +10,10 @@ if [ ! -d destroot/Library/Frameworks/iphoneos/hermes.framework ]; then
     ios_deployment_target=$(get_ios_deployment_target)
 
     build_apple_framework "iphoneos" "armv7;armv7s;arm64" "$ios_deployment_target"
-    build_apple_framework "iphonesimulator" "x86_64;i386" "$ios_deployment_target"
+    build_apple_framework "iphonesimulator" "x86_64;arm64" "$ios_deployment_target"
+    build_apple_framework "catalyst" "x86_64;arm64" "$ios_deployment_target"
 
-    create_universal_framework "iphoneos" "iphonesimulator"
+    create_universal_framework "iphoneos" "iphonesimulator" "catalyst"
 else
     echo "Skipping; Clean \"destroot\" to rebuild".
 fi

--- a/utils/build-ios-framework.sh
+++ b/utils/build-ios-framework.sh
@@ -10,7 +10,7 @@ if [ ! -d destroot/Library/Frameworks/iphoneos/hermes.framework ]; then
     ios_deployment_target=$(get_ios_deployment_target)
 
     build_apple_framework "iphoneos" "armv7;armv7s;arm64" "$ios_deployment_target"
-    build_apple_framework "iphonesimulator" "x86_64;arm64" "$ios_deployment_target"
+    build_apple_framework "iphonesimulator" "x86_64;i386;arm64" "$ios_deployment_target"
     build_apple_framework "catalyst" "x86_64;arm64" "$ios_deployment_target"
 
     create_universal_framework "iphoneos" "iphonesimulator" "catalyst"


### PR DESCRIPTION
Summary:
Edits build scripts to allow merging architectures into .xcframework instead of using lipo for building fat framework.
Adds compatibility with arm64 iOS Simulators on Apple M1 Macs and allows using Hermes with RN apps built for Mac Catalyst.

Fixes https://github.com/facebook/hermes/issues/460 and https://github.com/facebook/hermes/issues/468

Pull Request resolved: https://github.com/facebook/hermes/pull/475

Differential Revision: D29465045

Pulled By: Huxpro

