### PR TITLE
Selectively enable the 64-to-32 bit truncation diagnostic

### DIFF
--- a/cmake/modules/Hermes.cmake
+++ b/cmake/modules/Hermes.cmake
@@ -397,6 +397,12 @@ if (GCC_COMPATIBLE)
   check_cxx_compiler_flag("-Wnoexcept-type" CXX_SUPPORTS_NOEXCEPT_TYPE_FLAG)
   append_if(CXX_SUPPORTS_NOEXCEPT_TYPE_FLAG "-Wno-noexcept-type" CMAKE_CXX_FLAGS)
 
+  # Enable the GCC pragma warning about 64-to-32 bit truncation, if supported.
+  check_cxx_compiler_flag("-Wshorten-64-to-32" CXX_SUPPORTS_SHORTEN_64_TO_32)
+  if (${CXX_SUPPORTS_SHORTEN_64_TO_32})
+    add_definitions(-DHERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32)
+  endif ()
+
   # Check if -Wnon-virtual-dtor warns even though the class is marked final.
   # If it does, don't add it. So it won't be added on clang 3.4 and older.
   # This also catches cases when -Wnon-virtual-dtor isn't supported by

--- a/external/llvh/include/llvh/ADT/APInt.h
+++ b/external/llvh/include/llvh/ADT/APInt.h
@@ -23,7 +23,10 @@
 #include <string>
 
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 
 namespace llvh {
 class FoldingSetNodeID;

--- a/external/llvh/include/llvh/ADT/DenseMap.h
+++ b/external/llvh/include/llvh/ADT/DenseMap.h
@@ -31,7 +31,10 @@
 #include <utility>
 
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 
 namespace llvh {
 

--- a/external/llvh/include/llvh/ADT/DenseMapInfo.h
+++ b/external/llvh/include/llvh/ADT/DenseMapInfo.h
@@ -24,7 +24,10 @@
 #include <utility>
 
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 
 namespace llvh {
 

--- a/external/llvh/include/llvh/ADT/Hashing.h
+++ b/external/llvh/include/llvh/ADT/Hashing.h
@@ -55,7 +55,10 @@
 #include <utility>
 
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 
 namespace llvh {
 

--- a/external/llvh/include/llvh/ADT/MapVector.h
+++ b/external/llvh/include/llvh/ADT/MapVector.h
@@ -27,7 +27,10 @@
 #include <vector>
 
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 
 namespace llvh {
 

--- a/external/llvh/include/llvh/ADT/SmallVector.h
+++ b/external/llvh/include/llvh/ADT/SmallVector.h
@@ -34,7 +34,10 @@
 #include <utility>
 
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 
 namespace llvh {
 

--- a/external/llvh/include/llvh/ADT/StringRef.h
+++ b/external/llvh/include/llvh/ADT/StringRef.h
@@ -22,7 +22,10 @@
 #include <utility>
 
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 
 namespace llvh {
 

--- a/external/llvh/include/llvh/IR/InstrTypes.h
+++ b/external/llvh/include/llvh/IR/InstrTypes.h
@@ -43,7 +43,10 @@
 #include <vector>
 
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 
 namespace llvh {
 

--- a/external/llvh/include/llvh/Support/MathExtras.h
+++ b/external/llvh/include/llvh/Support/MathExtras.h
@@ -24,7 +24,10 @@
 #include <type_traits>
 
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 
 #ifdef __ANDROID_NDK__
 #include <android/api-level.h>

--- a/external/llvh/patches/ifdef_around_ignore_Wshorten-64-to-32_warning.patch
+++ b/external/llvh/patches/ifdef_around_ignore_Wshorten-64-to-32_warning.patch
@@ -1,0 +1,126 @@
+diff --git a/xplat/hermes/external/llvh/include/llvh/ADT/APInt.h b/xplat/hermes/external/llvh/include/llvh/ADT/APInt.h
+--- a/xplat/hermes/external/llvh/include/llvh/ADT/APInt.h
++++ b/xplat/hermes/external/llvh/include/llvh/ADT/APInt.h
+@@ -23,7 +23,10 @@
+ #include <string>
+ 
+ #pragma GCC diagnostic push
++
++#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
+ #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
++#endif
+ 
+ namespace llvh {
+ class FoldingSetNodeID;
+diff --git a/xplat/hermes/external/llvh/include/llvh/ADT/DenseMap.h b/xplat/hermes/external/llvh/include/llvh/ADT/DenseMap.h
+--- a/xplat/hermes/external/llvh/include/llvh/ADT/DenseMap.h
++++ b/xplat/hermes/external/llvh/include/llvh/ADT/DenseMap.h
+@@ -31,7 +31,10 @@
+ #include <utility>
+ 
+ #pragma GCC diagnostic push
++
++#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
+ #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
++#endif
+ 
+ namespace llvh {
+ 
+diff --git a/xplat/hermes/external/llvh/include/llvh/ADT/DenseMapInfo.h b/xplat/hermes/external/llvh/include/llvh/ADT/DenseMapInfo.h
+--- a/xplat/hermes/external/llvh/include/llvh/ADT/DenseMapInfo.h
++++ b/xplat/hermes/external/llvh/include/llvh/ADT/DenseMapInfo.h
+@@ -24,7 +24,10 @@
+ #include <utility>
+ 
+ #pragma GCC diagnostic push
++
++#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
+ #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
++#endif
+ 
+ namespace llvh {
+ 
+diff --git a/xplat/hermes/external/llvh/include/llvh/ADT/Hashing.h b/xplat/hermes/external/llvh/include/llvh/ADT/Hashing.h
+--- a/xplat/hermes/external/llvh/include/llvh/ADT/Hashing.h
++++ b/xplat/hermes/external/llvh/include/llvh/ADT/Hashing.h
+@@ -55,7 +55,10 @@
+ #include <utility>
+ 
+ #pragma GCC diagnostic push
++
++#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
+ #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
++#endif
+ 
+ namespace llvh {
+ 
+diff --git a/xplat/hermes/external/llvh/include/llvh/ADT/MapVector.h b/xplat/hermes/external/llvh/include/llvh/ADT/MapVector.h
+--- a/xplat/hermes/external/llvh/include/llvh/ADT/MapVector.h
++++ b/xplat/hermes/external/llvh/include/llvh/ADT/MapVector.h
+@@ -27,7 +27,10 @@
+ #include <vector>
+ 
+ #pragma GCC diagnostic push
++
++#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
+ #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
++#endif
+ 
+ namespace llvh {
+ 
+diff --git a/xplat/hermes/external/llvh/include/llvh/ADT/SmallVector.h b/xplat/hermes/external/llvh/include/llvh/ADT/SmallVector.h
+--- a/xplat/hermes/external/llvh/include/llvh/ADT/SmallVector.h
++++ b/xplat/hermes/external/llvh/include/llvh/ADT/SmallVector.h
+@@ -34,7 +34,10 @@
+ #include <utility>
+ 
+ #pragma GCC diagnostic push
++
++#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
+ #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
++#endif
+ 
+ namespace llvh {
+ 
+diff --git a/xplat/hermes/external/llvh/include/llvh/ADT/StringRef.h b/xplat/hermes/external/llvh/include/llvh/ADT/StringRef.h
+--- a/xplat/hermes/external/llvh/include/llvh/ADT/StringRef.h
++++ b/xplat/hermes/external/llvh/include/llvh/ADT/StringRef.h
+@@ -22,7 +22,10 @@
+ #include <utility>
+ 
+ #pragma GCC diagnostic push
++
++#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
+ #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
++#endif
+ 
+ namespace llvh {
+ 
+diff --git a/xplat/hermes/external/llvh/include/llvh/IR/InstrTypes.h b/xplat/hermes/external/llvh/include/llvh/IR/InstrTypes.h
+--- a/xplat/hermes/external/llvh/include/llvh/IR/InstrTypes.h
++++ b/xplat/hermes/external/llvh/include/llvh/IR/InstrTypes.h
+@@ -43,7 +43,10 @@
+ #include <vector>
+ 
+ #pragma GCC diagnostic push
++
++#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
+ #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
++#endif
+ 
+ namespace llvh {
+ 
+diff --git a/xplat/hermes/external/llvh/include/llvh/Support/MathExtras.h b/xplat/hermes/external/llvh/include/llvh/Support/MathExtras.h
+--- a/xplat/hermes/external/llvh/include/llvh/Support/MathExtras.h
++++ b/xplat/hermes/external/llvh/include/llvh/Support/MathExtras.h
+@@ -24,7 +24,10 @@
+ #include <type_traits>
+ 
+ #pragma GCC diagnostic push
++
++#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
+ #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
++#endif
+ 
+ #ifdef __ANDROID_NDK__
+ #include <android/api-level.h>

--- a/include/hermes/ADT/BitArray.h
+++ b/include/hermes/ADT/BitArray.h
@@ -14,7 +14,10 @@
 #include <bitset>
 
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 
 namespace hermes {
 

--- a/include/hermes/ADT/CompactArray.h
+++ b/include/hermes/ADT/CompactArray.h
@@ -14,7 +14,10 @@
 #include <cassert>
 #include <limits>
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 
 namespace vm {

--- a/include/hermes/ADT/SafeInt.h
+++ b/include/hermes/ADT/SafeInt.h
@@ -12,7 +12,10 @@
 #include <cstdint>
 #include <limits>
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 
 /// To avoid overflow, we introduce the SafeUInt32 which can be used

--- a/include/hermes/BCGen/HBC/Bytecode.h
+++ b/include/hermes/BCGen/HBC/Bytecode.h
@@ -23,7 +23,10 @@
 
 #include <memory>
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 class SourceMapGenerator;
 

--- a/include/hermes/BCGen/HBC/BytecodeDataProvider.h
+++ b/include/hermes/BCGen/HBC/BytecodeDataProvider.h
@@ -24,7 +24,10 @@
 #include <thread>
 
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 
 namespace hermes {
 namespace hbc {

--- a/include/hermes/BCGen/HBC/BytecodeInstructionGenerator.h
+++ b/include/hermes/BCGen/HBC/BytecodeInstructionGenerator.h
@@ -12,7 +12,10 @@
 
 #include <vector>
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace hbc {
 

--- a/include/hermes/Regex/RegexBytecode.h
+++ b/include/hermes/Regex/RegexBytecode.h
@@ -14,7 +14,10 @@
 #include <cstdint>
 #include <vector>
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace regex {
 

--- a/include/hermes/SourceMap/SourceMap.h
+++ b/include/hermes/SourceMap/SourceMap.h
@@ -16,7 +16,10 @@
 
 #include <vector>
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 
 /// Represent a source location in original JS source file.

--- a/include/hermes/SourceMap/SourceMapGenerator.h
+++ b/include/hermes/SourceMap/SourceMapGenerator.h
@@ -16,7 +16,10 @@
 #include <llvh/ADT/DenseMap.h>
 #include <vector>
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 
 /// A class representing a JavaScript source map, version 3 only. It borrows

--- a/include/hermes/Support/Allocator.h
+++ b/include/hermes/Support/Allocator.h
@@ -18,7 +18,10 @@
 #include <memory>
 #include <vector>
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 
 /// A slab based BumpPtrAllocator where the pointer can be saved and restored.

--- a/include/hermes/Support/BigIntSupport.h
+++ b/include/hermes/Support/BigIntSupport.h
@@ -21,7 +21,10 @@
 #include <string>
 #include <vector>
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace bigint {
 

--- a/include/hermes/Support/RegExpSerialization.h
+++ b/include/hermes/Support/RegExpSerialization.h
@@ -16,7 +16,10 @@
 #include <memory>
 #include <string>
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace llvh {
 class raw_ostream;
 }

--- a/include/hermes/VM/ArrayLike.h
+++ b/include/hermes/VM/ArrayLike.h
@@ -13,7 +13,10 @@
 #include "hermes/VM/JSArray.h"
 #include "hermes/VM/JSObject.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/include/hermes/VM/ArrayStorage.h
+++ b/include/hermes/VM/ArrayStorage.h
@@ -15,7 +15,10 @@
 
 #include "llvh/Support/TrailingObjects.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/include/hermes/VM/BigIntPrimitive.h
+++ b/include/hermes/VM/BigIntPrimitive.h
@@ -18,7 +18,10 @@
 #include "llvh/Support/MathExtras.h"
 #include "llvh/Support/TrailingObjects.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 /// A variable size GCCell used to store the words that compose the bigint.

--- a/include/hermes/VM/Callable.h
+++ b/include/hermes/VM/Callable.h
@@ -15,7 +15,10 @@
 #include "hermes/VM/NativeArgs.h"
 #include "hermes/VM/Runtime-inline.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/include/hermes/VM/CodeBlock.h
+++ b/include/hermes/VM/CodeBlock.h
@@ -24,7 +24,10 @@
 #include <memory>
 #include <vector>
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/include/hermes/VM/DictPropertyMap.h
+++ b/include/hermes/VM/DictPropertyMap.h
@@ -15,7 +15,10 @@
 
 #include "llvh/Support/TrailingObjects.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/include/hermes/VM/GCBase.h
+++ b/include/hermes/VM/GCBase.h
@@ -50,7 +50,10 @@
 #include <system_error>
 #include <vector>
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/include/hermes/VM/GCCell.h
+++ b/include/hermes/VM/GCCell.h
@@ -18,7 +18,10 @@
 #include <cstddef>
 #include <cstdint>
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/include/hermes/VM/HandleRootOwner.h
+++ b/include/hermes/VM/HandleRootOwner.h
@@ -15,7 +15,10 @@
 #include "hermes/VM/SymbolID.h"
 
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/include/hermes/VM/HeapAlign.h
+++ b/include/hermes/VM/HeapAlign.h
@@ -12,7 +12,10 @@
 
 #include "llvh/Support/MathExtras.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/include/hermes/VM/HermesValue.h
+++ b/include/hermes/VM/HermesValue.h
@@ -110,7 +110,10 @@
 #include <cmath>
 #include <cstdint>
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace llvh {
 class raw_ostream;
 }

--- a/include/hermes/VM/IdentifierTable.h
+++ b/include/hermes/VM/IdentifierTable.h
@@ -24,7 +24,10 @@
 #include "llvh/ADT/BitVector.h"
 #include "llvh/ADT/DenseMap.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/include/hermes/VM/JSObject.h
+++ b/include/hermes/VM/JSObject.h
@@ -20,7 +20,10 @@
 #include "hermes/VM/VTable.h"
 
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/include/hermes/VM/PointerBase.h
+++ b/include/hermes/VM/PointerBase.h
@@ -16,7 +16,10 @@
 #include <cassert>
 #include <cstdint>
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/include/hermes/VM/Profiler/InlineCacheProfiler.h
+++ b/include/hermes/VM/Profiler/InlineCacheProfiler.h
@@ -11,7 +11,10 @@
 #include "hermes/VM/SymbolID.h"
 #include "llvh/ADT/DenseMap.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace inst {
 struct Inst;

--- a/include/hermes/VM/RuntimeModule.h
+++ b/include/hermes/VM/RuntimeModule.h
@@ -20,7 +20,10 @@
 #include "llvh/ADT/simple_ilist.h"
 
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/include/hermes/VM/SegmentedArray.h
+++ b/include/hermes/VM/SegmentedArray.h
@@ -16,7 +16,10 @@
 
 #include <limits>
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/include/hermes/VM/SmallHermesValue-inline.h
+++ b/include/hermes/VM/SmallHermesValue-inline.h
@@ -17,7 +17,10 @@
 #include "hermes/VM/PointerBase.h"
 #include "hermes/VM/StringPrimitive.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/include/hermes/VM/SmallHermesValue.h
+++ b/include/hermes/VM/SmallHermesValue.h
@@ -20,7 +20,10 @@
 #include <cmath>
 #include <cstdint>
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/include/hermes/VM/StackTracesTree-NoRuntime.h
+++ b/include/hermes/VM/StackTracesTree-NoRuntime.h
@@ -23,7 +23,10 @@
 #include <map>
 #include <memory>
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/include/hermes/VM/StringPrimitive.h
+++ b/include/hermes/VM/StringPrimitive.h
@@ -20,7 +20,10 @@
 
 #include <type_traits>
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/include/hermes/VM/StringView.h
+++ b/include/hermes/VM/StringView.h
@@ -14,7 +14,10 @@
 #include "hermes/VM/StringRefUtils.h"
 #include "hermes/VM/TwineChar16.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/include/hermes/VM/VTable.h
+++ b/include/hermes/VM/VTable.h
@@ -20,7 +20,10 @@
 #include <cstdint>
 
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/include/hermes/VM/detail/IdentifierHashTable.h
+++ b/include/hermes/VM/detail/IdentifierHashTable.h
@@ -16,7 +16,10 @@
 
 #include "llvh/Support/MathExtras.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 class IdentifierTable;

--- a/lib/VM/BigIntPrimitive.cpp
+++ b/lib/VM/BigIntPrimitive.cpp
@@ -14,7 +14,10 @@
 
 #include <cstdlib>
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/lib/VM/Callable.cpp
+++ b/lib/VM/Callable.cpp
@@ -27,7 +27,10 @@
 
 #include "llvh/ADT/ArrayRef.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/lib/VM/Debugger/Debugger.cpp
+++ b/lib/VM/Debugger/Debugger.cpp
@@ -21,7 +21,10 @@
 #include "hermes/VM/StackFrame-inline.h"
 #include "hermes/VM/StringView.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 #ifdef HERMES_ENABLE_DEBUGGER
 
 namespace hermes {

--- a/lib/VM/DecoratedObject.cpp
+++ b/lib/VM/DecoratedObject.cpp
@@ -9,7 +9,10 @@
 
 #include "hermes/VM/Runtime-inline.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 //===----------------------------------------------------------------------===//

--- a/lib/VM/Domain.cpp
+++ b/lib/VM/Domain.cpp
@@ -12,7 +12,10 @@
 #include "hermes/VM/JSLib.h"
 #include "hermes/VM/Profiler/SamplingProfiler.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/lib/VM/GCBase.cpp
+++ b/lib/VM/GCBase.cpp
@@ -30,7 +30,10 @@
 #include <stdexcept>
 #include <system_error>
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 using llvh::format;
 
 namespace hermes {

--- a/lib/VM/HeapSnapshot.cpp
+++ b/lib/VM/HeapSnapshot.cpp
@@ -19,7 +19,10 @@
 namespace hermes {
 namespace vm {
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 #ifdef HERMES_MEMORY_INSTRUMENTATION
 
 namespace {

--- a/lib/VM/HiddenClass.cpp
+++ b/lib/VM/HiddenClass.cpp
@@ -17,7 +17,10 @@
 
 #include "llvh/Support/Debug.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 using llvh::dbgs;
 
 namespace hermes {

--- a/lib/VM/IdentifierTable.cpp
+++ b/lib/VM/IdentifierTable.cpp
@@ -16,7 +16,10 @@
 
 #include "llvh/Support/Debug.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/lib/VM/Interpreter.cpp
+++ b/lib/VM/Interpreter.cpp
@@ -40,7 +40,10 @@
 #include "Interpreter-internal.h"
 
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 using llvh::dbgs;
 using namespace hermes::inst;
 

--- a/lib/VM/JSError.cpp
+++ b/lib/VM/JSError.cpp
@@ -20,7 +20,10 @@
 
 #include "llvh/ADT/ScopeExit.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 //===----------------------------------------------------------------------===//

--- a/lib/VM/JSLib/Array.cpp
+++ b/lib/VM/JSLib/Array.cpp
@@ -22,7 +22,10 @@
 
 #include "llvh/ADT/ScopeExit.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/lib/VM/JSLib/ArrayBuffer.cpp
+++ b/lib/VM/JSLib/ArrayBuffer.cpp
@@ -18,7 +18,10 @@
 #include "hermes/VM/Operations.h"
 #include "hermes/VM/StringPrimitive.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/lib/VM/JSLib/DataView.cpp
+++ b/lib/VM/JSLib/DataView.cpp
@@ -12,7 +12,10 @@
 #include "hermes/VM/JSTypedArray.h"
 #include "hermes/VM/StringPrimitive.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/lib/VM/JSLib/Date.cpp
+++ b/lib/VM/JSLib/Date.cpp
@@ -18,7 +18,10 @@
 #include "hermes/VM/JSLib/RuntimeCommonStorage.h"
 #include "hermes/VM/Operations.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/lib/VM/JSLib/DateUtil.cpp
+++ b/lib/VM/JSLib/DateUtil.cpp
@@ -23,7 +23,10 @@
 #include <cmath>
 #include <ctime>
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/lib/VM/JSLib/HermesInternal.cpp
+++ b/lib/VM/JSLib/HermesInternal.cpp
@@ -24,7 +24,10 @@
 #include <cstring>
 #include <random>
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/lib/VM/JSLib/JSLibInternal.cpp
+++ b/lib/VM/JSLib/JSLibInternal.cpp
@@ -16,7 +16,10 @@
 #include "hermes/VM/StringPrimitive.h"
 #include "hermes/VM/StringView.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/lib/VM/JSLib/Math.cpp
+++ b/lib/VM/JSLib/Math.cpp
@@ -26,7 +26,10 @@
 
 #include "llvh/Support/MathExtras.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/lib/VM/JSLib/Number.cpp
+++ b/lib/VM/JSLib/Number.cpp
@@ -22,7 +22,10 @@
 #include "llvh/ADT/SmallString.h"
 #include "llvh/Support/Format.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/lib/VM/JSLib/RegExp.cpp
+++ b/lib/VM/JSLib/RegExp.cpp
@@ -18,7 +18,10 @@
 #include "hermes/VM/StringPrimitive.h"
 #include "hermes/VM/StringView.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/lib/VM/JSLib/String.cpp
+++ b/lib/VM/JSLib/String.cpp
@@ -30,7 +30,10 @@
 
 #include <locale>
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/lib/VM/JSLib/TypedArray.cpp
+++ b/lib/VM/JSLib/TypedArray.cpp
@@ -18,7 +18,10 @@
 #include "hermes/VM/StringBuilder.h"
 #include "hermes/VM/StringView.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/lib/VM/JSLib/escape.cpp
+++ b/lib/VM/JSLib/escape.cpp
@@ -14,7 +14,10 @@
 
 #include "llvh/Support/ConvertUTF.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/lib/VM/JSNativeFunctions.cpp
+++ b/lib/VM/JSNativeFunctions.cpp
@@ -22,7 +22,10 @@
 #include <limits>
 
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/lib/VM/JSObject.cpp
+++ b/lib/VM/JSObject.cpp
@@ -19,7 +19,10 @@
 
 #include "llvh/ADT/SmallSet.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/lib/VM/JSProxy.cpp
+++ b/lib/VM/JSProxy.cpp
@@ -17,7 +17,10 @@
 #include "llvh/ADT/SmallSet.h"
 
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/lib/VM/JSRegExp.cpp
+++ b/lib/VM/JSRegExp.cpp
@@ -18,7 +18,10 @@
 #include "hermes/VM/StringView.h"
 
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/lib/VM/JSTypedArray.cpp
+++ b/lib/VM/JSTypedArray.cpp
@@ -11,7 +11,10 @@
 #include "hermes/VM/Callable.h"
 
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/lib/VM/JSWeakMapImpl.cpp
+++ b/lib/VM/JSWeakMapImpl.cpp
@@ -10,7 +10,10 @@
 #include "hermes/VM/Casting.h"
 #include "hermes/VM/Runtime-inline.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/lib/VM/Runtime.cpp
+++ b/lib/VM/Runtime.cpp
@@ -57,7 +57,10 @@
 
 #include <future>
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/lib/VM/StackTracesTree.cpp
+++ b/lib/VM/StackTracesTree.cpp
@@ -15,7 +15,10 @@
 #include "hermes/VM/StringPrimitive.h"
 #include "hermes/VM/StringView.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/lib/VM/StorageProvider.cpp
+++ b/lib/VM/StorageProvider.cpp
@@ -21,7 +21,10 @@
 #include <random>
 #include <stack>
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/lib/VM/StringPrimitive.cpp
+++ b/lib/VM/StringPrimitive.cpp
@@ -17,7 +17,10 @@
 #include "hermes/VM/StringView.h"
 #include "llvh/Support/ConvertUTF.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/lib/VM/StringView.cpp
+++ b/lib/VM/StringView.cpp
@@ -7,7 +7,10 @@
 
 #include "hermes/VM/StringView.h"
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/lib/VM/gcs/CardTableNC.cpp
+++ b/lib/VM/gcs/CardTableNC.cpp
@@ -16,7 +16,10 @@
 #include <cstdint>
 #include <functional>
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 

--- a/lib/VM/gcs/HadesGC.cpp
+++ b/lib/VM/gcs/HadesGC.cpp
@@ -22,7 +22,10 @@
 #include <stack>
 
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 
 namespace hermes {
 namespace vm {

--- a/public/hermes/Public/DebuggerTypes.h
+++ b/public/hermes/Public/DebuggerTypes.h
@@ -11,7 +11,10 @@
 #include <string>
 #include <vector>
 #pragma GCC diagnostic push
+
+#ifdef HERMES_COMPILER_SUPPORTS_WSHORTEN_64_TO_32
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#endif
 namespace hermes {
 namespace vm {
 class Debugger;


### PR DESCRIPTION
Summary:
Ensures the  GCC diagnostic ignored "-Wshorten-64-to-32" is only
enabled if the C++ compiler supports it.

Differential Revision: D39100412

