### PR TITLE
Fix cmake build

### DIFF
--- a/lib/VM/CMakeLists.txt
+++ b/lib/VM/CMakeLists.txt
@@ -53,11 +53,11 @@ set(source_files
   RuntimeModule.cpp
   Profiler/ChromeTraceSerializer.cpp
   Profiler/CodeCoverageProfiler.cpp
-  Profiler/GlobalProfiler.cpp
   Profiler/InlineCacheProfiler.cpp
   Profiler/SamplingProfiler.cpp
   Profiler/SamplingProfilerPosix.cpp
   Profiler/SamplingProfilerWindows.cpp
+  Profiler/SamplingProfilerSampler.cpp
   SegmentedArray.cpp
   SerializedLiteralParser.cpp
   SingleObject.cpp


### PR DESCRIPTION
Summary:
The SamplingProfiler refactor broke the cmake build when it renamed GlobalProfiler.cpp
to SamplingProfilerSampler.cpp. This change fixes that breakage.

Differential Revision: D41721242

