### PR TITLE
Object::instanceOf() should be const-qualified

### DIFF
--- a/API/jsi/jsi/jsi.h
+++ b/API/jsi/jsi/jsi.h
@@ -666,7 +666,7 @@ class JSI_EXPORT Object : public Pointer {
   }
 
   /// \return the result of `this instanceOf ctor` in JS.
-  bool instanceOf(Runtime& rt, const Function& ctor) {
+  bool instanceOf(Runtime& rt, const Function& ctor) const {
     return rt.instanceOf(*this, ctor);
   }
 


### PR DESCRIPTION
The virtual function on jsi::Runtime already takes a const Object.

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `main`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/HEAD/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.
-->

## Summary

It is annoying and potentially expensive to have to copy the `Object` just to check if it is an instance of some class.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
-->

## Test Plan

If it compiles, it should be fine.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes the user interface.
-->
