### PR TITLE
Eliminate Impl pointer

### DIFF
--- a/include/hermes/Platform/Intl/PlatformIntl.h
+++ b/include/hermes/Platform/Intl/PlatformIntl.h
@@ -100,9 +100,11 @@ enum class NativeType {
 };
 
 class Collator : public vm::DecoratedObject::Decoration {
- public:
+ protected:
   Collator();
-  ~Collator();
+
+ public:
+  ~Collator() override;
 
   static constexpr NativeType getNativeType() {
     return NativeType::Collator;
@@ -113,23 +115,21 @@ class Collator : public vm::DecoratedObject::Decoration {
       const std::vector<std::u16string> &locales,
       const Options &options) noexcept;
 
-  vm::ExecutionStatus initialize(
+  static vm::CallResult<std::unique_ptr<Collator>> create(
       vm::Runtime &runtime,
       const std::vector<std::u16string> &locales,
       const Options &options) noexcept;
   Options resolvedOptions() noexcept;
 
   double compare(const std::u16string &x, const std::u16string &y) noexcept;
-
- private:
-  struct Impl;
-  std::unique_ptr<Impl> impl_;
 };
 
 class DateTimeFormat : public vm::DecoratedObject::Decoration {
- public:
+ protected:
   DateTimeFormat();
-  ~DateTimeFormat();
+
+ public:
+  ~DateTimeFormat() override;
 
   static constexpr NativeType getNativeType() {
     return NativeType::DateTimeFormat;
@@ -140,7 +140,7 @@ class DateTimeFormat : public vm::DecoratedObject::Decoration {
       const std::vector<std::u16string> &locales,
       const Options &options) noexcept;
 
-  vm::ExecutionStatus initialize(
+  static vm::CallResult<std::unique_ptr<DateTimeFormat>> create(
       vm::Runtime &runtime,
       const std::vector<std::u16string> &locales,
       const Options &options) noexcept;
@@ -148,16 +148,14 @@ class DateTimeFormat : public vm::DecoratedObject::Decoration {
 
   std::u16string format(double jsTimeValue) noexcept;
   std::vector<Part> formatToParts(double jsTimeValue) noexcept;
-
- private:
-  struct Impl;
-  std::unique_ptr<Impl> impl_;
 };
 
 class NumberFormat : public vm::DecoratedObject::Decoration {
- public:
+ protected:
   NumberFormat();
-  ~NumberFormat();
+
+ public:
+  ~NumberFormat() override;
 
   static constexpr NativeType getNativeType() {
     return NativeType::NumberFormat;
@@ -168,7 +166,7 @@ class NumberFormat : public vm::DecoratedObject::Decoration {
       const std::vector<std::u16string> &locales,
       const Options &options) noexcept;
 
-  vm::ExecutionStatus initialize(
+  static vm::CallResult<std::unique_ptr<NumberFormat>> create(
       vm::Runtime &runtime,
       const std::vector<std::u16string> &locales,
       const Options &options) noexcept;
@@ -176,10 +174,6 @@ class NumberFormat : public vm::DecoratedObject::Decoration {
 
   std::u16string format(double jsTimeValue) noexcept;
   std::vector<Part> formatToParts(double jsTimeValue) noexcept;
-
- private:
-  struct Impl;
-  std::unique_ptr<Impl> impl_;
 };
 
 } // namespace platform_intl

--- a/lib/Platform/Intl/PlatformIntlApple.mm
+++ b/lib/Platform/Intl/PlatformIntlApple.mm
@@ -874,20 +874,35 @@ vm::CallResult<std::u16string> toLocaleUpperCase(
       uppercaseStringWithLocale:[[NSLocale alloc] initWithLocaleIdentifier:L]]);
 }
 
-struct Collator::Impl {
-  NSLocale *nsLocale;
-  NSStringCompareOptions nsCompareOptions;
-  std::u16string locale;
-  std::u16string usage;
-  std::u16string collation;
-  std::u16string caseFirst;
-  std::u16string sensitivity;
-  bool numeric;
-  bool ignorePunctuation;
-};
+namespace {
+class CollatorApple : public Collator {
+ public:
+  CollatorApple() = default;
 
-Collator::Collator() : impl_(std::make_unique<Impl>()) {}
-Collator::~Collator() {}
+  vm::ExecutionStatus initialize(
+      vm::Runtime &runtime,
+      const std::vector<std::u16string> &locales,
+      const Options &options) noexcept;
+
+  Options resolvedOptions() noexcept;
+
+  double compare(const std::u16string &x, const std::u16string &y) noexcept;
+
+ private:
+  NSLocale *nsLocale_;
+  NSStringCompareOptions nsCompareOptions_;
+  std::u16string locale_;
+  std::u16string usage_;
+  std::u16string collation_;
+  std::u16string caseFirst_;
+  std::u16string sensitivity_;
+  bool numeric_;
+  bool ignorePunctuation_;
+};
+} // namespace
+
+Collator::Collator() = default;
+Collator::~Collator() = default;
 
 /// https://402.ecma-international.org/8.0/#sec-intl.collator.supportedlocalesof
 vm::CallResult<std::vector<std::u16string>> Collator::supportedLocalesOf(
@@ -905,7 +920,7 @@ vm::CallResult<std::vector<std::u16string>> Collator::supportedLocalesOf(
 }
 
 /// https://402.ecma-international.org/8.0/#sec-initializecollator
-vm::ExecutionStatus Collator::initialize(
+vm::ExecutionStatus CollatorApple::initialize(
     vm::Runtime &runtime,
     const std::vector<std::u16string> &locales,
     const Options &options) noexcept {
@@ -922,7 +937,7 @@ vm::ExecutionStatus Collator::initialize(
   if (LLVM_UNLIKELY(usageRes == vm::ExecutionStatus::EXCEPTION))
     return vm::ExecutionStatus::EXCEPTION;
   // 4. Set collator.[[Usage]] to usage.
-  impl_->usage = std::move(**usageRes);
+  usage_ = std::move(**usageRes);
   // 5. If usage is "sort", then
   // a. Let localeData be %Collator%.[[SortLocaleData]].
   // 6. Else,
@@ -983,30 +998,30 @@ vm::ExecutionStatus Collator::initialize(
   auto r = resolveLocale(
       getAvailableLocales(), *requestedLocalesRes, opt, relevantExtensionKeys);
   // 20. Set collator.[[Locale]] to r.[[locale]].
-  impl_->locale = std::move(r.locale);
+  locale_ = std::move(r.locale);
   // 21. Let collation be r.[[co]].
   auto coIt = r.extensions.find(u"co");
   // 22. If collation is null, let collation be "default".
   // 23. Set collator.[[Collation]] to collation.
   if (coIt == r.extensions.end())
-    impl_->collation = u"default";
+    collation_ = u"default";
   else
-    impl_->collation = std::move(coIt->second);
+    collation_ = std::move(coIt->second);
   // 24. If relevantExtensionKeys contains "kn", then
   // a. Set collator.[[Numeric]] to ! SameValue(r.[[kn]], "true").
   auto knIt = r.extensions.find(u"kn");
   if (knIt == r.extensions.end())
-    impl_->numeric = false;
+    numeric_ = false;
   else
-    impl_->numeric = (knIt->second == u"true");
+    numeric_ = (knIt->second == u"true");
 
   // 25. If relevantExtensionKeys contains "kf", then
   // a. Set collator.[[CaseFirst]] to r.[[kf]].
   auto kfIt = r.extensions.find(u"kf");
   if (kfIt == r.extensions.end())
-    impl_->caseFirst = u"false";
+    caseFirst_ = u"false";
   else
-    impl_->caseFirst = kfIt->second;
+    caseFirst_ = kfIt->second;
 
   // 26. Let sensitivity be ? GetOption(options, "sensitivity", "string", «
   // "base", "accent", "case", "variant" », undefined).
@@ -1025,65 +1040,82 @@ vm::ExecutionStatus Collator::initialize(
   // iii. Let sensitivity be dataLocaleData.[[sensitivity]].
   // 28. Set collator.[[Sensitivity]] to sensitivity.
   if (auto &sensitivityOpt = *sensitivityRes)
-    impl_->sensitivity = std::move(*sensitivityOpt);
+    sensitivity_ = std::move(*sensitivityOpt);
   else
-    impl_->sensitivity = u"variant";
+    sensitivity_ = u"variant";
 
   // 29. Let ignorePunctuation be ? GetOption(options, "ignorePunctuation",
   // "boolean", undefined,false).
   auto ignorePunctuationOpt =
       getOptionBool(runtime, options, u"ignorePunctuation", false);
   // 30. Set collator.[[IgnorePunctuation]] to ignorePunctuation.
-  impl_->ignorePunctuation = *ignorePunctuationOpt;
+  ignorePunctuation_ = *ignorePunctuationOpt;
 
   // Set up the state for calling into Obj-C APIs.
   NSStringCompareOptions cmpOpts = 0;
-  if (impl_->numeric)
+  if (numeric_)
     cmpOpts |= NSNumericSearch;
-  if (impl_->sensitivity == u"base")
+  if (sensitivity_ == u"base")
     cmpOpts |= (NSDiacriticInsensitiveSearch | NSCaseInsensitiveSearch);
-  else if (impl_->sensitivity == u"accent")
+  else if (sensitivity_ == u"accent")
     cmpOpts |= NSCaseInsensitiveSearch;
-  else if (impl_->sensitivity == u"case")
+  else if (sensitivity_ == u"case")
     cmpOpts |= NSDiacriticInsensitiveSearch;
-  impl_->nsCompareOptions = cmpOpts;
+  nsCompareOptions_ = cmpOpts;
 
   std::u16string nsLocaleExtensions;
-  if (impl_->collation != u"default")
-    nsLocaleExtensions.append(u"-co-").append(impl_->collation);
-  else if (impl_->usage == u"search")
+  if (collation_ != u"default")
+    nsLocaleExtensions.append(u"-co-").append(collation_);
+  else if (usage_ == u"search")
     nsLocaleExtensions.append(u"-co-search");
-  if (impl_->caseFirst != u"false")
-    nsLocaleExtensions.append(u"-kf-").append(impl_->caseFirst);
+  if (caseFirst_ != u"false")
+    nsLocaleExtensions.append(u"-kf-").append(caseFirst_);
   auto nsLocaleIdentifier = r.dataLocale;
   if (!nsLocaleExtensions.empty())
     nsLocaleIdentifier.append(u"-u").append(nsLocaleExtensions);
-  impl_->nsLocale = [NSLocale
+  nsLocale_ = [NSLocale
       localeWithLocaleIdentifier:u16StringToNSString(nsLocaleIdentifier)];
   // 31. Return collator.
   return vm::ExecutionStatus::RETURNED;
 }
 
+vm::CallResult<std::unique_ptr<Collator>> Collator::create(
+    vm::Runtime &runtime,
+    const std::vector<std::u16string> &locales,
+    const Options &options) noexcept {
+  auto instance = std::make_unique<CollatorApple>();
+  if (LLVM_UNLIKELY(
+          instance->initialize(runtime, locales, options) ==
+          vm::ExecutionStatus::EXCEPTION)) {
+    return vm::ExecutionStatus::EXCEPTION;
+  }
+  return instance;
+}
+
 /// https://402.ecma-international.org/8.0/#sec-intl.collator.prototype.resolvedoptions
-Options Collator::resolvedOptions() noexcept {
+Options CollatorApple::resolvedOptions() noexcept {
   Options options;
-  options.emplace(u"locale", Option(impl_->locale));
-  options.emplace(u"usage", Option(impl_->usage));
-  options.emplace(u"sensitivity", Option(impl_->sensitivity));
-  options.emplace(u"ignorePunctuation", Option(impl_->ignorePunctuation));
-  options.emplace(u"collation", Option(impl_->collation));
-  options.emplace(u"numeric", Option(impl_->numeric));
-  options.emplace(u"caseFirst", Option(impl_->caseFirst));
+  options.emplace(u"locale", Option(locale_));
+  options.emplace(u"usage", Option(usage_));
+  options.emplace(u"sensitivity", Option(sensitivity_));
+  options.emplace(u"ignorePunctuation", Option(ignorePunctuation_));
+  options.emplace(u"collation", Option(collation_));
+  options.emplace(u"numeric", Option(numeric_));
+  options.emplace(u"caseFirst", Option(caseFirst_));
   return options;
 }
 
+Options Collator::resolvedOptions() noexcept {
+  return static_cast<CollatorApple *>(this)->resolvedOptions();
+}
+
 /// https://402.ecma-international.org/8.0/#sec-intl.collator.prototype.compare
-double Collator::compare(
+double CollatorApple::compare(
     const std::u16string &x,
     const std::u16string &y) noexcept {
   NSString *nsX = u16StringToNSString(x);
   NSString *nsY = u16StringToNSString(y);
-  if (impl_->ignorePunctuation) {
+  if (ignorePunctuation_) {
     // Unfortunately, NSLocale does not provide a way to specify alternate
     // handling, so we simulate it by manually stripping punctuation and
     // whitespace.
@@ -1101,14 +1133,38 @@ double Collator::compare(
     nsY = removePunctuation(nsY);
   }
   return [nsX compare:nsY
-              options:impl_->nsCompareOptions
+              options:nsCompareOptions_
                 range:NSMakeRange(0, nsX.length)
-               locale:impl_->nsLocale];
+               locale:nsLocale_];
 }
 
+double Collator::compare(
+    const std::u16string &x,
+    const std::u16string &y) noexcept {
+  return static_cast<CollatorApple *>(this)->compare(x, y);
+}
+
+namespace {
 // Implementation of
 // https://402.ecma-international.org/8.0/#datetimeformat-objects
-struct DateTimeFormat::Impl {
+class DateTimeFormatApple : public DateTimeFormat {
+ public:
+  DateTimeFormatApple() = default;
+
+  vm::ExecutionStatus initialize(
+      vm::Runtime &runtime,
+      const std::vector<std::u16string> &locales,
+      const Options &inputOptions) noexcept;
+
+  Options resolvedOptions() noexcept;
+
+  std::u16string format(double jsTimeValue) noexcept;
+
+  std::vector<Part> formatToParts(double x) noexcept;
+
+ private:
+  void initializeNSDateFormatter() noexcept;
+
   // https://402.ecma-international.org/8.0/#sec-properties-of-intl-datetimeformat-instances
   // Intl.DateTimeFormat instances have an [[InitializedDateTimeFormat]]
   // internal slot.
@@ -1117,10 +1173,10 @@ struct DateTimeFormat::Impl {
   // slots that are computed by the constructor:
   // [[Locale]] is a String value with the language tag of the locale whose
   // localization is used for formatting.
-  std::u16string locale;
+  std::u16string locale_;
   // [[Calendar]] is a String value with the "type" given in Unicode Technical
   // Standard 35 for the calendar used for formatting.
-  std::optional<std::u16string> calendar;
+  std::optional<std::u16string> calendar_;
   // [[NumberingSystem]] is a String value with the "type" given in Unicode
   // Technical Standard 35 for the numbering system used for formatting.
   // NOTE: Even though NSDateFormatter formats date and time using different
@@ -1129,37 +1185,37 @@ struct DateTimeFormat::Impl {
   // unsupported.
   // [[TimeZone]] is a String value with the IANA time zone name of the time
   // zone used for formatting.
-  std::u16string timeZone;
+  std::u16string timeZone_;
   // [[Weekday]], [[Era]], [[Year]], [[Month]], [[Day]], [[DayPeriod]],
   // [[Hour]], [[Minute]], [[Second]], [[TimeZoneName]] are each either
   // undefined, indicating that the component is not used for formatting, or one
   // of the String values given in Table 4, indicating how the component should
   // be presented in the formatted output.
-  std::optional<std::u16string> weekday;
-  std::optional<std::u16string> era;
-  std::optional<std::u16string> year;
-  std::optional<std::u16string> month;
-  std::optional<std::u16string> day;
-  std::optional<std::u16string> dayPeriod;
-  std::optional<std::u16string> hour;
-  std::optional<std::u16string> minute;
-  std::optional<std::u16string> second;
-  std::optional<std::u16string> timeZoneName;
+  std::optional<std::u16string> weekday_;
+  std::optional<std::u16string> era_;
+  std::optional<std::u16string> year_;
+  std::optional<std::u16string> month_;
+  std::optional<std::u16string> day_;
+  std::optional<std::u16string> dayPeriod_;
+  std::optional<std::u16string> hour_;
+  std::optional<std::u16string> minute_;
+  std::optional<std::u16string> second_;
+  std::optional<std::u16string> timeZoneName_;
   // [[FractionalSecondDigits]] is either undefined or a positive, non-zero
   // integer Number value indicating the fraction digits to be used for
   // fractional seconds. Numbers will be rounded or padded with trailing zeroes
   // if necessary.
-  std::optional<uint8_t> fractionalSecondDigits;
+  std::optional<uint8_t> fractionalSecondDigits_;
   // [[HourCycle]] is a String value indicating whether the 12-hour format
   // ("h11", "h12") or the 24-hour format ("h23", "h24") should be used. "h11"
   // and "h23" start with hour 0 and go up to 11 and 23 respectively. "h12" and
   // "h24" start with hour 1 and go up to 12 and 24. [[HourCycle]] is only used
   // when [[Hour]] is not undefined.
-  std::optional<std::u16string> hourCycle;
+  std::optional<std::u16string> hourCycle_;
   // [[DateStyle]], [[TimeStyle]] are each either undefined, or a String value
   // with values "full", "long", "medium", or "short".
-  std::optional<std::u16string> dateStyle;
-  std::optional<std::u16string> timeStyle;
+  std::optional<std::u16string> dateStyle_;
+  std::optional<std::u16string> timeStyle_;
   // [[Pattern]] is a String value as described in 11.3.3.
   // [[RangePatterns]] is a Record as described in 11.3.3.
   // Finally, Intl.DateTimeFormat instances have a [[BoundFormat]]
@@ -1167,12 +1223,12 @@ struct DateTimeFormat::Impl {
   // (11.4.3).
   // NOTE: Pattern and RangePatterns are not implemented. BoundFormat is
   // implemented in Intl.cpp.
-  NSDateFormatter *nsDateFormatter;
-  void initializeNSDateFormatter() noexcept;
+  NSDateFormatter *nsDateFormatter_;
 };
+} // namespace
 
-DateTimeFormat::DateTimeFormat() : impl_(std::make_unique<Impl>()) {}
-DateTimeFormat::~DateTimeFormat() {}
+DateTimeFormat::DateTimeFormat() = default;
+DateTimeFormat::~DateTimeFormat() = default;
 
 // Implementation of
 // https://402.ecma-international.org/8.0/#sec-intl.datetimeformat.supportedlocalesof
@@ -1190,7 +1246,7 @@ vm::CallResult<std::vector<std::u16string>> DateTimeFormat::supportedLocalesOf(
 
 // Implementation of
 // https://402.ecma-international.org/8.0/#sec-initializedatetimeformat
-vm::ExecutionStatus DateTimeFormat::initialize(
+vm::ExecutionStatus DateTimeFormatApple::initialize(
     vm::Runtime &runtime,
     const std::vector<std::u16string> &locales,
     const Options &inputOptions) noexcept {
@@ -1275,16 +1331,16 @@ vm::ExecutionStatus DateTimeFormat::initialize(
   auto r = resolveLocale(
       getAvailableLocales(), *requestedLocalesRes, opt, relevantExtensionKeys);
   // 18. Set dateTimeFormat.[[Locale]] to r.[[locale]].
-  impl_->locale = std::move(r.locale);
+  locale_ = std::move(r.locale);
   // 19. Let calendar be r.[[ca]].
   auto caIt = r.extensions.find(u"ca");
   // 20. Set dateTimeFormat.[[Calendar]] to calendar.
   if (caIt != r.extensions.end())
-    impl_->calendar = std::move(caIt->second);
+    calendar_ = std::move(caIt->second);
   // 21. Set dateTimeFormat.[[HourCycle]] to r.[[hc]].
   auto hcIt = r.extensions.find(u"hc");
   if (hcIt != r.extensions.end())
-    impl_->hourCycle = std::move(hcIt->second);
+    hourCycle_ = std::move(hcIt->second);
   // 22. Set dateTimeFormat.[[NumberingSystem]] to r.[[nu]].
   // 23. Let dataLocale be r.[[dataLocale]].
   auto dataLocale = r.dataLocale;
@@ -1308,7 +1364,7 @@ vm::ExecutionStatus DateTimeFormat::initialize(
     timeZone = canonicalizeTimeZoneName(timeZone);
   }
   // 27. Set dateTimeFormat.[[TimeZone]] to timeZone.
-  impl_->timeZone = timeZone;
+  timeZone_ = timeZone;
   // 28. Let opt be a new Record.
   // 29. For each row of Table 4, except the header row, in table order, do
   // a. Let prop be the name given in the Property column of the row.
@@ -1332,7 +1388,7 @@ vm::ExecutionStatus DateTimeFormat::initialize(
   if (LLVM_UNLIKELY(dateStyleRes == vm::ExecutionStatus::EXCEPTION))
     return vm::ExecutionStatus::EXCEPTION;
   // 33. Set dateTimeFormat.[[DateStyle]] to dateStyle.
-  impl_->dateStyle = *dateStyleRes;
+  dateStyle_ = *dateStyleRes;
   // 34. Let timeStyle be ? GetOption(options, "timeStyle", "string", « "full",
   // "long", "medium", "short" », undefined).
   static constexpr std::u16string_view timeStyles[] = {
@@ -1342,7 +1398,7 @@ vm::ExecutionStatus DateTimeFormat::initialize(
   if (LLVM_UNLIKELY(timeStyleRes == vm::ExecutionStatus::EXCEPTION))
     return vm::ExecutionStatus::EXCEPTION;
   // 35. Set dateTimeFormat.[[TimeStyle]] to timeStyle.
-  impl_->timeStyle = *timeStyleRes;
+  timeStyle_ = *timeStyleRes;
 
   // Initialize properties using values from the input options.
   static constexpr std::u16string_view weekdayValues[] = {
@@ -1351,21 +1407,21 @@ vm::ExecutionStatus DateTimeFormat::initialize(
       getOptionString(runtime, inputOptions, u"weekday", weekdayValues, {});
   if (LLVM_UNLIKELY(weekdayRes == vm::ExecutionStatus::EXCEPTION))
     return vm::ExecutionStatus::EXCEPTION;
-  impl_->weekday = *weekdayRes;
+  weekday_ = *weekdayRes;
 
   static constexpr std::u16string_view eraValues[] = {
       u"narrow", u"short", u"long"};
   auto eraRes = getOptionString(runtime, inputOptions, u"era", eraValues, {});
   if (LLVM_UNLIKELY(eraRes == vm::ExecutionStatus::EXCEPTION))
     return vm::ExecutionStatus::EXCEPTION;
-  impl_->era = *eraRes;
+  era_ = *eraRes;
 
   static constexpr std::u16string_view yearValues[] = {u"2-digit", u"numeric"};
   auto yearRes =
       getOptionString(runtime, inputOptions, u"year", yearValues, {});
   if (LLVM_UNLIKELY(yearRes == vm::ExecutionStatus::EXCEPTION))
     return vm::ExecutionStatus::EXCEPTION;
-  impl_->year = *yearRes;
+  year_ = *yearRes;
 
   static constexpr std::u16string_view monthValues[] = {
       u"2-digit", u"numeric", u"narrow", u"short", u"long"};
@@ -1373,13 +1429,13 @@ vm::ExecutionStatus DateTimeFormat::initialize(
       getOptionString(runtime, inputOptions, u"month", monthValues, {});
   if (LLVM_UNLIKELY(monthRes == vm::ExecutionStatus::EXCEPTION))
     return vm::ExecutionStatus::EXCEPTION;
-  impl_->month = *monthRes;
+  month_ = *monthRes;
 
   static constexpr std::u16string_view dayValues[] = {u"2-digit", u"numeric"};
   auto dayRes = getOptionString(runtime, inputOptions, u"day", dayValues, {});
   if (LLVM_UNLIKELY(dayRes == vm::ExecutionStatus::EXCEPTION))
     return vm::ExecutionStatus::EXCEPTION;
-  impl_->day = *dayRes;
+  day_ = *dayRes;
 
   static constexpr std::u16string_view dayPeriodValues[] = {
       u"narrow", u"short", u"long"};
@@ -1387,14 +1443,14 @@ vm::ExecutionStatus DateTimeFormat::initialize(
       getOptionString(runtime, inputOptions, u"dayPeriod", dayPeriodValues, {});
   if (LLVM_UNLIKELY(dayPeriodRes == vm::ExecutionStatus::EXCEPTION))
     return vm::ExecutionStatus::EXCEPTION;
-  impl_->dayPeriod = *dayPeriodRes;
+  dayPeriod_ = *dayPeriodRes;
 
   static constexpr std::u16string_view hourValues[] = {u"2-digit", u"numeric"};
   auto hourRes =
       getOptionString(runtime, inputOptions, u"hour", hourValues, {});
   if (LLVM_UNLIKELY(hourRes == vm::ExecutionStatus::EXCEPTION))
     return vm::ExecutionStatus::EXCEPTION;
-  impl_->hour = *hourRes;
+  hour_ = *hourRes;
 
   static constexpr std::u16string_view minuteValues[] = {
       u"2-digit", u"numeric"};
@@ -1402,7 +1458,7 @@ vm::ExecutionStatus DateTimeFormat::initialize(
       getOptionString(runtime, inputOptions, u"minute", minuteValues, {});
   if (LLVM_UNLIKELY(minuteRes == vm::ExecutionStatus::EXCEPTION))
     return vm::ExecutionStatus::EXCEPTION;
-  impl_->minute = *minuteRes;
+  minute_ = *minuteRes;
 
   static constexpr std::u16string_view secondValues[] = {
       u"2-digit", u"numeric"};
@@ -1410,14 +1466,14 @@ vm::ExecutionStatus DateTimeFormat::initialize(
       getOptionString(runtime, inputOptions, u"second", secondValues, {});
   if (LLVM_UNLIKELY(secondRes == vm::ExecutionStatus::EXCEPTION))
     return vm::ExecutionStatus::EXCEPTION;
-  impl_->second = *secondRes;
+  second_ = *secondRes;
 
   auto fractionalSecondDigitsRes = getNumberOption(
       runtime, inputOptions, u"fractionalSecondDigits", 1, 3, {});
   if (LLVM_UNLIKELY(
           fractionalSecondDigitsRes == vm::ExecutionStatus::EXCEPTION))
     return vm::ExecutionStatus::EXCEPTION;
-  impl_->fractionalSecondDigits = *fractionalSecondDigitsRes;
+  fractionalSecondDigits_ = *fractionalSecondDigitsRes;
 
   // NOTE: "shortOffset", "longOffset", "shortGeneric", "longGeneric"
   // are specified here:
@@ -1435,7 +1491,7 @@ vm::ExecutionStatus DateTimeFormat::initialize(
       runtime, inputOptions, u"timeZoneName", timeZoneNameValues, {});
   if (LLVM_UNLIKELY(timeZoneNameRes == vm::ExecutionStatus::EXCEPTION))
     return vm::ExecutionStatus::EXCEPTION;
-  impl_->timeZoneName = *timeZoneNameRes;
+  timeZoneName_ = *timeZoneNameRes;
   // NOTE: We don't have access to localeData, instead we'll defer to NSLocale
   // wherever it is needed.
   // 36. If dateStyle is not undefined or timeStyle is not undefined, then
@@ -1461,9 +1517,9 @@ vm::ExecutionStatus DateTimeFormat::initialize(
   // ii. Set dateTimeFormat's internal slot whose name is the Internal
   // Slot column of the row to p.
   // 39. If dateTimeFormat.[[Hour]] is undefined, then
-  if (!impl_->hour.has_value()) {
+  if (!hour_.has_value()) {
     // a. Set dateTimeFormat.[[HourCycle]] to undefined.
-    impl_->hourCycle = std::nullopt;
+    hourCycle_ = std::nullopt;
     // b. Let pattern be bestFormat.[[pattern]].
     // c. Let rangePatterns be bestFormat.[[rangePatterns]].
     // 40. Else,
@@ -1471,7 +1527,7 @@ vm::ExecutionStatus DateTimeFormat::initialize(
     // a. Let hcDefault be dataLocaleData.[[hourCycle]].
     auto hcDefault = getDefaultHourCycle(localeData);
     // b. Let hc be dateTimeFormat.[[HourCycle]].
-    auto hc = impl_->hourCycle;
+    auto hc = hourCycle_;
     // c. If hc is null, then
     if (!hc.has_value())
       // i. Set hc to hcDefault.
@@ -1504,7 +1560,7 @@ vm::ExecutionStatus DateTimeFormat::initialize(
       }
     }
     // e. Set dateTimeFormat.[[HourCycle]] to hc.
-    impl_->hourCycle = hc;
+    hourCycle_ = hc;
     // f. If dateTimeformat.[[HourCycle]] is "h11" or "h12", then
     // i. Let pattern be bestFormat.[[pattern12]].
     // ii. Let rangePatterns be bestFormat.[[rangePatterns12]].
@@ -1515,48 +1571,65 @@ vm::ExecutionStatus DateTimeFormat::initialize(
   // 41. Set dateTimeFormat.[[Pattern]] to pattern.
   // 42. Set dateTimeFormat.[[RangePatterns]] to rangePatterns.
   // 43. Return dateTimeFormat.
-  impl_->initializeNSDateFormatter();
+  initializeNSDateFormatter();
   return vm::ExecutionStatus::RETURNED;
 }
+
+vm::CallResult<std::unique_ptr<DateTimeFormat>> DateTimeFormat::create(
+    vm::Runtime &runtime,
+    const std::vector<std::u16string> &locales,
+    const Options &inputOptions) noexcept {
+  auto instance = std::make_unique<DateTimeFormatApple>();
+  if (LLVM_UNLIKELY(
+          instance->initialize(runtime, locales, inputOptions) ==
+          vm::ExecutionStatus::EXCEPTION)) {
+    return vm::ExecutionStatus::EXCEPTION;
+  }
+  return instance;
+}
+
 // Implementer note: This method corresponds roughly to
 // https://402.ecma-international.org/8.0/#sec-intl.datetimeformat.prototype.resolvedoptions
-Options DateTimeFormat::resolvedOptions() noexcept {
+Options DateTimeFormatApple::resolvedOptions() noexcept {
   Options options;
-  options.emplace(u"locale", Option(impl_->locale));
-  options.emplace(u"timeZone", Option(impl_->timeZone));
-  if (impl_->calendar)
-    options.emplace(u"calendar", Option(*impl_->calendar));
-  if (impl_->hourCycle.has_value()) {
-    options.emplace(u"hourCycle", *impl_->hourCycle);
-    options.emplace(
-        u"hour12", impl_->hourCycle == u"h11" || impl_->hourCycle == u"h12");
+  options.emplace(u"locale", Option(locale_));
+  options.emplace(u"timeZone", Option(timeZone_));
+  if (calendar_)
+    options.emplace(u"calendar", Option(*calendar_));
+  if (hourCycle_.has_value()) {
+    options.emplace(u"hourCycle", *hourCycle_);
+    options.emplace(u"hour12", hourCycle_ == u"h11" || hourCycle_ == u"h12");
   }
-  if (impl_->weekday.has_value())
-    options.emplace(u"weekday", *impl_->weekday);
-  if (impl_->era.has_value())
-    options.emplace(u"era", *impl_->era);
-  if (impl_->year.has_value())
-    options.emplace(u"year", *impl_->year);
-  if (impl_->month.has_value())
-    options.emplace(u"month", *impl_->month);
-  if (impl_->day.has_value())
-    options.emplace(u"day", *impl_->day);
-  if (impl_->hour.has_value())
-    options.emplace(u"hour", *impl_->hour);
-  if (impl_->minute.has_value())
-    options.emplace(u"minute", *impl_->minute);
-  if (impl_->second.has_value())
-    options.emplace(u"second", *impl_->second);
-  if (impl_->timeZoneName.has_value())
-    options.emplace(u"timeZoneName", *impl_->timeZoneName);
-  if (impl_->dateStyle.has_value())
-    options.emplace(u"dateStyle", *impl_->dateStyle);
-  if (impl_->timeStyle.has_value())
-    options.emplace(u"timeStyle", *impl_->timeStyle);
+  if (weekday_.has_value())
+    options.emplace(u"weekday", *weekday_);
+  if (era_.has_value())
+    options.emplace(u"era", *era_);
+  if (year_.has_value())
+    options.emplace(u"year", *year_);
+  if (month_.has_value())
+    options.emplace(u"month", *month_);
+  if (day_.has_value())
+    options.emplace(u"day", *day_);
+  if (hour_.has_value())
+    options.emplace(u"hour", *hour_);
+  if (minute_.has_value())
+    options.emplace(u"minute", *minute_);
+  if (second_.has_value())
+    options.emplace(u"second", *second_);
+  if (timeZoneName_.has_value())
+    options.emplace(u"timeZoneName", *timeZoneName_);
+  if (dateStyle_.has_value())
+    options.emplace(u"dateStyle", *dateStyle_);
+  if (timeStyle_.has_value())
+    options.emplace(u"timeStyle", *timeStyle_);
   return options;
 }
 
-void DateTimeFormat::Impl::initializeNSDateFormatter() noexcept {
+Options DateTimeFormat::resolvedOptions() noexcept {
+  return static_cast<DateTimeFormatApple *>(this)->resolvedOptions();
+}
+
+void DateTimeFormatApple::initializeNSDateFormatter() noexcept {
   static constexpr std::u16string_view kLong = u"long", kShort = u"short",
                                        kNarrow = u"narrow", kMedium = u"medium",
                                        kFull = u"full", kNumeric = u"numeric",
@@ -1566,112 +1639,112 @@ void DateTimeFormat::Impl::initializeNSDateFormatter() noexcept {
                                        kShortGeneric = u"shortGeneric",
                                        kLongGeneric = u"longGeneric";
 
-  nsDateFormatter = [[NSDateFormatter alloc] init];
-  if (timeStyle.has_value()) {
-    if (*timeStyle == kFull) {
-      nsDateFormatter.timeStyle = NSDateFormatterFullStyle;
-    } else if (*timeStyle == kLong) {
-      nsDateFormatter.timeStyle = NSDateFormatterLongStyle;
-    } else if (*timeStyle == kMedium) {
-      nsDateFormatter.timeStyle = NSDateFormatterMediumStyle;
+  nsDateFormatter_ = [[NSDateFormatter alloc] init];
+  if (timeStyle_.has_value()) {
+    if (*timeStyle_ == kFull) {
+      nsDateFormatter_.timeStyle = NSDateFormatterFullStyle;
+    } else if (*timeStyle_ == kLong) {
+      nsDateFormatter_.timeStyle = NSDateFormatterLongStyle;
+    } else if (*timeStyle_ == kMedium) {
+      nsDateFormatter_.timeStyle = NSDateFormatterMediumStyle;
     } else {
-      assert(*timeStyle == kShort && "No other valid timeStyle.");
-      nsDateFormatter.timeStyle = NSDateFormatterShortStyle;
+      assert(*timeStyle_ == kShort && "No other valid timeStyle.");
+      nsDateFormatter_.timeStyle = NSDateFormatterShortStyle;
     }
   }
-  if (dateStyle.has_value()) {
-    if (*dateStyle == kFull) {
-      nsDateFormatter.dateStyle = NSDateFormatterFullStyle;
-    } else if (*dateStyle == kLong) {
-      nsDateFormatter.dateStyle = NSDateFormatterLongStyle;
-    } else if (*dateStyle == kMedium) {
-      nsDateFormatter.dateStyle = NSDateFormatterMediumStyle;
+  if (dateStyle_.has_value()) {
+    if (*dateStyle_ == kFull) {
+      nsDateFormatter_.dateStyle = NSDateFormatterFullStyle;
+    } else if (*dateStyle_ == kLong) {
+      nsDateFormatter_.dateStyle = NSDateFormatterLongStyle;
+    } else if (*dateStyle_ == kMedium) {
+      nsDateFormatter_.dateStyle = NSDateFormatterMediumStyle;
     } else {
-      assert(*dateStyle == kShort && "No other valid dateStyle.");
-      nsDateFormatter.dateStyle = NSDateFormatterShortStyle;
+      assert(*dateStyle_ == kShort && "No other valid dateStyle.");
+      nsDateFormatter_.dateStyle = NSDateFormatterShortStyle;
     }
   }
-  nsDateFormatter.timeZone =
-      [[NSTimeZone alloc] initWithName:u16StringToNSString(timeZone)];
-  nsDateFormatter.locale =
-      [[NSLocale alloc] initWithLocaleIdentifier:u16StringToNSString(locale)];
-  if (calendar)
-    nsDateFormatter.calendar = [[NSCalendar alloc]
-        initWithCalendarIdentifier:u16StringToNSString(*calendar)];
-  if (timeStyle.has_value() || dateStyle.has_value())
+  nsDateFormatter_.timeZone =
+      [[NSTimeZone alloc] initWithName:u16StringToNSString(timeZone_)];
+  nsDateFormatter_.locale =
+      [[NSLocale alloc] initWithLocaleIdentifier:u16StringToNSString(locale_)];
+  if (calendar_)
+    nsDateFormatter_.calendar = [[NSCalendar alloc]
+        initWithCalendarIdentifier:u16StringToNSString(*calendar_)];
+  if (timeStyle_.has_value() || dateStyle_.has_value())
     return;
   // The following options cannot be used in conjunction with timeStyle or
   // dateStyle
   // Form a custom format string It will be reordered according to
   // locale later
   NSMutableString *customFormattedDate = [[NSMutableString alloc] init];
-  if (timeZoneName.has_value()) {
-    if (*timeZoneName == kShort) {
+  if (timeZoneName_.has_value()) {
+    if (*timeZoneName_ == kShort) {
       [customFormattedDate appendString:@"z"];
-    } else if (*timeZoneName == kLong) {
+    } else if (*timeZoneName_ == kLong) {
       [customFormattedDate appendString:@"zzzz"];
-    } else if (*timeZoneName == kShortOffset) {
+    } else if (*timeZoneName_ == kShortOffset) {
       [customFormattedDate appendString:@"O"];
-    } else if (*timeZoneName == kLongOffset) {
+    } else if (*timeZoneName_ == kLongOffset) {
       [customFormattedDate appendString:@"OOOO"];
-    } else if (*timeZoneName == kShortGeneric) {
+    } else if (*timeZoneName_ == kShortGeneric) {
       [customFormattedDate appendString:@"v"];
     } else {
-      assert(*timeZoneName == kLongGeneric && "No other valid timeZoneName");
+      assert(*timeZoneName_ == kLongGeneric && "No other valid timeZoneName");
       [customFormattedDate appendString:@"vvvv"];
     }
   }
-  if (era.has_value()) {
-    if (*era == kNarrow) {
+  if (era_.has_value()) {
+    if (*era_ == kNarrow) {
       [customFormattedDate appendString:@"GGGGG"];
-    } else if (*era == kShort) {
+    } else if (*era_ == kShort) {
       [customFormattedDate appendString:@"G"];
     } else {
-      assert(*era == kLong && "No other valid era.");
+      assert(*era_ == kLong && "No other valid era.");
       [customFormattedDate appendString:@"GGGG"];
     }
   }
-  if (year.has_value()) {
-    if (*year == kNumeric) {
+  if (year_.has_value()) {
+    if (*year_ == kNumeric) {
       [customFormattedDate appendString:@"yyyy"];
     } else {
-      assert(*year == kTwoDigit && "No other valid year.");
+      assert(*year_ == kTwoDigit && "No other valid year.");
       [customFormattedDate appendString:@"yy"];
     }
   }
-  if (month.has_value()) {
-    if (*month == kNarrow) {
+  if (month_.has_value()) {
+    if (*month_ == kNarrow) {
       [customFormattedDate appendString:@"MMMMM"];
-    } else if (*month == kNumeric) {
+    } else if (*month_ == kNumeric) {
       [customFormattedDate appendString:@"M"];
-    } else if (*month == kTwoDigit) {
+    } else if (*month_ == kTwoDigit) {
       [customFormattedDate appendString:@"MM"];
-    } else if (*month == kShort) {
+    } else if (*month_ == kShort) {
       [customFormattedDate appendString:@"MMM"];
     } else {
-      assert(*month == kLong && "No other valid month.");
+      assert(*month_ == kLong && "No other valid month.");
       [customFormattedDate appendString:@"MMMM"];
     }
   }
-  if (weekday.has_value()) {
-    if (*weekday == kNarrow) {
+  if (weekday_.has_value()) {
+    if (*weekday_ == kNarrow) {
       [customFormattedDate appendString:@"EEEEE"];
-    } else if (*weekday == kShort) {
+    } else if (*weekday_ == kShort) {
       [customFormattedDate appendString:@"E"];
     } else {
-      assert(*weekday == kLong && "No other valid weekday.");
+      assert(*weekday_ == kLong && "No other valid weekday.");
       [customFormattedDate appendString:@"EEEE"];
     }
   }
-  if (day.has_value()) {
-    if (*day == kNumeric) {
+  if (day_.has_value()) {
+    if (*day_ == kNumeric) {
       [customFormattedDate appendString:@"d"];
     } else {
-      assert(*day == kTwoDigit && "No other valid day.");
+      assert(*day_ == kTwoDigit && "No other valid day.");
       [customFormattedDate appendString:@"dd"];
     }
   }
-  if (hour.has_value()) {
+  if (hour_.has_value()) {
     // Ignore the hour12 bool in the impl_ struct
     // a = AM/PM for 12 hr clocks, automatically added depending on locale
     // AM/PM not multilingual, de-DE should be "03 Uhr" not "3 AM"
@@ -1679,55 +1752,55 @@ void DateTimeFormat::Impl::initializeNSDateFormatter() noexcept {
     // h = h12 = 1-12
     // H = h23 = 0-23
     // k = h24 = 1-24
-    if (hourCycle == u"h12") {
-      if (*hour == kNumeric) {
+    if (hourCycle_ == u"h12") {
+      if (*hour_ == kNumeric) {
         [customFormattedDate appendString:@"h"];
       } else {
-        assert(*hour == kTwoDigit && "No other valid hour.");
+        assert(*hour_ == kTwoDigit && "No other valid hour.");
         [customFormattedDate appendString:@"hh"];
       }
-    } else if (hourCycle == u"h24") {
-      if (*hour == kNumeric) {
+    } else if (hourCycle_ == u"h24") {
+      if (*hour_ == kNumeric) {
         [customFormattedDate appendString:@"k"];
       } else {
-        assert(*hour == kTwoDigit && "No other valid hour.");
+        assert(*hour_ == kTwoDigit && "No other valid hour.");
         [customFormattedDate appendString:@"kk"];
       }
-    } else if (hourCycle == u"h11") {
-      if (*hour == kNumeric) {
+    } else if (hourCycle_ == u"h11") {
+      if (*hour_ == kNumeric) {
         [customFormattedDate appendString:@"K"];
       } else {
-        assert(*hour == kTwoDigit && "No other valid hour.");
+        assert(*hour_ == kTwoDigit && "No other valid hour.");
         [customFormattedDate appendString:@"KK"];
       }
     } else { // h23
-      if (*hour == kNumeric) {
+      if (*hour_ == kNumeric) {
         [customFormattedDate appendString:@"H"];
       } else {
-        assert(*hour == kTwoDigit && "No other valid hour.");
+        assert(*hour_ == kTwoDigit && "No other valid hour.");
         [customFormattedDate appendString:@"HH"];
       }
     }
   }
-  if (minute.has_value()) {
-    if (*minute == kNumeric) {
+  if (minute_.has_value()) {
+    if (*minute_ == kNumeric) {
       [customFormattedDate appendString:@"m"];
     } else {
-      assert(*minute == kTwoDigit && "No other valid minute.");
+      assert(*minute_ == kTwoDigit && "No other valid minute.");
       [customFormattedDate appendString:@"mm"];
     }
   }
-  if (second.has_value()) {
-    if (*second == kNumeric) {
+  if (second_.has_value()) {
+    if (*second_ == kNumeric) {
       [customFormattedDate appendString:@"s"];
     } else {
-      assert(*second == kTwoDigit && "No other valid second.");
+      assert(*second_ == kTwoDigit && "No other valid second.");
       [customFormattedDate appendString:@"ss"];
     }
   }
-  if (fractionalSecondDigits.has_value()) {
+  if (fractionalSecondDigits_.has_value()) {
     // This currently outputs to 3 digits only with the date?
-    switch (*fractionalSecondDigits) {
+    switch (*fractionalSecondDigits_) {
       case 1:
         [customFormattedDate appendString:@"S"];
       case 2:
@@ -1741,16 +1814,20 @@ void DateTimeFormat::Impl::initializeNSDateFormatter() noexcept {
   // automatically separate the order) Only set a template format if it isn't
   // empty
   if (customFormattedDate.length > 0) {
-    [nsDateFormatter setLocalizedDateFormatFromTemplate:customFormattedDate];
+    [nsDateFormatter_ setLocalizedDateFormatFromTemplate:customFormattedDate];
   } else {
-    nsDateFormatter.dateStyle = NSDateFormatterShortStyle;
+    nsDateFormatter_.dateStyle = NSDateFormatterShortStyle;
   }
 }
 
-std::u16string DateTimeFormat::format(double jsTimeValue) noexcept {
+std::u16string DateTimeFormatApple::format(double jsTimeValue) noexcept {
   auto timeInSeconds = jsTimeValue / 1000;
   NSDate *date = [NSDate dateWithTimeIntervalSince1970:timeInSeconds];
-  return nsStringToU16String([impl_->nsDateFormatter stringFromDate:date]);
+  return nsStringToU16String([nsDateFormatter_ stringFromDate:date]);
+}
+
+std::u16string DateTimeFormat::format(double jsTimeValue) noexcept {
+  return static_cast<DateTimeFormatApple *>(this)->format(jsTimeValue);
 }
 
 static std::u16string returnTypeOfDate(const char16_t &c16) {
@@ -1781,11 +1858,11 @@ static std::u16string returnTypeOfDate(const char16_t &c16) {
 
 // Implementer note: This method corresponds roughly to
 // https://402.ecma-international.org/8.0/#sec-formatdatetimetoparts
-std::vector<Part> DateTimeFormat::formatToParts(double x) noexcept {
+std::vector<Part> DateTimeFormatApple::formatToParts(double x) noexcept {
   // NOTE: We dont have access to localeData.patterns. Instead we use
   // NSDateFormatter's foramt string, and break it into components.
   // 1. Let parts be ? PartitionDateTimePattern(dateTimeFormat, x).
-  auto fmt = nsStringToU16String(impl_->nsDateFormatter.dateFormat);
+  auto fmt = nsStringToU16String(nsDateFormatter_.dateFormat);
   std::unique(fmt.begin(), fmt.end());
   auto formattedDate = format(x);
   // 2. Let result be ArrayCreate(0).
@@ -1821,18 +1898,35 @@ std::vector<Part> DateTimeFormat::formatToParts(double x) noexcept {
   return result;
 }
 
-struct NumberFormat::Impl {
+std::vector<Part> DateTimeFormat::formatToParts(double x) noexcept {
+  return static_cast<DateTimeFormatApple *>(this)->formatToParts(x);
+}
+
+class NumberFormatApple : public NumberFormat {
+ public:
+  NumberFormatApple() = default;
+
+  vm::ExecutionStatus initialize(
+      vm::Runtime &runtime,
+      const std::vector<std::u16string> &locales,
+      const Options &options) noexcept;
+
+  Options resolvedOptions() noexcept;
+
+  std::u16string format(double number) noexcept;
+
+ private:
   // https://402.ecma-international.org/8.0/#sec-properties-of-intl-numberformat-instances
   // Intl.NumberFormat instances have an [[InitializedNumberFormat]] internal
   // slot.
   // NOTE: InitializedNumberFormat is not implemented.
   // [[Locale]] is a String value with the language tag of the locale whose
   // localization is used for formatting.
-  std::u16string locale;
+  std::u16string locale_;
   // [[DataLocale]] is a String value with the language tag of the nearest
   // locale for which the implementation has data to perform the formatting
   // operation. It will be a parent locale of [[Locale]].
-  std::u16string dataLocale;
+  std::u16string dataLocale_;
   // [[NumberingSystem]] is a String value with the "type" given in Unicode
   // Technical Standard 35 for the numbering system used for formatting.
   // NOTE: Even though NSNumberFormatter formats numbers and time using
@@ -1841,35 +1935,35 @@ struct NumberFormat::Impl {
   // feature unsupported.
   // [[Style]] is one of the String values "decimal", "currency", "percent", or
   // "unit", identifying the type of quantity being measured.
-  std::u16string style;
+  std::u16string style_;
   // [[Currency]] is a String value with the currency code identifying the
   // currency to be used if formatting with the "currency" unit type. It is only
   // used when [[Style]] has the value "currency".
-  std::optional<std::u16string> currency;
+  std::optional<std::u16string> currency_;
   // [[CurrencyDisplay]] is one of the String values "code", "symbol",
   // "narrowSymbol", or "name", specifying whether to display the currency as an
   // ISO 4217 alphabetic currency code, a localized currency symbol, or a
   // localized currency name if formatting with the "currency" style. It is only
   // used when [[Style]] has the value "currency".
-  std::optional<std::u16string> currencyDisplay;
+  std::optional<std::u16string> currencyDisplay_;
   // [[CurrencySign]] is one of the String values "standard" or "accounting",
   // specifying whether to render negative numbers in accounting format, often
   // signified by parenthesis. It is only used when [[Style]] has the value
   // "currency" and when [[SignDisplay]] is not "never".
-  std::optional<std::u16string> currencySign;
+  std::optional<std::u16string> currencySign_;
   // [[Unit]] is a core unit identifier, as defined by Unicode Technical
   // Standard #35, Part 2, Section 6. It is only used when [[Style]] has the
   // value "unit".
-  std::optional<std::u16string> unit;
+  std::optional<std::u16string> unit_;
   // [[UnitDisplay]] is one of the String values "short", "narrow", or "long",
   // specifying whether to display the unit as a symbol, narrow symbol, or
   // localized long name if formatting with the "unit" style. It is only used
   // when [[Style]] has the value "unit".
-  std::optional<std::u16string> unitDisplay;
+  std::optional<std::u16string> unitDisplay_;
   // [[MinimumIntegerDigits]] is a non-negative integer Number value indicating
   // the minimum integer digits to be used. Numbers will be padded with leading
   // zeroes if necessary.
-  uint8_t minimumIntegerDigits;
+  uint8_t minimumIntegerDigits_;
 
   struct NumDigits {
     uint8_t minimum;
@@ -1880,16 +1974,16 @@ struct NumberFormat::Impl {
   // be used. Numbers will be rounded or padded with trailing zeroes if
   // necessary. These properties are only used when [[RoundingType]] is
   // fractionDigits.
-  std::optional<NumDigits> fractionDigits;
+  std::optional<NumDigits> fractionDigits_;
   // [[MinimumSignificantDigits]] and [[MaximumSignificantDigits]] are positive
   // integer Number values indicating the minimum and maximum fraction digits to
   // be shown. If present, the formatter uses however many fraction digits are
   // required to display the specified number of significant digits. These
   // properties are only used when [[RoundingType]] is significantDigits.
-  std::optional<NumDigits> significantDigits;
+  std::optional<NumDigits> significantDigits_;
   // [[UseGrouping]] is a Boolean value indicating whether a grouping separator
   // should be used.
-  bool useGrouping;
+  bool useGrouping_;
   // [[RoundingType]] is one of the values fractionDigits, significantDigits, or
   // compactRounding, indicating which rounding strategy to use. If
   // fractionDigits, the number is rounded according to
@@ -1899,7 +1993,7 @@ struct NumberFormat::Impl {
   // above. If compactRounding, the number is rounded to 1 maximum fraction
   // digit if there is 1 digit before the decimal separator, and otherwise round
   // to 0 fraction digits.
-  std::u16string roundingType;
+  std::u16string roundingType_;
   // [[Notation]] is one of the String values "standard", "scientific",
   // "engineering", or "compact", specifying whether the number should be
   // displayed without scaling, scaled to the units place with the power of ten
@@ -1907,25 +2001,25 @@ struct NumberFormat::Impl {
   // ten in scientific notation, or scaled to the nearest locale-dependent
   // compact decimal notation power of ten with the corresponding compact
   // decimal notation affix.
-  std::u16string notation;
+  std::u16string notation_;
   // [[CompactDisplay]] is one of the String values "short" or "long",
   // specifying whether to display compact notation affixes in short form ("5K")
   // or long form ("5 thousand") if formatting with the "compact" notation. It
   // is only used when [[Notation]] has the value "compact".
-  std::optional<std::u16string> compactDisplay;
+  std::optional<std::u16string> compactDisplay_;
   // [[SignDisplay]] is one of the String values "auto", "always", "never", or
   // "exceptZero", specifying whether to show the sign on negative numbers only,
   // positive and negative numbers including zero, neither positive nor negative
   // numbers, or positive and negative numbers but not zero. In scientific
   // notation, this slot affects the sign display of the mantissa but not the
   // exponent.
-  std::u16string signDisplay;
+  std::u16string signDisplay_;
   // Finally, Intl.NumberFormat instances have a [[BoundFormat]] internal slot
   // that caches the function returned by the format accessor (15.4.3).
   // NOTE: BoundFormat is not implemented.
-  NSNumberFormatter *nsNumberFormatter;
-  NSMeasurementFormatter *nsMeasurementFormatter;
-  NSUnit *nsUnit;
+  NSNumberFormatter *nsNumberFormatter_;
+  NSMeasurementFormatter *nsMeasurementFormatter_;
+  NSUnit *nsUnit_;
 
   vm::ExecutionStatus setNumberFormatUnitOptions(
       vm::Runtime &runtime,
@@ -1939,8 +2033,8 @@ struct NumberFormat::Impl {
   void initializeNSFormatters() noexcept;
 };
 
-NumberFormat::NumberFormat() : impl_(std::make_unique<Impl>()) {}
-NumberFormat::~NumberFormat() {}
+NumberFormat::NumberFormat() = default;
+NumberFormat::~NumberFormat() = default;
 
 // https://402.ecma-international.org/8.0/#sec-intl.numberformat.supportedlocalesof
 vm::CallResult<std::vector<std::u16string>> NumberFormat::supportedLocalesOf(
@@ -1956,7 +2050,7 @@ vm::CallResult<std::vector<std::u16string>> NumberFormat::supportedLocalesOf(
 }
 
 // https://402.ecma-international.org/8.0/#sec-setnumberformatunitoptions
-vm::ExecutionStatus NumberFormat::Impl::setNumberFormatUnitOptions(
+vm::ExecutionStatus NumberFormatApple::setNumberFormatUnitOptions(
     vm::Runtime &runtime,
     const Options &options) noexcept {
   //  1. Assert: Type(intlObj) is Object.
@@ -1971,7 +2065,7 @@ vm::ExecutionStatus NumberFormat::Impl::setNumberFormatUnitOptions(
     return vm::ExecutionStatus::EXCEPTION;
   auto styleOpt = *styleRes;
   //  4. Set intlObj.[[Style]] to style.
-  style = *styleOpt;
+  style_ = *styleOpt;
   //  5. Let currency be ? GetOption(options, "currency", "string", undefined,
   //  undefined).
   auto currencyRes = getOptionString(runtime, options, u"currency", {}, {});
@@ -1981,7 +2075,7 @@ vm::ExecutionStatus NumberFormat::Impl::setNumberFormatUnitOptions(
   //  6. If currency is undefined, then
   if (!currencyOpt) {
     //  a. If style is "currency", throw a TypeError exception.
-    if (style == u"currency")
+    if (style_ == u"currency")
       return runtime.raiseTypeError("Currency is undefined");
     //  7. Else,
   } else {
@@ -2017,7 +2111,7 @@ vm::ExecutionStatus NumberFormat::Impl::setNumberFormatUnitOptions(
   //  11. If unit is undefined, then
   if (!unitOpt) {
     //  a. If style is "unit", throw a TypeError exception.
-    if (style == u"unit")
+    if (style_ == u"unit")
       return runtime.raiseTypeError("Unit is undefined");
     //  12. Else,
   } else {
@@ -2036,28 +2130,28 @@ vm::ExecutionStatus NumberFormat::Impl::setNumberFormatUnitOptions(
     return vm::ExecutionStatus::EXCEPTION;
   auto unitDisplayOpt = *unitDisplayRes;
   //  14. If style is "currency", then
-  if (style == u"currency") {
+  if (style_ == u"currency") {
     //  a. Let currency be the result of converting currency to upper case as
     //  specified in 6.1.
     //  b. Set intlObj.[[Currency]] to currency.
-    currency = toASCIIUppercase(*currencyOpt);
+    currency_ = toASCIIUppercase(*currencyOpt);
     //  c. Set intlObj.[[CurrencyDisplay]] to currencyDisplay.
-    currencyDisplay = *currencyDisplayOpt;
+    currencyDisplay_ = *currencyDisplayOpt;
     //  d. Set intlObj.[[CurrencySign]] to currencySign.
-    currencySign = *currencySignOpt;
+    currencySign_ = *currencySignOpt;
   }
   //  15. If style is "unit", then
-  if (style == u"unit") {
+  if (style_ == u"unit") {
     //  a. Set intlObj.[[Unit]] to unit.
     //  b. Set intlObj.[[UnitDisplay]] to unitDisplay.
-    unit = *unitOpt;
-    unitDisplay = *unitDisplayOpt;
+    unit_ = *unitOpt;
+    unitDisplay_ = *unitDisplayOpt;
   }
   return vm::ExecutionStatus::RETURNED;
 }
 
 // https://402.ecma-international.org/8.0/#sec-setnfdigitoptions
-vm::ExecutionStatus NumberFormat::Impl::setNumberFormatDigitOptions(
+vm::ExecutionStatus NumberFormatApple::setNumberFormatDigitOptions(
     vm::Runtime &runtime,
     const Options &options,
     uint8_t mnfdDefault,
@@ -2083,11 +2177,11 @@ vm::ExecutionStatus NumberFormat::Impl::setNumberFormatDigitOptions(
   // 9. Let mxsd be ? Get(options, "maximumSignificantDigits").
   auto mxsdIt = options.find(u"maximumSignificantDigits");
   // 10. Set intlObj.[[MinimumIntegerDigits]] to mnid.
-  minimumIntegerDigits = *mnidOpt;
+  minimumIntegerDigits_ = *mnidOpt;
   // 11. If mnsd is not undefined or mxsd is not undefined, then
   if (mnsdIt != options.end() || mxsdIt != options.end()) {
     // a. Set intlObj.[[RoundingType]] to significantDigits.
-    roundingType = u"significantDigits";
+    roundingType_ = u"significantDigits";
     // b. Let mnsd be ? DefaultNumberOption(mnsd, 1, 21, 1).
     auto mnsdValue =
         mnsdIt == options.end() ? std::nullopt : std::optional(mnsdIt->second);
@@ -2106,11 +2200,11 @@ vm::ExecutionStatus NumberFormat::Impl::setNumberFormatDigitOptions(
     auto mxsdOpt = *mxsdRes;
     // d. Set intlObj.[[MinimumSignificantDigits]] to mnsd.
     // e. Set intlObj.[[MaximumSignificantDigits]] to mxsd.
-    significantDigits = {*mnsdOpt, *mxsdOpt};
+    significantDigits_ = {*mnsdOpt, *mxsdOpt};
     // 12. Else if mnfd is not undefined or mxfd is not undefined, then
   } else if (mnfdIt != options.end() || mxfdIt != options.end()) {
     // a. Set intlObj.[[RoundingType]] to fractionDigits.
-    roundingType = u"fractionDigits";
+    roundingType_ = u"fractionDigits";
     // b. Let mnfd be ? DefaultNumberOption(mnfd, 0, 20, undefined).
     auto mnfdValue =
         mnfdIt == options.end() ? std::nullopt : std::optional(mnfdIt->second);
@@ -2140,24 +2234,24 @@ vm::ExecutionStatus NumberFormat::Impl::setNumberFormatDigitOptions(
     }
     // g. Set intlObj.[[MinimumFractionDigits]] to mnfd.
     // h. Set intlObj.[[MaximumFractionDigits]] to mxfd.
-    fractionDigits = {*mnfdOpt, *mxfdOpt};
+    fractionDigits_ = {*mnfdOpt, *mxfdOpt};
     // 13. Else if notation is "compact", then
-  } else if (notation == u"compact") {
+  } else if (notation_ == u"compact") {
     // a. Set intlObj.[[RoundingType]] to compactRounding.
-    roundingType = u"compactRounding";
+    roundingType_ = u"compactRounding";
     // 14. Else,
   } else {
     // a. Set intlObj.[[RoundingType]] to fractionDigits.
-    roundingType = u"fractionDigits";
+    roundingType_ = u"fractionDigits";
     // b. Set intlObj.[[MinimumFractionDigits]] to mnfdDefault.
     // c. Set intlObj.[[MaximumFractionDigits]] to mxfdDefault.
-    fractionDigits = {mnfdDefault, mxfdDefault};
+    fractionDigits_ = {mnfdDefault, mxfdDefault};
   }
   return vm::ExecutionStatus::RETURNED;
 }
 
 // https://402.ecma-international.org/8.0/#sec-initializenumberformat
-vm::ExecutionStatus NumberFormat::initialize(
+vm::ExecutionStatus NumberFormatApple::initialize(
     vm::Runtime &runtime,
     const std::vector<std::u16string> &locales,
     const Options &options) noexcept {
@@ -2208,22 +2302,22 @@ vm::ExecutionStatus NumberFormat::initialize(
   auto r = resolveLocale(
       getAvailableLocales(), *requestedLocales, opt, relevantExtensionKeys);
   // 11. Set numberFormat.[[Locale]] to r.[[locale]].
-  impl_->locale = r.locale;
+  locale_ = r.locale;
   // 12. Set numberFormat.[[DataLocale]] to r.[[dataLocale]].
-  impl_->dataLocale = r.dataLocale;
+  dataLocale_ = r.dataLocale;
   // 13. Set numberFormat.[[NumberingSystem]] to r.[[nu]].
   // 14. Perform ? SetNumberFormatUnitOptions(numberFormat, options).
-  auto setUnitOptionsRes = impl_->setNumberFormatUnitOptions(runtime, options);
+  auto setUnitOptionsRes = setNumberFormatUnitOptions(runtime, options);
   if (LLVM_UNLIKELY(setUnitOptionsRes == vm::ExecutionStatus::EXCEPTION))
     return vm::ExecutionStatus::EXCEPTION;
   // 15. Let style be numberFormat.[[Style]].
-  auto style = impl_->style;
+  auto style = style_;
   uint8_t mnfdDefault, mxfdDefault;
   // 16. If style is "currency", then
   if (style == u"currency") {
     // a. Let currency be numberFormat.[[Currency]].
     // b. Let cDigits be CurrencyDigits(currency).
-    auto cDigits = getCurrencyDigits(*impl_->currency);
+    auto cDigits = getCurrencyDigits(*currency_);
     // c. Let mnfdDefault be cDigits.
     mnfdDefault = cDigits;
     // d. Let mxfdDefault be cDigits.
@@ -2252,11 +2346,11 @@ vm::ExecutionStatus NumberFormat::initialize(
     return vm::ExecutionStatus::EXCEPTION;
   auto notationOpt = *notationRes;
   // 19. Set numberFormat.[[Notation]] to notation.
-  impl_->notation = *notationOpt;
+  notation_ = *notationOpt;
   // Perform ? SetNumberFormatDigitOptions(numberFormat, options, mnfdDefault,
   // mxfdDefault, notation).
-  auto setDigitOptionsRes = impl_->setNumberFormatDigitOptions(
-      runtime, options, mnfdDefault, mxfdDefault, impl_->notation);
+  auto setDigitOptionsRes = setNumberFormatDigitOptions(
+      runtime, options, mnfdDefault, mxfdDefault, notation_);
   if (LLVM_UNLIKELY(setDigitOptionsRes == vm::ExecutionStatus::EXCEPTION))
     return vm::ExecutionStatus::EXCEPTION;
   // 21. Let compactDisplay be ? GetOption(options, "compactDisplay", "string",
@@ -2271,12 +2365,12 @@ vm::ExecutionStatus NumberFormat::initialize(
   // 22. If notation is "compact", then
   if (*notationOpt == u"compact")
     //   a. Set numberFormat.[[CompactDisplay]] to compactDisplay.
-    impl_->compactDisplay = *compactDisplayOpt;
+    compactDisplay_ = *compactDisplayOpt;
   // 23. Let useGrouping be ? GetOption(options, "useGrouping", "boolean",
   // undefined, true).
   auto useGroupingOpt = getOptionBool(runtime, options, u"useGrouping", true);
   // 24. Set numberFormat.[[UseGrouping]] to useGrouping.
-  impl_->useGrouping = *useGroupingOpt;
+  useGrouping_ = *useGroupingOpt;
   // 25. Let signDisplay be ? GetOption(options, "signDisplay", "string", «
   // "auto", "never", "always", "exceptZero" », "auto").
   static constexpr std::u16string_view signDisplayValues[] = {
@@ -2287,51 +2381,66 @@ vm::ExecutionStatus NumberFormat::initialize(
     return vm::ExecutionStatus::EXCEPTION;
   auto signDisplayOpt = *signDisplayRes;
   // 26. Set numberFormat.[[SignDisplay]] to signDisplay.
-  impl_->signDisplay = *signDisplayOpt;
+  signDisplay_ = *signDisplayOpt;
 
-  impl_->initializeNSFormatters();
+  initializeNSFormatters();
   return vm::ExecutionStatus::RETURNED;
 }
 
+vm::CallResult<std::unique_ptr<NumberFormat>> NumberFormat::create(
+    vm::Runtime &runtime,
+    const std::vector<std::u16string> &locales,
+    const Options &inputOptions) noexcept {
+  auto instance = std::make_unique<NumberFormatApple>();
+  if (LLVM_UNLIKELY(
+          instance->initialize(runtime, locales, inputOptions) ==
+          vm::ExecutionStatus::EXCEPTION)) {
+    return vm::ExecutionStatus::EXCEPTION;
+  }
+  return instance;
+}
+
 // https://402.ecma-international.org/8.0/#sec-intl.numberformat.prototype.resolvedoptions
-Options NumberFormat::resolvedOptions() noexcept {
+Options NumberFormatApple::resolvedOptions() noexcept {
   Options options;
-  options.emplace(u"locale", impl_->locale);
-  options.emplace(u"style", impl_->style);
-  if (impl_->currency)
-    options.emplace(u"currency", *impl_->currency);
-  if (impl_->currencyDisplay)
-    options.emplace(u"currencyDisplay", *impl_->currencyDisplay);
-  if (impl_->currencySign)
-    options.emplace(u"currencySign", *impl_->currencySign);
-  if (impl_->unit)
-    options.emplace(u"unit", *impl_->unit);
-  if (impl_->unitDisplay)
-    options.emplace(u"unitDisplay", *impl_->unitDisplay);
-  options.emplace(u"minimumIntegerDigits", (double)impl_->minimumIntegerDigits);
-  if (impl_->fractionDigits) {
-    options.emplace(
-        u"minimumFractionDigits", (double)impl_->fractionDigits->minimum);
-    options.emplace(
-        u"maximumFractionDigits", (double)impl_->fractionDigits->maximum);
+  options.emplace(u"locale", locale_);
+  options.emplace(u"style", style_);
+  if (currency_)
+    options.emplace(u"currency", *currency_);
+  if (currencyDisplay_)
+    options.emplace(u"currencyDisplay", *currencyDisplay_);
+  if (currencySign_)
+    options.emplace(u"currencySign", *currencySign_);
+  if (unit_)
+    options.emplace(u"unit", *unit_);
+  if (unitDisplay_)
+    options.emplace(u"unitDisplay", *unitDisplay_);
+  options.emplace(u"minimumIntegerDigits", (double)minimumIntegerDigits_);
+  if (fractionDigits_) {
+    options.emplace(u"minimumFractionDigits", (double)fractionDigits_->minimum);
+    options.emplace(u"maximumFractionDigits", (double)fractionDigits_->maximum);
   }
-  if (impl_->significantDigits) {
+  if (significantDigits_) {
     options.emplace(
-        u"minimumSignificantDigits", (double)impl_->significantDigits->minimum);
+        u"minimumSignificantDigits", (double)significantDigits_->minimum);
     options.emplace(
-        u"maximumSignificantDigits", (double)impl_->significantDigits->maximum);
+        u"maximumSignificantDigits", (double)significantDigits_->maximum);
   }
-  options.emplace(u"useGrouping", impl_->useGrouping);
-  options.emplace(u"roundingType", impl_->roundingType);
-  options.emplace(u"notation", impl_->notation);
-  if (impl_->compactDisplay)
-    options.emplace(u"compactDisplay", *impl_->compactDisplay);
-  options.emplace(u"signDisplay", impl_->signDisplay);
+  options.emplace(u"useGrouping", useGrouping_);
+  options.emplace(u"roundingType", roundingType_);
+  options.emplace(u"notation", notation_);
+  if (compactDisplay_)
+    options.emplace(u"compactDisplay", *compactDisplay_);
+  options.emplace(u"signDisplay", signDisplay_);
   return options;
 }
 
+Options NumberFormat::resolvedOptions() noexcept {
+  return static_cast<NumberFormatApple *>(this)->resolvedOptions();
+}
+
 // https://402.ecma-international.org/8.0/#sec-formatnumber
-void NumberFormat::Impl::initializeNSFormatters() noexcept {
+void NumberFormatApple::initializeNSFormatters() noexcept {
   // NOTE: NSNumberFormatter has following limitations:
   // - "scientific" notation is supprted, "engineering" and "compact" are not.
   // - roundingType is not supported.
@@ -2339,69 +2448,72 @@ void NumberFormat::Impl::initializeNSFormatters() noexcept {
   // - signDisplay is not supported.
   // - NSNumberFormatter has maximumIntegerDigits, which is 42 by default
   auto nsLocale =
-      [NSLocale localeWithLocaleIdentifier:u16StringToNSString(dataLocale)];
-  nsNumberFormatter = [NSNumberFormatter new];
-  nsNumberFormatter.locale = nsLocale;
-  if (style == u"decimal") {
-    nsNumberFormatter.numberStyle = NSNumberFormatterDecimalStyle;
-    if (notation == u"scientific") {
-      nsNumberFormatter.numberStyle = NSNumberFormatterScientificStyle;
+      [NSLocale localeWithLocaleIdentifier:u16StringToNSString(dataLocale_)];
+  nsNumberFormatter_ = [NSNumberFormatter new];
+  nsNumberFormatter_.locale = nsLocale;
+  if (style_ == u"decimal") {
+    nsNumberFormatter_.numberStyle = NSNumberFormatterDecimalStyle;
+    if (notation_ == u"scientific") {
+      nsNumberFormatter_.numberStyle = NSNumberFormatterScientificStyle;
     }
-  } else if (style == u"currency") {
-    nsNumberFormatter.numberStyle = NSNumberFormatterCurrencyStyle;
-    nsNumberFormatter.currencyCode = u16StringToNSString(*currency);
-    if (currencyDisplay == u"code") {
-      nsNumberFormatter.numberStyle = NSNumberFormatterCurrencyISOCodeStyle;
-    } else if (currencyDisplay == u"symbol") {
-      nsNumberFormatter.numberStyle = NSNumberFormatterCurrencyStyle;
-    } else if (currencyDisplay == u"narrowSymbol") {
-      nsNumberFormatter.numberStyle = NSNumberFormatterCurrencyStyle;
-    } else if (currencyDisplay == u"name") {
-      nsNumberFormatter.numberStyle = NSNumberFormatterCurrencyPluralStyle;
+  } else if (style_ == u"currency") {
+    nsNumberFormatter_.numberStyle = NSNumberFormatterCurrencyStyle;
+    nsNumberFormatter_.currencyCode = u16StringToNSString(*currency_);
+    if (currencyDisplay_ == u"code") {
+      nsNumberFormatter_.numberStyle = NSNumberFormatterCurrencyISOCodeStyle;
+    } else if (currencyDisplay_ == u"symbol") {
+      nsNumberFormatter_.numberStyle = NSNumberFormatterCurrencyStyle;
+    } else if (currencyDisplay_ == u"narrowSymbol") {
+      nsNumberFormatter_.numberStyle = NSNumberFormatterCurrencyStyle;
+    } else if (currencyDisplay_ == u"name") {
+      nsNumberFormatter_.numberStyle = NSNumberFormatterCurrencyPluralStyle;
     }
-    if (signDisplay != u"never" && currencySign == u"accounting") {
-      nsNumberFormatter.numberStyle = NSNumberFormatterCurrencyAccountingStyle;
+    if (signDisplay_ != u"never" && currencySign_ == u"accounting") {
+      nsNumberFormatter_.numberStyle = NSNumberFormatterCurrencyAccountingStyle;
     }
-  } else if (style == u"percent") {
-    nsNumberFormatter.numberStyle = NSNumberFormatterPercentStyle;
-  } else if (style == u"unit") {
-    nsNumberFormatter.numberStyle = NSNumberFormatterNoStyle;
+  } else if (style_ == u"percent") {
+    nsNumberFormatter_.numberStyle = NSNumberFormatterPercentStyle;
+  } else if (style_ == u"unit") {
+    nsNumberFormatter_.numberStyle = NSNumberFormatterNoStyle;
   }
-  nsNumberFormatter.minimumIntegerDigits = minimumIntegerDigits;
-  if (fractionDigits) {
-    nsNumberFormatter.minimumFractionDigits = fractionDigits->minimum;
-    nsNumberFormatter.maximumFractionDigits = fractionDigits->maximum;
+  nsNumberFormatter_.minimumIntegerDigits = minimumIntegerDigits_;
+  if (fractionDigits_) {
+    nsNumberFormatter_.minimumFractionDigits = fractionDigits_->minimum;
+    nsNumberFormatter_.maximumFractionDigits = fractionDigits_->maximum;
   }
-  if (significantDigits) {
-    nsNumberFormatter.minimumSignificantDigits = significantDigits->minimum;
-    nsNumberFormatter.maximumSignificantDigits = significantDigits->maximum;
+  if (significantDigits_) {
+    nsNumberFormatter_.minimumSignificantDigits = significantDigits_->minimum;
+    nsNumberFormatter_.maximumSignificantDigits = significantDigits_->maximum;
   }
-  nsNumberFormatter.usesGroupingSeparator = useGrouping;
-  if (style == u"unit") {
-    nsMeasurementFormatter = [NSMeasurementFormatter new];
-    nsMeasurementFormatter.numberFormatter = nsNumberFormatter;
-    nsMeasurementFormatter.locale = nsLocale;
-    if (unitDisplay == u"short") {
-      nsMeasurementFormatter.unitStyle = NSFormattingUnitStyleShort;
-    } else if (unitDisplay == u"narrow") {
-      nsMeasurementFormatter.unitStyle = NSFormattingUnitStyleMedium;
-    } else if (unitDisplay == u"long") {
-      nsMeasurementFormatter.unitStyle = NSFormattingUnitStyleLong;
+  nsNumberFormatter_.usesGroupingSeparator = useGrouping_;
+  if (style_ == u"unit") {
+    nsMeasurementFormatter_ = [NSMeasurementFormatter new];
+    nsMeasurementFormatter_.numberFormatter = nsNumberFormatter_;
+    nsMeasurementFormatter_.locale = nsLocale;
+    if (unitDisplay_ == u"short") {
+      nsMeasurementFormatter_.unitStyle = NSFormattingUnitStyleShort;
+    } else if (unitDisplay_ == u"narrow") {
+      nsMeasurementFormatter_.unitStyle = NSFormattingUnitStyleMedium;
+    } else if (unitDisplay_ == u"long") {
+      nsMeasurementFormatter_.unitStyle = NSFormattingUnitStyleLong;
     }
-    nsUnit = unitIdentifierToNSUnit(*unit);
+    nsUnit_ = unitIdentifierToNSUnit(*unit_);
   }
 }
 
-std::u16string NumberFormat::format(double number) noexcept {
-  if (impl_->nsMeasurementFormatter) {
-    assert(impl_->style == u"unit");
-    auto m = [[NSMeasurement alloc] initWithDoubleValue:number
-                                                   unit:impl_->nsUnit];
+std::u16string NumberFormatApple::format(double number) noexcept {
+  if (nsMeasurementFormatter_) {
+    assert(style_ == u"unit");
+    auto m = [[NSMeasurement alloc] initWithDoubleValue:number unit:nsUnit_];
     return nsStringToU16String(
-        [impl_->nsMeasurementFormatter stringFromMeasurement:m]);
+        [nsMeasurementFormatter_ stringFromMeasurement:m]);
   }
-  return nsStringToU16String([impl_->nsNumberFormatter
-      stringFromNumber:[NSNumber numberWithDouble:number]]);
+  return nsStringToU16String(
+      [nsNumberFormatter_ stringFromNumber:[NSNumber numberWithDouble:number]]);
+}
+
+std::u16string NumberFormat::format(double number) noexcept {
+  return static_cast<NumberFormatApple *>(this)->format(number);
 }
 
 std::vector<std::unordered_map<std::u16string, std::u16string>>

--- a/lib/Platform/Intl/PlatformIntlDummy.cpp
+++ b/lib/Platform/Intl/PlatformIntlDummy.cpp
@@ -36,12 +36,15 @@ vm::CallResult<std::u16string> toLocaleUpperCase(
   return std::u16string(u"uppered");
 }
 
-struct Collator::Impl {
+namespace {
+struct CollatorDummy : Collator {
+  CollatorDummy(const char16_t *l) : locale(l) {}
   std::u16string locale;
 };
+} // namespace
 
-Collator::Collator() : impl_(std::make_unique<Impl>()) {}
-Collator::~Collator() {}
+Collator::Collator() = default;
+Collator::~Collator() = default;
 
 vm::CallResult<std::vector<std::u16string>> Collator::supportedLocalesOf(
     vm::Runtime &runtime,
@@ -50,17 +53,17 @@ vm::CallResult<std::vector<std::u16string>> Collator::supportedLocalesOf(
   return std::vector<std::u16string>{u"en-CA", u"de-DE"};
 }
 
-vm::ExecutionStatus Collator::initialize(
+vm::CallResult<std::unique_ptr<Collator>> Collator::create(
     vm::Runtime &runtime,
     const std::vector<std::u16string> &locales,
     const Options &options) noexcept {
-  impl_->locale = u"en-US";
-  return vm::ExecutionStatus::RETURNED;
+  return std::make_unique<CollatorDummy>(u"en-US");
 }
 
 Options Collator::resolvedOptions() noexcept {
   Options options;
-  options.emplace(u"locale", Option(impl_->locale));
+  options.emplace(
+      u"locale", Option(static_cast<CollatorDummy *>(this)->locale));
   options.emplace(u"numeric", Option(false));
   return options;
 }
@@ -71,12 +74,15 @@ double Collator::compare(
   return x.compare(y);
 }
 
-struct DateTimeFormat::Impl {
+namespace {
+struct DateTimeFormatDummy : DateTimeFormat {
+  DateTimeFormatDummy(const char16_t *l) : locale(l) {}
   std::u16string locale;
 };
+} // namespace
 
-DateTimeFormat::DateTimeFormat() : impl_(std::make_unique<Impl>()) {}
-DateTimeFormat::~DateTimeFormat() {}
+DateTimeFormat::DateTimeFormat() = default;
+DateTimeFormat::~DateTimeFormat() = default;
 
 vm::CallResult<std::vector<std::u16string>> DateTimeFormat::supportedLocalesOf(
     vm::Runtime &runtime,
@@ -85,17 +91,17 @@ vm::CallResult<std::vector<std::u16string>> DateTimeFormat::supportedLocalesOf(
   return std::vector<std::u16string>{u"en-CA", u"de-DE"};
 }
 
-vm::ExecutionStatus DateTimeFormat::initialize(
+vm::CallResult<std::unique_ptr<DateTimeFormat>> DateTimeFormat::create(
     vm::Runtime &runtime,
     const std::vector<std::u16string> &locales,
     const Options &options) noexcept {
-  impl_->locale = u"en-US";
-  return vm::ExecutionStatus::RETURNED;
+  return std::make_unique<DateTimeFormatDummy>(u"en-US");
 }
 
 Options DateTimeFormat::resolvedOptions() noexcept {
   Options options;
-  options.emplace(u"locale", Option(impl_->locale));
+  options.emplace(
+      u"locale", Option(static_cast<DateTimeFormatDummy *>(this)->locale));
   options.emplace(u"numeric", Option(false));
   return options;
 }
@@ -115,12 +121,15 @@ DateTimeFormat::formatToParts(double jsTimeValue) noexcept {
   return std::vector<std::unordered_map<std::u16string, std::u16string>>{part};
 }
 
-struct NumberFormat::Impl {
+namespace {
+struct NumberFormatDummy : NumberFormat {
+  NumberFormatDummy(const char16_t *l) : locale(l) {}
   std::u16string locale;
 };
+} // namespace
 
-NumberFormat::NumberFormat() : impl_(std::make_unique<Impl>()) {}
-NumberFormat::~NumberFormat() {}
+NumberFormat::NumberFormat() = default;
+NumberFormat::~NumberFormat() = default;
 
 vm::CallResult<std::vector<std::u16string>> NumberFormat::supportedLocalesOf(
     vm::Runtime &runtime,
@@ -129,17 +138,17 @@ vm::CallResult<std::vector<std::u16string>> NumberFormat::supportedLocalesOf(
   return std::vector<std::u16string>{u"en-CA", u"de-DE"};
 }
 
-vm::ExecutionStatus NumberFormat::initialize(
+vm::CallResult<std::unique_ptr<NumberFormat>> NumberFormat::create(
     vm::Runtime &runtime,
     const std::vector<std::u16string> &locales,
     const Options &options) noexcept {
-  impl_->locale = u"en-US";
-  return vm::ExecutionStatus::RETURNED;
+  return std::make_unique<NumberFormatDummy>(u"en-US");
 }
 
 Options NumberFormat::resolvedOptions() noexcept {
   Options options;
-  options.emplace(u"locale", Option(impl_->locale));
+  options.emplace(
+      u"locale", Option(static_cast<NumberFormatDummy *>(this)->locale));
   options.emplace(u"numeric", Option(false));
   return options;
 }

--- a/lib/VM/JSLib/Intl.cpp
+++ b/lib/VM/JSLib/Intl.cpp
@@ -441,12 +441,12 @@ CallResult<HermesValue> intlServiceConstructor(
     return ExecutionStatus::EXCEPTION;
   }
 
-  auto native = std::make_unique<T>();
-  if (LLVM_UNLIKELY(
-          native->initialize(runtime, *localesRes, *optionsRes) ==
-          ExecutionStatus::EXCEPTION)) {
+  CallResult<std::unique_ptr<T>> nativeRes =
+      T::create(runtime, *localesRes, *optionsRes);
+  if (LLVM_UNLIKELY(nativeRes == ExecutionStatus::EXCEPTION)) {
     return ExecutionStatus::EXCEPTION;
   }
+  std::unique_ptr<T> native = std::move(*nativeRes);
 
   auto typeHandle = runtime.makeHandle(
       HermesValue::encodeNumberValue((uint32_t)T::getNativeType()));
@@ -1424,17 +1424,17 @@ CallResult<HermesValue> intlDatePrototypeToSomeLocaleString(
     }
     toDateTimeOptions(*optionsRes, dtoFlags);
 
-    platform_intl::DateTimeFormat dtf;
-    if (LLVM_UNLIKELY(
-            dtf.initialize(runtime, *localesRes, *optionsRes) ==
-            ExecutionStatus::EXCEPTION)) {
+    CallResult<std::unique_ptr<platform_intl::DateTimeFormat>> dtfRes =
+        platform_intl::DateTimeFormat::create(
+            runtime, *localesRes, *optionsRes);
+    if (LLVM_UNLIKELY(dtfRes == ExecutionStatus::EXCEPTION)) {
       return ExecutionStatus::EXCEPTION;
     }
 
     // Naively, the spec requires TimeClip to be called here, but
     // since in this code path, x comes from a Date slot which has
     // already been clipped, there's no reason to do it again.
-    str = dtf.format(x);
+    str = (*dtfRes)->format(x);
   }
 
   return StringPrimitive::createEfficient(runtime, std::move(str));
@@ -1498,13 +1498,12 @@ intlNumberPrototypeToLocaleString(void *, Runtime &runtime, NativeArgs args) {
     return ExecutionStatus::EXCEPTION;
   }
 
-  platform_intl::NumberFormat nf;
-  if (LLVM_UNLIKELY(
-          nf.initialize(runtime, *localesRes, *optionsRes) ==
-          ExecutionStatus::EXCEPTION)) {
+  CallResult<std::unique_ptr<platform_intl::NumberFormat>> nfRes =
+      platform_intl::NumberFormat::create(runtime, *localesRes, *optionsRes);
+  if (LLVM_UNLIKELY(nfRes == ExecutionStatus::EXCEPTION)) {
     return ExecutionStatus::EXCEPTION;
   }
-  return StringPrimitive::createEfficient(runtime, nf.format(x));
+  return StringPrimitive::createEfficient(runtime, (*nfRes)->format(x));
 }
 
 CallResult<HermesValue>
@@ -1534,14 +1533,14 @@ intlStringPrototypeLocaleCompare(void *, Runtime &runtime, NativeArgs args) {
     return ExecutionStatus::EXCEPTION;
   }
 
-  platform_intl::Collator collator;
-  if (LLVM_UNLIKELY(
-          collator.initialize(runtime, *localesRes, *optionsRes) ==
-          ExecutionStatus::EXCEPTION)) {
+  CallResult<std::unique_ptr<platform_intl::Collator>> collatorRes =
+      platform_intl::Collator::create(runtime, *localesRes, *optionsRes);
+  if (LLVM_UNLIKELY(collatorRes == ExecutionStatus::EXCEPTION)) {
     return ExecutionStatus::EXCEPTION;
   }
 
-  return HermesValue::encodeNumberValue(collator.compare(*thisRes, *thatRes));
+  return HermesValue::encodeNumberValue(
+      (*collatorRes)->compare(*thisRes, *thatRes));
 }
 
 CallResult<HermesValue> intlStringPrototypeToLocaleLowerCase(


### PR DESCRIPTION
Summary:
Removes the pImpl indirection in Intl implementations. This is possible due to
the fact that there's only ever one Intl implementation compiled in hermes, so we
can safely down cast from the base Intl classes to the Native ones.

Differential Revision: D39115523

