### PR TITLE
Use existing downloaded test262 for Intl tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -588,7 +588,12 @@ jobs:
           path: hermes
       - run:
           name: Setup dependencies
-          command: (yes | sdkmanager "cmake;3.10.2.4988404" --verbose) || true
+          command: |
+            (yes | sdkmanager "cmake;3.10.2.4988404" --verbose) || true
+            # Check out test262 at a pinned revision to reduce flakiness
+            git clone https://github.com/tc39/test262
+            cd test262
+            git checkout c27f6a5b9a30c219b3b95769d52dc587a9af61ab
       - run:
           name: Build Hermes Compiler
           command: |

--- a/android/intltest/build.gradle
+++ b/android/intltest/build.gradle
@@ -18,50 +18,33 @@ import de.undercouch.gradle.tasks.download.Download
 buildDir = "${rootProject.ext.hermes_ws}/build_android/intltest"
 buildDir.mkdirs()
 
-// Download the test262 snapshot at c27f6a (June 30 2021).
-def test262CommitHash = "c27f6a5b9a30c219b3b95769d52dc587a9af61ab"
-def test262DownloadsDirPath = "${rootProject.ext.hermes_ws}/build_android/intltest/downloads/test262"
-def test262Staging = "${rootProject.ext.hermes_ws}/build_android/intltest/downloads/test262-staging"
 def testDestination = "java/com/facebook/hermes/test/assets"
-task createDownloadsDir {
-  new File(test262DownloadsDirPath).mkdirs()
-}
 
