### PR TITLE
Split out creating the macos CLI from the framework

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,9 +300,10 @@ jobs:
           environment:
             TAR_NAME: hermes-cli-darwin.tar.gz
           command: |
-            mkdir output
-            tar -czvf output/${TAR_NAME} build/bin/hermes build/bin/hvm \
-              build/bin/hbcdump build/bin/hermesc build_hdb/bin/hdb
+            mkdir output staging
+            cp build/bin/hermes build/bin/hvm build/bin/hbcdump \
+              build/bin/hermesc build_hdb/bin/hdb staging
+            tar -C staging -czvf output/${TAR_NAME} .
             shasum -a 256 output/${TAR_NAME} > output/${TAR_NAME}.sha256
       - store_artifacts:
           path: output

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ workflows:
     jobs:
       - android
       - linux
+      - macos
       - build-apple-runtime
       - test-macos
       - test-apple-runtime:
@@ -37,6 +38,7 @@ workflows:
             - linux
             - package-apple-runtime
             - windows
+            - macos
       - test-emscripten
       - test-linux
       - test-e2e
@@ -259,15 +261,6 @@ jobs:
 
             tar -C /tmp/cocoapods-package-root/ -czvf /tmp/hermes/output/hermes-runtime-darwin-v$(get_release_version).tar.gz .
       - run:
-          name: Package the CLI
-          command: |
-            . ./utils/build-apple-framework.sh
-
-            mkdir -p /tmp/hermes-cli-root
-            cp -R ./destroot/bin/* /tmp/hermes-cli-root
-
-            tar -C /tmp/hermes-cli-root/ -czvf /tmp/hermes/output/hermes-cli-darwin-v$(get_release_version).tar.gz .
-      - run:
           name: Checksum artifacts
           command: |
             cd /tmp/hermes/output
@@ -279,6 +272,46 @@ jobs:
           path: /tmp/hermes/output/
       - persist_to_workspace:
           root: /tmp/hermes/output/
+          paths:
+            - .
+
+  macos:
+    macos:
+      xcode: 13.4.1
+    steps:
+      - checkout:
+          path: hermes
+      - run:
+          name: Install dependencies
+          command: |
+            brew install cmake ninja
+      - run:
+          name: Build macOS CLI
+          environment:
+            RELEASE_FLAGS: -DCMAKE_BUILD_TYPE=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=True -DCMAKE_OSX_ARCHITECTURES=x86_64;arm64
+          command: |
+            cmake -S hermes -B build -G Ninja ${RELEASE_FLAGS} -DHERMES_ENABLE_DEBUGGER=False
+            cmake --build ./build  --target hermes hvm hbcdump hermesc check-hermes
+            cmake -S hermes -B build_hdb -G Ninja ${RELEASE_FLAGS}
+            cmake --build ./build_hdb  --target hdb check-hermes
+      - run:
+          name: Create CLI tarball
+          command: |
+            mkdir output
+            tar -czvf output/hermes-cli-darwin-${CIRCLE_BRANCH}.tar.gz \
+              build/bin/hermes build/bin/hvm build/bin/hbcdump build/bin/hermesc build_dbg/bin/hdb
+      - run:
+          name: Checksum artifacts
+          command: |
+            cd output
+            for file in *
+            do
+              sha256sum "$file" > "$file.sha256"
+            done
+      - store_artifacts:
+          path: output
+      - persist_to_workspace:
+          root: output
           paths:
             - .
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,18 +297,13 @@ jobs:
             cmake --build ./build_hdb  --target hdb check-hermes
       - run:
           name: Create CLI tarball
+          environment:
+            TAR_NAME: hermes-cli-darwin.tar.gz
           command: |
             mkdir output
-            tar -czvf output/hermes-cli-darwin-${CIRCLE_BRANCH}.tar.gz \
-              build/bin/hermes build/bin/hvm build/bin/hbcdump build/bin/hermesc build_dbg/bin/hdb
-      - run:
-          name: Checksum artifacts
-          command: |
-            cd output
-            for file in *
-            do
-              sha256sum "$file" > "$file.sha256"
-            done
+            tar -czvf output/${TAR_NAME} build/bin/hermes build/bin/hvm \
+              build/bin/hbcdump build/bin/hermesc build_hdb/bin/hdb
+            sha256sum output/${TAR_NAME} > output/${TAR_NAME}.sha256
       - store_artifacts:
           path: output
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,9 +292,9 @@ jobs:
             RELEASE_FLAGS: -DCMAKE_BUILD_TYPE=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=True -DCMAKE_OSX_ARCHITECTURES=x86_64;arm64
           command: |
             cmake -S hermes -B build -G Ninja ${RELEASE_FLAGS} -DHERMES_ENABLE_DEBUGGER=False
-            cmake --build ./build  --target hermes hvm hbcdump hermesc check-hermes
+            cmake --build ./build --target hermes hvm hbcdump hermesc check-hermes
             cmake -S hermes -B build_hdb -G Ninja ${RELEASE_FLAGS}
-            cmake --build ./build_hdb  --target hdb check-hermes
+            cmake --build ./build_hdb --target hdb check-hermes
       - run:
           name: Create CLI tarball
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,7 +303,7 @@ jobs:
             mkdir output
             tar -czvf output/${TAR_NAME} build/bin/hermes build/bin/hvm \
               build/bin/hbcdump build/bin/hermesc build_hdb/bin/hdb
-            sha256sum output/${TAR_NAME} > output/${TAR_NAME}.sha256
+            shasum -a 256 output/${TAR_NAME} > output/${TAR_NAME}.sha256
       - store_artifacts:
           path: output
       - persist_to_workspace:

--- a/npm/unpack-builds.js
+++ b/npm/unpack-builds.js
@@ -132,7 +132,7 @@ var inputs = [
     dest: "linux64-bin"
   },
   {
-    name: "hermes-cli-darwin-v" + releaseVersion + ".tar.gz",
+    name: "hermes-cli-darwin.tar.gz",
     dest: "osx-bin"
   }
 ]


### PR DESCRIPTION
We currently generate the CLI together with generating the framework
for macOS. However, this is not ideal for two reasons:
1. The framework is now built by React Native, so the framework CI will
be deleted soon.
2. We don't maintain the ability to fully control how the macOS CLI is
built, like turning on LTO and disabling the debugger.