### PR TITLE
Use Debian Buster for linux jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
 
   linux:
     docker:
-      - image: debian:stretch
+      - image: debian:buster
     environment:
       - HERMES_WS_DIR: /tmp/hermes
       - TERM: dumb
@@ -171,7 +171,7 @@ jobs:
     # linked release mode, so this job is just a duplicate of the Linux job
     # that builds in dynamically linked debug mode
     docker:
-      - image: debian:stretch
+      - image: debian:buster
     environment:
       - HERMES_WS_DIR: /tmp/hermes
       - TERM: dumb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-cmake_minimum_required(VERSION 3.7.0)
+cmake_minimum_required(VERSION 3.8.0)
 
 # Set the VERSION variables based on the project command
 if (POLICY CMP0048)


### PR DESCRIPTION
Summary: Linux tests are failing because the default version of CMake in Debian stretch, upgrade to Buster.

Differential Revision: D34907878

