### PR TITLE
Extract Keywords into a separate file

### DIFF
--- a/include/hermes/ADT/ScopedHashTable.h
+++ b/include/hermes/ADT/ScopedHashTable.h
@@ -162,6 +162,15 @@ class ScopedHashTable {
     return result->second->value_;
   }
 
+  /// Return a pointer to the innermost value for a key, or nullptr if none.
+  V *find(const K &key) {
+    auto result = map_.find(key);
+    if (result == map_.end())
+      return nullptr;
+
+    return &result->second->value_;
+  }
+
   // Gets all values currently in scope.
   std::unique_ptr<llvh::DenseMap<K, V>> flatten() const {
     std::unique_ptr<llvh::DenseMap<K, V>> result{

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -7,6 +7,7 @@ add_hermes_library(hermesAST
     ASTBuilder.cpp
     ESTree.cpp
     ESTreeJSONDumper.cpp
+    Keywords.cpp Keywords.h
     SemValidate.cpp
     SemanticValidator.cpp SemanticValidator.h
     CommonJS.cpp

--- a/lib/AST/Keywords.cpp
+++ b/lib/AST/Keywords.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "Keywords.h"
+
+#include "hermes/AST/Context.h"
+#include "hermes/Support/RegExpSerialization.h"
+
+namespace hermes {
+namespace sem {
+
+Keywords::Keywords(Context &astContext)
+    : identArguments(
+          astContext.getIdentifier("arguments").getUnderlyingPointer()),
+      identEval(astContext.getIdentifier("eval").getUnderlyingPointer()),
+      identDelete(astContext.getIdentifier("delete").getUnderlyingPointer()),
+      identThis(astContext.getIdentifier("this").getUnderlyingPointer()),
+      identUseStrict(
+          astContext.getIdentifier("use strict").getUnderlyingPointer()),
+      identShowSource(
+          astContext.getIdentifier("show source").getUnderlyingPointer()),
+      identHideSource(
+          astContext.getIdentifier("hide source").getUnderlyingPointer()),
+      identSensitive(
+          astContext.getIdentifier("sensitive").getUnderlyingPointer()),
+      identVar(astContext.getIdentifier("var").getUnderlyingPointer()),
+      identLet(astContext.getIdentifier("let").getUnderlyingPointer()),
+      identConst(astContext.getIdentifier("const").getUnderlyingPointer()),
+      identPlus(astContext.getIdentifier("+").getUnderlyingPointer()),
+      identMinus(astContext.getIdentifier("-").getUnderlyingPointer()),
+      identAssign(astContext.getIdentifier("=").getUnderlyingPointer()),
+      identNew(astContext.getIdentifier("new").getUnderlyingPointer()),
+      identTarget(astContext.getIdentifier("target").getUnderlyingPointer()),
+      identTypeof(astContext.getIdentifier("typeof").getUnderlyingPointer()) {}
+
+} // namespace sem
+} // namespace hermes

--- a/lib/AST/Keywords.h
+++ b/lib/AST/Keywords.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef HERMES_AST_KEYWORDS_H
+#define HERMES_AST_KEYWORDS_H
+
+#include "hermes/AST/SemValidate.h"
+
+#include "hermes/AST/RecursiveVisitor.h"
+
+namespace hermes {
+
+class Context;
+
+namespace sem {
+
+class Keywords {
+ public:
+  /// Identifier for "arguments".
+  const UniqueString *const identArguments;
+  /// Identifier for "eval".
+  const UniqueString *const identEval;
+  /// Identifier for "delete".
+  const UniqueString *const identDelete;
+  /// Identifier for "this".
+  const UniqueString *const identThis;
+  /// Identifier for "use strict".
+  const UniqueString *const identUseStrict;
+  /// Identifier for "show source ".
+  const UniqueString *const identShowSource;
+  /// Identifier for "hide source ".
+  const UniqueString *const identHideSource;
+  /// Identifier for "sensitive".
+  const UniqueString *const identSensitive;
+  /// Identifier for "var".
+  const UniqueString *const identVar;
+  /// Identifier for "let".
+  const UniqueString *const identLet;
+  /// Identifier for "const".
+  const UniqueString *const identConst;
+  /// "+".
+  const UniqueString *const identPlus;
+  /// "-".
+  const UniqueString *const identMinus;
+  /// "=".
+  const UniqueString *const identAssign;
+  /// "new"
+  const UniqueString *const identNew;
+  /// "target"
+  const UniqueString *const identTarget;
+  /// "typeof".
+  const UniqueString *const identTypeof;
+
+  Keywords(Context &astContext);
+};
+
+} // namespace sem
+} // namespace hermes
+
+#endif

--- a/lib/AST/SemanticValidator.cpp
+++ b/lib/AST/SemanticValidator.cpp
@@ -22,30 +22,6 @@ namespace hermes {
 namespace sem {
 
 //===----------------------------------------------------------------------===//
-// Keywords
-
-Keywords::Keywords(Context &astContext)
-    : identArguments(
-          astContext.getIdentifier("arguments").getUnderlyingPointer()),
-      identEval(astContext.getIdentifier("eval").getUnderlyingPointer()),
-      identDelete(astContext.getIdentifier("delete").getUnderlyingPointer()),
-      identThis(astContext.getIdentifier("this").getUnderlyingPointer()),
-      identUseStrict(
-          astContext.getIdentifier("use strict").getUnderlyingPointer()),
-      identShowSource(
-          astContext.getIdentifier("show source").getUnderlyingPointer()),
-      identHideSource(
-          astContext.getIdentifier("hide source").getUnderlyingPointer()),
-      identSensitive(
-          astContext.getIdentifier("sensitive").getUnderlyingPointer()),
-      identVar(astContext.getIdentifier("var").getUnderlyingPointer()),
-      identLet(astContext.getIdentifier("let").getUnderlyingPointer()),
-      identConst(astContext.getIdentifier("const").getUnderlyingPointer()),
-      identPlus(astContext.getIdentifier("+").getUnderlyingPointer()),
-      identMinus(astContext.getIdentifier("-").getUnderlyingPointer()),
-      identAssign(astContext.getIdentifier("=").getUnderlyingPointer()) {}
-
-//===----------------------------------------------------------------------===//
 // SemanticValidator
 
 SemanticValidator::SemanticValidator(

--- a/lib/AST/SemanticValidator.h
+++ b/lib/AST/SemanticValidator.h
@@ -10,6 +10,7 @@
 
 #include "hermes/AST/SemValidate.h"
 
+#include "Keywords.h"
 #include "hermes/AST/RecursiveVisitor.h"
 
 namespace hermes {
@@ -20,43 +21,6 @@ using namespace hermes::ESTree;
 // Forward declarations
 class FunctionContext;
 class SemanticValidator;
-
-//===----------------------------------------------------------------------===//
-// Keywords
-
-class Keywords {
- public:
-  /// Identifier for "arguments".
-  const UniqueString *const identArguments;
-  /// Identifier for "eval".
-  const UniqueString *const identEval;
-  /// Identifier for "delete".
-  const UniqueString *const identDelete;
-  /// Identifier for "this".
-  const UniqueString *const identThis;
-  /// Identifier for "use strict".
-  const UniqueString *const identUseStrict;
-  /// Identifier for "show source ".
-  const UniqueString *const identShowSource;
-  /// Identifier for "hide source ".
-  const UniqueString *const identHideSource;
-  /// Identifier for "sensitive".
-  const UniqueString *const identSensitive;
-  /// Identifier for "var".
-  const UniqueString *const identVar;
-  /// Identifier for "let".
-  const UniqueString *const identLet;
-  /// Identifier for "const".
-  const UniqueString *const identConst;
-  /// "+".
-  const UniqueString *const identPlus;
-  /// "-".
-  const UniqueString *const identMinus;
-  /// "=".
-  const UniqueString *const identAssign;
-
-  Keywords(Context &astContext);
-};
 
 //===----------------------------------------------------------------------===//
 // SemanticValidator


### PR DESCRIPTION
Summary:
For easier reusability, move the class into another file.
Eventually we can move it from the `sem` namespace into `sema`,
but for now keep everything working as it is.

Differential Revision: D39985176

