### PR TITLE
Add new SemanticResolver

### DIFF
--- a/include/hermes/ADT/ScopedHashTable.h
+++ b/include/hermes/ADT/ScopedHashTable.h
@@ -162,6 +162,15 @@ class ScopedHashTable {
     return result->second->value_;
   }
 
+  /// Return a pointer to the innermost value for a key, or nullptr if none.
+  V *find(const K &key) {
+    auto result = map_.find(key);
+    if (result == map_.end())
+      return nullptr;
+
+    return &result->second->value_;
+  }
+
   // Gets all values currently in scope.
   std::unique_ptr<llvh::DenseMap<K, V>> flatten() const {
     std::unique_ptr<llvh::DenseMap<K, V>> result{

--- a/include/hermes/AST/ESTree.h
+++ b/include/hermes/AST/ESTree.h
@@ -896,6 +896,9 @@ NodeList &getParams(FunctionLikeNode *node);
 /// functions.
 BlockStatementNode *getBlockStatement(FunctionLikeNode *node);
 
+/// \return the name of the function.
+Node *getIdentifier(FunctionLikeNode *node);
+
 /// \return the object of the member expression node.
 Node *getObject(MemberExpressionLikeNode *node);
 

--- a/include/hermes/AST/SemContext.h
+++ b/include/hermes/AST/SemContext.h
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef HERMES_AST_SEMCONTEXT_H
+#define HERMES_AST_SEMCONTEXT_H
+
+#include "hermes/AST/ESTree.h"
+
+#include <deque>
+
+namespace hermes {
+namespace sema {
+
+class Decl;
+class LexicalScope;
+class FunctionInfo;
+class SemContext;
+
+/// Variable declaration.
+class Decl {
+ public:
+  /// The kind of variable declaration.
+  /// Determines scoping, among other things.
+  enum class Kind : uint8_t {
+    // ==== Let-like declarations ===
+    Let,
+    Const,
+    Class,
+    Import,
+    /// A single catch variable declared like this "catch (e)", see
+    /// ES10 B.3.5 VariableStatements in Catch Blocks
+    ES5Catch,
+
+    // ==== other declarations ===
+    FunctionExprName,
+    /// Function declaration visible only in its lexical scope.
+    ScopedFunction,
+
+    // ==== Var-like declarations ===
+
+    /// "var" in function scope.
+    Var,
+    Parameter,
+    /// "var" in global scope.
+    GlobalProperty,
+    UndeclaredGlobalProperty,
+  };
+
+  enum class Special : uint8_t {
+    NotSpecial,
+    Arguments,
+    Eval,
+  };
+
+  /// \return true if this kind of declaration is function scope (and can be
+  /// re-declared).
+  static bool isKindVarLike(Kind kind) {
+    return kind >= Kind::Var;
+  }
+  static bool isKindVarLikeOrScopedFunction(Kind kind) {
+    return kind >= Kind::ScopedFunction;
+  }
+  /// \return true if this kind of declaration is lexically scoped (and cannot
+  /// be re-declared).
+  static bool isKindLetLike(Kind kind) {
+    return kind <= Kind::ES5Catch;
+  }
+  /// \return true if this kind of declaration is a global property.
+  static bool isKindGlobal(Kind kind) {
+    return kind >= Kind::GlobalProperty;
+  }
+
+  /// Identifier that is declared.
+  Identifier const name;
+  /// What kind of declaration it is.
+  Kind kind;
+  /// If this is a special declaration, identify which one.
+  Special const special;
+
+  /// The lexical scope of the declaration. Could be nullptr for special
+  /// declarations, since they are technically unscoped.
+  LexicalScope *const scope;
+
+  Decl(Identifier name, Kind kind, LexicalScope *scope)
+      : name(name), kind(kind), special(Special::NotSpecial), scope(scope) {}
+  Decl(Identifier name, Kind kind, Special special)
+      : name(name), kind(kind), special(special), scope(nullptr) {}
+  Decl(Identifier name, Kind kind, Special special, LexicalScope *scope)
+      : name(name), kind(kind), special(special), scope(scope) {}
+
+  void dump(unsigned level = 0) const;
+};
+
+/// Lexical scopes within a function.
+class LexicalScope {
+ public:
+  /// The global depth of this scope, where 0 is the root scope.
+  uint32_t depth;
+  /// The function owning this lexical scope.
+  FunctionInfo *const parentFunction{};
+  /// The enclosing lexical scope (it could be in another function).
+  LexicalScope *const parentScope{};
+
+  /// All declarations made in this scope.
+  llvh::SmallVector<Decl *, 2> decls{};
+
+  /// A list of functions that need to be hoisted and materialized before we
+  /// can generate the rest of the scope.
+  llvh::SmallVector<ESTree::FunctionDeclarationNode *, 2> hoistedFunctions{};
+
+  /// True if this scope or any descendent scopes have a local eval call.
+  /// If any descendent uses local eval,
+  /// it's impossible to know whether local variables are modified.
+  bool localEval;
+
+  /// \param parentFunction may be null.
+  /// \param parentScope may be null.
+  LexicalScope(FunctionInfo *parentFunction, LexicalScope *parentScope)
+      : depth(parentScope ? parentScope->depth + 1 : 0),
+        parentFunction(parentFunction),
+        parentScope(parentScope) {}
+
+  void dump(const SemContext *sem = nullptr, unsigned level = 0) const;
+};
+
+/// Semantic information about functions.
+class FunctionInfo {
+ public:
+  /// The function surrounding this function.
+  FunctionInfo *const parentFunction;
+  /// The enclosing lexical scope.
+  LexicalScope *const parentScope;
+  /// All lexical scopes in this function.
+  /// The first one is the function scope.
+  llvh::SmallVector<LexicalScope *, 4> scopes{};
+  /// The implicitly declared "arguments" object.
+  /// It is declared only if it is used.
+  /// Should be populated by calling \c SemContext::funcArgumentsDecl.
+  hermes::OptValue<Decl *> argumentsDecl{llvh::None};
+  /// True if the function is strict mode.
+  bool strict;
+  /// True if this function is an arrow function.
+  bool arrow;
+  /// How many labels have been allocated in this function so far.
+  uint32_t numLabels{0};
+
+  /// Allocate a new label and return its index.
+  uint32_t allocateLabel() {
+    return numLabels++;
+  }
+
+  FunctionInfo(
+      ESTree::FunctionLikeNode *funcNode,
+      FunctionInfo *parentFunction,
+      LexicalScope *parentScope,
+      bool strict)
+      : parentFunction(parentFunction),
+        parentScope(parentScope),
+        strict(strict),
+        arrow(llvh::isa<ESTree::ArrowFunctionExpressionNode>(funcNode)) {}
+
+  /// \return the top-level lexical scope of the function.
+  LexicalScope *getFunctionScope() const {
+    return scopes[0];
+  }
+
+  void dump(const SemContext *sem = nullptr, unsigned level = 0) const;
+};
+
+/// Semantic information regarding the program.
+/// Storage for FunctionInfo and LexicalScope.
+class SemContext {
+ public:
+  SemContext(Context &ctx);
+  ~SemContext();
+
+  /// \return a new function.
+  FunctionInfo *newFunction(
+      ESTree::FunctionLikeNode *funcNode,
+      FunctionInfo *parentFunction,
+      LexicalScope *parentScope,
+      bool strict);
+  /// \return a new lexical scope.
+  LexicalScope *newScope(
+      FunctionInfo *parentFunction,
+      LexicalScope *parentScope);
+  /// \return a new declaration in \p scope.
+  Decl *newDecl(
+      UniqueString *name,
+      Decl::Kind kind,
+      LexicalScope *scope,
+      Decl::Special special = Decl::Special::NotSpecial);
+  /// \return a new declaration in \p scope.
+  Decl *newDeclInScope(
+      UniqueString *name,
+      Decl::Kind kind,
+      LexicalScope *scope,
+      Decl::Special special = Decl::Special::NotSpecial);
+
+  /// \return a new global property.
+  Decl *newGlobal(UniqueString *name, Decl::Kind kind);
+
+  /// \return the global function.
+  FunctionInfo *getGlobalFunction() {
+    return &functions_.at(0);
+  }
+  /// \return the global lexical scope.
+  LexicalScope *getGlobalScope() {
+    return &scopes_.at(0);
+  }
+
+  /// Create or retrieve the arguments declaeration in \p func.
+  /// If `func` is an arrow function, find the closest ancestor that
+  /// is not an arrow function and use that function's `arguments`.
+  /// \p name the object doesn't have access to the AST node, so it has
+  ///   to be passed in.
+  /// \return the special arguments declaration in the specified function.
+  Decl *funcArgumentsDecl(FunctionInfo *func, UniqueString *name);
+
+  /// An identifier set used to prevent adding more than one global with the
+  /// same name durinng initialization.
+  using NameSet = llvh::SmallDenseSet<UniqueString *, 1>;
+
+  void dump() const;
+
+ private:
+  /// The special global "eval" declaration.
+  /// Stored to know when we are performing "eval" anywhere in the function.
+  Decl *evalDecl_;
+
+  /// Storage for all functions.
+  std::deque<FunctionInfo> functions_{};
+
+  /// Storage for all lexical scopes.
+  std::deque<LexicalScope> scopes_{};
+
+  /// Storage for all variable declarations.
+  std::deque<Decl> decls_{};
+};
+
+} // namespace sema
+} // namespace hermes
+
+#endif

--- a/include/hermes/AST/SemResolve.h
+++ b/include/hermes/AST/SemResolve.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef HERMES_AST_SEMRESOLVE_H
+#define HERMES_AST_SEMRESOLVE_H
+
+namespace hermes {
+
+class Context;
+
+namespace ESTree {
+class Node;
+}
+
+namespace sema {
+
+class SemContext;
+
+/// Perform semantic resolution of the entire AST, starting from the specified
+/// root, which should be ProgramNode.
+/// \return true on success, false if errors were reported.
+bool resolveAST(Context &astContext, SemContext &semCtx, ESTree::Node *root);
+
+/// Perform semantic resolution of the entire AST, without preparing the AST for
+/// compilation. This will not error on features we can parse but not compile,
+/// transform the AST, or perform compilation specific validation.
+/// \return true on success, false if errors were reported.
+bool resolveASTForParser(
+    Context &astContext,
+    SemContext &semCtx,
+    ESTree::Node *root);
+
+} // namespace sema
+} // namespace hermes
+
+#endif

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -11,7 +11,10 @@ add_hermes_library(hermesAST
     SemValidate.cpp
     SemanticValidator.cpp SemanticValidator.h
     SemContext.cpp
+    SemResolve.cpp
+    SemanticResolver.cpp SemanticResolver.h
     DeclCollector.cpp DeclCollector.h
+    ScopedFunctionPromoter.cpp ScopedFunctionPromoter.h
     CommonJS.cpp
     LINK_OBJLIBS
     hermesSupport

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -10,6 +10,7 @@ add_hermes_library(hermesAST
     Keywords.cpp Keywords.h
     SemValidate.cpp
     SemanticValidator.cpp SemanticValidator.h
+    SemContext.cpp
     CommonJS.cpp
     LINK_OBJLIBS
     hermesSupport

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -11,6 +11,7 @@ add_hermes_library(hermesAST
     SemValidate.cpp
     SemanticValidator.cpp SemanticValidator.h
     SemContext.cpp
+    DeclCollector.cpp DeclCollector.h
     CommonJS.cpp
     LINK_OBJLIBS
     hermesSupport

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -7,6 +7,7 @@ add_hermes_library(hermesAST
     ASTBuilder.cpp
     ESTree.cpp
     ESTreeJSONDumper.cpp
+    Keywords.cpp Keywords.h
     SemValidate.cpp
     SemanticValidator.cpp SemanticValidator.h
     CommonJS.cpp

--- a/lib/AST/DeclCollector.cpp
+++ b/lib/AST/DeclCollector.cpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "DeclCollector.h"
+
+using namespace hermes::ESTree;
+
+namespace hermes {
+namespace sema {
+
+/* static */ DeclCollector DeclCollector::run(
+    ESTree::Node *root,
+    const sem::Keywords &kw) {
+  DeclCollector dc{root, kw};
+  dc.runImpl();
+  return dc;
+}
+
+void DeclCollector::runImpl() {
+  if (auto *func = llvh::dyn_cast<FunctionDeclarationNode>(root_)) {
+    newScope();
+    // Visit the children of the body, since we don't want to associate a
+    // scope with it.
+    visitESTreeChildren(*this, llvh::cast<BlockStatementNode>(func->_body));
+    closeScope(root_);
+    return;
+  }
+  if (auto *func = llvh::dyn_cast<FunctionExpressionNode>(root_)) {
+    newScope();
+    // Visit the children of the body, since we don't want to associate a
+    // scope with it.
+    visitESTreeChildren(*this, llvh::cast<BlockStatementNode>(func->_body));
+    closeScope(root_);
+    return;
+  }
+
+  if (auto *func = llvh::dyn_cast<ArrowFunctionExpressionNode>(root_)) {
+    newScope();
+    // If there is a BlockStatement, don't visit it, just visit its children.
+    if (auto *block = llvh::dyn_cast<BlockStatementNode>(func->_body)) {
+      visitESTreeChildren(*this, block);
+    } else {
+      visitESTreeChildren(*this, root_);
+    }
+    closeScope(root_);
+    return;
+  }
+
+  newScope();
+  visitESTreeChildren(*this, root_);
+  closeScope(root_);
+}
+
+void DeclCollector::setScopeDeclsForNode(ESTree::Node *node, ScopeDecls decls) {
+  scopes_[node] = decls;
+}
+void DeclCollector::addScopeDeclForFunc(ESTree::Node *node) {
+  scopes_[root_].push_back(node);
+}
+
+void DeclCollector::visit(ESTree::VariableDeclarationNode *node) {
+  if (node->_kind == kw_.identVar) {
+    addToFunc(node);
+  } else {
+    addToCur(node);
+  }
+  visitESTreeChildren(*this, node);
+}
+void DeclCollector::visit(ESTree::ClassDeclarationNode *node) {
+  addToCur(node);
+  visitESTreeChildren(*this, node);
+}
+void DeclCollector::visit(ESTree::ImportDeclarationNode *node) {
+  addToCur(node);
+  visitESTreeChildren(*this, node);
+}
+
+void DeclCollector::visit(ESTree::FunctionDeclarationNode *node) {
+  // Record but don't descend.
+  addToCur(node);
+  if (scopeStack_.size() > 1) {
+    scopedFuncDecls_.push_back(node);
+  }
+}
+
+void DeclCollector::visit(ESTree::BlockStatementNode *node) {
+  newScope();
+  visitESTreeChildren(*this, node);
+  closeScope(node);
+}
+void DeclCollector::visit(ESTree::ForStatementNode *node) {
+  newScope();
+  visitESTreeChildren(*this, node);
+  closeScope(node);
+}
+void DeclCollector::visit(ESTree::ForInStatementNode *node) {
+  newScope();
+  visitESTreeChildren(*this, node);
+  closeScope(node);
+}
+void DeclCollector::visit(ESTree::ForOfStatementNode *node) {
+  newScope();
+  visitESTreeChildren(*this, node);
+  closeScope(node);
+}
+void DeclCollector::visit(ESTree::SwitchStatementNode *node) {
+  newScope();
+  visitESTreeChildren(*this, node);
+  closeScope(node);
+}
+
+void DeclCollector::closeScope(ESTree::Node *node) {
+  assert(!scopeStack_.empty() && "no scope to close");
+
+  // Move the popped scope out so we can put it in the `scopes_` map.
+  ScopeDecls decls = std::move(scopeStack_.back());
+  scopeStack_.pop_back();
+
+  // Only store to the map if there's something to store.
+  if (!decls.empty()) {
+    auto result = scopes_.try_emplace(node, decls);
+    (void)result;
+    assert(result.second && "Tried to collect same node twice");
+  }
+}
+
+} // namespace sema
+} // namespace hermes

--- a/lib/AST/DeclCollector.h
+++ b/lib/AST/DeclCollector.h
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef HERMES_AST_DECLCOLLECTOR_H
+#define HERMES_AST_DECLCOLLECTOR_H
+
+#include "Keywords.h"
+#include "hermes/AST/RecursiveVisitor.h"
+#include "hermes/AST/SemContext.h"
+#include "hermes/AST/SemValidate.h"
+
+namespace hermes {
+namespace sema {
+
+class SemanticResolver;
+
+/// All the declarations in a scope.
+using ScopeDecls = std::vector<ESTree::Node *>;
+
+/// Collect all declarations in every scope of a function.
+/// All declarations will have to be hoisted to the top of a function or scope,
+/// so store them all up front in a single pass.
+/// Do not descend into nested functions.
+class DeclCollector {
+ public:
+  /// \return a DeclCollector which has collected all declarations in \p root.
+  static DeclCollector run(ESTree::Node *root, const sem::Keywords &kw);
+
+  /// \return the optional ScopeDecls for an AST node.
+  hermes::OptValue<llvh::ArrayRef<ESTree::Node *>> getScopeDeclsForNode(
+      ESTree::Node *node) const {
+    auto it = scopes_.find(node);
+    if (it == scopes_.end())
+      return llvh::None;
+    return {it->second};
+  }
+  /// Set the ScopeDecls for an AST node.
+  /// Replaces ScopeDecls if it already exists.
+  void setScopeDeclsForNode(ESTree::Node *node, ScopeDecls decls);
+  /// Add a single ScopeDecl for the root AST node of the function.
+  /// Used for promoting a function declaration to the function scope.
+  void addScopeDeclForFunc(ESTree::Node *node);
+
+  /// Return a list of all scoped function declarations in the function.
+  llvh::ArrayRef<ESTree::Node *> getScopedFuncDecls() const {
+    return scopedFuncDecls_;
+  }
+
+  void visit(ESTree::Node *node) {
+    visitESTreeChildren(*this, node);
+  }
+
+  void visit(ESTree::VariableDeclarationNode *node);
+  void visit(ESTree::ClassDeclarationNode *node);
+  void visit(ESTree::ImportDeclarationNode *node);
+
+  void visit(ESTree::FunctionDeclarationNode *node);
+
+  /// Don't descend.
+  void visit(ESTree::FunctionExpressionNode *node) {}
+  /// Don't descend.
+  void visit(ESTree::ArrowFunctionExpressionNode *node) {}
+
+  void visit(ESTree::BlockStatementNode *node);
+  void visit(ESTree::ForStatementNode *node);
+  void visit(ESTree::ForInStatementNode *node);
+  void visit(ESTree::ForOfStatementNode *node);
+  void visit(ESTree::SwitchStatementNode *node);
+
+  /// Needed by RecursiveVisitorDispatch. Optionally can protect against too
+  /// deep nesting.
+  bool incRecursionDepth(ESTree::Node *) {
+    return true;
+  }
+  void decRecursionDepth() {}
+
+ private:
+  explicit DeclCollector(ESTree::Node *root, const sem::Keywords &kw)
+      : root_(root), kw_(kw) {}
+
+  /// Actually run the root node.
+  void runImpl();
+
+  /// Add a declaration to the function itself.
+  void addToFunc(ESTree::Node *node) {
+    assert(!scopeStack_.empty() && "missing function scope");
+    scopeStack_.front().push_back(node);
+  }
+  /// Add a declaration to the current lexical scope.
+  void addToCur(ESTree::Node *node) {
+    assert(!scopeStack_.empty() && "no current scope");
+    scopeStack_.back().push_back(node);
+  }
+
+  /// Push a scope onto the stack.
+  void newScope() {
+    scopeStack_.emplace_back();
+  }
+  /// Pop a scope from the stack.
+  /// If it contains declarations, add them to \c scopes_.
+  void closeScope(ESTree::Node *node);
+
+  /// Root node for the collection.
+  ESTree::Node *root_;
+
+  const sem::Keywords &kw_;
+
+  /// Associate a ScopeDecls structure with the node that creates the scope.
+  llvh::DenseMap<ESTree::Node *, ScopeDecls> scopes_{};
+
+  /// Function declarations in a block scope.
+  /// They have special rules described in Annex B 3.3.
+  std::vector<ESTree::Node *> scopedFuncDecls_{};
+
+  /// Stack of active scopes.
+  /// Once a scope is closed, it is attached to an AST node.
+  llvh::SmallVector<ScopeDecls, 4> scopeStack_{};
+};
+
+} // namespace sema
+} // namespace hermes
+
+#endif

--- a/lib/AST/ESTree.cpp
+++ b/lib/AST/ESTree.cpp
@@ -49,6 +49,21 @@ BlockStatementNode *getBlockStatement(FunctionLikeNode *node) {
   }
 }
 
+Node *getIdentifier(FunctionLikeNode *node) {
+  switch (node->getKind()) {
+    default:
+      assert(
+          node->getKind() == NodeKind::Program && "invalid FunctionLikeNode");
+      return nullptr;
+    case NodeKind::FunctionExpression:
+      return cast<FunctionExpressionNode>(node)->_id;
+    case NodeKind::ArrowFunctionExpression:
+      return cast<ArrowFunctionExpressionNode>(node)->_id;
+    case NodeKind::FunctionDeclaration:
+      return cast<FunctionDeclarationNode>(node)->_id;
+  }
+}
+
 Node *getObject(MemberExpressionLikeNode *node) {
   switch (node->getKind()) {
     case NodeKind::MemberExpression:

--- a/lib/AST/Keywords.cpp
+++ b/lib/AST/Keywords.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "Keywords.h"
+
+#include "hermes/AST/Context.h"
+#include "hermes/Support/RegExpSerialization.h"
+
+namespace hermes {
+namespace sem {
+
+Keywords::Keywords(Context &astContext)
+    : identArguments(
+          astContext.getIdentifier("arguments").getUnderlyingPointer()),
+      identEval(astContext.getIdentifier("eval").getUnderlyingPointer()),
+      identDelete(astContext.getIdentifier("delete").getUnderlyingPointer()),
+      identThis(astContext.getIdentifier("this").getUnderlyingPointer()),
+      identUseStrict(
+          astContext.getIdentifier("use strict").getUnderlyingPointer()),
+      identShowSource(
+          astContext.getIdentifier("show source").getUnderlyingPointer()),
+      identHideSource(
+          astContext.getIdentifier("hide source").getUnderlyingPointer()),
+      identSensitive(
+          astContext.getIdentifier("sensitive").getUnderlyingPointer()),
+      identVar(astContext.getIdentifier("var").getUnderlyingPointer()),
+      identLet(astContext.getIdentifier("let").getUnderlyingPointer()),
+      identConst(astContext.getIdentifier("const").getUnderlyingPointer()),
+      identPlus(astContext.getIdentifier("+").getUnderlyingPointer()),
+      identMinus(astContext.getIdentifier("-").getUnderlyingPointer()),
+      identAssign(astContext.getIdentifier("=").getUnderlyingPointer()),
+      identNew(astContext.getIdentifier("new").getUnderlyingPointer()),
+      identTarget(astContext.getIdentifier("target").getUnderlyingPointer()),
+      identTypeof(astContext.getIdentifier("typeof").getUnderlyingPointer()) {}
+
+} // namespace sem
+} // namespace hermes

--- a/lib/AST/Keywords.h
+++ b/lib/AST/Keywords.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef HERMES_AST_KEYWORDS_H
+#define HERMES_AST_KEYWORDS_H
+
+#include "hermes/AST/SemValidate.h"
+
+#include "hermes/AST/RecursiveVisitor.h"
+
+namespace hermes {
+
+class Context;
+
+namespace sem {
+
+class Keywords {
+ public:
+  /// Identifier for "arguments".
+  const UniqueString *const identArguments;
+  /// Identifier for "eval".
+  const UniqueString *const identEval;
+  /// Identifier for "delete".
+  const UniqueString *const identDelete;
+  /// Identifier for "this".
+  const UniqueString *const identThis;
+  /// Identifier for "use strict".
+  const UniqueString *const identUseStrict;
+  /// Identifier for "show source ".
+  const UniqueString *const identShowSource;
+  /// Identifier for "hide source ".
+  const UniqueString *const identHideSource;
+  /// Identifier for "sensitive".
+  const UniqueString *const identSensitive;
+  /// Identifier for "var".
+  const UniqueString *const identVar;
+  /// Identifier for "let".
+  const UniqueString *const identLet;
+  /// Identifier for "const".
+  const UniqueString *const identConst;
+  /// "+".
+  const UniqueString *const identPlus;
+  /// "-".
+  const UniqueString *const identMinus;
+  /// "=".
+  const UniqueString *const identAssign;
+  /// "new"
+  const UniqueString *const identNew;
+  /// "target"
+  const UniqueString *const identTarget;
+  /// "typeof".
+  const UniqueString *const identTypeof;
+
+  Keywords(Context &astContext);
+};
+
+} // namespace sem
+} // namespace hermes
+
+#endif

--- a/lib/AST/ScopedFunctionPromoter.cpp
+++ b/lib/AST/ScopedFunctionPromoter.cpp
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ScopedFunctionPromoter.h"
+
+#include "Keywords.h"
+#include "SemanticResolver.h"
+#include "hermes/AST/ESTree.h"
+#include "hermes/AST/SemContext.h"
+
+using namespace hermes::ESTree;
+
+namespace hermes {
+namespace sema {
+
+namespace {
+
+/// Visitor class for promoting scoped function declarations.
+class ScopedFunctionPromoter {
+ public:
+  explicit ScopedFunctionPromoter(SemanticResolver &resolver)
+      : resolver_(resolver) {}
+
+  /// Run the AST pass.
+  void run(FunctionLikeNode *funcNode);
+
+  /// Handle the default case for all nodes which we ignore, but we still want
+  /// to visit their children.
+  void visit(Node *node) {
+    visitESTreeChildren(*this, node);
+  }
+
+  /// Do not descend into nested functions.
+  void visit(FunctionLikeNode *) {}
+
+  // All nodes with scopes.
+
+  void visit(SwitchStatementNode *node) {
+    visitScope(node);
+  }
+  void visit(BlockStatementNode *node) {
+    visitScope(node);
+  }
+  void visit(ForStatementNode *node) {
+    visitScope(node);
+  }
+  void visit(ForInStatementNode *node) {
+    visitScope(node);
+  }
+  void visit(ForOfStatementNode *node) {
+    visitScope(node);
+  }
+  void visit(WithStatementNode *node) {
+    visitScope(node);
+  }
+
+  /// Needed by RecursiveVisitorDispatch. Optionally can protect against too
+  /// deep nesting.
+  bool incRecursionDepth(ESTree::Node *) {
+    return true;
+  }
+  void decRecursionDepth() {}
+
+ private:
+  /// Visit any statement starting a scope.
+  void visitScope(Node *node);
+
+  /// Process the declarations in a scope.
+  /// This is the core of the algorithm, it updates the binding tables, etc.
+  void processDeclarations(Node *scope);
+
+  /// Extract the list of declared identifiers in a declaration node into
+  /// `idents`.
+  /// \return the declaration kind of the node.
+  /// Function declarations are always returned as `ScopedFunction`,
+  /// so they can be distinguished.
+  Decl::Kind extractDeclaredIdents(
+      Node *node,
+      llvh::SmallVectorImpl<IdentifierNode *> &idents);
+
+ private:
+  SemanticResolver &resolver_;
+
+  /// The names of the scoped functions. We will ignore all other identifiers.
+  llvh::SmallDenseSet<UniqueString *> funcNames_{};
+
+  /// The scoped function declarations. We remove each from this set once
+  /// we encounter it.
+  llvh::SmallDenseSet<FunctionDeclarationNode *> funcDecls_{};
+
+  using BindingTableTy = hermes::ScopedHashTable<UniqueString *, bool>;
+  using BindingTableScopeTy =
+      hermes::ScopedHashTableScope<UniqueString *, bool>;
+
+  /// The currently lexically visible names.
+  BindingTableTy bindingTable_{};
+};
+
+void ScopedFunctionPromoter::run(FunctionLikeNode *funcNode) {
+  llvh::ArrayRef<Node *> decls =
+      resolver_.functionContext()->decls.getScopedFuncDecls();
+
+  // Populate the sets.
+  for (Node *node : decls) {
+    auto *funcDecl = cast<FunctionDeclarationNode>(node);
+    funcNames_.insert(cast<IdentifierNode>(funcDecl->_id)->_name);
+    funcDecls_.insert(funcDecl);
+  }
+
+  visitESTreeChildren(*this, funcNode);
+}
+
+void ScopedFunctionPromoter::visitScope(Node *node) {
+  BindingTableScopeTy bindingScope{bindingTable_};
+  processDeclarations(node);
+}
+
+void ScopedFunctionPromoter::processDeclarations(Node *scope) {
+  auto declsOpt =
+      resolver_.functionContext()->decls.getScopeDeclsForNode(scope);
+  if (!declsOpt) {
+    return;
+  }
+  llvh::ArrayRef<Node *> decls = *declsOpt;
+
+  llvh::SmallVector<IdentifierNode *, 4> idents{};
+  // Whenever we encounter one of the scoped func decls we are trying to
+  // promote, we store the address of its list entry here (so we can clear it
+  // if we want to).
+  llvh::SmallVector<Node *const *, 4> foundDecls{};
+
+  for (auto &nodeRef : decls) {
+    Node *node = nodeRef;
+    if (!node)
+      continue;
+
+    if (auto *funcDecl = llvh::dyn_cast<FunctionDeclarationNode>(node)) {
+      if (funcDecls_.count(funcDecl)) {
+        // We encountered one of the candidate declarations.
+        // Add it to the found_decls list and move on.
+        foundDecls.push_back(&nodeRef);
+      }
+      continue;
+    }
+
+    // Extract idents, report errors.
+    idents.clear();
+    Decl::Kind declKind = extractDeclaredIdents(node, idents);
+
+    // We are only interested in let-like declarations.
+    if (!Decl::isKindLetLike(declKind))
+      continue;
+
+    // Remember only idents matching the set.
+    for (IdentifierNode *idNode : idents) {
+      if (funcNames_.count(idNode->_name)) {
+        bindingTable_.insert(idNode->_name, true);
+      }
+    }
+  }
+
+  if (foundDecls.empty()) {
+    // No work to do.
+    return;
+  }
+
+  ScopeDecls newDecls{};
+
+  // Did we finally encounter one of the scoped function declarations?
+  for (Node *const *funcDeclRef : foundDecls) {
+    auto *funcDecl = cast<FunctionDeclarationNode>(*funcDeclRef);
+    // Remove it from the set, since we are no longer interested in it.
+    funcDecls_.erase(funcDecl);
+
+    if (funcDecl->_id) {
+      // Is there a visible let-like declaration with the same name?
+      // If so, it can't be promoted because it would shadow a `let`,
+      // so keep it in `newDecls` and move on.
+      if (bindingTable_.lookup(cast<IdentifierNode>(funcDecl->_id)->_name)) {
+        newDecls.push_back(funcDecl);
+        continue;
+      }
+    } else {
+      // No name on the declaration, nothing to promote.
+      newDecls.push_back(funcDecl);
+      continue;
+    }
+
+    // This block-scoped function declaration can (and should) be promoted.
+    // 1. Don't add it to the new_decls list.
+    // 2. Add it to the function scope list.
+    resolver_.functionContext()->decls.addScopeDeclForFunc(funcDecl);
+  }
+
+  resolver_.functionContext()->decls.setScopeDeclsForNode(
+      scope, std::move(newDecls));
+}
+
+Decl::Kind ScopedFunctionPromoter::extractDeclaredIdents(
+    Node *node,
+    llvh::SmallVectorImpl<IdentifierNode *> &idents) {
+  if (auto *varDeclaration = llvh::dyn_cast<VariableDeclarationNode>(node)) {
+    for (Node &declarator : varDeclaration->_declarations) {
+      resolver_.extractDeclaredIdentsFromID(
+          cast<VariableDeclaratorNode>(declarator)._id, idents);
+    }
+    if (varDeclaration->_kind == resolver_.keywords().identLet) {
+      return Decl::Kind::Let;
+    } else if (varDeclaration->_kind == resolver_.keywords().identConst) {
+      return Decl::Kind::Const;
+    } else {
+      assert(varDeclaration->_kind == resolver_.keywords().identVar);
+      return Decl::Kind::Var;
+    }
+  }
+
+  if (auto *fd = llvh::dyn_cast<FunctionDeclarationNode>(node)) {
+    resolver_.extractDeclaredIdentsFromID(fd->_id, idents);
+    return Decl::Kind::ScopedFunction;
+  }
+
+  if (auto *cd = llvh::dyn_cast<ClassDeclarationNode>(node)) {
+    resolver_.extractDeclaredIdentsFromID(cd->_id, idents);
+    return Decl::Kind::Class;
+  }
+
+  {
+    auto *id = llvh::cast<ImportDeclarationNode>(node);
+    for (Node &spec : id->_specifiers) {
+      if (auto *is = llvh::dyn_cast<ImportSpecifierNode>(&spec)) {
+        resolver_.extractDeclaredIdentsFromID(is->_local, idents);
+      } else if (
+          auto *ids = llvh::dyn_cast<ImportDefaultSpecifierNode>(&spec)) {
+        resolver_.extractDeclaredIdentsFromID(ids->_local, idents);
+      } else {
+        auto *ins = cast<ImportNamespaceSpecifierNode>(&spec);
+        resolver_.extractDeclaredIdentsFromID(ins->_local, idents);
+      }
+    }
+    return Decl::Kind::Import;
+  }
+}
+
+} // anonymous namespace
+
+void promoteScopedFuncDecls(
+    SemanticResolver &resolver,
+    ESTree::FunctionLikeNode *funcNode) {
+  if (resolver.functionContext()->decls.getScopedFuncDecls().empty()) {
+    // No scoped function declarations, nothing to promote.
+    return;
+  }
+  ScopedFunctionPromoter{resolver}.run(funcNode);
+}
+
+} // namespace sema
+} // namespace hermes

--- a/lib/AST/ScopedFunctionPromoter.h
+++ b/lib/AST/ScopedFunctionPromoter.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef HERMES_AST_SCOPEDFUNCTIONPROMOTER_H
+#define HERMES_AST_SCOPEDFUNCTIONPROMOTER_H
+
+#include "hermes/AST/ESTree.h"
+
+namespace hermes {
+
+namespace sem {
+class Keywords;
+}
+
+namespace sema {
+
+class SemanticResolver;
+
+/// This function checks whether it is safe to promote block-scoped function
+/// declarations to function scope. i.e. whether it is safe to replace one with
+/// "var" without creating a conflict.
+///
+/// A conflict exists if a let-like declaration is visible in the declaration
+/// scope. The checker starts with a list of all block scoped function
+/// declarations. Then it visits all scopes recursively, maintaining a scoped
+/// table of let-like declarations with matching names. When it encounters a
+/// block-scoped function declaration, it checks whether a matching let-like
+/// declaration is visible. If not, it is safe to promote.
+///
+/// The input is a list of block-scoped function function declarations. The
+/// ones that can be promoted are deleted from their own scope and added to the
+/// function scope.
+void promoteScopedFuncDecls(
+    SemanticResolver &resolver,
+    ESTree::FunctionLikeNode *funcNode);
+
+} // namespace sema
+} // namespace hermes
+
+#endif

--- a/lib/AST/SemContext.cpp
+++ b/lib/AST/SemContext.cpp
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "hermes/AST/SemContext.h"
+
+namespace hermes {
+namespace sema {
+
+#ifndef NDEBUG
+static llvh::FormattedString ind(unsigned level) {
+  return llvh::left_justify("", level * 4);
+}
+#endif
+
+void Decl::dump(unsigned level) const {
+#ifndef NDEBUG
+  llvh::outs() << ind(level) << "Decl '" << name << "' ";
+  const char *s;
+#define CASE(x) \
+  case Kind::x: \
+    s = #x;     \
+    break;
+  switch (kind) {
+    CASE(Let)
+    CASE(Const)
+    CASE(Class)
+    CASE(Import)
+    CASE(ES5Catch)
+    CASE(FunctionExprName)
+    CASE(ScopedFunction)
+    CASE(Var)
+    CASE(Parameter)
+    CASE(GlobalProperty)
+    CASE(UndeclaredGlobalProperty)
+  }
+  llvh::outs() << s;
+#undef CASE
+#define CASE(x)    \
+  case Special::x: \
+    s = #x;        \
+    break;
+  switch (special) {
+    CASE(NotSpecial)
+    CASE(Arguments)
+    CASE(Eval)
+  }
+#undef CASE
+  llvh::outs() << "\n";
+#endif
+}
+
+void LexicalScope::dump(const SemContext *sd, unsigned int level) const {
+#ifndef NDEBUG
+  llvh::outs() << ind(level) << "Scope " << llvh::format("%p", this) << "\n";
+  for (const auto &decl : decls) {
+    decl->dump(level + 1);
+  }
+  for (const auto *fd : hoistedFunctions) {
+    llvh::outs() << ind(level + 1) << "hoistedFunction "
+                 << llvh::cast<ESTree::IdentifierNode>(fd->_id)->_name->str()
+                 << "\n";
+  }
+#endif
+}
+
+void FunctionInfo::dump(const SemContext *sd, unsigned level) const {
+#ifndef NDEBUG
+  llvh::outs() << ind(level) << "Func\n";
+  std::map<const LexicalScope *, llvh::SmallVector<const LexicalScope *, 2>>
+      children;
+
+  for (const auto *sc : scopes) {
+    if (sc == scopes[0])
+      continue;
+    children[sc->parentScope].push_back(sc);
+  }
+
+  unsigned processedCount = 0;
+  std::function<void(const LexicalScope *, unsigned)> dumpScope =
+      [&dumpScope, &children, &processedCount, sd](
+          const LexicalScope *sc, unsigned level) {
+        sc->dump(sd, level);
+        ++processedCount;
+        auto it = children.find(sc);
+        if (it == children.end())
+          return;
+        for (auto *childScope : it->second)
+          dumpScope(childScope, level + 1);
+      };
+
+  dumpScope(scopes[0], level + 1);
+  assert(processedCount == scopes.size() && "not all scopes were visited");
+#endif
+}
+
+void SemContext::dump() const {
+#ifndef NDEBUG
+  llvh::outs() << "SemContext\n";
+  std::map<const FunctionInfo *, llvh::SmallVector<const FunctionInfo *, 2>>
+      children;
+
+  for (const auto &F : functions_) {
+    if (&F == &functions_[0])
+      continue;
+    children[F.parentFunction].push_back(&F);
+  }
+
+  unsigned processedCount = 0;
+  std::function<void(const FunctionInfo *, unsigned)> dumpFunction =
+      [&dumpFunction, &children, &processedCount, this](
+          const FunctionInfo *F, unsigned level) {
+        F->dump(this, level);
+        ++processedCount;
+        auto it = children.find(F);
+        if (it == children.end())
+          return;
+        for (auto *childFunc : it->second)
+          dumpFunction(childFunc, level + 1);
+      };
+
+  dumpFunction(&functions_[0], 0);
+  assert(processedCount == functions_.size() && "not all scopes were visited");
+#endif
+}
+
+SemContext::SemContext(Context &ctx) {
+  decls_.emplace_back(
+      ctx.getIdentifier("eval"),
+      Decl::Kind::UndeclaredGlobalProperty,
+      Decl::Special::Eval);
+  evalDecl_ = &decls_.back();
+}
+
+SemContext::~SemContext() = default;
+
+FunctionInfo *SemContext::newFunction(
+    ESTree::FunctionLikeNode *funcNode,
+    FunctionInfo *parentFunction,
+    LexicalScope *parentScope,
+    bool strict) {
+  functions_.emplace_back(funcNode, parentFunction, parentScope, strict);
+  return &functions_.back();
+}
+
+LexicalScope *SemContext::newScope(
+    FunctionInfo *parentFunction,
+    LexicalScope *parentScope) {
+  scopes_.emplace_back(parentFunction, parentScope);
+  LexicalScope *res = &scopes_.back();
+  parentFunction->scopes.push_back(res);
+  return res;
+}
+
+Decl *SemContext::newDecl(
+    UniqueString *name,
+    Decl::Kind kind,
+    LexicalScope *scope,
+    Decl::Special special) {
+  return newDeclInScope(name, kind, scope, special);
+}
+
+Decl *SemContext::newDeclInScope(
+    UniqueString *name,
+    Decl::Kind kind,
+    LexicalScope *scope,
+    Decl::Special special) {
+  assert(!Decl::isKindGlobal(kind) && "invalid non-global declaration kind");
+  decls_.emplace_back(Identifier::getFromPointer(name), kind, special, scope);
+  auto res = &decls_.back();
+  scope->decls.push_back(res);
+  return res;
+}
+
+Decl *SemContext::newGlobal(hermes::UniqueString *name, Decl::Kind kind) {
+  assert(Decl::isKindGlobal(kind) && "invalid global declaration kind");
+  return newDecl(name, kind, getGlobalScope());
+}
+
+Decl *SemContext::funcArgumentsDecl(FunctionInfo *func, UniqueString *name) {
+  // Find the closest non-arrow ancestor.
+  FunctionInfo *argumentsFunc = func;
+  while (argumentsFunc->arrow) {
+    if (argumentsFunc->parentFunction) {
+      argumentsFunc = argumentsFunc->parentFunction;
+    } else {
+      break;
+    }
+  }
+
+  // 'arguments' already exists, avoid redeclaring.
+  if (argumentsFunc->argumentsDecl)
+    return *argumentsFunc->argumentsDecl;
+
+  Decl *decl;
+  if (argumentsFunc == getGlobalFunction()) {
+    // `arguments` must simply be treated as a global property in top level
+    // contexts.
+    decl = newDeclInScope(
+        name,
+        Decl::Kind::UndeclaredGlobalProperty,
+        argumentsFunc->scopes.front());
+  } else {
+    // Otherwise, regular function-level "arguments" declaration.
+    decl = newDeclInScope(
+        name,
+        Decl::Kind::Var,
+        argumentsFunc->scopes.front(),
+        Decl::Special::Arguments);
+  }
+
+  // Store it for future use.
+  argumentsFunc->argumentsDecl = decl;
+
+  return decl;
+}
+
+} // namespace sema
+} // namespace hermes

--- a/lib/AST/SemResolve.cpp
+++ b/lib/AST/SemResolve.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "hermes/AST/SemResolve.h"
+
+#include "SemanticResolver.h"
+#include "hermes/AST/ESTree.h"
+#include "hermes/Support/PerfSection.h"
+
+namespace hermes {
+namespace sema {
+
+bool resolveAST(Context &astContext, SemContext &semCtx, ESTree::Node *root) {
+  PerfSection validation("Resolving JavaScript function AST");
+  // Resolve the entire AST.
+  SemanticResolver resolver{astContext, semCtx, true};
+  return resolver.run(root);
+}
+
+bool resolveASTForParser(
+    Context &astContext,
+    SemContext &semCtx,
+    ESTree::Node *root) {
+  SemanticResolver resolver{astContext, semCtx, false};
+  return resolver.run(root);
+}
+
+} // namespace sema
+} // namespace hermes

--- a/lib/AST/SemanticResolver.cpp
+++ b/lib/AST/SemanticResolver.cpp
@@ -1,0 +1,1058 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "SemanticResolver.h"
+
+#include "ScopedFunctionPromoter.h"
+#include "hermes/AST/SemContext.h"
+#include "hermes/Support/RegExpSerialization.h"
+
+#include "llvh/ADT/ScopeExit.h"
+#include "llvh/Support/SaveAndRestore.h"
+
+using namespace hermes::ESTree;
+
+namespace hermes {
+namespace sema {
+
+SemanticResolver::SemanticResolver(
+    Context &astContext,
+    sema::SemContext &semCtx,
+    bool compile)
+    : astContext_(astContext),
+      sm_(astContext.getSourceErrorManager()),
+      bufferMessages_{&sm_},
+      semCtx_(semCtx),
+      initialErrorCount_(sm_.getErrorCount()),
+      kw_{astContext},
+      compile_(compile) {}
+
+bool SemanticResolver::run(ESTree::Node *rootNode) {
+  visitESTreeNode(*this, rootNode);
+  return sm_.getErrorCount() == initialErrorCount_;
+}
+
+void SemanticResolver::visit(ESTree::ProgramNode *node) {
+  FunctionContext newFuncCtx{*this, node, nullptr, astContext_.isStrictMode()};
+  if (findUseStrict(node->_body)) {
+    curFunctionInfo()->strict = true;
+  }
+  node->strictness = makeStrictness(curFunctionInfo()->strict);
+
+  {
+    ScopeRAII programScope{*this, node};
+    globalScope_ = &programScope.getBindingScope();
+
+    processCollectedDeclarations(node);
+    visitESTreeChildren(*this, node);
+  }
+}
+
+void SemanticResolver::visit(ESTree::FunctionDeclarationNode *funcDecl) {
+  curScope_->hoistedFunctions.push_back(funcDecl);
+  visitFunctionLike(funcDecl, funcDecl->_body, funcDecl->_params);
+}
+void SemanticResolver::visit(ESTree::FunctionExpressionNode *funcExpr) {
+  visitFunctionExpression(funcExpr, funcExpr->_body, funcExpr->_params);
+}
+void SemanticResolver::visit(ESTree::ArrowFunctionExpressionNode *arrowFunc) {
+  visitFunctionLike(arrowFunc, arrowFunc->_body, arrowFunc->_params);
+}
+
+void SemanticResolver::visit(
+    ESTree::IdentifierNode *identifier,
+    ESTree::Node *parent) {
+  if (auto *prop = llvh::dyn_cast<PropertyNode>(parent)) {
+    if (!prop->_computed && prop->_key == identifier) {
+      // { identifier: ... }
+      return;
+    }
+  }
+
+  if (auto *mem = llvh::dyn_cast<MemberExpressionNode>(parent)) {
+    if (!mem->_computed && mem->_property == identifier) {
+      // expr.identifier
+      return;
+    }
+  }
+
+  // Identifiers that aren't variables.
+  if (llvh::isa<MetaPropertyNode>(parent) ||
+      llvh::isa<BreakStatementNode>(parent) ||
+      llvh::isa<ContinueStatementNode>(parent) ||
+      llvh::isa<LabeledStatementNode>(parent)) {
+    return;
+  }
+
+  // typeof
+  if (auto *unary = llvh::dyn_cast<UnaryExpressionNode>(parent)) {
+    if (unary->_operator == kw_.identTypeof) {
+      resolveIdentifier(identifier, true);
+    }
+  }
+
+  resolveIdentifier(identifier, false);
+}
+
+void SemanticResolver::visit(ESTree::AssignmentExpressionNode *assignment) {
+  validateAssignmentTarget(assignment->_left);
+  visitESTreeChildren(*this, assignment);
+}
+
+void SemanticResolver::visit(ESTree::UpdateExpressionNode *node) {
+  if (!isLValue(node->_argument)) {
+    sm_.error(
+        node->_argument->getSourceRange(),
+        "invalid operand in update operation");
+  }
+  visitESTreeChildren(*this, node);
+}
+
+void SemanticResolver::visit(ESTree::UnaryExpressionNode *node) {
+  // Check for unqualified delete in strict mode.
+  if (node->_operator == kw_.identDelete) {
+    if (curFunctionInfo()->strict &&
+        llvh::isa<IdentifierNode>(node->_argument)) {
+      sm_.error(
+          node->getSourceRange(),
+          "'delete' of a variable is not allowed in strict mode");
+    }
+  }
+  visitESTreeChildren(*this, node);
+}
+
+void SemanticResolver::visit(ESTree::BlockStatementNode *node) {
+  // Some nodes with attached BlockStatement have already dealt with the scope.
+  if (llvh::isa<FunctionDeclarationNode>(node) ||
+      llvh::isa<FunctionExpressionNode>(node) ||
+      llvh::isa<ArrowFunctionExpressionNode>(node) ||
+      llvh::isa<CatchClauseNode>(node)) {
+    return visitESTreeChildren(*this, node);
+  }
+
+  if (hermes::OptValue<llvh::ArrayRef<ESTree::Node *>> declsOpt =
+          functionContext()->decls.getScopeDeclsForNode(node)) {
+    // Only create a lexical scope if there are declarations in it.
+    ScopeRAII blockScope{*this, node};
+    processDeclarations(*declsOpt);
+    visitESTreeChildren(*this, node);
+  } else {
+    visitESTreeChildren(*this, node);
+  }
+}
+
+void SemanticResolver::visit(ESTree::SwitchStatementNode *node) {
+  // Visit the discriminant before creating a new scope.
+  visitESTreeNode(*this, node->_discriminant, node);
+
+  node->setLabelIndex(curFunctionInfo()->allocateLabel());
+
+  llvh::SaveAndRestore<StatementNode *> saveSwitch(currentLoopOrSwitch_, node);
+
+  {
+    ScopeRAII nameScope{*this, node};
+    if (hermes::OptValue<llvh::ArrayRef<ESTree::Node *>> declsOpt =
+            functionContext()->decls.getScopeDeclsForNode(node)) {
+      // Only create a lexical scope if there are declarations in it.
+      processDeclarations(*declsOpt);
+    }
+
+    for (ESTree::Node &c : node->_cases)
+      visitESTreeNode(*this, &c, node);
+  }
+}
+
+void SemanticResolver::visitForInOf(
+    ESTree::LoopStatementNode *node,
+    ESTree::ScopeDecorationBase *scopeDeco,
+    ESTree::Node *left) {
+  node->setLabelIndex(curFunctionInfo()->allocateLabel());
+
+  llvh::SaveAndRestore<LoopStatementNode *> saveLoop(currentLoop_, node);
+  llvh::SaveAndRestore<StatementNode *> saveSwitch(currentLoopOrSwitch_, node);
+
+  // Ensure the initializer is valid.
+  if (auto *vd = llvh::dyn_cast<VariableDeclarationNode>(left)) {
+    assert(
+        vd->_declarations.size() == 1 &&
+        "for-in/for-of must have a single binding");
+
+    auto *declarator =
+        llvh::cast<ESTree::VariableDeclaratorNode>(&vd->_declarations.front());
+
+    if (declarator->_init) {
+      if (llvh::isa<ESTree::PatternNode>(declarator->_id)) {
+        sm_.error(
+            declarator->_init->getSourceRange(),
+            "destructuring declaration cannot be initialized in for-in/for-of loop");
+      } else if (!(llvh::isa<ForInStatementNode>(node) &&
+                   !curFunctionInfo()->strict && vd->_kind == kw_.identVar)) {
+        sm_.error(
+            declarator->_init->getSourceRange(),
+            "for-in/for-of variable declaration may not be initialized");
+      }
+    }
+  } else {
+    validateAssignmentTarget(left);
+  }
+
+  if (hermes::OptValue<llvh::ArrayRef<ESTree::Node *>> declsOpt =
+          functionContext()->decls.getScopeDeclsForNode(node)) {
+    // Only create a lexical scope if there are declarations in it.
+    ScopeRAII nameScope{*this, scopeDeco};
+    processDeclarations(*declsOpt);
+    visitESTreeChildren(*this, node);
+  } else {
+    visitESTreeChildren(*this, node);
+  }
+}
+
+void SemanticResolver::visit(ESTree::ForStatementNode *node) {
+  node->setLabelIndex(curFunctionInfo()->allocateLabel());
+
+  llvh::SaveAndRestore<LoopStatementNode *> saveLoop(currentLoop_, node);
+  llvh::SaveAndRestore<StatementNode *> saveSwitch(currentLoopOrSwitch_, node);
+
+  if (hermes::OptValue<llvh::ArrayRef<ESTree::Node *>> declsOpt =
+          functionContext()->decls.getScopeDeclsForNode(node)) {
+    // Only create a lexical scope if there are declarations in it.
+    ScopeRAII nameScope{*this, node};
+    processDeclarations(*declsOpt);
+    visitESTreeChildren(*this, node);
+  } else {
+    visitESTreeChildren(*this, node);
+  }
+}
+
+void SemanticResolver::visit(ESTree::DoWhileStatementNode *node) {
+  node->setLabelIndex(curFunctionInfo()->allocateLabel());
+
+  llvh::SaveAndRestore<LoopStatementNode *> saveLoop(currentLoop_, node);
+  llvh::SaveAndRestore<StatementNode *> saveSwitch(currentLoopOrSwitch_, node);
+
+  visitESTreeChildren(*this, node);
+}
+void SemanticResolver::visit(ESTree::WhileStatementNode *node) {
+  node->setLabelIndex(curFunctionInfo()->allocateLabel());
+
+  llvh::SaveAndRestore<LoopStatementNode *> saveLoop(currentLoop_, node);
+  llvh::SaveAndRestore<StatementNode *> saveSwitch(currentLoopOrSwitch_, node);
+
+  visitESTreeChildren(*this, node);
+}
+
+void SemanticResolver::visit(ESTree::LabeledStatementNode *node) {
+  node->setLabelIndex(curFunctionInfo()->allocateLabel());
+
+  // Determine the target statement. We need to check if it directly encloses
+  // a loop or another label enclosing a loop.
+  StatementNode *targetStmt = node;
+  {
+    Node *curStmt = node;
+    while (auto *curLabeled = llvh::dyn_cast<LabeledStatementNode>(curStmt)) {
+      if (auto *ls = llvh::dyn_cast<LoopStatementNode>(curLabeled->_body)) {
+        targetStmt = ls;
+        break;
+      }
+      curStmt = curLabeled->_body;
+    }
+  }
+  assert(
+      (llvh::isa<LoopStatementNode>(targetStmt) ||
+       llvh::isa<LabeledStatementNode>(targetStmt)) &&
+      "invalid target statement detected for label");
+
+  auto *id = cast<IdentifierNode>(node->_label);
+  // Define the new label, checking for a previous definition.
+  auto insertRes = functionContext()->labelMap.try_emplace(
+      id->_name, FunctionContext::Label{id, targetStmt});
+  if (!insertRes.second) {
+    sm_.error(
+        id->getSourceRange(),
+        llvh::Twine("label '") + id->_name->str() + "' is already defined");
+    sm_.note(
+        insertRes.first->second.declarationNode->getSourceRange(),
+        "previous definition");
+  }
+  // Auto-erase the label on exit, if we inserted it.
+  const auto &deleter = llvh::make_scope_exit([=]() {
+    if (insertRes.second)
+      functionContext()->labelMap.erase(id->_name);
+  });
+  (void)deleter;
+
+  visitESTreeChildren(*this, node);
+}
+
+void SemanticResolver::visit(ESTree::BreakStatementNode *node) {
+  if (node->_label) {
+    const NodeLabel &name = llvh::cast<IdentifierNode>(node->_label)->_name;
+    auto it = functionContext()->labelMap.find(name);
+    if (it == functionContext()->labelMap.end()) {
+      sm_.error(
+          node->getSourceRange(),
+          llvh::Twine("label '") + name->str() + "' is not defined");
+    }
+  } else {
+    if (!currentLoopOrSwitch_) {
+      sm_.error(node->getSourceRange(), "'break' not within a loop or switch");
+    }
+  }
+
+  visitESTreeChildren(*this, node);
+}
+
+void SemanticResolver::visit(ESTree::ContinueStatementNode *node) {
+  if (node->_label) {
+    const NodeLabel &name = llvh::cast<IdentifierNode>(node->_label)->_name;
+    auto it = functionContext()->labelMap.find(name);
+    if (it == functionContext()->labelMap.end()) {
+      sm_.error(
+          node->getSourceRange(),
+          llvh::Twine("label '") + name->str() + "' is not defined");
+    }
+    if (!llvh::isa<LabeledStatementNode>(it->second.targetStatement)) {
+      sm_.error(
+          node->getSourceRange(),
+          llvh::Twine("'continue' label '") + name->str() +
+              "' is not a loop label");
+    }
+  } else {
+    if (!currentLoopOrSwitch_) {
+      sm_.error(
+          node->getSourceRange(), "'continue' not within a loop or switch");
+    }
+  }
+
+  visitESTreeChildren(*this, node);
+}
+
+void SemanticResolver::visit(ESTree::WithStatementNode *node) {
+  visitESTreeChildren(*this, node);
+  // FIXME: Run an unresolver pass.
+}
+
+void SemanticResolver::visit(ESTree::CatchClauseNode *node) {
+  ScopeRAII scope{*this, node};
+
+  if (auto *id = llvh::dyn_cast<IdentifierNode>(node->_param)) {
+    // For compatibility with ES5,
+    // we need to treat a single catch variable specially, see:
+    // B.3.5 VariableStatements in Catch Blocks
+    // https://www.ecma-international.org/ecma-262/10.0/index.html#sec-variablestatements-in-catch-blocks
+    validateAndDeclareIdentifier(Decl::Kind::ES5Catch, id);
+  } else {
+    llvh::SmallVector<IdentifierNode *, 4> idents{};
+    extractDeclaredIdentsFromID(node->_param, idents);
+    for (IdentifierNode *id : idents) {
+      validateAndDeclareIdentifier(Decl::Kind::Let, id);
+    }
+  }
+
+  // Process body's declarations, skip visiting it, visit its children.
+  processCollectedDeclarations(node->_body);
+  visitESTreeChildren(*this, node->_body);
+}
+
+void SemanticResolver::visit(RegExpLiteralNode *regexp) {
+  llvh::StringRef regexpError;
+  if (compile_ &&
+      !CompiledRegExp::tryCompile(
+          regexp->_pattern->str(), regexp->_flags->str(), &regexpError)) {
+    sm_.error(
+        regexp->getSourceRange(),
+        "Invalid regular expression: " + Twine(regexpError));
+  }
+  visitESTreeChildren(*this, regexp);
+}
+
+void SemanticResolver::visit(ESTree::MetaPropertyNode *node) {
+  auto *meta = llvh::cast<IdentifierNode>(node->_meta);
+  auto *property = llvh::cast<IdentifierNode>(node->_property);
+
+  if (meta->_name == kw_.identNew && property->_name == kw_.identTarget &&
+      functionContext()->isGlobalScope()) {
+    // ES9.0 15.1.1:
+    // It is a Syntax Error if StatementList Contains NewTarget unless the
+    // source code containing NewTarget is eval code that is being processed
+    // by a direct eval.
+    // Hermes does not support local eval, so we assume that this is not
+    // inside a local eval call.
+    sm_.error(node->getSourceRange(), "'new.target' not in a function");
+  }
+
+  sm_.error(
+      node->getSourceRange(),
+      llvh::Twine("invalid meta property ") + meta->_name->str() + "." +
+          property->_name->str());
+}
+
+void SemanticResolver::visit(ESTree::ImportDeclarationNode *node) {
+  visitESTreeChildren(*this, node);
+  // TODO: Multi-file dependency resolution.
+}
+void SemanticResolver::visit(ESTree::ClassDeclarationNode *node) {
+  // Classes must be in strict mode.
+  llvh::SaveAndRestore<bool> oldStrict{curFunctionInfo()->strict, true};
+  visitESTreeChildren(*this, node);
+}
+void SemanticResolver::visit(ESTree::ClassExpressionNode *node) {
+  // Classes must be in strict mode.
+  llvh::SaveAndRestore<bool> oldStrict{curFunctionInfo()->strict, true};
+  visitESTreeChildren(*this, node);
+}
+
+void SemanticResolver::visit(PrivateNameNode *node) {
+  if (compile_)
+    sm_.error(node->getSourceRange(), "private properties are not supported");
+  visitESTreeChildren(*this, node);
+}
+
+void SemanticResolver::visit(ClassPrivatePropertyNode *node) {
+  if (compile_)
+    sm_.error(node->getSourceRange(), "private properties are not supported");
+  visitESTreeChildren(*this, node);
+}
+
+void SemanticResolver::visit(ESTree::CallExpressionNode *node) {
+  // FIXME: Check for local 'eval'.
+  visitESTreeChildren(*this, node);
+}
+
+void SemanticResolver::visit(ESTree::SpreadElementNode *node, Node *parent) {
+  if (!llvh::isa<ESTree::ObjectExpressionNode>(parent) &&
+      !llvh::isa<ESTree::ArrayExpressionNode>(parent) &&
+      !llvh::isa<ESTree::CallExpressionNode>(parent) &&
+      !llvh::isa<ESTree::OptionalCallExpressionNode>(parent) &&
+      !llvh::isa<ESTree::NewExpressionNode>(parent))
+    sm_.error(node->getSourceRange(), "spread operator is not supported");
+  visitESTreeChildren(*this, node);
+}
+
+void SemanticResolver::visit(ESTree::ReturnStatementNode *returnStmt) {
+  if (functionContext()->isGlobalScope() &&
+      !astContext_.allowReturnOutsideFunction())
+    sm_.error(returnStmt->getSourceRange(), "'return' not in a function");
+  visitESTreeChildren(*this, returnStmt);
+}
+
+void SemanticResolver::visit(ESTree::YieldExpressionNode *node) {
+  if (functionContext()->isGlobalScope() ||
+      (functionContext()->node &&
+       !ESTree::isGenerator(functionContext()->node))) {
+    sm_.error(node->getSourceRange(), "'yield' not in a generator function");
+  }
+
+  visitESTreeChildren(*this, node);
+}
+
+void SemanticResolver::visit(ESTree::AwaitExpressionNode *awaitExpr) {
+  if (functionContext()->isGlobalScope() ||
+      (functionContext()->node && !ESTree::isAsync(functionContext()->node))) {
+    sm_.error(awaitExpr->getSourceRange(), "'await' not in an async function");
+  }
+
+  visitESTreeChildren(*this, awaitExpr);
+}
+
+void SemanticResolver::visit(CoverEmptyArgsNode *node) {
+  sm_.error(node->getSourceRange(), "invalid empty parentheses '( )'");
+}
+
+void SemanticResolver::visit(CoverTrailingCommaNode *node) {
+  sm_.error(node->getSourceRange(), "expression expected after ','");
+}
+
+void SemanticResolver::visit(CoverInitializerNode *node) {
+  sm_.error(node->getStartLoc(), "':' expected in property initialization");
+}
+
+void SemanticResolver::visit(CoverRestElementNode *node) {
+  sm_.error(node->getSourceRange(), "'...' not allowed in this context");
+}
+
+#if HERMES_PARSE_FLOW
+void SemanticResolver::visit(CoverTypedIdentifierNode *node) {
+  sm_.error(node->getSourceRange(), "typecast not allowed in this context");
+}
+#endif
+
+void SemanticResolver::visitFunctionLike(
+    ESTree::FunctionLikeNode *node,
+    ESTree::Node *body,
+    ESTree::NodeList &params) {
+  FunctionContext newFuncCtx{*this, node, nullptr, curFunctionInfo()->strict};
+
+  llvh::SaveAndRestore<bool> oldIsFormalParamsFn{isFormalParams_, false};
+
+  ESTree::Node *useStrictNode = nullptr;
+
+  // Note that body might be empty (for lazy functions)
+  // or an expression (for arrow functions).
+  auto *blockBody = llvh::dyn_cast<BlockStatementNode>(body);
+  if (blockBody) {
+    useStrictNode = findUseStrict(blockBody->_body);
+  }
+
+  // Set the strictness if necessary.
+  if (useStrictNode) {
+    curFunctionInfo()->strict = true;
+  }
+  node->strictness = makeStrictness(curFunctionInfo()->strict);
+
+  // Create the function body scope.
+  // Note that we are associating the new scope with the body.
+  // We are doing this because function expressions need an extra scope
+  // for the name, and we associate that with the function expression itself.
+  ScopeRAII scope{*this, blockBody};
+
+  // Set to false if the parameter list contains binding patterns.
+  bool simpleParameterList = true;
+  // All parameter identifiers.
+  llvh::SmallVector<IdentifierNode *, 4> paramIds{};
+  for (auto &param : params) {
+    simpleParameterList &= !llvh::isa<PatternNode>(param);
+    extractDeclaredIdentsFromID(&param, paramIds);
+  }
+
+  if (!simpleParameterList && useStrictNode) {
+    sm_.error(
+        useStrictNode->getSourceRange(),
+        "'use strict' not allowed inside function with non-simple parameter list");
+  }
+
+  // Whether parameters must be unique.
+  bool const uniqueParams = !simpleParameterList || curFunctionInfo()->strict ||
+      llvh::isa<ArrowFunctionExpressionNode>(node);
+
+  // Declare the parameters
+  for (IdentifierNode *paramId : paramIds) {
+    validateDeclarationName(Decl::Kind::Parameter, paramId);
+
+    Decl *paramDecl =
+        semCtx_.newDecl(paramId->_name, Decl::Kind::Parameter, curScope_);
+    paramId->setDecl(paramDecl);
+    Binding *prevName = bindingTable_.find(paramId->_name);
+    if (prevName && prevName->decl->scope == curScope_) {
+      // Check for parameter re-declaration.
+      if (uniqueParams) {
+        sm_.error(
+            paramId->getSourceRange(),
+            "cannot declare two parameters with the same name '" +
+                paramId->_name->str() + "'");
+      }
+
+      // Update the name binding to point to the latest declaration.
+      prevName->decl = paramDecl;
+      prevName->ident = paramId;
+    } else {
+      // Just add the new parameter.
+      bindingTable_.insert(paramId->_name, Binding{paramDecl, paramId});
+    }
+  }
+
+  // Do not visit the identifier node, because that would try to resolve it
+  // in an incorrect scope!
+  // visitESTreeNode(*this, getIdentifier(node), node);
+
+  // Visit the parameters before we have hoisted the body declarations.
+  {
+    llvh::SaveAndRestore<bool> oldIsFormalParams{isFormalParams_, true};
+    for (auto &param : getParams(node))
+      visitESTreeNode(*this, &param, node);
+  }
+
+  // Promote hoisted functions.
+  if (blockBody) {
+    if (!curFunctionInfo()->strict) {
+      promoteScopedFuncDecls(*this, node);
+    }
+  }
+  processCollectedDeclarations(node);
+
+  // Finally visit the body.
+  visitESTreeNode(*this, body, node);
+
+  // FIXME: Check for local eval and run the unresolver pass in non-strict mode.
+}
+
+void SemanticResolver::visitFunctionExpression(
+    ESTree::FunctionExpressionNode *node,
+    ESTree::Node *body,
+    ESTree::NodeList &params) {
+  if (ESTree::IdentifierNode *ident =
+          llvh::dyn_cast_or_null<IdentifierNode>(node->_id)) {
+    // If there is a name, declare it.
+    ScopeRAII scope{*this, node};
+    if (validateDeclarationName(Decl::Kind::FunctionExprName, ident)) {
+      Decl *decl = semCtx_.newDecl(
+          ident->_name, Decl::Kind::FunctionExprName, curScope_);
+      ident->setDecl(decl);
+      bindingTable_.insert(ident->_name, Binding{decl, ident});
+    }
+    visitFunctionLike(node, body, params);
+  } else {
+    // Otherwise, no extra scope needed, just move on.
+    visitFunctionLike(node, body, params);
+  }
+}
+
+void SemanticResolver::resolveIdentifier(
+    IdentifierNode *identifier,
+    bool inTypeof) {
+  Decl *decl = checkIdentifierResolved(identifier);
+
+  // Is this "arguments" in a function?
+  if (identifier->_name == kw_.identArguments &&
+      !functionContext()->isGlobalScope()) {
+    if (!decl || decl->scope->parentFunction != curFunctionInfo()) {
+      hermes::OptValue<Decl *> argumentsDeclOpt =
+          semCtx_.funcArgumentsDecl(curFunctionInfo(), identifier->_name);
+      if (argumentsDeclOpt) {
+        identifier->setDecl(argumentsDeclOpt.getValue());
+      }
+    }
+    return;
+  }
+
+  // Resolved the identifier to a declaration, done.
+  if (decl) {
+    return;
+  }
+
+  // Undeclared variables outside `typeof` cause runtime errors in strict mode.
+  if (!inTypeof && curFunctionInfo()->strict) {
+    UniqueString *funcName = functionContext()->getFunctionName();
+
+    sm_.warning(
+        Warning::UndefinedVariable,
+        identifier->getSourceRange(),
+        Twine("the variable \"") + identifier->_name->str() +
+            "\" was not declared in function \"" +
+            (funcName ? funcName->str() : "global") + "\"");
+  }
+
+  // Declare an ambient global property.
+  Decl *globalDecl = semCtx_.newGlobal(
+      identifier->_name, Decl::Kind::UndeclaredGlobalProperty);
+  identifier->setDecl(globalDecl);
+
+  bindingTable_.insertIntoScope(
+      globalScope_, identifier->_name, Binding{decl, identifier});
+}
+
+Decl *SemanticResolver::checkIdentifierResolved(
+    ESTree::IdentifierNode *identifier) {
+  // If identifier already resolved or unresolvable,
+  // pick the resolved declaration.
+  if (LLVM_UNLIKELY(identifier->isUnresolvable()))
+    return nullptr;
+  if (identifier->getDecl())
+    return identifier->getDecl();
+
+  // If we find the binding, assign the associated declaration and return it.
+  if (Binding *binding = bindingTable_.find(identifier->_name)) {
+    identifier->setDecl(binding->decl);
+    return binding->decl;
+  }
+
+  // Failed to resolve.
+  return nullptr;
+}
+
+void SemanticResolver::processCollectedDeclarations(ESTree::Node *scopeNode) {
+  if (hermes::OptValue<llvh::ArrayRef<ESTree::Node *>> declsOpt =
+          functionContext()->decls.getScopeDeclsForNode(scopeNode)) {
+    processDeclarations(*declsOpt);
+  }
+}
+
+void SemanticResolver::processDeclarations(const ScopeDecls &decls) {
+  for (ESTree::Node *decl : decls) {
+    llvh::SmallVector<ESTree::IdentifierNode *, 4> idents{};
+    Decl::Kind kind = extractIdentsFromDecl(decl, idents);
+
+    for (ESTree::IdentifierNode *ident : idents) {
+      validateAndDeclareIdentifier(kind, ident);
+    }
+  }
+}
+
+Decl::Kind SemanticResolver::extractIdentsFromDecl(
+    ESTree::Node *node,
+    llvh::SmallVectorImpl<ESTree::IdentifierNode *> &idents) {
+  assert(node && "Node is not optional");
+  if (auto *varDecl = llvh::dyn_cast<VariableDeclarationNode>(node)) {
+    for (auto &decl : varDecl->_declarations) {
+      extractDeclaredIdentsFromID(
+          llvh::cast<VariableDeclaratorNode>(&decl)->_id, idents);
+    }
+    if (varDecl->_kind == kw_.identVar) {
+      if (functionContext()->isGlobalScope()) {
+        return Decl::Kind::GlobalProperty;
+      } else {
+        return Decl::Kind::Var;
+      }
+    }
+    if (varDecl->_kind == kw_.identLet) {
+      return Decl::Kind::Let;
+    } else {
+      return Decl::Kind::Const;
+    }
+  }
+
+  if (auto *funcDecl = llvh::dyn_cast<FunctionDeclarationNode>(node)) {
+    extractDeclaredIdentsFromID(funcDecl->_id, idents);
+    if (functionContext()->isGlobalScope()) {
+      return Decl::Kind::GlobalProperty;
+    } else {
+      return Decl::Kind::ScopedFunction;
+    }
+  }
+
+  if (auto *classDecl = llvh::dyn_cast<ClassDeclarationNode>(node)) {
+    extractDeclaredIdentsFromID(classDecl->_id, idents);
+    return Decl::Kind::Class;
+  }
+
+  if (auto *importDecl = llvh::dyn_cast<ImportDeclarationNode>(node)) {
+    for (auto &spec : importDecl->_specifiers) {
+      if (auto *inner = llvh::dyn_cast<ImportSpecifierNode>(&spec)) {
+        extractDeclaredIdentsFromID(inner->_local, idents);
+      } else if (
+          auto *inner = llvh::dyn_cast<ImportDefaultSpecifierNode>(&spec)) {
+        extractDeclaredIdentsFromID(inner->_local, idents);
+      } else if (
+          auto *inner = llvh::dyn_cast<ImportNamespaceSpecifierNode>(&spec)) {
+        extractDeclaredIdentsFromID(inner->_local, idents);
+      }
+    }
+    return Decl::Kind::Import;
+  }
+
+  sm_.error(node->getSourceRange(), "unsuppported declaration kind");
+  return Decl::Kind::Var;
+}
+
+void SemanticResolver::extractDeclaredIdentsFromID(
+    ESTree::Node *node,
+    llvh::SmallVectorImpl<ESTree::IdentifierNode *> &idents) {
+  // The identifier is sometimes optional, in which case it is valid.
+  if (!node)
+    return;
+
+  if (auto *idNode = llvh::dyn_cast<IdentifierNode>(node)) {
+    idents.push_back(idNode);
+    return;
+  }
+
+  if (llvh::isa<EmptyNode>(node))
+    return;
+
+  if (auto *assign = llvh::dyn_cast<AssignmentPatternNode>(node))
+    return extractDeclaredIdentsFromID(assign->_left, idents);
+
+  if (auto *array = llvh::dyn_cast<ArrayPatternNode>(node)) {
+    for (auto &elem : array->_elements) {
+      extractDeclaredIdentsFromID(&elem, idents);
+    }
+    return;
+  }
+
+  if (auto *restElem = llvh::dyn_cast<RestElementNode>(node)) {
+    return extractDeclaredIdentsFromID(restElem->_argument, idents);
+  }
+
+  if (auto *obj = llvh::dyn_cast<ObjectPatternNode>(node)) {
+    for (auto &propNode : obj->_properties) {
+      if (auto *prop = llvh::dyn_cast<PropertyNode>(&propNode)) {
+        extractDeclaredIdentsFromID(prop->_value, idents);
+      } else {
+        auto *rest = cast<RestElementNode>(&propNode);
+        extractDeclaredIdentsFromID(rest->_argument, idents);
+      }
+    }
+    return;
+  }
+
+  sm_.error(node->getSourceRange(), "invalid destructuring target");
+}
+
+void SemanticResolver::validateAndDeclareIdentifier(
+    Decl::Kind kind,
+    ESTree::IdentifierNode *ident) {
+  if (!validateDeclarationName(kind, ident))
+    return;
+
+  Binding prevName = bindingTable_.lookup(ident->_name);
+
+  // Redeclaration of `arguments` in non-strict mode is allowed at the function
+  // level, so we don't need to declare a new variable. We do need to check that
+  // this isn't the global function, because `arguments` is a valid variable
+  // name in the global function in non-strict mode.
+  if (!curFunctionInfo()->strict && ident->_name == kw_.identArguments &&
+      Decl::isKindVarLike(kind) && !functionContext()->isGlobalScope()) {
+    return;
+  }
+
+  // Ignore declarations in enclosing functions.
+  if (prevName.isValid() && !declInCurFunction(prevName.decl)) {
+    prevName.invalidate();
+  }
+
+  Decl *decl = nullptr;
+
+  // Handle re-declarations, ignoring ambient properties.
+  if (prevName.isValid() &&
+      prevName.decl->kind != Decl::Kind::UndeclaredGlobalProperty) {
+    const Decl::Kind prevKind = prevName.decl->kind;
+    const bool sameScope = prevName.decl->scope == curScope_;
+
+    // Check whether the redeclaration is invalid.
+    // Note that since "var" declarations have been hoisted to the function
+    // scope, we cannot catch cases where "var" follows something declared in a
+    // surrounding lexical scope.
+    //
+    // ES5Catch, var
+    //          -> valid, special case ES10 B.3.5, but we can't catch it here.
+    // var|scopedFunction, var|scopedFunction
+    //          -> always valid
+    // let, var
+    //          -> always invalid
+    // let, scopedFunction
+    //          -> invalid if same scope
+    // var|scopedFunction|let, let
+    //          -> invalid if the same scope
+
+    if ((Decl::isKindLetLike(prevKind) && Decl::isKindVarLike(kind)) ||
+        (Decl::isKindLetLike(prevKind) && kind == Decl::Kind::ScopedFunction &&
+         sameScope) ||
+        (Decl::isKindLetLike(kind) && sameScope)) {
+      sm_.error(
+          ident->getSourceRange(),
+          llvh::Twine("Identifier '") + ident->_name->str() +
+              "' is already declared");
+      if (prevName.ident)
+        sm_.note(prevName.ident->getSourceRange(), "previous declaration");
+      return;
+    }
+
+    // When to create a new declaration?
+    //
+    // Var, Var -> use prev
+    if (Decl::isKindVarLike(prevKind) && Decl::isKindVarLike(kind)) {
+      decl = prevName.decl;
+    }
+    // Var, ScopedFunc -> if non-strict or same scope, then use prev,
+    //                    else declare new
+    else if (
+        Decl::isKindVarLike(prevKind) &&
+        Decl::isKindVarLikeOrScopedFunction(kind)) {
+      if (sameScope || !curFunctionInfo()->strict)
+        decl = prevName.decl;
+      else
+        decl = nullptr;
+    }
+    // ScopedFunc, ScopedFunc same scope -> use prev
+    // ScopedFunc, ScopedFunc new scope -> declare new
+    else if (
+        prevKind == Decl::Kind::ScopedFunction &&
+        kind == Decl::Kind::ScopedFunction) {
+      if (sameScope) {
+        decl = prevName.decl;
+      } else {
+        decl = nullptr;
+      }
+    }
+    // ScopedFunc, Var -> convert to var
+    else if (
+        prevKind == Decl::Kind::ScopedFunction && Decl::isKindVarLike(kind)) {
+      assert(
+          sameScope &&
+          "we can only encounter Var after ScopedFunction in the same scope");
+      // Since they are in the same scope, we can simply convert the existing
+      // ScopedFunction to Var.
+      decl = prevName.decl;
+      decl->kind = Decl::Kind::Var;
+    } else {
+      decl = nullptr;
+    }
+  }
+
+  // Create new decl.
+  if (!decl) {
+    if (Decl::isKindGlobal(kind))
+      decl = semCtx_.newGlobal(ident->_name, kind);
+    else
+      decl = semCtx_.newDecl(ident->_name, kind, curScope_);
+    bindingTable_.insert(ident->_name, Binding{decl, ident});
+  }
+
+  ident->setDecl(decl);
+}
+
+bool SemanticResolver::validateDeclarationName(
+    Decl::Kind declKind,
+    const ESTree::IdentifierNode *idNode) const {
+  if (curFunctionInfo()->strict) {
+    // - 'arguments' cannot be redeclared in strict mode.
+    // - 'eval' cannot be redeclared in strict mode. If it is disabled we
+    // we don't report an error because it will be reported separately.
+    if (idNode->_name == kw_.identArguments ||
+        (idNode->_name == kw_.identEval && astContext_.getEnableEval())) {
+      sm_.error(
+          idNode->getSourceRange(),
+          "cannot declare '" + cast<IdentifierNode>(idNode)->_name->str() +
+              "' in strict mode");
+      return false;
+    }
+
+    // Parameter cannot be named "let".
+    if (declKind == Decl::Kind::Parameter && idNode->_name == kw_.identLet) {
+      sm_.error(
+          idNode->getSourceRange(),
+          "invalid parameter name 'let' in strict mode");
+      return false;
+    }
+  }
+
+  if ((declKind == Decl::Kind::Let || declKind == Decl::Kind::Const) &&
+      idNode->_name == kw_.identLet) {
+    // ES9.0 13.3.1.1
+    // LexicalDeclaration : LetOrConst BindingList
+    // It is a Syntax Error if the BoundNames of BindingList
+    // contains "let".
+    sm_.error(
+        idNode->getSourceRange(),
+        "'let' is disallowed as a lexically bound name");
+    return false;
+  }
+
+  return true;
+}
+
+void SemanticResolver::validateAssignmentTarget(const Node *node) {
+  if (llvh::isa<EmptyNode>(node))
+    return;
+
+  if (auto *assign = llvh::dyn_cast<AssignmentPatternNode>(node)) {
+    return validateAssignmentTarget(assign->_left);
+  }
+
+  if (auto *prop = llvh::dyn_cast<PropertyNode>(node)) {
+    return validateAssignmentTarget(prop->_value);
+  }
+
+  if (auto *arr = llvh::dyn_cast<ArrayPatternNode>(node)) {
+    for (auto &elem : arr->_elements) {
+      validateAssignmentTarget(&elem);
+    }
+    return;
+  }
+
+  if (auto *obj = llvh::dyn_cast<ObjectPatternNode>(node)) {
+    for (auto &propNode : obj->_properties) {
+      validateAssignmentTarget(&propNode);
+    }
+    return;
+  }
+
+  if (auto *rest = llvh::dyn_cast<RestElementNode>(node)) {
+    return validateAssignmentTarget(rest->_argument);
+  }
+
+  if (!isLValue(node))
+    sm_.error(node->getSourceRange(), "invalid assignment left-hand side");
+}
+
+bool SemanticResolver::isLValue(const ESTree::Node *node) {
+  if (llvh::isa<MemberExpressionNode>(node))
+    return true;
+
+  if (auto *id = llvh::dyn_cast<IdentifierNode>(node)) {
+    if (LLVM_UNLIKELY(id->_name == kw_.identArguments)) {
+      // "arguments" is only valid assignment in loose mode.
+      return !curFunctionInfo()->strict;
+    }
+    if (LLVM_UNLIKELY(id->_name == kw_.identEval)) {
+      // "eval" is only valid assignment in loose mode.
+      return !curFunctionInfo()->strict;
+    }
+    return true;
+  }
+
+  return false;
+}
+
+void SemanticResolver::recursionDepthExceeded(ESTree::Node *n) {
+  sm_.error(
+      n->getEndLoc(), "Too many nested expressions/statements/declarations");
+}
+
+ESTree::Node *SemanticResolver::findUseStrict(ESTree::NodeList &body) const {
+  for (auto &node : body) {
+    if (auto *expr = llvh::dyn_cast<ExpressionStatementNode>(&node)) {
+      if (expr->_directive == kw_.identUseStrict) {
+        return &node;
+      }
+    }
+  }
+  return nullptr;
+}
+
+SemanticResolver::ScopeRAII::ScopeRAII(
+    SemanticResolver &resolver,
+    ESTree::ScopeDecorationBase *scopeNode)
+    : resolver_(resolver),
+      oldScope_(resolver_.curScope_),
+      bindingScope_(resolver_.bindingTable_) {
+  // Create a new scope.
+  LexicalScope *scope = resolver.semCtx_.newScope(
+      resolver_.curFunctionInfo(), resolver_.curScope_);
+  resolver.curScope_ = scope;
+  // Associate the scope with the node.
+  scopeNode->setScope(scope);
+}
+SemanticResolver::ScopeRAII::~ScopeRAII() {
+  resolver_.curScope_ = oldScope_;
+}
+
+//===----------------------------------------------------------------------===//
+// FunctionContext
+
+FunctionContext::FunctionContext(
+    SemanticResolver &resolver,
+    ESTree::FunctionLikeNode *node,
+    FunctionInfo *semInfo,
+    bool strict)
+    : resolver_(resolver),
+      semInfo(resolver.semCtx_
+                  .newFunction(node, semInfo, resolver.curScope_, strict)),
+      node(node),
+      decls(DeclCollector::run(node, resolver.keywords())) {
+  resolver.functionStack_.push_back(this);
+}
+
+FunctionContext::~FunctionContext() {
+  assert(
+      resolver_.curFunctionInfo() == semInfo &&
+      "FunctionContext out of sync with SemContext");
+  // If not the global function, pop it.
+  resolver_.functionStack_.pop_back();
+}
+
+UniqueString *FunctionContext::getFunctionName() const {
+  if (node) {
+    if (auto *idNode =
+            llvh::dyn_cast_or_null<IdentifierNode>(getIdentifier(node)))
+      return idNode->_name;
+  }
+  return nullptr;
+}
+
+} // namespace sema
+} // namespace hermes

--- a/lib/AST/SemanticResolver.h
+++ b/lib/AST/SemanticResolver.h
@@ -1,0 +1,423 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef HERMES_AST_SEMANTICRESOLVER_H
+#define HERMES_AST_SEMANTICRESOLVER_H
+
+#include "SemanticValidator.h"
+
+#include "DeclCollector.h"
+#include "Keywords.h"
+#include "hermes/ADT/ScopedHashTable.h"
+#include "hermes/AST/RecursiveVisitor.h"
+
+namespace hermes {
+namespace sema {
+
+class FunctionContext;
+class SemContext;
+
+/// Class the performs all resolution.
+/// Reports errors if validation fails.
+class SemanticResolver {
+  Context &astContext_;
+  /// A copy of Context::getSM() for easier access.
+  SourceErrorManager &sm_;
+
+  /// Buffer all generated messages and print them sorted in the end.
+  SourceErrorManager::SaveAndBufferMessages bufferMessages_;
+
+  /// Global function context, nullptr until populated.
+  FunctionContext *globalFunctionContext_{nullptr};
+
+  /// All semantic tables are persisted here.
+  SemContext &semCtx_;
+
+  /// Save the initial error count so we know whether we generated any errors.
+  const unsigned initialErrorCount_;
+
+  /// Keywords we will be checking for.
+  hermes::sem::Keywords kw_;
+
+  /// Stack of function contexts.
+  std::vector<FunctionContext *> functionStack_{};
+
+  /// Current lexical scope.
+  LexicalScope *curScope_{nullptr};
+
+  /// Most nested active loop statement.
+  ESTree::LoopStatementNode *currentLoop_{nullptr};
+
+  /// The most nested active loop or switch statement.
+  ESTree::StatementNode *currentLoopOrSwitch_{nullptr};
+
+  /// True if we are validating a formal parameter list.
+  bool isFormalParams_{false};
+
+  /// Binding between an identifier and its declaration in a scope.
+  struct Binding {
+    Decl *decl = nullptr;
+    /// The declaring node. Note that this is nullable.
+    ESTree::IdentifierNode *ident = nullptr;
+
+    Binding() = default;
+    Binding(Decl *decl, ESTree::IdentifierNode *ident)
+        : decl(decl), ident(ident) {}
+
+    bool isValid() const {
+      return decl != nullptr;
+    }
+    void invalidate() {
+      decl = nullptr;
+      ident = nullptr;
+    }
+  };
+
+  /// The scoped binding table mapping from string to binding.
+  using BindingTableTy = hermes::ScopedHashTable<UniqueString *, Binding>;
+  using BindingTableScopeTy =
+      hermes::ScopedHashTableScope<UniqueString *, Binding>;
+
+  /// The currently lexically visible names.
+  BindingTableTy bindingTable_{};
+
+  /// The global scope.
+  BindingTableScopeTy *globalScope_ = nullptr;
+  /// Depth of the global scope in bindingTable.
+  /// None until we have actually entered global scope.
+  hermes::OptValue<uint32_t> globalBindingScopeDepth;
+
+  /// True if we are preparing the AST to be compiled by Hermes, including
+  /// erroring on features which we parse but don't compile and transforming
+  /// the AST. False if we just want to validate the AST.
+  bool compile_;
+
+  /// The maximum AST nesting level. Once we reach it, we report an error and
+  /// stop.
+  static constexpr unsigned MAX_RECURSION_DEPTH =
+#if defined(HERMES_LIMIT_STACK_DEPTH) || defined(_MSC_VER)
+      512
+#else
+      1024
+#endif
+      ;
+  /// MAX_RECURSION_DEPTH minus the current AST nesting level. Once it reaches
+  /// 0, we report an error and stop modifying it.
+  unsigned recursionDepth_ = MAX_RECURSION_DEPTH;
+
+ public:
+  /// \param semCtx the result of resolution will be stored here.
+  /// \param compile whether this resolution is intended to compile or just
+  ///   parsing.
+  explicit SemanticResolver(
+      Context &astContext,
+      sema::SemContext &semCtx,
+      bool compile);
+
+  /// Run semantic resolution and store the result in \c semCtx_.
+  /// \return false on error.
+  bool run(ESTree::Node *rootNode);
+
+  /// \return a reference to the keywords struct.
+  const sem::Keywords &keywords() const {
+    return kw_;
+  }
+
+  /// \return the current function context.
+  FunctionContext *functionContext() {
+    return functionStack_.back();
+  }
+  /// \return the current function context.
+  const FunctionContext *functionContext() const {
+    return functionStack_.back();
+  }
+
+  /// Extract the declared identifiers from a declaration AST node's "id" field.
+  /// Normally that is just a single identifier, but it can be more in case of
+  /// destructuring.
+  void extractDeclaredIdentsFromID(
+      ESTree::Node *node,
+      llvh::SmallVectorImpl<ESTree::IdentifierNode *> &idents);
+
+  /// Default case for all ignored nodes, we still want to visit their children.
+  void visit(ESTree::Node *node) {
+    visitESTreeChildren(*this, node);
+  }
+
+  void visit(ESTree::ProgramNode *node);
+
+  void visit(ESTree::FunctionDeclarationNode *funcDecl);
+  void visit(ESTree::FunctionExpressionNode *funcExpr);
+  void visit(ESTree::ArrowFunctionExpressionNode *arrowFunc);
+
+  void visit(ESTree::IdentifierNode *identifier, ESTree::Node *parent);
+
+  void visit(ESTree::AssignmentExpressionNode *assignment);
+  void visit(ESTree::UpdateExpressionNode *node);
+  void visit(ESTree::UnaryExpressionNode *node);
+
+  void visit(ESTree::BlockStatementNode *node);
+
+  void visit(ESTree::SwitchStatementNode *node);
+
+  void visit(ESTree::ForInStatementNode *node) {
+    visitForInOf(node, node, node->_left);
+  }
+  void visit(ESTree::ForOfStatementNode *node) {
+    visitForInOf(node, node, node->_left);
+  }
+  void visitForInOf(
+      ESTree::LoopStatementNode *node,
+      ESTree::ScopeDecorationBase *scopeDeco,
+      ESTree::Node *left);
+
+  void visit(ESTree::ForStatementNode *node);
+
+  void visit(ESTree::DoWhileStatementNode *node);
+  void visit(ESTree::WhileStatementNode *node);
+
+  void visit(ESTree::LabeledStatementNode *node);
+
+  void visit(ESTree::BreakStatementNode *node);
+  void visit(ESTree::ContinueStatementNode *node);
+
+  void visit(ESTree::WithStatementNode *node);
+
+  void visit(ESTree::CatchClauseNode *node);
+
+  void visit(ESTree::RegExpLiteralNode *regexp);
+
+  void visit(ESTree::MetaPropertyNode *node);
+
+  void visit(ESTree::ImportDeclarationNode *node);
+
+  void visit(ESTree::ClassDeclarationNode *node);
+  void visit(ESTree::ClassExpressionNode *node);
+  void visit(ESTree::PrivateNameNode *node);
+  void visit(ESTree::ClassPrivatePropertyNode *node);
+
+  void visit(ESTree::CallExpressionNode *node);
+
+  void visit(ESTree::SpreadElementNode *node, ESTree::Node *parent);
+
+  void visit(ESTree::ReturnStatementNode *node);
+  void visit(ESTree::YieldExpressionNode *node);
+  void visit(ESTree::AwaitExpressionNode *awaitExpr);
+
+  void visit(ESTree::CoverEmptyArgsNode *node);
+  void visit(ESTree::CoverTrailingCommaNode *node);
+  void visit(ESTree::CoverInitializerNode *node);
+  void visit(ESTree::CoverRestElementNode *node);
+#if HERMES_PARSE_FLOW
+  void visit(ESTree::CoverTypedIdentifierNode *node);
+#endif
+
+  /// This method implements the first part of the protocol defined by
+  /// RecursiveVisitor. It is supposed to return true if everything is normal,
+  /// and false if we should not visit the current node.
+  /// It maintains the current AST nesting level, and generates an error the
+  /// first time it exceeds the maximum nesting level. Once that happens, it
+  /// always returns false.
+  bool incRecursionDepth(ESTree::Node *n) {
+    if (LLVM_UNLIKELY(recursionDepth_ == 0))
+      return false;
+    --recursionDepth_;
+    if (LLVM_UNLIKELY(recursionDepth_ == 0)) {
+      recursionDepthExceeded(n);
+      return false;
+    }
+    return true;
+  }
+
+  /// This is the second part of the protocol defined by RecursiveVisitor.
+  /// Once we have reached the maximum nesting level, it does nothing. Otherwise
+  /// it decrements the nesting level.
+  void decRecursionDepth() {
+    assert(
+        recursionDepth_ < MAX_RECURSION_DEPTH &&
+        "recursionDepth_ cannot go negative");
+    if (LLVM_LIKELY(recursionDepth_ != 0))
+      ++recursionDepth_;
+  }
+
+  friend class FunctionContext;
+
+ private:
+  /// A RAII object automatic scopes.
+  /// On construction it creates a new binding table scope and a new
+  /// semantic scope, setting curScope_.
+  /// On destruction it destroys the binding scope and resets curScope_.
+  /// \param scopeDecoration if not null, will associate the new scope with
+  ///   the node provided.
+  class ScopeRAII {
+   public:
+    /// Create a binding scope and push a semantic scope.
+    /// \param scopeNode is the AST node with which to associate the scope.
+    explicit ScopeRAII(
+        SemanticResolver &resolver,
+        ESTree::ScopeDecorationBase *scopeDecoration);
+
+    /// Pops the created scope if it was pushed.
+    ~ScopeRAII();
+
+    BindingTableScopeTy &getBindingScope() {
+      return bindingScope_;
+    }
+
+   private:
+    /// The semantic context. If non-null, pop a scope on destruction.
+    SemanticResolver &resolver_;
+    /// Old LexicalScope to restore on pop.
+    LexicalScope *oldScope_;
+    /// The binding table scope.
+    BindingTableScopeTy bindingScope_;
+  };
+
+  inline FunctionInfo *curFunctionInfo();
+  inline const FunctionInfo *curFunctionInfo() const;
+
+  void visitFunctionLike(
+      ESTree::FunctionLikeNode *node,
+      ESTree::Node *body,
+      ESTree::NodeList &params);
+  void visitFunctionExpression(
+      ESTree::FunctionExpressionNode *node,
+      ESTree::Node *body,
+      ESTree::NodeList &params);
+
+  /// Resolve an identifier to a declaration and record the resolution.
+  /// Emit a warning for undeclared identifiers in strict mode.
+  /// Record an undeclared global property if no declaration is found.
+  void resolveIdentifier(ESTree::IdentifierNode *identifier, bool inTypeof);
+
+  /// Look up \p identifier to see if it already has been resolved or has a
+  /// binding assigned.
+  /// Assigns the associated declaration if it exists.
+  /// \return the declaration, `nullptr` if unresolvable or failed to resolve.
+  Decl *checkIdentifierResolved(ESTree::IdentifierNode *identifier);
+
+  /// Declare all declarations optionally associated with \p scopeNode
+  /// by the DeclCollector in the current scope.
+  void processCollectedDeclarations(ESTree::Node *scopeNode);
+
+  /// Declare all declarations in \p decls by calling
+  /// `validateAndDeclareIdentifier`.
+  void processDeclarations(const ScopeDecls &decls);
+
+  /// Extract the list of declared identifiers in a declaration node and return
+  /// the declaration kind of the node.
+  /// Function declarations are returned as DeclKind::ScopedFunction,
+  /// so they can be distinguished.
+  Decl::Kind extractIdentsFromDecl(
+      ESTree::Node *node,
+      llvh::SmallVectorImpl<ESTree::IdentifierNode *> &idents);
+
+  /// Try to create a declaration of the specified kind and name in the current
+  /// scope. If the declaration is invalid, print an error message without
+  /// creating it.
+  /// \param declKind the semantic declaration kind
+  /// \param idNode the AST node containing the name
+  /// \param declNode the AST node of the declaration. Used for function
+  ///     declarations.
+  void validateAndDeclareIdentifier(
+      Decl::Kind kind,
+      ESTree::IdentifierNode *ident);
+
+  /// Ensure that the specified identifier is valid to be used in a declaration.
+  /// Return true if valid, otherwise generate an error and return false.
+  bool validateDeclarationName(
+      Decl::Kind declKind,
+      const ESTree::IdentifierNode *idNode) const;
+
+  /// Ensure that the specified node is a valid target for an assignment, in
+  /// other words it is an l-value, a Pattern (checked recursively) or an Empty
+  /// (used by elision).
+  /// Report errors if any are found.
+  void validateAssignmentTarget(const ESTree::Node *node);
+
+  /// \return true if the `node` is an LValue: a member expression or an
+  /// identifier which is a valid LValue.
+  bool isLValue(const ESTree::Node *node);
+
+  /// Scan a list of directives in the beginning of a program or function
+  /// (see ES5.1 4.1 - a directive is a statement consisting of a single
+  /// string literal).
+  /// \param body list of statements to scan.
+  /// \return the node containing "use strict" or nullptr.
+  ESTree::Node *findUseStrict(ESTree::NodeList &body) const;
+
+  // \param decl must be non-null.
+  // \return whether the specified declaration is in the current function.
+  bool declInCurFunction(Decl *decl) {
+    assert(decl && "declInCurFunction requires non-null arg");
+    return decl->scope->parentFunction == curFunctionInfo();
+  }
+
+  /// We call this when we exceed the maximum recursion depth.
+  void recursionDepthExceeded(ESTree::Node *n);
+};
+
+/// RAII class which holds per-function state during resolution,
+/// including a pointer to the SemContext's \c FunctionInfo.
+/// Includes label tables and collected declarations.
+/// Must always be constructed on the stack.
+/// At construction: pushes itself onto the \c functionStack_.
+/// At destruction: pops itself from the \c functionStack_.
+class FunctionContext {
+  SemanticResolver &resolver_;
+
+ public:
+  struct Label {
+    /// Where it was declared.
+    ESTree::IdentifierNode *declarationNode;
+
+    /// Statement targeted by the label. It is either a LoopStatement or a
+    /// LabeledStatement.
+    ESTree::StatementNode *targetStatement;
+  };
+
+  /// The associated seminfo object
+  sema::FunctionInfo *semInfo;
+
+  /// The AST node of the function.
+  ESTree::FunctionLikeNode *const node;
+
+  /// The currently active labels in the function.
+  llvh::DenseMap<ESTree::NodeLabel, Label> labelMap;
+
+  /// All declarations in the function.
+  DeclCollector decls;
+
+  explicit FunctionContext(
+      SemanticResolver &resolver,
+      ESTree::FunctionLikeNode *node,
+      FunctionInfo *semInfo,
+      bool strict);
+
+  ~FunctionContext();
+
+  /// \return true if this is the "global scope" function context, in other
+  /// words not a real function.
+  bool isGlobalScope() const {
+    return this == resolver_.globalFunctionContext_;
+  }
+
+  /// \return the optional function name, or nullptr.
+  UniqueString *getFunctionName() const;
+};
+
+inline FunctionInfo *SemanticResolver::curFunctionInfo() {
+  return functionContext()->semInfo;
+}
+const FunctionInfo *SemanticResolver::curFunctionInfo() const {
+  return functionContext()->semInfo;
+}
+
+} // namespace sema
+} // namespace hermes
+
+#endif

--- a/lib/AST/SemanticValidator.cpp
+++ b/lib/AST/SemanticValidator.cpp
@@ -22,30 +22,6 @@ namespace hermes {
 namespace sem {
 
 //===----------------------------------------------------------------------===//
-// Keywords
-
-Keywords::Keywords(Context &astContext)
-    : identArguments(
-          astContext.getIdentifier("arguments").getUnderlyingPointer()),
-      identEval(astContext.getIdentifier("eval").getUnderlyingPointer()),
-      identDelete(astContext.getIdentifier("delete").getUnderlyingPointer()),
-      identThis(astContext.getIdentifier("this").getUnderlyingPointer()),
-      identUseStrict(
-          astContext.getIdentifier("use strict").getUnderlyingPointer()),
-      identShowSource(
-          astContext.getIdentifier("show source").getUnderlyingPointer()),
-      identHideSource(
-          astContext.getIdentifier("hide source").getUnderlyingPointer()),
-      identSensitive(
-          astContext.getIdentifier("sensitive").getUnderlyingPointer()),
-      identVar(astContext.getIdentifier("var").getUnderlyingPointer()),
-      identLet(astContext.getIdentifier("let").getUnderlyingPointer()),
-      identConst(astContext.getIdentifier("const").getUnderlyingPointer()),
-      identPlus(astContext.getIdentifier("+").getUnderlyingPointer()),
-      identMinus(astContext.getIdentifier("-").getUnderlyingPointer()),
-      identAssign(astContext.getIdentifier("=").getUnderlyingPointer()) {}
-
-//===----------------------------------------------------------------------===//
 // SemanticValidator
 
 SemanticValidator::SemanticValidator(

--- a/lib/AST/SemanticValidator.h
+++ b/lib/AST/SemanticValidator.h
@@ -10,6 +10,7 @@
 
 #include "hermes/AST/SemValidate.h"
 
+#include "Keywords.h"
 #include "hermes/AST/RecursiveVisitor.h"
 
 namespace hermes {
@@ -20,43 +21,6 @@ using namespace hermes::ESTree;
 // Forward declarations
 class FunctionContext;
 class SemanticValidator;
-
-//===----------------------------------------------------------------------===//
-// Keywords
-
-class Keywords {
- public:
-  /// Identifier for "arguments".
-  const UniqueString *const identArguments;
-  /// Identifier for "eval".
-  const UniqueString *const identEval;
-  /// Identifier for "delete".
-  const UniqueString *const identDelete;
-  /// Identifier for "this".
-  const UniqueString *const identThis;
-  /// Identifier for "use strict".
-  const UniqueString *const identUseStrict;
-  /// Identifier for "show source ".
-  const UniqueString *const identShowSource;
-  /// Identifier for "hide source ".
-  const UniqueString *const identHideSource;
-  /// Identifier for "sensitive".
-  const UniqueString *const identSensitive;
-  /// Identifier for "var".
-  const UniqueString *const identVar;
-  /// Identifier for "let".
-  const UniqueString *const identLet;
-  /// Identifier for "const".
-  const UniqueString *const identConst;
-  /// "+".
-  const UniqueString *const identPlus;
-  /// "-".
-  const UniqueString *const identMinus;
-  /// "=".
-  const UniqueString *const identAssign;
-
-  Keywords(Context &astContext);
-};
 
 //===----------------------------------------------------------------------===//
 // SemanticValidator


### PR DESCRIPTION
Summary:
Implement a new SemanticResolver which extracts all the resolution
information into `SemContext`.

This is based directly on Juno's implementation with the same
structure except for the fact that we use RAII classes instead
of the callback structure. There's nothing preventing the callback
structure from being used here, and helper methods for using callbacks
can be easily added in the future, it's just that RAII seemed fairly
straightforward and simple for this implementation.

With the exception of the Unresolver pass,
everything in the Juno implementation is contained in this diff.

The Hermes implementation also does some manipulation of the AST,
including the try/catch transform, which will be in future diffs.

Differential Revision: D39985175

