### PR TITLE
Update test262 for Android Intl

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -596,7 +596,7 @@ jobs:
             # Check out test262 at a pinned revision to reduce flakiness
             git clone https://github.com/tc39/test262
             cd test262
-            git checkout c27f6a5b9a30c219b3b95769d52dc587a9af61ab
+            git checkout 19da3ca0757248f7595ee09d532bb83dd438f2b5
       - run:
           name: Build Hermes Compiler
           command: |

--- a/android/intltest/java/com/facebook/hermes/test/HermesIntlDateFormatTest.java
+++ b/android/intltest/java/com/facebook/hermes/test/HermesIntlDateFormatTest.java
@@ -120,9 +120,9 @@ public class HermesIntlDateFormatTest extends HermesIntlTest262Base {
                 // timeStyle: "" }) throws RangeError
                 // Expected a RangeError to be thrown
                 // but no exception was thrown at all
-                "constructor-options-timeStyle-valid.js" // Expected SameValue(«undefined», «full»)
+                "constructor-options-timeStyle-valid.js", // Expected SameValue(«undefined», «full»)
                 // to be true
-                ));
+                "constructor-options-timeZoneName-valid.js"));
 
     Set<String> testIssuesList =
         new HashSet<>(
@@ -192,9 +192,9 @@ public class HermesIntlDateFormatTest extends HermesIntlTest262Base {
                 // night») to be true
                 "dayPeriod-long-en.js", // 00:00, long format Expected SameValue(«12/12/2017», «at
                 // night») to be true
-                "fractionalSecondDigits.js" // 1 fractionalSecondDigits round down Expected
+                "fractionalSecondDigits.js", // 1 fractionalSecondDigits round down Expected
                 // SameValue(«02:03», «02:03.2») to be true
-                ));
+                "temporal-objects-resolved-time-zone.js"));
 
     // ICU APIs not available prior to 24.
     Set<String> pre24Issues = new HashSet<>();
@@ -228,9 +228,9 @@ public class HermesIntlDateFormatTest extends HermesIntlTest262Base {
                 // SameValue(«5», «1») to be true
                 "dayPeriod-long-en.js", // length should be 1, 00:00, long format Expected
                 // SameValue(«5», «1») to be true
-                "dayPeriod-short-en.js" // length should be 1, 00:00, short format Expected
+                "dayPeriod-short-en.js", // length should be 1, 00:00, short format Expected
                 // SameValue(«5», «1») to be true
-                ));
+                "temporal-objects-resolved-time-zone.js"));
 
     // ICU APIs not available prior to 24.
     Set<String> pre24Issues = new HashSet<>();

