### PR TITLE
Fix TypedArray functions

### DIFF
--- a/lib/VM/JSLib/TypedArray.cpp
+++ b/lib/VM/JSLib/TypedArray.cpp
@@ -747,7 +747,8 @@ typedArrayPrototypeByteLength(void *, Runtime &runtime, NativeArgs args) {
     return ExecutionStatus::EXCEPTION;
   }
   auto self = args.vmcastThis<JSTypedArrayBase>();
-  return HermesValue::encodeNumberValue(self->attached(runtime) ? self->getByteLength() : 0);
+  return HermesValue::encodeNumberValue(
+      self->attached(runtime) ? self->getByteLength() : 0);
 }
 
 /// ES6 22.2.3.3
@@ -1238,7 +1239,8 @@ typedArrayPrototypeLength(void *, Runtime &runtime, NativeArgs args) {
     return ExecutionStatus::EXCEPTION;
   }
   auto self = args.vmcastThis<JSTypedArrayBase>();
-  return HermesValue::encodeNumberValue(self->attached(runtime) ? self->getLength() : 0);
+  return HermesValue::encodeNumberValue(
+      self->attached(runtime) ? self->getLength() : 0);
 }
 
 CallResult<HermesValue>

--- a/lib/VM/JSLib/TypedArray.cpp
+++ b/lib/VM/JSLib/TypedArray.cpp
@@ -747,7 +747,7 @@ typedArrayPrototypeByteLength(void *, Runtime &runtime, NativeArgs args) {
     return ExecutionStatus::EXCEPTION;
   }
   auto self = args.vmcastThis<JSTypedArrayBase>();
-  return HermesValue::encodeNumberValue(self->getByteLength());
+  return HermesValue::encodeNumberValue(self->attached(runtime) ? self->getByteLength() : 0);
 }
 
 /// ES6 22.2.3.3
@@ -1238,7 +1238,7 @@ typedArrayPrototypeLength(void *, Runtime &runtime, NativeArgs args) {
     return ExecutionStatus::EXCEPTION;
   }
   auto self = args.vmcastThis<JSTypedArrayBase>();
-  return HermesValue::encodeNumberValue(self->getLength());
+  return HermesValue::encodeNumberValue(self->attached(runtime) ? self->getLength() : 0);
 }
 
 CallResult<HermesValue>


### PR DESCRIPTION
## Summary

Fix TypedArray `byteLength()` and `length()` functions when the buffer is detached.
Before the change they return non-zero value.
The PR is fixing it and they return zero in such case.

## Test Plan

The new code passes Node-API tests in hermes-windows repo which are otherwise fail.
It seems that hermes does not have any unit tests for the detached buffer.
I am looking for some advice on how I must add the new test.
