### PR TITLE
Simplify CircleCI emscripten build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -464,69 +464,34 @@ jobs:
   # test to build with emscripten, not run
   test-emscripten:
     docker:
-      # emcc requires Python 3.7+
-      - image: debian:buster
-    environment:
-      - HERMES_WS_DIR: /tmp/hermes
-      - EMSDK: /tmp/emsdk
-      - TERM: dumb
-      - DEBIAN_FRONTEND: noninteractive
+      - image: emscripten/emsdk:2.0.9
+    working_directory: /root
     steps:
       - run:
           name: Install dependencies
           command: |
-            apt-get update
-            apt-get install -y \
-                sudo git openssh-client cmake ninja-build python \
-                build-essential libreadline-dev libicu-dev zip python3 \
-                curl
-      - run:
-          name: Setup Emscripten
-          command: |
-            set -x
-            EMSDK_VERSION=2.0.9
-            curl -sfLO "https://github.com/emscripten-core/emsdk/archive/$EMSDK_VERSION.tar.gz"
-            tar -xf "$EMSDK_VERSION.tar.gz"
-            mv "emsdk-$EMSDK_VERSION" "$EMSDK"
-            rm "$EMSDK_VERSION.tar.gz"
-            "$EMSDK/emsdk" install latest
-            "$EMSDK/emsdk" activate latest
-      - checkout
-      - run:
-          name: Set up workspace
-          command: |
-            mkdir -p "$HERMES_WS_DIR"
-            ln -sf "$PWD" "$HERMES_WS_DIR/hermes"
-            sudo cp /usr/bin/ninja /usr/bin/ninja.real
-            # See top comment
-            printf '%s\n' '#!/bin/sh' 'ninja.real -j4 "$@" || ninja.real -j1 "$@"' | sudo tee /usr/bin/ninja
+            apt update
+            apt install -y libicu-dev
+      - checkout:
+          path: hermes
       - run:
           name: Build Hermes Compiler
           command: |
-            cd "$HERMES_WS_DIR"
-            cmake -S hermes -B build_host_hermesc -G Ninja
-            # Build the Hermes compiler so that the cross compiler build can
-            # access it to build the VM
-            cmake --build ./build_host_hermesc --target hermesc
+            cmake -S hermes -B build_host_hermesc
+            cmake --build ./build_host_hermesc --target hermesc -j 4
       - run:
           name: Build Hermes with Emscripten
           command: |
-            set -x
-            cd "$HERMES_WS_DIR"
-            source "$EMSDK/emsdk_env.sh"
-            "$EMSDK"/upstream/emscripten/emcc --version
-
-            cmake ./hermes \
-                -Bembuild \
-                -GNinja \
+            cmake -S hermes -B embuild \
                 -DCMAKE_BUILD_TYPE=Release  \
                 -DCMAKE_EXE_LINKER_FLAGS="-s NODERAWFS=1 -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s LLD_REPORT_UNDEFINED=1" \
                 -DCMAKE_TOOLCHAIN_FILE="$EMSDK/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake" \
                 -DIMPORT_HERMESC="$PWD/build_host_hermesc/ImportHermesc.cmake"
-            cmake --build ./embuild --target hermes
-            cmake --build ./embuild --target hermesc
-            cmake --build ./embuild --target emhermesc
+            cmake --build ./embuild --target hermes -j 4
+            cmake --build ./embuild --target hermesc -j 4
+            cmake --build ./embuild --target emhermesc -j 4
             EMHERMESC="$PWD/embuild/bin/emhermesc.js" node ./hermes/tools/emhermesc/test.js
+
   test-e2e:
     executor:
       name: android/android-machine


### PR DESCRIPTION
Simplify the emscripten build in CircleCI by using a docker image with
emsdk already installed, so that we don't need to do it manually.