### PR TITLE
Fix -Wstring-conversion warnings

### DIFF
--- a/API/hermes/TracingRuntime.cpp
+++ b/API/hermes/TracingRuntime.cpp
@@ -691,7 +691,7 @@ std::unique_ptr<TracingHermesRuntime> makeTracingHermesRuntime(
         traceScratchPath.c_str(),
         ec.message().c_str());
     return makeTracingHermesRuntime(
-        std::move(hermesRuntime), runtimeConfig, nullptr, "");
+        std::move(hermesRuntime), runtimeConfig, nullptr, true);
   }
 
   return makeTracingHermesRuntimeImpl(


### PR DESCRIPTION
Summary: As is always the risk with overloaded function names, this callsite is ambiguous with its intent.  It was either A) passing `""` to a `bool` argument or B) missing the last argument.  Preserving the logic as-is by replacing `""` with `true`.

Differential Revision: D33796848

