### PR TITLE
Fix compilation for Windows ARM64

### DIFF
--- a/lib/Support/OSCompatWindows.cpp
+++ b/lib/Support/OSCompatWindows.cpp
@@ -423,14 +423,14 @@ int sched_getcpu() {
 }
 
 uint64_t cpu_cycle_counter() {
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
   return __rdtsc();
 #elif __has_builtin(__builtin_readcyclecounter)
   return __builtin_readcyclecounter();
 #else
   LARGE_INTEGER cnt;
   QueryPerformanceCounter(&cnt);
-  return cnt;
+  return static_cast<uint64_t>(cnt.QuadPart);
 #endif
 }
 


### PR DESCRIPTION
## Summary

Currently code in `OSCompatWindows.cpp` causes a compilation error for ARM64 platform.
The issue is that the `__rdtsc()` intrinsic function is defined only for x86 and x64 CPUs and it is not available for ARM64.
The PR addresses this issue and also fixes incorrect `return` statement in the `#else` branch that is used for ARM64.

## Test Plan

All unit tests are passing. No changes in code flow.