### PR TITLE
Fix broken test-e2e by providing a symlink to ninja

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -567,10 +567,12 @@ jobs:
           name: Setup dependencies
           command: |
             (yes | sdkmanager "cmake;3.18.1" --verbose) || true
+            sudo apt-get update
+            sudo apt-get install -y ninja-build
       - run:
           name: Prepare RNTester
           command: |
-            git clone https://github.com/facebook/react-native
+            git clone --depth=1 https://github.com/facebook/react-native
             cd react-native
             yarn install
             npm install /tmp/input/hermes-engine-v*.tgz


### PR DESCRIPTION
Summary: This should address the failures of `test-e2e` as a symlink to `ninja` was missing.

Differential Revision: D34863751

