### PR TITLE
Fix broken test-e2e by providing a symlink to ninja

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -564,13 +564,15 @@ jobs:
           install-yarn: true
           lts: true
       - run:
-          name: Setup dependencies
+          name: Set up workspace and install dependencies
           command: |
             (yes | sdkmanager "cmake;3.18.1" --verbose) || true
+            ln -sf /usr/bin/ninja /opt/android/sdk/cmake/3.18.1/bin/ninja
+
       - run:
           name: Prepare RNTester
           command: |
-            git clone https://github.com/facebook/react-native
+            git clone --depth=1 https://github.com/facebook/react-native
             cd react-native
             yarn install
             npm install /tmp/input/hermes-engine-v*.tgz


### PR DESCRIPTION
## Summary

This should address the failures of `test-e2e` as a symlink to `ninja` was missing.

## Test Plan

I wasn't able to verify on my CircleCI instance because the build was taking too long. Deferring to Upstream CI instance.