### PR TITLE
Export public directory from Hermes API targets

### DIFF
--- a/API/hermes/CMakeLists.txt
+++ b/API/hermes/CMakeLists.txt
@@ -38,7 +38,7 @@ add_hermes_library(synthTraceParser SynthTraceParser.cpp LINK_LIBS hermesSupport
 set(HERMES_ENABLE_EH OFF)
 
 # compileJS uses neither exceptions nor RTTI
-add_hermes_library(compileJS STATIC CompileJS.cpp)
+add_hermes_library(compileJS STATIC CompileJS.cpp LINK_LIBS hermesPublic)
 
 # Restore EH and RTTI (Note: At the time of writing, there is no usage of
 # add_hermes_library either after this line in this file or in a sub directory.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -593,7 +593,6 @@ include_directories(
 include_directories(BEFORE
   ${CMAKE_CURRENT_BINARY_DIR}/include
   ${CMAKE_CURRENT_SOURCE_DIR}/include
-  ${CMAKE_CURRENT_SOURCE_DIR}/public
   ${CMAKE_CURRENT_SOURCE_DIR}/external/flowparser/include
   ${CMAKE_CURRENT_SOURCE_DIR}/external
   )

--- a/lib/BCGen/HBC/CMakeLists.txt
+++ b/lib/BCGen/HBC/CMakeLists.txt
@@ -34,6 +34,7 @@ add_hermes_library(hermesHBCBackend
   hermesInst
   hermesSourceMap
   hermesAST
+  hermesPublic
 )
 
 add_hermes_library(hermesHBCBackendLean
@@ -46,6 +47,7 @@ add_hermes_library(hermesHBCBackendLean
   UniquingFilenameTable.cpp
   LINK_LIBS
   hermesSupport
+  hermesPublic
 )
 
 target_compile_definitions(hermesHBCBackendLean PUBLIC HERMESVM_LEAN)

--- a/lib/Platform/Intl/CMakeLists.txt
+++ b/lib/Platform/Intl/CMakeLists.txt
@@ -6,18 +6,16 @@
 if(HERMES_ENABLE_INTL)
   if(HERMES_IS_ANDROID)
     add_hermes_library(hermesPlatformIntl STATIC PlatformIntlAndroid.cpp
-        LINK_LIBS
-        fbjni::fbjni
+        LINK_LIBS fbjni::fbjni hermesPublic
     )
     target_compile_options(hermesPlatformIntl PRIVATE -frtti -fexceptions)
   elseif(APPLE)
     add_hermes_library(hermesPlatformIntl STATIC PlatformIntlApple.mm
-        LINK_LIBS
-        ${FOUNDATION}
+        LINK_LIBS ${FOUNDATION} hermesPublic
     )
     # Work around a bug in unity builds where it tries to build Obj-C as C++.
     set_target_properties(hermesPlatformIntl PROPERTIES UNITY_BUILD false)
   else()
-    add_hermes_library(hermesPlatformIntl STATIC PlatformIntlDummy.cpp)
+    add_hermes_library(hermesPlatformIntl STATIC PlatformIntlDummy.cpp LINK_LIBS hermesPublic)
   endif()
 endif()

--- a/lib/VM/CMakeLists.txt
+++ b/lib/VM/CMakeLists.txt
@@ -162,6 +162,7 @@ set(link_libs
   hermesSupport
   hermesPlatform
   hermesInternalBytecode
+  hermesPublic
   dtoa
 )
 

--- a/public/hermes/Public/CMakeLists.txt
+++ b/public/hermes/Public/CMakeLists.txt
@@ -3,5 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+add_library(hermesPublic INTERFACE)
+target_include_directories(hermesPublic INTERFACE ../../)
+
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/public/hermes/Public" DESTINATION include/hermes
   FILES_MATCHING PATTERN "*.h")

--- a/unittests/API/CMakeLists.txt
+++ b/unittests/API/CMakeLists.txt
@@ -25,7 +25,7 @@ set(SamplingProfilerSources
 set(HERMES_LINK_COMPONENTS LLVHSupport)
 
 # Build SegmentTestCompile without EH and RTTI
-add_hermes_library(SegmentTestCompile STATIC ${APISegmentTestCompileSources})
+add_hermes_library(SegmentTestCompile STATIC ${APISegmentTestCompileSources} LINK_LIBS hermesHBCBackend)
 
 # Turn on EH and RTTI for APITests
 set(HERMES_ENABLE_EH ON)

--- a/unittests/Support/CMakeLists.txt
+++ b/unittests/Support/CMakeLists.txt
@@ -32,5 +32,6 @@ add_hermes_unittest(HermesSupportTests
 target_link_libraries(HermesSupportTests
  hermesPlatform
  hermesSupport
+ hermesPublic
  dtoa
  )


### PR DESCRIPTION
Summary:
The headers under the `public` directory are not exported by our API
targets, which means that something taking a dependency on those
targets won't automatically get the headers.

This diff creates a new `hermesPublic` header-only target to get the
headers exported correctly.

An alternative approach could have been to continue including those
headers in our other targets normally, and then only exporting them at
the API level. This would be more consistent with how the rest of our
build works, since we don't usually rely on include directories
exported from targets. However, this approach would have the drawback
of being  harder to test and maintain, since we don't have testing for
which headers are exported from the API level.

Differential Revision: D34673711

