### PR TITLE
Moving ELI5 video above Features

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -58,7 +58,7 @@ function VideoContainer() {
               width="560"
               height="315"
               src="https://www.youtube.com/embed/JsppO1HUYx4"
-              title="Explain Like I'm 5: Infer"
+              title="Explain Like I'm 5: Hermes"
               frameBorder="0"
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
               allowFullScreen

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -48,18 +48,22 @@ const features = [
   },
 ];
 
-function ELIVideo() {
+function VideoContainer() {
   return (
-    <div className={styles.videoContainer}>
-      <div className={styles.videoWrapper}>
-        <iframe
-          width="560"
-          height="315"
-          src="https://www.youtube.com/embed/JsppO1HUYx4"
-          title="Explained Like I'm 5: Hermes"
-          frameborder="0"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-          allowfullscreen="true"></iframe>
+    <div className="container text--center margin-bottom--xl margin-top--lg">
+      <div className="row">
+        <div className="col">
+          <h2>Check it out in the intro video</h2>
+            <iframe
+              width="560"
+              height="315"
+              src="https://www.youtube.com/embed/JsppO1HUYx4"
+              title="Explain Like I'm 5: Infer"
+              frameBorder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+            />
+        </div>
       </div>
     </div>
   );
@@ -89,6 +93,7 @@ function Home() {
         </div>
       </header>
       <main>
+        <VideoContainer />
         {features && features.length && (
           <section className={styles.features}>
             <div className="container">
@@ -114,11 +119,6 @@ function Home() {
             </div>
           </section>
         )}
-        <div className={classnames(styles.videoSection)}>
-          <div className="container">
-            <ELIVideo />
-          </div>
-        </div>
       </main>
     </Layout>
   );

--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -42,27 +42,3 @@
   height: 180px;
   width: 180px;
 }
-
-.videoSection {
-  padding: 4rem 0;
-  padding-top: 1rem;
-}
-
-.videoContainer {
-  max-width: 560px;
-  margin: 0 auto;
-}
-
-.videoWrapper {
-  position: relative;
-  padding-bottom: 56.25%; /* 16:9 */
-  height: 0;
-}
-
-.videoWrapper iframe {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `main`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/HEAD/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.
-->

## Summary

Here at Meta Open Source, we've been creating short-form videos to explain Meta OSS projects in the simplest terms possible. We started embedding these videos into project pages as you can see in Docusaurus home page](https://docusaurus.io/) and found that it's best to position the videos above Features as it acts as a short intro for the projects.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
-->

We started adding 

## Test Plan

This is how it's rendered:
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/12485205/154297592-f83df61b-dbe9-4601-9547-d27f0b827545.png">

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes the user interface.
-->