--- a/android/intltest/java/com/facebook/hermes/test/HermesIntlNumberFormatTest.java
+++ b/android/intltest/java/com/facebook/hermes/test/HermesIntlNumberFormatTest.java
@@ -39,12 +39,13 @@ public class HermesIntlNumberFormatTest extends HermesIntlTest262Base {
                 // thrown.
                 "currency-digits.js", // Didn't get correct minimumFractionDigts for currency AFN.
                 // Expected SameValue(«0», «2») to be true
-                "constructor-unit.js" // com.facebook.hermes.intl.JSRangeErrorException: Unknown
+                "constructor-unit.js", // com.facebook.hermes.intl.JSRangeErrorException: Unknown
                 // unit: acre-per-acre .. We support only units directly known
                 // to
                 // https://developer.android.com/reference/android/icu/util/MeasureUnit ..
                 // MeasureFormat.format requires an instance of MeasureUnit.
-                ));
+                "constructor-options-roundingMode-invalid.js",
+                "constructor-options-throwing-getters-rounding-mode.js"));
 
     Set<String> testIssues =
         new HashSet<>(
@@ -122,10 +123,11 @@ public class HermesIntlNumberFormatTest extends HermesIntlTest262Base {
     Set<String> deviations =
         new HashSet<>(
             Arrays.asList(
-                "order.js" // // Expected SameValue(«Object», «Intl.NumberFormat») to be true ..
+                "order.js", // Expected SameValue(«Object», «Intl.NumberFormat») to be true ..
                 // Test expects new Intl.NumberFormat().toString() to return "[object
                 // Intl.NumberFormat]" which Firefox does.. but hermes (and Chrome)
                 // returns "[object Object]:
+                "roundingMode.js" // Not implemented
                 ));
 
     Set<String> skipList = deviations;
@@ -176,7 +178,6 @@ public class HermesIntlNumberFormatTest extends HermesIntlTest262Base {
       icuIssues.addAll(
           Arrays.asList(
               "engineering-scientific-de-DE.js", // Expected SameValue(«-∞E0», «-∞») to be true
-              "engineering-scientific-zh-TW.js", // Expected SameValue(«-∞E0», «-∞») to be true
               "engineering-scientific-ja-JP.js", // Expected SameValue(«-∞E0», «-∞») to be true
               "numbering-systems.js", // numberingSystem: diak, digit: 0 Expected SameValue(«0»,
               // «𑥐») to be true
@@ -209,8 +210,7 @@ public class HermesIntlNumberFormatTest extends HermesIntlTest262Base {
           Arrays.asList(
               "notation-compact-ko-KR.js", // Expected SameValue(«9,900만», «9877만») to be true
               "notation-compact-en-US.js", // Expected SameValue(«990M», «988M») to be true
-              "notation-compact-ja-JP.js", // Expected SameValue(«9,900万», «9877万») to be true
-              "notation-compact-zh-TW.js" // Expected SameValue(«9,900萬», «9877萬») to be true
+              "notation-compact-ja-JP.js" // Expected SameValue(«9,900万», «9877万») to be true
               ));
     }
 
@@ -221,7 +221,6 @@ public class HermesIntlNumberFormatTest extends HermesIntlTest262Base {
           Arrays.asList(
               "unit-ko-KR.js", // : Expected SameValue(«-987», «-987km/h») to be true
               "unit-de-DE.js", // : Expected SameValue(«-987», «-987 km/h») to be true
-              "unit-zh-TW.js", // : Expected SameValue(«-987», «-987 公里/小時») to be true
               "format-fraction-digits-precision.js", // : Unexpected formatted 1.1 for
               // en-US-u-nu-hanidec and options
               // {"useGrouping":false,"minimumIntegerDigits":3,"minimumFractionDigits":1,"maximumFractionDigits":3}: 〇〇〈.〈
@@ -235,11 +234,32 @@ public class HermesIntlNumberFormatTest extends HermesIntlTest262Base {
               ));
     }
 
+    Set<String> roundingMode = new HashSet<>();
+    roundingMode.addAll(
+        Arrays.asList(
+            "format-rounding-mode-trunc.js",
+            "format-rounding-mode-ceil.js",
+            "format-rounding-mode-floor.js",
+            "format-rounding-mode-half-floor.js",
+            "format-rounding-mode-half-even.js",
+            "format-rounding-mode-half-trunc.js",
+            "format-rounding-mode-half-ceil.js",
+            "format-rounding-mode-expand.js"));
+
+    // There seem to be significant gaps in the implementation for zh-TW, even
+    // with the latest API.
+    Set<String> zh_TW = new HashSet<>();
+    zh_TW.addAll(
+        Arrays.asList(
+            "engineering-scientific-zh-TW.js", "unit-zh-TW.js", "notation-compact-zh-TW.js"));
+
     Set<String> skipList = new HashSet<>();
     skipList.addAll(signDisplayList);
     skipList.addAll(unitIssues);
     skipList.addAll(icuIssues);
     skipList.addAll(pre24Issues);
+    skipList.addAll(roundingMode);
+    skipList.addAll(zh_TW);
 
     runTests(basePath, skipList);
   }
@@ -313,8 +333,6 @@ public class HermesIntlNumberFormatTest extends HermesIntlTest262Base {
               // SameValue(«4», «2») to be true
               "notation-compact-en-US.js", // Compact short: 987654321: parts[1].type Expected
               // SameValue(«literal», «compact») to be true
-              "engineering-scientific-zh-TW.js", // -Infinity - engineering: length Expected
-              // SameValue(«4», «2») to be true
               "engineering-scientific-ja-JP.js", // -Infinity - engineering: length Expected
               // SameValue(«4», «2») to be true
               "notation-compact-ja-JP.js", // Compact short: 987654321: parts[3].type Expected
@@ -334,12 +352,16 @@ public class HermesIntlNumberFormatTest extends HermesIntlTest262Base {
               ));
     }
 
+    Set<String> zh_TW = new HashSet<>();
+    zh_TW.addAll(Arrays.asList("engineering-scientific-zh-TW.js", "notation-compact-zh-TW.js"));
+
     Set<String> skipList = new HashSet<>();
 
     skipList.addAll(signDisplayList);
     skipList.addAll(unitList);
     skipList.addAll(icuIssues);
     skipList.addAll(pre24Issues);
+    skipList.addAll(zh_TW);
 
     runTests(basePath, skipList);
   }

--- a/android/intltest/java/com/facebook/hermes/test/HermesIntlTest262Base.java
+++ b/android/intltest/java/com/facebook/hermes/test/HermesIntlTest262Base.java
@@ -54,7 +54,6 @@ public class HermesIntlTest262Base extends InstrumentationTestCase {
     evalScriptFromAsset(rt, "test262/harness/compareArray.js");
     evalScriptFromAsset(rt, "test262/harness/dateConstants.js");
     evalScriptFromAsset(rt, "test262/harness/isConstructor.js");
-    evalScriptFromAsset(rt, "test262/harness/arrayContains.js");
   }
 
   protected void runTests(String basePath) throws IOException {


### PR DESCRIPTION
Summary:
Update the version of test262 used in Android Intl testing, and update
the skiplists.

Differential Revision: D32233285

