### PR TITLE
Fix compilation warnings in BigIntSupport.h

### DIFF
--- a/include/hermes/Support/BigIntSupport.h
+++ b/include/hermes/Support/BigIntSupport.h
@@ -68,15 +68,17 @@ std::optional<std::string> getNumericValueDigits(
 using SignedBigIntDigitType = int64_t;
 using BigIntDigitType = uint64_t;
 
-static constexpr size_t BigIntDigitSizeInBytes = sizeof(BigIntDigitType);
-static constexpr size_t BigIntDigitSizeInBits = BigIntDigitSizeInBytes * 8;
+inline constexpr uint32_t BigIntDigitSizeInBytes =
+    static_cast<uint32_t>(sizeof(BigIntDigitType));
+inline constexpr uint32_t BigIntDigitSizeInBits = BigIntDigitSizeInBytes * 8;
 
 /// Arbitrary upper limit on number of Digits a bigint may have.
-static constexpr size_t BigIntMaxSizeInDigits = 0x400; // 1k digits == 8k bytes
+inline constexpr uint32_t BigIntMaxSizeInDigits =
+    0x400; // 1k digits == 8k bytes
 
 /// Helper function that should be called before allocating a Digits array on
 /// the stack.
-inline constexpr bool tooManyDigits(unsigned numDigits) {
+inline constexpr bool tooManyDigits(uint32_t numDigits) {
   return BigIntMaxSizeInDigits < numDigits;
 }
 
@@ -93,12 +95,12 @@ inline size_t numDigitsForSizeInBytes(uint32_t v) {
 }
 
 /// \return how many chars in base \p radix fit a BigIntDigitType.
-inline unsigned constexpr maxCharsPerDigitInRadix(uint8_t radix) {
+inline uint32_t constexpr maxCharsPerDigitInRadix(uint8_t radix) {
   // To compute the lower bound of bits in a BigIntDigitType "covered" by a
   // char. For power of 2 radixes, it is known (exactly) that each character
   // covers log2(radix) bits. For non-power of 2 radixes, a lower bound is
   // log2(greatest power of 2 that is less than radix).
-  unsigned minNumBitsPerChar = radix < 4 ? 1
+  uint32_t minNumBitsPerChar = radix < 4 ? 1
       : radix < 8                        ? 2
       : radix < 16                       ? 3
       : radix < 32                       ? 4
@@ -107,8 +109,7 @@ inline unsigned constexpr maxCharsPerDigitInRadix(uint8_t radix) {
   // With minNumBitsPerChar being the lower bound estimate of how many bits each
   // char can represent, the upper bound of how many chars "fit" in a bigint
   // digit is ceil(sizeofInBits(bigint digit) / minNumBitsPerChar).
-  unsigned numCharsPerDigits =
-      static_cast<unsigned>(BigIntDigitSizeInBits) / (1 << minNumBitsPerChar);
+  uint32_t numCharsPerDigits = BigIntDigitSizeInBits / (1 << minNumBitsPerChar);
 
   return numCharsPerDigits;
 }
@@ -122,7 +123,7 @@ llvh::ArrayRef<uint8_t> dropExtraSignBits(llvh::ArrayRef<uint8_t> src);
 /// byte. I.e., returns 0 if \p value is 0b0xxx....xxx, and ~0, if \p value is
 /// 0x1xxx....xxx.
 template <typename D, typename T, typename UT = std::make_unsigned_t<T>>
-static constexpr std::enable_if_t<std::is_integral_v<T>, D> getSignExtValue(
+inline constexpr std::enable_if_t<std::is_integral_v<T>, D> getSignExtValue(
     const T &value) {
   uint32_t UnsignedTSizeInBits = sizeof(UT) * 8;
   UT unsignedValue = value;

--- a/include/hermes/Support/BigIntSupport.h
+++ b/include/hermes/Support/BigIntSupport.h
@@ -97,7 +97,7 @@ inline unsigned constexpr maxCharsPerDigitInRadix(uint8_t radix) {
   // To compute the lower bound of bits in a BigIntDigitType "covered" by a
   // char. For power of 2 radixes, it is known (exactly) that each character
   // covers log2(radix) bits. For non-power of 2 radixes, a lower bound is
-  // log2(greates power of 2 that is less than radix).
+  // log2(greatest power of 2 that is less than radix).
   unsigned minNumBitsPerChar = radix < 4 ? 1
       : radix < 8                        ? 2
       : radix < 16                       ? 3
@@ -107,7 +107,8 @@ inline unsigned constexpr maxCharsPerDigitInRadix(uint8_t radix) {
   // With minNumBitsPerChar being the lower bound estimate of how many bits each
   // char can represent, the upper bound of how many chars "fit" in a bigint
   // digit is ceil(sizeofInBits(bigint digit) / minNumBitsPerChar).
-  unsigned numCharsPerDigits = BigIntDigitSizeInBits / (1 << minNumBitsPerChar);
+  unsigned numCharsPerDigits =
+      static_cast<unsigned>(BigIntDigitSizeInBits) / (1 << minNumBitsPerChar);
 
   return numCharsPerDigits;
 }
@@ -281,7 +282,7 @@ asIntN(MutableBigIntRef dst, uint64_t n, ImmutableBigIntRef src);
 int compare(ImmutableBigIntRef lhs, ImmutableBigIntRef rhs);
 int compare(ImmutableBigIntRef lhs, SignedBigIntDigitType rhs);
 
-/// \return Whether \p src can be losslessly trucated to a single
+/// \return Whether \p src can be losslessly truncated to a single
 /// SignedBigIntDigitType (if signedTruncation == true) or BigIntDigitType
 /// (signedTruncation == false) digit.
 bool isSingleDigitTruncationLossless(


### PR DESCRIPTION
## Summary

Fix compilation warnings in `BigIntSupport.h`.
The related changes in `BigIntSupport.h`:
- `size_t` constants are changed to `uint32_t` to avoid unnecessary conversion between 32 and 64 integers.
- `unsigned` type changed to `uint32_t` to be explict about the type size.
- `static` keyword for standalone variables and functions is changed to `inline`. The `static` keyword in header files forces creation of copies of the variables and functions in each compilation unit that use the header file and unnecessary increases size of binary code.
- Fixed a couple of typos in comments. 

## Details

Currently the code in `BigIntSupport.h` produces the following warnings in MSVC:

> [build] (...clipped...)\include\hermes/Support/BigIntSupport.h(111,55): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?) [(...clipped...)\build\lib\VM\hermesVMRuntime.vcxproj]

After the fix we do not see these warnings anymore.

The new code also produces more efficient machine code.
See below x64 debug assembly before and after the change.

Before the change:
![Before_Fix](https://user-images.githubusercontent.com/972834/188001836-8072d7cd-953e-434d-874a-e3c7ccf3fac3.png)

After the change:
![After_Fix](https://user-images.githubusercontent.com/972834/188001833-b5638021-e16c-4c79-9897-a0697ae4f980.png)

The new code is shorter by 5 bytes.

Though, the code is probably completely optimized out for the Release bits and the only real benefit is that we do not see the warnings anymore.

## Test Plan

All unit tests are passing. No changes in program logic.
