### PR TITLE
Fix creation of std::unique_ptr<const Buffer>

### DIFF
--- a/lib/BCGen/HBC/BytecodeFormConverter.cpp
+++ b/lib/BCGen/HBC/BytecodeFormConverter.cpp
@@ -165,7 +165,7 @@ class BytecodeFormConverter {
       BytecodeForm sourceForm)
       : bytes_(bytes), fields_(fields) {
     auto res = hbc::BCProviderFromBuffer::createBCProviderFromBuffer(
-        std::make_unique<Buffer>(bytes.data(), bytes.size()), sourceForm);
+        std::make_unique<const Buffer>(bytes.data(), bytes.size()), sourceForm);
     if (!res.first) {
       hermes_fatal(res.second.c_str());
     }


### PR DESCRIPTION
## Summary

The `hbc::BCProviderFromBuffer::createBCProviderFromBuffer` method expects `std::unique_ptr<const Buffer>`, but we currently provide `std::unique_ptr<Buffer>` (no `const`). It is more optimal to provide value of the same type to avoid any unnecessary value conversion.
The code is changed to call `std::make_unique<const Buffer>` instead of `std::make_unique<Buffer>`.

## Test Plan

All unit tests are passing. There are no changes in program flow.
