### PR TITLE
Use latest node in e2e test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,9 +39,9 @@ workflows:
             - windows
       - test-emscripten
       - test-linux
-      - test-e2e
-          # requires:
-          #   - npm
+      - test-e2e:
+          requires:
+            - npm
       - test-e2e-intl
 
 # Default settings for Apple jobs (apple-runtime, test-apple-runtime)
@@ -565,7 +565,6 @@ jobs:
       - run:
           name: Prepare RNTester
           command: |
-            node --version
             git clone https://github.com/facebook/react-native
             cd react-native
             yarn install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -562,6 +562,7 @@ jobs:
           at: /tmp/input
       - node/install:
           install-yarn: true
+          lts: true
       - run:
           name: Prepare RNTester
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -565,7 +565,7 @@ jobs:
             npm install --global yarn
             git clone https://github.com/facebook/react-native
             cd react-native
-            yarn install
+            yarn install --ignore-engines
             npm install /tmp/input/hermes-engine-v*.tgz
             echo "console.log('Using Hermes: ' + (global.HermesInternal != null));" >> packages/rn-tester/js/RNTesterApp.android.js
       - android/start-emulator-and-run-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,9 +38,9 @@ workflows:
             - windows
       - test-emscripten
       - test-linux
-      - test-e2e:
-          requires:
-            - npm
+      - test-e2e
+          # requires:
+          #   - npm
       - test-e2e-intl
 
 # Default settings for Apple jobs (apple-runtime, test-apple-runtime)
@@ -559,11 +559,12 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/input
+      - node/install:
+          install-yarn: true
       - run:
           name: Prepare RNTester
           command: |
-            nvm install node
-            npm install --global yarn
+            node --version
             git clone https://github.com/facebook/react-native
             cd react-native
             yarn install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ version: 2.1
 orbs:
   win: circleci/windows@2.4.0
   android: circleci/android@1.0.3
+  node: circleci/node@4.7.0
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -562,10 +562,11 @@ jobs:
       - run:
           name: Prepare RNTester
           command: |
+            nvm install node
             npm install --global yarn
             git clone https://github.com/facebook/react-native
             cd react-native
-            yarn install --ignore-engines
+            yarn install
             npm install /tmp/input/hermes-engine-v*.tgz
             echo "console.log('Using Hermes: ' + (global.HermesInternal != null));" >> packages/rn-tester/js/RNTesterApp.android.js
       - android/start-emulator-and-run-tests:


### PR DESCRIPTION
Some RN dependencies have hard requirements on recent versions of node, causing the test to fail. Make sure we're always using the newest version of node.