### PR TITLE
Bump CMake Android version to 3.18.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
       - run:
           name: Set up workspace and install dependencies
           command: |
-            yes | sdkmanager "cmake;3.10.2.4988404" &
+            yes | sdkmanager "cmake;3.18.1" &
             mkdir -p "$HERMES_WS_DIR" "$HERMES_WS_DIR/output"
             ln -sf "$PWD" "$HERMES_WS_DIR/hermes"
             sudo apt-get update
@@ -80,7 +80,7 @@ jobs:
             sudo cp /usr/bin/ninja /usr/bin/ninja.real
             # See top comment
             printf '%s\n' '#!/bin/sh' 'ninja.real -j4 "$@" || ninja.real -j1 "$@"' | sudo tee /usr/bin/ninja
-            ln -sf /usr/bin/ninja /opt/android/sdk/cmake/3.10.2.4988404/bin/ninja
+            ln -sf /usr/bin/ninja /opt/android/sdk/cmake/3.18.1/bin/ninja
       - run:
           name: Build Hermes Compiler
           command: |
@@ -592,7 +592,7 @@ jobs:
       - run:
           name: Setup dependencies
           command: |
-            (yes | sdkmanager "cmake;3.10.2.4988404" --verbose) || true
+            (yes | sdkmanager "cmake;3.18.1" --verbose) || true
             # Check out test262 at a pinned revision to reduce flakiness
             git clone https://github.com/tc39/test262
             cd test262

--- a/android/cppruntime/build.gradle
+++ b/android/cppruntime/build.gradle
@@ -29,7 +29,7 @@ android {
 
   externalNativeBuild {
     cmake {
-      version "3.10.2"
+      version "3.18.1"
       path "src/main/cpp/CMakeLists.txt"
       buildStagingDirectory = "${rootProject.ext.hermes_ws}/staging/cppruntime"
       buildStagingDirectory.mkdirs()

--- a/android/hermes/build.gradle
+++ b/android/hermes/build.gradle
@@ -36,7 +36,7 @@ android {
 
   externalNativeBuild {
     cmake {
-      version "3.10.2"
+      version "3.18.1"
       path "../../CMakeLists.txt"
       buildStagingDirectory = "${rootProject.ext.hermes_ws}/staging/hermes"
       buildStagingDirectory.mkdirs()

--- a/android/intltest/build.gradle
+++ b/android/intltest/build.gradle
@@ -84,7 +84,7 @@ android {
 
   externalNativeBuild {
     cmake {
-      version "3.10.2"
+      version "3.18.1"
       path "../../CMakeLists.txt"
       buildStagingDirectory = "${rootProject.ext.hermes_ws}/staging/intl"
       buildStagingDirectory.mkdirs()


### PR DESCRIPTION
Summary:
This Diff attemps to bump the CMake version used to build hermes for Android to the latest one `3.18.1`. That's the same version used inside React Native and will reduce discrepancies between the two build pipelines.

See here: https://github.com/react-native-community/docker-android/blob/b84350256b5361d30e69c6148ac17b5acd2df2cf/Dockerfile#L112

Differential Revision: D34681716

