### PR TITLE
Use multiple cores when building with CMake

### DIFF
--- a/utils/build-apple-framework.sh
+++ b/utils/build-apple-framework.sh
@@ -89,7 +89,8 @@ function build_apple_framework {
   if [[ "$BUILD_SYSTEM" == "Ninja" ]]; then
     (cd "./build_$1" && ninja install/strip)
   else
-    (cd "./build_$1" && make install/strip)
+    NUM_CORES=$(sysctl -n hw.ncpu)
+    (cd "./build_$1" && make install/strip -j "${NUM_CORES}")
   fi
 }
 


### PR DESCRIPTION
Summary:
When installing RNTester in React Native we build hermes from source. Currently, we are not asking our users to install ninja, so the build fallback uses CMake. We realized that we have very long builds and that is because we are not using multiple cores when building Hermes.

This diff tries to address that problem, using the same code we are using in other CI jobs

Differential Revision: D39538731

