### PR TITLE
Drop 32 bit build on iOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,7 +271,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v3-repo-{{ .Environment.CIRCLE_SHA1 }}
+          key: v4-repo-{{ .Environment.CIRCLE_SHA1 }}
       - run:
           name: Set up workspace
           command: mkdir -p /tmp/hermes/output

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ endif()
 # - npm/package.json
 # - hermes-engine.podspec
 project(Hermes
-        VERSION 0.8.0
+        VERSION 0.8.1
         LANGUAGES C CXX)
 # Optional suffix like "-rc3"
 set(VERSION_SUFFIX "")

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,8 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// This must be consistent with the release_version in npm/package.json
-// and the HERMES_RELEASE_VERSION in CMakeLists.txt
+// This must be consistent with the release_version in:
+// - CMakeLists.txt
+// - npm/package.json
+// - hermes-engine.podspec
 def release_version = "0.8.1"
 
 buildscript {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@
 
 // This must be consistent with the release_version in npm/package.json
 // and the HERMES_RELEASE_VERSION in CMakeLists.txt
-def release_version = "0.8.0"
+def release_version = "0.8.1"
 
 buildscript {
   ext {

--- a/hermes-engine.podspec
+++ b/hermes-engine.podspec
@@ -10,6 +10,10 @@ end
 
 Pod::Spec.new do |spec|
   spec.name        = "hermes-engine"
+  # This must be consistent with the release_version in:
+  # - android/build.gradle
+  # - npm/package.json
+  # - CMakeLists.txt 
   spec.version     = "0.8.1"
   spec.summary     = "Hermes is a small and lightweight JavaScript engine optimized for running React Native."
   spec.description = "Hermes is a JavaScript engine optimized for fast start-up of React Native apps. It features ahead-of-time static optimization and compact bytecode."

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.0",
+  "version": "0.8.1",
   "scripts": {
     "unpack-builds": "node unpack-builds.js",
     "unpack-builds-dev": "node unpack-builds.js --dev",

--- a/utils/build-ios-framework.sh
+++ b/utils/build-ios-framework.sh
@@ -9,7 +9,7 @@
 if [ ! -d destroot/Library/Frameworks/universal/hermes.xcframework ]; then
     ios_deployment_target=$(get_ios_deployment_target)
 
-    build_apple_framework "iphoneos" "armv7;armv7s;arm64" "$ios_deployment_target"
+    build_apple_framework "iphoneos" "arm64" "$ios_deployment_target"
     build_apple_framework "iphonesimulator" "x86_64;arm64" "$ios_deployment_target"
     build_apple_framework "catalyst" "x86_64;arm64" "$ios_deployment_target"
 


### PR DESCRIPTION
armv7 and armv7s are 32 bit and iOS 11 is 64 only.
Dropping to fix the build and as a bonus make it faster