### PR TITLE
Add external ArrayBuffers to JSI

### DIFF
--- a/API/hermes/TracingRuntime.cpp
+++ b/API/hermes/TracingRuntime.cpp
@@ -583,6 +583,11 @@ jsi::Array TracingRuntime::createArray(size_t length) {
   return arr;
 }
 
+jsi::ArrayBuffer TracingRuntime::createArrayBuffer(
+    std::shared_ptr<jsi::MutableBuffer> buffer) {
+  throw std::logic_error("Cannot create external ArrayBuffers in trace mode.");
+}
+
 size_t TracingRuntime::size(const jsi::Array &arr) {
   // Array size inquiries read from the length property, which is
   // non-configurable and thus cannot have side effects.

--- a/API/hermes/TracingRuntime.h
+++ b/API/hermes/TracingRuntime.h
@@ -90,6 +90,8 @@ class TracingRuntime : public jsi::RuntimeDecorator<jsi::Runtime> {
   jsi::Value lockWeakObject(jsi::WeakObject &wo) override;
 
   jsi::Array createArray(size_t length) override;
+  jsi::ArrayBuffer createArrayBuffer(
+      std::shared_ptr<jsi::MutableBuffer> buffer) override;
 
   size_t size(const jsi::Array &arr) override;
   size_t size(const jsi::ArrayBuffer &buf) override;

--- a/API/hermes/hermes.cpp
+++ b/API/hermes/hermes.cpp
@@ -737,6 +737,8 @@ class HermesRuntimeImpl final : public HermesRuntime,
   jsi::Value lockWeakObject(jsi::WeakObject &) override;
 
   jsi::Array createArray(size_t length) override;
+  jsi::ArrayBuffer createArrayBuffer(
+      std::shared_ptr<jsi::MutableBuffer> buffer) override;
   size_t size(const jsi::Array &) override;
   size_t size(const jsi::ArrayBuffer &) override;
   uint8_t *data(const jsi::ArrayBuffer &) override;
@@ -1985,6 +1987,24 @@ jsi::Array HermesRuntimeImpl::createArray(size_t length) {
   auto result = vm::JSArray::create(runtime_, length, length);
   checkStatus(result.getStatus());
   return add<jsi::Object>(result->getHermesValue()).getArray(*this);
+}
+
+jsi::ArrayBuffer HermesRuntimeImpl::createArrayBuffer(
+    std::shared_ptr<jsi::MutableBuffer> buffer) {
+  vm::GCScope gcScope(runtime_);
+  auto buf = runtime_.makeHandle(vm::JSArrayBuffer::create(
+      runtime_,
+      vm::Handle<vm::JSObject>::vmcast(&runtime_.arrayBufferPrototype)));
+  auto size = buffer->size();
+  auto *data = buffer->data();
+  auto *ctx = new std::shared_ptr<jsi::MutableBuffer>(std::move(buffer));
+  auto finalize = [](void *ctx) {
+    delete static_cast<std::shared_ptr<jsi::MutableBuffer> *>(ctx);
+  };
+  auto res = vm::JSArrayBuffer::setExternalDataBlock(
+      runtime_, buf, data, size, ctx, finalize);
+  checkStatus(res);
+  return add<jsi::Object>(buf.getHermesValue()).getArrayBuffer(*this);
 }
 
 size_t HermesRuntimeImpl::size(const jsi::Array &arr) {

--- a/API/jsi/jsi/decorator.h
+++ b/API/jsi/jsi/decorator.h
@@ -302,6 +302,10 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   Array createArray(size_t length) override {
     return plain_.createArray(length);
   };
+  ArrayBuffer createArrayBuffer(
+      std::shared_ptr<MutableBuffer> buffer) override {
+    return plain_.createArrayBuffer(std::move(buffer));
+  };
   size_t size(const Array& a) override {
     return plain_.size(a);
   };
@@ -700,6 +704,10 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
   Array createArray(size_t length) override {
     Around around{with_};
     return RD::createArray(length);
+  };
+  ArrayBuffer createArrayBuffer(
+      std::shared_ptr<MutableBuffer> buffer) override {
+    return RD::createArrayBuffer(std::move(buffer));
   };
   size_t size(const Array& a) override {
     Around around{with_};

--- a/API/jsi/jsi/jsi.cpp
+++ b/API/jsi/jsi/jsi.cpp
@@ -66,6 +66,8 @@ Value callGlobalFunction(Runtime& runtime, const char* name, const Value& arg) {
 
 Buffer::~Buffer() = default;
 
+MutableBuffer::~MutableBuffer() = default;
+
 PreparedJavaScript::~PreparedJavaScript() = default;
 
 Value HostObject::get(Runtime&, const PropNameID&) {

--- a/unittests/API/APITest.cpp
+++ b/unittests/API/APITest.cpp
@@ -10,6 +10,7 @@
 #include <hermes/CompileJS.h>
 #include <hermes/Public/JSOutOfMemoryError.h>
 #include <hermes/hermes.h>
+#include <jsi/instrumentation.h>
 
 #include <tuple>
 
@@ -103,6 +104,68 @@ TEST_F(HermesRuntimeTest, ArrayBufferTest) {
   int32_t *buffer = reinterpret_cast<int32_t *>(arrayBuffer.data(*rt));
   EXPECT_EQ(buffer[0], 1234);
   EXPECT_EQ(buffer[1], 5678);
+}
+
+class HermesRuntimeTestMethodsTest : public HermesRuntimeTestBase {
+ public:
+  HermesRuntimeTestMethodsTest()
+      : HermesRuntimeTestBase(::hermes::vm::RuntimeConfig::Builder()
+                                  .withEnableHermesInternalTestMethods(true)
+                                  .build()) {}
+};
+
+TEST_F(HermesRuntimeTestMethodsTest, ExternalArrayBufferTest) {
+  struct FixedBuffer : MutableBuffer {
+    size_t size() const override {
+      return sizeof(arr);
+    }
+    uint8_t *data() override {
+      return reinterpret_cast<uint8_t *>(arr.data());
+    }
+
+    std::array<uint32_t, 256> arr;
+  };
+
+  {
+    auto buf = std::make_shared<FixedBuffer>();
+    for (uint32_t i = 0; i < buf->arr.size(); i++)
+      buf->arr[i] = i;
+    auto arrayBuffer = ArrayBuffer(*rt, buf);
+    auto square = eval(
+        R"#(
+(function (buf) {
+  var view = new Uint32Array(buf);
+  for(var i = 0; i < view.length; i++) view[i] = view[i] * view[i];
+})
+)#");
+    square.asObject(*rt).asFunction(*rt).call(*rt, arrayBuffer);
+    for (uint32_t i = 0; i < 256; i++)
+      EXPECT_EQ(buf->arr[i], i * i);
+  }
+
+  {
+    auto buf = std::make_shared<FixedBuffer>();
+    std::weak_ptr<FixedBuffer> weakBuf(buf);
+    auto arrayBuffer = ArrayBuffer(*rt, std::move(buf));
+    auto detach = eval(
+        R"#(
+(function (buf) {
+  var view = new Uint32Array(buf);
+  HermesInternal.detachArrayBuffer(buf);
+  view[0] = 5;
+})
+)#");
+    try {
+      detach.asObject(*rt).asFunction(*rt).call(*rt, arrayBuffer);
+      FAIL() << "Expected JSIException";
+    } catch (const JSError &ex) {
+      EXPECT_NE(
+          strstr(ex.what(), "Cannot set a value into a detached ArrayBuffer"),
+          nullptr);
+    }
+    rt->instrumentation().collectGarbage("");
+    EXPECT_TRUE(weakBuf.expired());
+  }
 }
 
 TEST_F(HermesRuntimeTest, BytecodeTest) {


### PR DESCRIPTION
Summary:
Add a JSI API for constructing `ArrayBuffer`s from a user provided
`jsi::MutableBuffer`.

Changelog: [General][Added] Added ability to construct ArrayBuffers from existing memory buffers.

Reviewed By: jpporto

Differential Revision: D37744467

