### PR TITLE
Fix path bug on windows in LLVH from LLVM that is fixed there.

### DIFF
--- a/external/llvh/lib/Support/Windows/Path.inc
+++ b/external/llvh/lib/Support/Windows/Path.inc
@@ -416,7 +416,7 @@ static std::error_code rename_internal(HANDLE FromHandle, const Twine &To,
       *reinterpret_cast<FILE_RENAME_INFO *>(RenameInfoBuf.data());
   RenameInfo.ReplaceIfExists = ReplaceIfExists;
   RenameInfo.RootDirectory = 0;
-  RenameInfo.FileNameLength = ToWide.size();
+  RenameInfo.FileNameLength = ToWide.size() * sizeof(wchar_t);
   std::copy(ToWide.begin(), ToWide.end(), &RenameInfo.FileName[0]);
 
   SetLastError(ERROR_SUCCESS);

--- a/external/llvh/patches/windows-rename-api-fix.patch
+++ b/external/llvh/patches/windows-rename-api-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/Support/Windows/Path.inc b/lib/Support/Windows/Path.inc
+index 2b30bd24..0f9a84c1 100644
+--- a/lib/Support/Windows/Path.inc
++++ b/lib/Support/Windows/Path.inc
+@@ -416,7 +416,7 @@ static std::error_code rename_internal(HANDLE FromHandle, const Twine &To,
+       *reinterpret_cast<FILE_RENAME_INFO *>(RenameInfoBuf.data());
+   RenameInfo.ReplaceIfExists = ReplaceIfExists;
+   RenameInfo.RootDirectory = 0;
+-  RenameInfo.FileNameLength = ToWide.size();
++  RenameInfo.FileNameLength = ToWide.size() * sizeof(wchar_t);
+   std::copy(ToWide.begin(), ToWide.end(), &RenameInfo.FileName[0]);
+ 
+   SetLastError(ERROR_SUCCESS);


### PR DESCRIPTION
## Summary

LLVH is a forked copy of LLVM. It has not been updated with the latest patches. Microsoft is running into an LLVM bug on Windows when using the [BuildXL](https://github.com/microsoft/buildxl)  build engine.
LLVM fixed this with: [[Support] Fix FileNameLength passed to SetFileInformationByHandle](https://github.com/llvm-mirror/llvm/commit/c94004ffdb1ee37b3c4e762e4e7576cc3844d79b) a few years ago.
This PR ports that fix to the LLVH forked copy in Hermes.

The LLVM commit has a good description of the issue, but TLDR: 
> The rename_internal function used for Windows has a minor bug where the filename length is passed as a character count instead of a byte count.

This change does not affect running Hermes running normally on window as windows ignores the size parameter to the api. This only affects when Hermes runs in a build process that detours/intercepts the rename file api and depens on that parameter. A build process (like the [BuildXL](https://github.com/microsoft/buildxl) engine) would detour/intercept all windows filesystem api's to keep track of file accesses does to guarantee a fast, reliable, cacheable and distributable build yet allow for an over approximation of file dependencies and not overbuild.

## Test Plan
* This change has been successfully running in LLVM for 3 years.
* This change has been put in the fork of Hermes that react-native-windows uses and tested by various Microsoft developers
