### PR TITLE
Add new SemContext struct

### DIFF
--- a/include/hermes/ADT/ScopedHashTable.h
+++ b/include/hermes/ADT/ScopedHashTable.h
@@ -162,6 +162,15 @@ class ScopedHashTable {
     return result->second->value_;
   }
 
+  /// Return a pointer to the innermost value for a key, or nullptr if none.
+  V *find(const K &key) {
+    auto result = map_.find(key);
+    if (result == map_.end())
+      return nullptr;
+
+    return &result->second->value_;
+  }
+
   // Gets all values currently in scope.
   std::unique_ptr<llvh::DenseMap<K, V>> flatten() const {
     std::unique_ptr<llvh::DenseMap<K, V>> result{

--- a/include/hermes/AST/ESTree.h
+++ b/include/hermes/AST/ESTree.h
@@ -896,6 +896,9 @@ NodeList &getParams(FunctionLikeNode *node);
 /// functions.
 BlockStatementNode *getBlockStatement(FunctionLikeNode *node);
 
+/// \return the name of the function.
+Node *getIdentifier(FunctionLikeNode *node);
+
 /// \return the object of the member expression node.
 Node *getObject(MemberExpressionLikeNode *node);
 

--- a/include/hermes/AST/SemContext.h
+++ b/include/hermes/AST/SemContext.h
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef HERMES_AST_SEMCONTEXT_H
+#define HERMES_AST_SEMCONTEXT_H
+
+#include "hermes/AST/ESTree.h"
+
+#include <deque>
+
+namespace hermes {
+namespace sema {
+
+class Decl;
+class LexicalScope;
+class FunctionInfo;
+class SemContext;
+
+/// Variable declaration.
+class Decl {
+ public:
+  /// The kind of variable declaration.
+  /// Determines scoping, among other things.
+  enum class Kind : uint8_t {
+    // ==== Let-like declarations ===
+    Let,
+    Const,
+    Class,
+    Import,
+    /// A single catch variable declared like this "catch (e)", see
+    /// ES10 B.3.5 VariableStatements in Catch Blocks
+    ES5Catch,
+
+    // ==== other declarations ===
+    FunctionExprName,
+    /// Function declaration visible only in its lexical scope.
+    ScopedFunction,
+
+    // ==== Var-like declarations ===
+
+    /// "var" in function scope.
+    Var,
+    Parameter,
+    /// "var" in global scope.
+    GlobalProperty,
+    UndeclaredGlobalProperty,
+  };
+
+  enum class Special : uint8_t {
+    NotSpecial,
+    Arguments,
+    Eval,
+  };
+
+  /// \return true if this kind of declaration is function scope (and can be
+  /// re-declared).
+  static bool isKindVarLike(Kind kind) {
+    return kind >= Kind::Var;
+  }
+  static bool isKindVarLikeOrScopedFunction(Kind kind) {
+    return kind >= Kind::ScopedFunction;
+  }
+  /// \return true if this kind of declaration is lexically scoped (and cannot
+  /// be re-declared).
+  static bool isKindLetLike(Kind kind) {
+    return kind <= Kind::ES5Catch;
+  }
+  /// \return true if this kind of declaration is a global property.
+  static bool isKindGlobal(Kind kind) {
+    return kind >= Kind::GlobalProperty;
+  }
+
+  /// Identifier that is declared.
+  Identifier const name;
+  /// What kind of declaration it is.
+  Kind kind;
+  /// If this is a special declaration, identify which one.
+  Special const special;
+
+  /// The lexical scope of the declaration. Could be nullptr for special
+  /// declarations, since they are technically unscoped.
+  LexicalScope *const scope;
+
+  Decl(Identifier name, Kind kind, LexicalScope *scope)
+      : name(name), kind(kind), special(Special::NotSpecial), scope(scope) {}
+  Decl(Identifier name, Kind kind, Special special)
+      : name(name), kind(kind), special(special), scope(nullptr) {}
+  Decl(Identifier name, Kind kind, Special special, LexicalScope *scope)
+      : name(name), kind(kind), special(special), scope(scope) {}
+
+  void dump(unsigned level = 0) const;
+};
+
+/// Lexical scopes within a function.
+class LexicalScope {
+ public:
+  /// The global depth of this scope, where 0 is the root scope.
+  uint32_t depth;
+  /// The function owning this lexical scope.
+  FunctionInfo *const parentFunction{};
+  /// The enclosing lexical scope (it could be in another function).
+  LexicalScope *const parentScope{};
+
+  /// All declarations made in this scope.
+  llvh::SmallVector<Decl *, 2> decls{};
+
+  /// A list of functions that need to be hoisted and materialized before we
+  /// can generate the rest of the scope.
+  llvh::SmallVector<ESTree::FunctionDeclarationNode *, 2> hoistedFunctions{};
+
+  /// True if this scope or any descendent scopes have a local eval call.
+  /// If any descendent uses local eval,
+  /// it's impossible to know whether local variables are modified.
+  bool localEval;
+
+  /// \param parentFunction may be null.
+  /// \param parentScope may be null.
+  LexicalScope(FunctionInfo *parentFunction, LexicalScope *parentScope)
+      : depth(parentScope ? parentScope->depth + 1 : 0),
+        parentFunction(parentFunction),
+        parentScope(parentScope) {}
+
+  void dump(const SemContext *sem = nullptr, unsigned level = 0) const;
+};
+
+/// Semantic information about functions.
+class FunctionInfo {
+ public:
+  /// The function surrounding this function.
+  FunctionInfo *const parentFunction;
+  /// The enclosing lexical scope.
+  LexicalScope *const parentScope;
+  /// All lexical scopes in this function.
+  /// The first one is the function scope.
+  llvh::SmallVector<LexicalScope *, 4> scopes{};
+  /// The implicitly declared "arguments" object.
+  /// It is declared only if it is used.
+  /// Should be populated by calling \c SemContext::funcArgumentsDecl.
+  hermes::OptValue<Decl *> argumentsDecl{llvh::None};
+  /// True if the function is strict mode.
+  bool strict;
+  /// True if this function is an arrow function.
+  bool arrow;
+  /// How many labels have been allocated in this function so far.
+  uint32_t numLabels{0};
+
+  /// Allocate a new label and return its index.
+  uint32_t allocateLabel() {
+    return numLabels++;
+  }
+
+  FunctionInfo(
+      ESTree::FunctionLikeNode *funcNode,
+      FunctionInfo *parentFunction,
+      LexicalScope *parentScope,
+      bool strict)
+      : parentFunction(parentFunction),
+        parentScope(parentScope),
+        strict(strict),
+        arrow(llvh::isa<ESTree::ArrowFunctionExpressionNode>(funcNode)) {}
+
+  /// \return the top-level lexical scope of the function.
+  LexicalScope *getFunctionScope() const {
+    return scopes[0];
+  }
+
+  void dump(const SemContext *sem = nullptr, unsigned level = 0) const;
+};
+
+/// Semantic information regarding the program.
+/// Storage for FunctionInfo and LexicalScope.
+class SemContext {
+ public:
+  SemContext(Context &ctx);
+  ~SemContext();
+
+  /// \return a new function.
+  FunctionInfo *newFunction(
+      ESTree::FunctionLikeNode *funcNode,
+      FunctionInfo *parentFunction,
+      LexicalScope *parentScope,
+      bool strict);
+  /// \return a new lexical scope.
+  LexicalScope *newScope(
+      FunctionInfo *parentFunction,
+      LexicalScope *parentScope);
+  /// \return a new declaration in \p scope.
+  Decl *newDecl(
+      UniqueString *name,
+      Decl::Kind kind,
+      LexicalScope *scope,
+      Decl::Special special = Decl::Special::NotSpecial);
+  /// \return a new declaration in \p scope.
+  Decl *newDeclInScope(
+      UniqueString *name,
+      Decl::Kind kind,
+      LexicalScope *scope,
+      Decl::Special special = Decl::Special::NotSpecial);
+
+  /// \return a new global property.
+  Decl *newGlobal(UniqueString *name, Decl::Kind kind);
+
+  /// \return the global function.
+  FunctionInfo *getGlobalFunction() {
+    return &functions_.at(0);
+  }
+  /// \return the global lexical scope.
+  LexicalScope *getGlobalScope() {
+    return &scopes_.at(0);
+  }
+
+  /// Create or retrieve the arguments declaeration in \p func.
+  /// If `func` is an arrow function, find the closest ancestor that
+  /// is not an arrow function and use that function's `arguments`.
+  /// \p name the object doesn't have access to the AST node, so it has
+  ///   to be passed in.
+  /// \return the special arguments declaration in the specified function.
+  Decl *funcArgumentsDecl(FunctionInfo *func, UniqueString *name);
+
+  /// An identifier set used to prevent adding more than one global with the
+  /// same name durinng initialization.
+  using NameSet = llvh::SmallDenseSet<UniqueString *, 1>;
+
+  void dump() const;
+
+ private:
+  /// The special global "eval" declaration.
+  /// Stored to know when we are performing "eval" anywhere in the function.
+  Decl *evalDecl_;
+
+  /// Storage for all functions.
+  std::deque<FunctionInfo> functions_{};
+
+  /// Storage for all lexical scopes.
+  std::deque<LexicalScope> scopes_{};
+
+  /// Storage for all variable declarations.
+  std::deque<Decl> decls_{};
+};
+
+} // namespace sema
+} // namespace hermes
+
+#endif

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -10,6 +10,7 @@ add_hermes_library(hermesAST
     Keywords.cpp Keywords.h
     SemValidate.cpp
     SemanticValidator.cpp SemanticValidator.h
+    SemContext.cpp
     CommonJS.cpp
     LINK_OBJLIBS
     hermesSupport

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -7,6 +7,7 @@ add_hermes_library(hermesAST
     ASTBuilder.cpp
     ESTree.cpp
     ESTreeJSONDumper.cpp
+    Keywords.cpp Keywords.h
     SemValidate.cpp
     SemanticValidator.cpp SemanticValidator.h
     CommonJS.cpp

--- a/lib/AST/ESTree.cpp
+++ b/lib/AST/ESTree.cpp
@@ -49,6 +49,21 @@ BlockStatementNode *getBlockStatement(FunctionLikeNode *node) {
   }
 }
 
+Node *getIdentifier(FunctionLikeNode *node) {
+  switch (node->getKind()) {
+    default:
+      assert(
+          node->getKind() == NodeKind::Program && "invalid FunctionLikeNode");
+      return nullptr;
+    case NodeKind::FunctionExpression:
+      return cast<FunctionExpressionNode>(node)->_id;
+    case NodeKind::ArrowFunctionExpression:
+      return cast<ArrowFunctionExpressionNode>(node)->_id;
+    case NodeKind::FunctionDeclaration:
+      return cast<FunctionDeclarationNode>(node)->_id;
+  }
+}
+
 Node *getObject(MemberExpressionLikeNode *node) {
   switch (node->getKind()) {
     case NodeKind::MemberExpression:

--- a/lib/AST/Keywords.cpp
+++ b/lib/AST/Keywords.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "Keywords.h"
+
+#include "hermes/AST/Context.h"
+#include "hermes/Support/RegExpSerialization.h"
+
+namespace hermes {
+namespace sem {
+
+Keywords::Keywords(Context &astContext)
+    : identArguments(
+          astContext.getIdentifier("arguments").getUnderlyingPointer()),
+      identEval(astContext.getIdentifier("eval").getUnderlyingPointer()),
+      identDelete(astContext.getIdentifier("delete").getUnderlyingPointer()),
+      identThis(astContext.getIdentifier("this").getUnderlyingPointer()),
+      identUseStrict(
+          astContext.getIdentifier("use strict").getUnderlyingPointer()),
+      identShowSource(
+          astContext.getIdentifier("show source").getUnderlyingPointer()),
+      identHideSource(
+          astContext.getIdentifier("hide source").getUnderlyingPointer()),
+      identSensitive(
+          astContext.getIdentifier("sensitive").getUnderlyingPointer()),
+      identVar(astContext.getIdentifier("var").getUnderlyingPointer()),
+      identLet(astContext.getIdentifier("let").getUnderlyingPointer()),
+      identConst(astContext.getIdentifier("const").getUnderlyingPointer()),
+      identPlus(astContext.getIdentifier("+").getUnderlyingPointer()),
+      identMinus(astContext.getIdentifier("-").getUnderlyingPointer()),
+      identAssign(astContext.getIdentifier("=").getUnderlyingPointer()),
+      identNew(astContext.getIdentifier("new").getUnderlyingPointer()),
+      identTarget(astContext.getIdentifier("target").getUnderlyingPointer()),
+      identTypeof(astContext.getIdentifier("typeof").getUnderlyingPointer()) {}
+
+} // namespace sem
+} // namespace hermes

--- a/lib/AST/Keywords.h
+++ b/lib/AST/Keywords.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef HERMES_AST_KEYWORDS_H
+#define HERMES_AST_KEYWORDS_H
+
+#include "hermes/AST/SemValidate.h"
+
+#include "hermes/AST/RecursiveVisitor.h"
+
+namespace hermes {
+
+class Context;
+
+namespace sem {
+
+class Keywords {
+ public:
+  /// Identifier for "arguments".
+  const UniqueString *const identArguments;
+  /// Identifier for "eval".
+  const UniqueString *const identEval;
+  /// Identifier for "delete".
+  const UniqueString *const identDelete;
+  /// Identifier for "this".
+  const UniqueString *const identThis;
+  /// Identifier for "use strict".
+  const UniqueString *const identUseStrict;
+  /// Identifier for "show source ".
+  const UniqueString *const identShowSource;
+  /// Identifier for "hide source ".
+  const UniqueString *const identHideSource;
+  /// Identifier for "sensitive".
+  const UniqueString *const identSensitive;
+  /// Identifier for "var".
+  const UniqueString *const identVar;
+  /// Identifier for "let".
+  const UniqueString *const identLet;
+  /// Identifier for "const".
+  const UniqueString *const identConst;
+  /// "+".
+  const UniqueString *const identPlus;
+  /// "-".
+  const UniqueString *const identMinus;
+  /// "=".
+  const UniqueString *const identAssign;
+  /// "new"
+  const UniqueString *const identNew;
+  /// "target"
+  const UniqueString *const identTarget;
+  /// "typeof".
+  const UniqueString *const identTypeof;
+
+  Keywords(Context &astContext);
+};
+
+} // namespace sem
+} // namespace hermes
+
+#endif

--- a/lib/AST/SemContext.cpp
+++ b/lib/AST/SemContext.cpp
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "hermes/AST/SemContext.h"
+
+namespace hermes {
+namespace sema {
+
+#ifndef NDEBUG
+static llvh::FormattedString ind(unsigned level) {
+  return llvh::left_justify("", level * 4);
+}
+#endif
+
+void Decl::dump(unsigned level) const {
+#ifndef NDEBUG
+  llvh::outs() << ind(level) << "Decl '" << name << "' ";
+  const char *s;
+#define CASE(x) \
+  case Kind::x: \
+    s = #x;     \
+    break;
+  switch (kind) {
+    CASE(Let)
+    CASE(Const)
+    CASE(Class)
+    CASE(Import)
+    CASE(ES5Catch)
+    CASE(FunctionExprName)
+    CASE(ScopedFunction)
+    CASE(Var)
+    CASE(Parameter)
+    CASE(GlobalProperty)
+    CASE(UndeclaredGlobalProperty)
+  }
+  llvh::outs() << s;
+#undef CASE
+#define CASE(x)    \
+  case Special::x: \
+    s = #x;        \
+    break;
+  switch (special) {
+    CASE(NotSpecial)
+    CASE(Arguments)
+    CASE(Eval)
+  }
+#undef CASE
+  llvh::outs() << "\n";
+#endif
+}
+
+void LexicalScope::dump(const SemContext *sd, unsigned int level) const {
+#ifndef NDEBUG
+  llvh::outs() << ind(level) << "Scope " << llvh::format("%p", this) << "\n";
+  for (const auto &decl : decls) {
+    decl->dump(level + 1);
+  }
+  for (const auto *fd : hoistedFunctions) {
+    llvh::outs() << ind(level + 1) << "hoistedFunction "
+                 << llvh::cast<ESTree::IdentifierNode>(fd->_id)->_name->str()
+                 << "\n";
+  }
+#endif
+}
+
+void FunctionInfo::dump(const SemContext *sd, unsigned level) const {
+#ifndef NDEBUG
+  llvh::outs() << ind(level) << "Func\n";
+  std::map<const LexicalScope *, llvh::SmallVector<const LexicalScope *, 2>>
+      children;
+
+  for (const auto *sc : scopes) {
+    if (sc == scopes[0])
+      continue;
+    children[sc->parentScope].push_back(sc);
+  }
+
+  unsigned processedCount = 0;
+  std::function<void(const LexicalScope *, unsigned)> dumpScope =
+      [&dumpScope, &children, &processedCount, sd](
+          const LexicalScope *sc, unsigned level) {
+        sc->dump(sd, level);
+        ++processedCount;
+        auto it = children.find(sc);
+        if (it == children.end())
+          return;
+        for (auto *childScope : it->second)
+          dumpScope(childScope, level + 1);
+      };
+
+  dumpScope(scopes[0], level + 1);
+  assert(processedCount == scopes.size() && "not all scopes were visited");
+#endif
+}
+
+void SemContext::dump() const {
+#ifndef NDEBUG
+  llvh::outs() << "SemContext\n";
+  std::map<const FunctionInfo *, llvh::SmallVector<const FunctionInfo *, 2>>
+      children;
+
+  for (const auto &F : functions_) {
+    if (&F == &functions_[0])
+      continue;
+    children[F.parentFunction].push_back(&F);
+  }
+
+  unsigned processedCount = 0;
+  std::function<void(const FunctionInfo *, unsigned)> dumpFunction =
+      [&dumpFunction, &children, &processedCount, this](
+          const FunctionInfo *F, unsigned level) {
+        F->dump(this, level);
+        ++processedCount;
+        auto it = children.find(F);
+        if (it == children.end())
+          return;
+        for (auto *childFunc : it->second)
+          dumpFunction(childFunc, level + 1);
+      };
+
+  dumpFunction(&functions_[0], 0);
+  assert(processedCount == functions_.size() && "not all scopes were visited");
+#endif
+}
+
+SemContext::SemContext(Context &ctx) {
+  decls_.emplace_back(
+      ctx.getIdentifier("eval"),
+      Decl::Kind::UndeclaredGlobalProperty,
+      Decl::Special::Eval);
+  evalDecl_ = &decls_.back();
+}
+
+SemContext::~SemContext() = default;
+
+FunctionInfo *SemContext::newFunction(
+    ESTree::FunctionLikeNode *funcNode,
+    FunctionInfo *parentFunction,
+    LexicalScope *parentScope,
+    bool strict) {
+  functions_.emplace_back(funcNode, parentFunction, parentScope, strict);
+  return &functions_.back();
+}
+
+LexicalScope *SemContext::newScope(
+    FunctionInfo *parentFunction,
+    LexicalScope *parentScope) {
+  scopes_.emplace_back(parentFunction, parentScope);
+  LexicalScope *res = &scopes_.back();
+  parentFunction->scopes.push_back(res);
+  return res;
+}
+
+Decl *SemContext::newDecl(
+    UniqueString *name,
+    Decl::Kind kind,
+    LexicalScope *scope,
+    Decl::Special special) {
+  return newDeclInScope(name, kind, scope, special);
+}
+
+Decl *SemContext::newDeclInScope(
+    UniqueString *name,
+    Decl::Kind kind,
+    LexicalScope *scope,
+    Decl::Special special) {
+  assert(!Decl::isKindGlobal(kind) && "invalid non-global declaration kind");
+  decls_.emplace_back(Identifier::getFromPointer(name), kind, special, scope);
+  auto res = &decls_.back();
+  scope->decls.push_back(res);
+  return res;
+}
+
+Decl *SemContext::newGlobal(hermes::UniqueString *name, Decl::Kind kind) {
+  assert(Decl::isKindGlobal(kind) && "invalid global declaration kind");
+  return newDecl(name, kind, getGlobalScope());
+}
+
+Decl *SemContext::funcArgumentsDecl(FunctionInfo *func, UniqueString *name) {
+  // Find the closest non-arrow ancestor.
+  FunctionInfo *argumentsFunc = func;
+  while (argumentsFunc->arrow) {
+    if (argumentsFunc->parentFunction) {
+      argumentsFunc = argumentsFunc->parentFunction;
+    } else {
+      break;
+    }
+  }
+
+  // 'arguments' already exists, avoid redeclaring.
+  if (argumentsFunc->argumentsDecl)
+    return *argumentsFunc->argumentsDecl;
+
+  Decl *decl;
+  if (argumentsFunc == getGlobalFunction()) {
+    // `arguments` must simply be treated as a global property in top level
+    // contexts.
+    decl = newDeclInScope(
+        name,
+        Decl::Kind::UndeclaredGlobalProperty,
+        argumentsFunc->scopes.front());
+  } else {
+    // Otherwise, regular function-level "arguments" declaration.
+    decl = newDeclInScope(
+        name,
+        Decl::Kind::Var,
+        argumentsFunc->scopes.front(),
+        Decl::Special::Arguments);
+  }
+
+  // Store it for future use.
+  argumentsFunc->argumentsDecl = decl;
+
+  return decl;
+}
+
+} // namespace sema
+} // namespace hermes

--- a/lib/AST/SemanticValidator.cpp
+++ b/lib/AST/SemanticValidator.cpp
@@ -22,30 +22,6 @@ namespace hermes {
 namespace sem {
 
 //===----------------------------------------------------------------------===//
-// Keywords
-
-Keywords::Keywords(Context &astContext)
-    : identArguments(
-          astContext.getIdentifier("arguments").getUnderlyingPointer()),
-      identEval(astContext.getIdentifier("eval").getUnderlyingPointer()),
-      identDelete(astContext.getIdentifier("delete").getUnderlyingPointer()),
-      identThis(astContext.getIdentifier("this").getUnderlyingPointer()),
-      identUseStrict(
-          astContext.getIdentifier("use strict").getUnderlyingPointer()),
-      identShowSource(
-          astContext.getIdentifier("show source").getUnderlyingPointer()),
-      identHideSource(
-          astContext.getIdentifier("hide source").getUnderlyingPointer()),
-      identSensitive(
-          astContext.getIdentifier("sensitive").getUnderlyingPointer()),
-      identVar(astContext.getIdentifier("var").getUnderlyingPointer()),
-      identLet(astContext.getIdentifier("let").getUnderlyingPointer()),
-      identConst(astContext.getIdentifier("const").getUnderlyingPointer()),
-      identPlus(astContext.getIdentifier("+").getUnderlyingPointer()),
-      identMinus(astContext.getIdentifier("-").getUnderlyingPointer()),
-      identAssign(astContext.getIdentifier("=").getUnderlyingPointer()) {}
-
-//===----------------------------------------------------------------------===//
 // SemanticValidator
 
 SemanticValidator::SemanticValidator(

--- a/lib/AST/SemanticValidator.h
+++ b/lib/AST/SemanticValidator.h
@@ -10,6 +10,7 @@
 
 #include "hermes/AST/SemValidate.h"
 
+#include "Keywords.h"
 #include "hermes/AST/RecursiveVisitor.h"
 
 namespace hermes {
@@ -20,43 +21,6 @@ using namespace hermes::ESTree;
 // Forward declarations
 class FunctionContext;
 class SemanticValidator;
-
-//===----------------------------------------------------------------------===//
-// Keywords
-
-class Keywords {
- public:
-  /// Identifier for "arguments".
-  const UniqueString *const identArguments;
-  /// Identifier for "eval".
-  const UniqueString *const identEval;
-  /// Identifier for "delete".
-  const UniqueString *const identDelete;
-  /// Identifier for "this".
-  const UniqueString *const identThis;
-  /// Identifier for "use strict".
-  const UniqueString *const identUseStrict;
-  /// Identifier for "show source ".
-  const UniqueString *const identShowSource;
-  /// Identifier for "hide source ".
-  const UniqueString *const identHideSource;
-  /// Identifier for "sensitive".
-  const UniqueString *const identSensitive;
-  /// Identifier for "var".
-  const UniqueString *const identVar;
-  /// Identifier for "let".
-  const UniqueString *const identLet;
-  /// Identifier for "const".
-  const UniqueString *const identConst;
-  /// "+".
-  const UniqueString *const identPlus;
-  /// "-".
-  const UniqueString *const identMinus;
-  /// "=".
-  const UniqueString *const identAssign;
-
-  Keywords(Context &astContext);
-};
 
 //===----------------------------------------------------------------------===//
 // SemanticValidator


### PR DESCRIPTION
Summary:
Place the new SemContext struct in the `sema` namespace.
It contains storage for information on functions, scopes, and decls.

The `SemContext` struct does NOT include the following mappings:
* identifier -> Decl
* AST node -> LexicalScope
These two mappings will be stored directly on the AST via the decoration
mechanism, which was not available in Juno.

Differential Revision: D39991926

