### PR TITLE
Align Android dependency versions between RN and Hermes

### DIFF
--- a/android/hermes/build.gradle
+++ b/android/hermes/build.gradle
@@ -100,9 +100,9 @@ android {
 
   dependencies {
     implementation 'com.facebook.fbjni:fbjni:0.2.2'
-    intlImplementation 'com.facebook.soloader:soloader:0.9.0'
-    intlImplementation 'com.facebook.yoga:proguard-annotations:1.14.1'
-    intlImplementation "androidx.annotation:annotation:1.1.0"
+    intlImplementation 'com.facebook.soloader:soloader:0.10.3'
+    intlImplementation 'com.facebook.yoga:proguard-annotations:1.19.0'
+    intlImplementation "androidx.annotation:annotation:1.3.0"
   }
 
   packagingOptions {

--- a/android/intltest/build.gradle
+++ b/android/intltest/build.gradle
@@ -103,13 +103,11 @@ android {
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     androidTestImplementation 'org.easytesting:fest-assert-core:2.0M10'
-    androidTestImplementation 'com.facebook.soloader:soloader:0.9.0'
-    androidTestImplementation 'com.facebook.yoga:proguard-annotations:1.14.1'
-  }
+    androidTestImplementation 'com.facebook.soloader:soloader:0.10.3'
+    androidTestImplementation 'com.facebook.yoga:proguard-annotations:1.19.0'
 
-  dependencies {
     implementation 'com.facebook.fbjni:fbjni:0.2.2'
-    implementation "androidx.annotation:annotation:1.1.0"
+    implementation "androidx.annotation:annotation:1.3.0"
     implementation "androidx.annotation:annotation-experimental:1.0.0"
   }
 


### PR DESCRIPTION
Summary:
This Diff aligns the Android deps versions to the one used inside RN. As React Native is using higher version of several dependencies, I'm bumping those versions inside Hermes as well.

Gradle will always resolve the highest available version for any dependency. Therefore those are safe to bump. We will catch any incompatibility early on in the Hermes build process by doing this.

Differential Revision: D34681789

