### PR TITLE
Fix to CircleCI test failure

### DIFF
--- a/tools/node-hermes/InternalBindings/file.cpp
+++ b/tools/node-hermes/InternalBindings/file.cpp
@@ -174,7 +174,7 @@ fstat(RuntimeState &rs, const jsi::Value *args, size_t count) {
   res.setProperty(rt, "size", (double)statbuf->st_size);
   res.setProperty(rt, "blocks", (double)statbuf->st_blocks);
 
-  return res;
+  return std::move(res);
 }
 
 /// Initializes a new JS function given a function pointer to the c++ function.


### PR DESCRIPTION
Summary: file.cpp had an error that was preventing the CircleCI test from building on linux.

Differential Revision: D29718313