-task downloadTest262(dependsOn: createDownloadsDir, type: Download) {
-  src("https://github.com/tc39/test262/archive/${test262CommitHash}.zip")
-  onlyIfNewer(true)
-  overwrite(true)
-  dest(new File(test262DownloadsDirPath, "test262.zip"))
-}
-
-task prepareTests(dependsOn: downloadTest262) {
+task prepareTests() {
   doLast {
-    // Only include the Intl402 test from the downloaded test262.
+    def test262Dir = file(rootProject.ext.fbsource).exists() ?
+                 "${rootProject.ext.fbsource}/xplat/third-party/javascript-test-suites/test262/" :
+                 "${rootProject.ext.hermes_ws}/test262"
+    assert file(test262Dir).exists() : "Test262 directory not found"
     copy{
-      from(zipTree(downloadTest262.dest)) {
-        include("test262-${test262CommitHash}/test/intl402/Collator/**/*.js")
-        include("test262-${test262CommitHash}/test/intl402/DateTimeFormat/**/*.js")
-        include("test262-${test262CommitHash}/test/intl402/NumberFormat/**/*.js")
-        include("test262-${test262CommitHash}/test/intl402/String/**/*.js")
-        include("test262-${test262CommitHash}/test/intl402/Number/**/*.js")
-        include("test262-${test262CommitHash}/test/intl402/Array/**/*.js")
-        include("test262-${test262CommitHash}/test/intl402/Date/**/*.js")
-        include("test262-${test262CommitHash}/test/intl402/Intl/**/*.js")
-        include("test262-${test262CommitHash}/harness/*.js")
+      from(test262Dir) {
+        include("test/intl402/Collator/**/*.js")
+        include("test/intl402/DateTimeFormat/**/*.js")
+        include("test/intl402/NumberFormat/**/*.js")
+        include("test/intl402/String/**/*.js")
+        include("test/intl402/Number/**/*.js")
+        include("test/intl402/Array/**/*.js")
+        include("test/intl402/Date/**/*.js")
+        include("test/intl402/Intl/**/*.js")
+        include("harness/*.js")
         includeEmptyDirs = false
       }
-      into(test262Staging)
-    }
-    // Rename the unzipped dir as just `test262` so the path is known to Java.
-    copy {
-      from("${test262Staging}/test262-${test262CommitHash}")
       into("${testDestination}/test262")
     }
     copy {
       from("../../test/hermes/intl")
       into("${testDestination}")
     }
-    delete "${test262Staging}"
   }
 }
 

--- a/android/intltest/java/com/facebook/hermes/test/HermesIntlArrayPrototypeTest.java
+++ b/android/intltest/java/com/facebook/hermes/test/HermesIntlArrayPrototypeTest.java
@@ -11,7 +11,7 @@ import java.util.HashSet;
 import java.util.Set;
 import org.junit.Test;
 
-// Run "./gradlew :intltest:prepareTests" from the root to download and copy the test files to the
+// Run "./gradlew :intltest:prepareTests" from the root to copy the test files to the
 // APK assets.
 public class HermesIntlArrayPrototypeTest extends HermesIntlTest262Base {
 

--- a/android/intltest/java/com/facebook/hermes/test/HermesIntlCollatorTest.java
+++ b/android/intltest/java/com/facebook/hermes/test/HermesIntlCollatorTest.java
@@ -11,7 +11,7 @@ import java.util.HashSet;
 import java.util.Set;
 import org.junit.Test;
 
-// Run "./gradlew :intltest:prepareTests" from the root to download and copy the test files to the
+// Run "./gradlew :intltest:prepareTests" from the root to copy the test files to the
 // APK assets.
 public class HermesIntlCollatorTest extends HermesIntlTest262Base {
 

--- a/android/intltest/java/com/facebook/hermes/test/HermesIntlDateFormatTest.java
+++ b/android/intltest/java/com/facebook/hermes/test/HermesIntlDateFormatTest.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-// Run "./gradlew :intltest:prepareTests" from the root to download and copy the test files to the
+// Run "./gradlew :intltest:prepareTests" from the root to copy the test files to the
 // APK assets.
 public class HermesIntlDateFormatTest extends HermesIntlTest262Base {
 

--- a/android/intltest/java/com/facebook/hermes/test/HermesIntlDatePrototypeTest.java
+++ b/android/intltest/java/com/facebook/hermes/test/HermesIntlDatePrototypeTest.java
@@ -10,7 +10,7 @@ import java.util.HashSet;
 import java.util.Set;
 import org.junit.Test;
 
-// Run "./gradlew :intltest:prepareTests" from the root to download and copy the test files to the
+// Run "./gradlew :intltest:prepareTests" from the root to copy the test files to the
 // APK assets.
 public class HermesIntlDatePrototypeTest extends HermesIntlTest262Base {
 

--- a/android/intltest/java/com/facebook/hermes/test/HermesIntlGetCanonicalLocalesTest.java
+++ b/android/intltest/java/com/facebook/hermes/test/HermesIntlGetCanonicalLocalesTest.java
@@ -11,7 +11,7 @@ import java.util.HashSet;
 import java.util.Set;
 import org.junit.Test;
 
-// Run "./gradlew :intltest:prepareTests" from the root to download and copy the test files to the
+// Run "./gradlew :intltest:prepareTests" from the root to copy the test files to the
 // APK assets.
 public class HermesIntlGetCanonicalLocalesTest extends HermesIntlTest262Base {
 

--- a/android/intltest/java/com/facebook/hermes/test/HermesIntlNumberFormatTest.java
+++ b/android/intltest/java/com/facebook/hermes/test/HermesIntlNumberFormatTest.java
@@ -11,7 +11,7 @@ import java.util.HashSet;
 import java.util.Set;
 import org.junit.Test;
 
-// Run "./gradlew :intltest:prepareTests" from the root to download and copy the test files to the
+// Run "./gradlew :intltest:prepareTests" from the root to copy the test files to the
 // APK assets.
 public class HermesIntlNumberFormatTest extends HermesIntlTest262Base {
 

--- a/android/intltest/java/com/facebook/hermes/test/HermesIntlNumberPrototypeTest.java
+++ b/android/intltest/java/com/facebook/hermes/test/HermesIntlNumberPrototypeTest.java
@@ -11,7 +11,7 @@ import java.util.HashSet;
 import java.util.Set;
 import org.junit.Test;
 
-// Run "./gradlew :intltest:prepareTests" from the root to download and copy the test files to the
+// Run "./gradlew :intltest:prepareTests" from the root to copy the test files to the
 // APK assets.
 public class HermesIntlNumberPrototypeTest extends HermesIntlTest262Base {
 

--- a/android/intltest/java/com/facebook/hermes/test/HermesIntlStringPrototypeTest.java
+++ b/android/intltest/java/com/facebook/hermes/test/HermesIntlStringPrototypeTest.java
@@ -10,7 +10,7 @@ import java.util.HashSet;
 import java.util.Set;
 import org.junit.Test;
 
-// Run "./gradlew :intltest:prepareTests" from the root to download and copy the test files to the
+// Run "./gradlew :intltest:prepareTests" from the root to copy the test files to the
 // APK assets.
 public class HermesIntlStringPrototypeTest extends HermesIntlTest262Base {
 

--- a/android/intltest/java/com/facebook/hermes/test/HermesIntlTest262Base.java
+++ b/android/intltest/java/com/facebook/hermes/test/HermesIntlTest262Base.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-// Run "./gradlew :intltest:prepareTests" from the root to download and copy the test files to the
+// Run "./gradlew :intltest:prepareTests" from the root to copy the test files to the
 // APK assets.
 public class HermesIntlTest262Base extends InstrumentationTestCase {
 

--- a/lib/VM/JSLib/Intl.cpp
+++ b/lib/VM/JSLib/Intl.cpp
@@ -1552,7 +1552,7 @@ CallResult<HermesValue> intlStringPrototypeToLocaleLowerCase(
     void *,
     Runtime *runtime,
     NativeArgs args) {
-  if (args.getThisArg().isUndefined() || args.getThisArg().isNumber()) {
+  if (args.getThisArg().isUndefined() || args.getThisArg().isNull()) {
     return runtime->raiseTypeError(
         "String.prototype.localeCompare called on null or undefined");
   }
@@ -1580,7 +1580,7 @@ CallResult<HermesValue> intlStringPrototypeToLocaleUpperCase(
     void *,
     Runtime *runtime,
     NativeArgs args) {
-  if (args.getThisArg().isUndefined() || args.getThisArg().isNumber()) {
+  if (args.getThisArg().isUndefined() || args.getThisArg().isNull()) {
     return runtime->raiseTypeError(
         "String.prototype.localeCompare called on null or undefined");
   }


### PR DESCRIPTION
Summary:
Instead of downloading test262 each time, allow the Intl tests to use
an existing downloaded test262. This brings them in line with how our
other test262 runner works.

Differential Revision: D32040806

