### PR TITLE
Use CallGraph when inlining

### DIFF
--- a/include/hermes/Optimizer/PassManager/Passes.def
+++ b/include/hermes/Optimizer/PassManager/Passes.def
@@ -29,6 +29,7 @@ PASS(SimpleStackPromotion, "simplestackpromotion", "Simple stack promotion")
 PASS(SimplifyCFG, "simplifycfg", "Simplify CFG")
 PASS(StackPromotion, "stackpromotion", "Stack promotion")
 PASS(TypeInference, "typeinference", "Type inference")
+PASS(FunctionAnalysis, "functionanalysis", "Function analysis")
 PASS(Inlining, "inlining", "Inlining")
 PASS(ResolveStaticRequire, "staticrequire", "Resolve static require")
 PASS(

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -21,6 +21,7 @@ add_hermes_library(hermesOptimizer
   Optimizer/Scalar/SimpleCallGraphProvider.cpp
   Optimizer/Scalar/FuncSigOpts.cpp
   Optimizer/Scalar/Utils.cpp
+  Optimizer/Scalar/FunctionAnalysis.cpp
   Optimizer/Scalar/Inlining.cpp
   Optimizer/Scalar/HoistStartGenerator.cpp
   Optimizer/Scalar/InstructionEscapeAnalysis.cpp

--- a/lib/IR/IR.cpp
+++ b/lib/IR/IR.cpp
@@ -201,6 +201,31 @@ bool Function::isGlobalScope() const {
   return parent_->getTopLevelFunction() == this;
 }
 
+std::string Function::Attributes::getDescriptionStr() const {
+  if (isEmpty())
+    return "";
+  std::string result{"["};
+
+  bool comma = false;
+
+  /// Add \p name to the result string if \p value is true.
+  const auto addFlag = [&comma, &result](
+                           bool value, llvh::StringRef name) -> void {
+    if (value) {
+      if (comma)
+        result += ',';
+      comma = true;
+      result += name;
+    }
+  };
+
+  addFlag(allCallsitesKnown, "allCallsitesKnown");
+  addFlag(pure, "pure");
+
+  result += "]";
+  return result;
+}
+
 std::string Function::getDefinitionKindStr(bool isDescriptive) const {
   switch (definitionKind_) {
     case Function::DefinitionKind::ES5Function:

--- a/lib/Optimizer/PassManager/Pipeline.cpp
+++ b/lib/Optimizer/PassManager/Pipeline.cpp
@@ -53,6 +53,7 @@ void hermes::runFullOptimizationPasses(Module &M) {
   PM.addSimpleStackPromotion();
   PM.addMem2Reg();
   PM.addSimpleStackPromotion();
+  PM.addFunctionAnalysis();
   PM.addInlining();
   PM.addTypeInference();
   PM.addSimpleStackPromotion();

--- a/lib/Optimizer/Scalar/FunctionAnalysis.cpp
+++ b/lib/Optimizer/Scalar/FunctionAnalysis.cpp
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#define DEBUG_TYPE "functionanalysis"
+
+#include "hermes/IR/IR.h"
+#include "hermes/Optimizer/PassManager/Pass.h"
+#include "hermes/Optimizer/Scalar/Utils.h"
+#include "hermes/Support/Statistic.h"
+
+#include "llvh/Support/Debug.h"
+
+namespace hermes {
+
+namespace {
+/// Registers the call by setting the target/env operands if possible,
+/// if they haven't been set yet.
+/// \param call the Call instruction being analyzed.
+/// \param callee the expected callee of the call instruction.
+void registerCallsite(BaseCallInst *call, BaseCreateCallableInst *callee) {
+  // Set the target/env operands if possible.
+  if (llvh::isa<EmptySentinel>(call->getTarget())) {
+    call->setTarget(callee->getFunctionCode());
+    if (auto *create = llvh::dyn_cast<HBCCreateFunctionInst>(callee)) {
+      // TODO: This can be done unconditionally once we store environments along
+      // with all CreateFunctionInsts as well.
+      call->setEnvironment(create->getEnvironment());
+    }
+  }
+}
+
+/// Find all callsites that could call a function via the closure created
+/// by the \p create instruction and register them.
+/// Looks at calls that use \p create as an operand themselves as well as
+/// calls that load \p create via a variable which is stored to once.
+void analyzeCreateCallable(BaseCreateCallableInst *create) {
+  Function *F = create->getFunctionCode();
+  for (Instruction *createUser : create->getUsers()) {
+    // Closure is used as the callee operand.
+    if (auto *call = llvh::dyn_cast<BaseCallInst>(createUser)) {
+      if (!isDirectCallee(create, call)) {
+        // F potentially escapes.
+        F->getAttributes().allCallsitesKnown = false;
+      }
+      if (call->getCallee() == create) {
+        registerCallsite(call, create);
+      }
+      continue;
+    }
+
+    // Construction setup instructions can't leak the closure on their own,
+    // but don't contribute to the call graph.
+    if (isConstructionSetup(createUser, create)) {
+      continue;
+    }
+
+    // Closure is stored to a variable, look at corresponding loads
+    // to find callsites.
+    if (auto *store = llvh::dyn_cast<StoreFrameInst>(createUser)) {
+      Variable *var = store->getVariable();
+      if (!isStoreOnceVariable(var)) {
+        // Multiple stores to the variable, give up.
+        F->getAttributes().allCallsitesKnown = false;
+        continue;
+      }
+      for (Instruction *varUser : var->getUsers()) {
+        auto *load = llvh::dyn_cast<LoadFrameInst>(varUser);
+        if (!load) {
+          // Skip all stores, because they'll all be storing the same closure.
+          assert(
+              llvh::isa<StoreFrameInst>(varUser) &&
+              "only Store and Load can use variables");
+          continue;
+        }
+        // Find any calls using the load.
+        for (Instruction *loadUser : load->getUsers()) {
+          // Construction setup instructions can't leak the closure on their
+          // own, but don't contribute to the call graph.
+          if (isConstructionSetup(createUser, create)) {
+            continue;
+          }
+          auto *call = llvh::dyn_cast<BaseCallInst>(loadUser);
+          if (!call) {
+            // Unknown instruction using the load, skip over the instruction
+            // because it's not a call, but it could lead to an unknown call.
+            F->getAttributes().allCallsitesKnown = false;
+            continue;
+          }
+          // Check if F potentially escapes via arguments to the call.
+          if (!isDirectCallee(load, call)) {
+            F->getAttributes().allCallsitesKnown = false;
+          }
+          // Make sure the function is actually used as the callee operand.
+          if (call->getCallee() == load) {
+            registerCallsite(call, create);
+          }
+        }
+      }
+      continue;
+    }
+
+    // Unknown user, F could escape somewhere.
+    F->getAttributes().allCallsitesKnown = false;
+  }
+}
+
+/// Find and register any callsites that can be found which call \p F.
+void analyzeFunctionCallsites(Function *F) {
+  if (F->getAttributes().allCallsitesKnown) {
+    return;
+  }
+
+  // Attempt to start from a position of knowing all callsites.
+  F->getAttributes().allCallsitesKnown = true;
+
+  if (!F->isStrictMode()) {
+    // Loose-mode functions can use things like `arguments.callee`
+    // or Error structured stack trace.
+    // Those could allow leaking the closure to unknown callsites.
+    F->getAttributes().allCallsitesKnown = false;
+  }
+
+  if (auto *newTargetParam = F->getNewTargetParam()) {
+    // Uses of new.target can be used to leak the closure.
+    // TODO: Allow certain instructions to use new.target.
+    if (newTargetParam->hasUsers())
+      F->getAttributes().allCallsitesKnown = false;
+  }
+
+  for (Instruction *user : F->getUsers()) {
+    if (auto *create = llvh::dyn_cast<BaseCreateCallableInst>(user)) {
+      assert(
+          create->getFunctionCode() == F &&
+          "Function can only be used as the FunctionCode operand");
+      analyzeCreateCallable(create);
+      continue;
+    }
+
+    if (auto *call = llvh::dyn_cast<BaseCallInst>(user)) {
+      // Ignore uses as call target.
+      assert(
+          call->getTarget() == F &&
+          "invalid use of Function as operand of call");
+      continue;
+    }
+
+    // Unknown user of Function.
+    LLVM_DEBUG(
+        llvh::dbgs() << "Unknown function user: " << user->getKindStr()
+                     << '\n');
+    F->getAttributes().allCallsitesKnown = false;
+  }
+}
+
+} // namespace
+
+Pass *createFunctionAnalysis() {
+  /// Analyze Function call graphs to update `target` operands and attributes.
+  class FunctionAnalysis : public ModulePass {
+   public:
+    explicit FunctionAnalysis() : hermes::ModulePass("FunctionAnalysis") {}
+    ~FunctionAnalysis() override = default;
+
+    /// Create the call graph for \p mod by analyzing all potential callsites
+    /// for all functions and populating the maps.
+    /// If a callee is definitely known, populate the target/env operands on the
+    /// \c BaseCallInst.
+    bool runOnModule(Module *M) override {
+      for (Function &F : *M) {
+        analyzeFunctionCallsites(&F);
+      }
+      return true;
+    }
+  };
+
+  return new FunctionAnalysis();
+}
+
+} // namespace hermes
+#undef DEBUG_TYPE

--- a/lib/Optimizer/Scalar/Inlining.cpp
+++ b/lib/Optimizer/Scalar/Inlining.cpp
@@ -13,6 +13,9 @@
 #include "hermes/Optimizer/Scalar/Utils.h"
 #include "hermes/Support/Statistic.h"
 
+#include "llvh/ADT/DenseSet.h"
+#include "llvh/ADT/SetVector.h"
+#include "llvh/ADT/SmallVector.h"
 #include "llvh/Support/Debug.h"
 
 STATISTIC(NumInlinedCalls, "Number of inlined calls");
@@ -42,18 +45,160 @@ static llvh::SmallVector<BasicBlock *, 4> orderDFS(Function *F) {
   return order;
 }
 
+/// \return a list of known callsites of \p F based on its users.
+/// It is possible that \p F has additional unknown callsites,
+/// read the `allCallsitesKnown` attribute to check that.
+static llvh::SmallVector<BaseCallInst *, 2> getKnownCallsites(Function *F) {
+  llvh::SmallVector<BaseCallInst *, 2> result{};
+  for (Instruction *user : F->getUsers()) {
+    if (auto *call = llvh::dyn_cast<BaseCallInst>(user)) {
+      assert(
+          call->getTarget() == F &&
+          "invalid usage of Function as operand of BaseCallInst");
+      result.push_back(call);
+    }
+  }
+  return result;
+}
+
+/// Iterates all instructions and extracts all populated \c target operands
+/// from call instructions.
+/// The callees of a function are not stored explicitly outside the insts
+/// themselves.
+/// \return a list of known callees of \p F.
+static llvh::SmallVector<Function *, 2> getKnownCallees(Function *F) {
+  // Use a SetVector to avoid duplicate entries.
+  // Return the vector to ensure deterministic iteration.
+  llvh::SetVector<Function *, llvh::SmallVector<Function *, 2>> result{};
+  for (BasicBlock &BB : *F) {
+    for (Instruction &I : BB) {
+      if (auto *call = llvh::dyn_cast<BaseCallInst>(&I)) {
+        if (auto *callee = llvh::dyn_cast<Function>(call->getTarget())) {
+          result.insert(callee);
+        }
+      }
+    }
+  }
+  return result.takeVector();
+}
+
+/// Make an order by which to visit functions for inlining.
+/// Because the call graph isn't acyclic or connected, we can't necessarily
+/// perfectly perform a topological sort, but we start at functions that
+/// have calls from no other known functions to ensure they're not going to
+/// be inlined anywhere, and once we've processed those,
+/// visit all the other functions.
+/// \return a list of Functions in a roughly leaf-to-root sorted manner.
+static std::vector<Function *> orderFunctions(Module *M) {
+  // Resultant ordering of functions.
+  std::vector<Function *> order{};
+
+  /// State to push onto the stack.
+  class State {
+   public:
+    Function *func;
+    /// All known callees of \c func.
+    /// When empty, iteration is complete.
+    llvh::SmallVector<Function *, 2> calledFunctions;
+
+    explicit State(Function *func, llvh::SmallVector<Function *, 2> &&called)
+        : func(func), calledFunctions(std::move(called)) {}
+
+    State(const State &) = delete;
+    State &operator=(const State &) = delete;
+
+    State(State &&) = default;
+  };
+
+  llvh::SmallDenseSet<Function *> visited{};
+
+  // Store the stack as a list of states to track whether the callees
+  // of each function have already been emplaced onto the stack.
+  // Store it outside `visitPostOrder` to avoid reallocating every call.
+  llvh::SmallVector<State, 4> stack{};
+
+  /// Run a post-order traversal of the function call graph starting at
+  /// \p cur, where the edges are from functions to the functions that they
+  /// are known to call.
+  /// If \p cur has already been visited, do nothing.
+  const auto visitPostOrder =
+      [&visited, &order, &stack](Function *cur) -> void {
+    if (!visited.insert(cur).second) {
+      // Visited this function on a previous invocation of visitPostOrder.
+      return;
+    }
+
+    assert(
+        stack.empty() &&
+        "stack must be empty by the end of every visitPostOrder call");
+
+    // Begin with the callees of the current function.
+    stack.emplace_back(cur, getKnownCallees(cur));
+
+    do {
+      while (!stack.back().calledFunctions.empty()) {
+        Function *next = stack.back().calledFunctions.pop_back_val();
+        if (visited.insert(next).second) {
+          // Haven't visited `next` before, add its callees to the stack.
+          stack.emplace_back(next, getKnownCallees(next));
+        }
+      }
+
+      order.push_back(stack.back().func);
+      stack.pop_back();
+    } while (!stack.empty());
+  };
+
+  // Functions that shouldn't be initial starting points in the BFS.
+  std::vector<Function *> functionsWithCallsites{};
+
+  // Run the visitor from each starting point to account for a disconnected
+  // graph, deferring functions with callsites until after functions without.
+  for (Function &F : *M) {
+    if (getKnownCallsites(&F).empty()) {
+      visitPostOrder(&F);
+    } else {
+      functionsWithCallsites.push_back(&F);
+    }
+  }
+  for (Function *F : functionsWithCallsites) {
+    visitPostOrder(F);
+  }
+
+  assert(
+      order.size() == M->getFunctionList().size() &&
+      "Didn't order all functions");
+
+  return order;
+}
+
 /// \return true if the function \p F satisfies the conditions for being
 ///   inlined.
 static bool canBeInlined(Function *F, Function *intoFunction) {
+  // If it's a recursive call, it can't be inlined.
+  if (F == intoFunction) {
+    LLVM_DEBUG(
+        llvh::dbgs() << "Cannot inline function '" << F->getInternalNameStr()
+                     << "' into itself\n");
+    return false;
+  }
+
   // If it has captured variables, it can't be inlined.
   if (!F->getFunctionScope()->getVariables().empty()) {
+    LLVM_DEBUG(
+        llvh::dbgs() << "Cannot inline function '" << F->getInternalNameStr()
+                     << "': has captured variables\n");
     return false;
   }
 
   // If the functions have different strictness, we can't inline them, since
   // we don't have strict/non-strict version of instructions (TODO).
-  if (F->isStrictMode() != intoFunction->isStrictMode())
+  if (F->isStrictMode() != intoFunction->isStrictMode()) {
+    LLVM_DEBUG(
+        llvh::dbgs() << "Cannot inline function '" << F->getInternalNameStr()
+                     << "': strict mode mismatch\n");
     return false;
+  }
 
   for (BasicBlock *oldBB : orderDFS(F)) {
     for (auto &I : *oldBB) {
@@ -64,10 +209,19 @@ static bool canBeInlined(Function *F, Function *intoFunction) {
         case ValueKind::CreateFunctionInstKind:
         case ValueKind::CreateGeneratorInstKind:
           // Fail.
+          LLVM_DEBUG(
+              llvh::dbgs() << "Cannot inline function '"
+                           << F->getInternalNameStr()
+                           << "': invalid instruction " << I.getKindStr()
+                           << '\n');
           return false;
         case ValueKind::CallBuiltinInstKind:
           if (cast<CallBuiltinInst>(&I)->getBuiltinIndex() ==
               BuiltinMethod::HermesBuiltin_copyRestArgs) {
+            LLVM_DEBUG(
+                llvh::dbgs()
+                << "Cannot inline function '" << F->getInternalNameStr()
+                << "': copies rest args\n");
             return false;
           }
           break;
@@ -253,64 +407,77 @@ bool Inlining::runOnModule(Module *M) {
 
   bool changed = false;
 
-  for (Function &F : *M) {
-    for (Instruction *I : F.getUsers()) {
-      auto *CFI = llvh::dyn_cast<BaseCreateCallableInst>(I);
-      if (!CFI)
-        continue;
+  std::vector<Function *> functionOrder = orderFunctions(M);
 
-      // Check if the function is used only once directly by a CallInst.
-      // We can't use getCallSites() (yet) because it also considers constructor
-      // calls as well usages through environment variables.
+  for (Function *FC : functionOrder) {
+    LLVM_DEBUG(
+        llvh::dbgs() << "Visiting function '" << FC->getInternalNameStr()
+                     << "'\n");
 
-      if (!CFI->hasOneUser() ||
-          CFI->getUsers()[0]->getKind() != ValueKind::CallInstKind) {
-        continue;
-      }
-      auto *CI = cast<CallInst>(CFI->getUsers()[0]);
-      if (!isDirectCallee(CFI, CI))
-        continue;
-
-      Function *intoFunction = CI->getParent()->getParent();
-
-      auto *FC = CFI->getFunctionCode();
-      if (!canBeInlined(FC, intoFunction))
-        continue;
-
-      LLVM_DEBUG(llvh::dbgs() << "Inlining function '"
-                              << FC->getInternalNameStr() << "' ";
-                 FC->getContext().getSourceErrorManager().dumpCoords(
-                     llvh::dbgs(), FC->getSourceRange().Start);
-                 llvh::dbgs() << " into function '"
-                              << intoFunction->getInternalNameStr() << "' ";
-                 FC->getContext().getSourceErrorManager().dumpCoords(
-                     llvh::dbgs(), intoFunction->getSourceRange().Start);
-                 llvh::dbgs() << "\n";);
-
-      IRBuilder builder(M);
-
-      // Split the block in two and move all instructions following the call
-      // to the new block.
-      BasicBlock *nextBlock = builder.createBasicBlock(intoFunction);
-      builder.setInsertionBlock(nextBlock);
-
-      // Move the rest of the instructions.
-      auto it = CI->getIterator();
-      ++it; // Skip over the call.
-      auto e = CI->getParent()->end();
-      while (it != e)
-        builder.transferInstructionToCurrentBlock(&*it++);
-
-      // Perform the inlining.
-      builder.setInsertionPointAfter(CI);
-
-      auto *returnValue = inlineFunction(builder, FC, CI, nextBlock);
-      CI->replaceAllUsesWith(returnValue);
-      CI->eraseFromParent();
-
-      ++NumInlinedCalls;
-      changed = true;
+    if (!FC->getAttributes().allCallsitesKnown) {
+      LLVM_DEBUG(
+          llvh::dbgs() << "Cannot inline function '" << FC->getInternalNameStr()
+                       << "': has unknown callsites\n");
+      continue;
     }
+
+    llvh::SmallVector<BaseCallInst *, 2> callsites = getKnownCallsites(FC);
+
+    if (callsites.size() != 1) {
+      LLVM_DEBUG(
+          llvh::dbgs() << "Cannot inline function '" << FC->getInternalNameStr()
+                       << llvh::format(
+                              "': has %u callsites (requires 1)\n",
+                              callsites.size()));
+      continue;
+    }
+
+    auto *CI = llvh::dyn_cast<CallInst>(*callsites.begin());
+    if (!CI) {
+      LLVM_DEBUG(
+          llvh::dbgs() << "Cannot inline function '" << FC->getInternalNameStr()
+                       << "': callsite is not a CallInst\n");
+      continue;
+    }
+
+    Function *intoFunction = CI->getParent()->getParent();
+
+    if (!canBeInlined(FC, intoFunction))
+      continue;
+
+    LLVM_DEBUG(llvh::dbgs()
+                   << "Inlining function '" << FC->getInternalNameStr() << "' ";
+               FC->getContext().getSourceErrorManager().dumpCoords(
+                   llvh::dbgs(), FC->getSourceRange().Start);
+               llvh::dbgs() << " into function '"
+                            << intoFunction->getInternalNameStr() << "' ";
+               FC->getContext().getSourceErrorManager().dumpCoords(
+                   llvh::dbgs(), intoFunction->getSourceRange().Start);
+               llvh::dbgs() << "\n";);
+
+    IRBuilder builder(M);
+
+    // Split the block in two and move all instructions following the call
+    // to the new block.
+    BasicBlock *nextBlock = builder.createBasicBlock(intoFunction);
+    builder.setInsertionBlock(nextBlock);
+
+    // Move the rest of the instructions.
+    auto it = CI->getIterator();
+    ++it; // Skip over the call.
+    auto e = CI->getParent()->end();
+    while (it != e)
+      builder.transferInstructionToCurrentBlock(&*it++);
+
+    // Perform the inlining.
+    builder.setInsertionPointAfter(CI);
+
+    auto *returnValue = inlineFunction(builder, FC, CI, nextBlock);
+    CI->replaceAllUsesWith(returnValue);
+    CI->eraseFromParent();
+
+    ++NumInlinedCalls;
+    changed = true;
   }
 
   return changed;

--- a/lib/Utils/Dumper.cpp
+++ b/lib/Utils/Dumper.cpp
@@ -215,6 +215,7 @@ void IRPrinter::printFunctionHeader(Function *F) {
   }
   os << ")";
   printTypeLabel(F->getType());
+  os << " " << F->getAttributes().getDescriptionStr();
 }
 
 void IRPrinter::printFunctionVariables(Function *F) {

--- a/test/BCGen/HBC/object_literal_opt.js
+++ b/test/BCGen/HBC/object_literal_opt.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// RUN: %hermes -dump-bytecode -pretty-disassemble=false -O %s | %FileCheck --match-full-lines %s
+// RUN: %hermes -dump-bytecode -pretty-disassemble=false -fno-inline -O %s | %FileCheck --match-full-lines %s
 
 function foo(p) {
   var obj = {a: 0, b: 1};
@@ -25,37 +25,46 @@ function foo(p) {
 }());
 
 //CHECK-LABEL:Global String Table:
-//CHECK-NEXT:s0[ASCII, {{.*}}]: fail
-//CHECK-NEXT:s1[ASCII, {{.*}}]: global
-//CHECK-NEXT:i2[ASCII, {{.*}}] #{{[0-9A-F]+}}: a
-//CHECK-NEXT:i3[ASCII, {{.*}}] #{{[0-9A-F]+}}: b
-//CHECK-NEXT:i4[ASCII, {{.*}}] #{{[0-9A-F]+}}: foo
-//CHECK-NEXT:i5[ASCII, {{.*}}] #{{[0-9A-F]+}}: hello
-//CHECK-NEXT:i6[ASCII, {{.*}}] #{{[0-9A-F]+}}: x
+//CHECK-NEXT:s0[ASCII, {{.*}}]:
+//CHECK-NEXT:s1[ASCII, {{.*}}]: fail
+//CHECK-NEXT:s2[ASCII, {{.*}}]: global
+//CHECK-NEXT:i3[ASCII, {{.*}}] #{{[0-9A-F]+}}: a
+//CHECK-NEXT:i4[ASCII, {{.*}}] #{{[0-9A-F]+}}: b
+//CHECK-NEXT:i5[ASCII, {{.*}}] #{{[0-9A-F]+}}: foo
+//CHECK-NEXT:i6[ASCII, {{.*}}] #{{[0-9A-F]+}}: hello
+//CHECK-NEXT:i7[ASCII, {{.*}}] #{{[0-9A-F]+}}: x
 //CHECK-LABEL:Object Key Buffer:
+//CHECK-NEXT:[String 3]
 //CHECK-NEXT:[String 4]
 //CHECK-NEXT:[String 5]
 //CHECK-NEXT:[String 6]
-//CHECK-NEXT:[String 2]
-//CHECK-NEXT:[String 3]
+//CHECK-NEXT:[String 7]
 //CHECK-LABEL:Object Value Buffer:
-//CHECK-NEXT:[String 0]
-//CHECK-NEXT:null
-//CHECK-NEXT:[int 5]
 //CHECK-NEXT:[int 0]
 //CHECK-NEXT:[int 1]
+//CHECK-NEXT:[String 1]
+//CHECK-NEXT:null
+//CHECK-NEXT:[int 5]
 
-//CHECK-LABEL:Function<global>(1 params, 2 registers, 0 symbols):
+//CHECK-LABEL:Function<global>(1 params, 10 registers, 0 symbols):
 //CHECK-NEXT:Offset in debug table: source 0x0000, lexical 0x0000
-//CHECK-NEXT:[@ {{.*}}] DeclareGlobalVar 4<UInt32>
+//CHECK-NEXT:[@ {{.*}}] DeclareGlobalVar 5<UInt32>
 //CHECK-NEXT:[@ {{.*}}] CreateEnvironment 0<Reg8>
-//CHECK-NEXT:[@ {{.*}}] CreateClosure 0<Reg8>, 0<Reg8>, 1<UInt16>
+//CHECK-NEXT:[@ {{.*}}] CreateClosure 2<Reg8>, 0<Reg8>, 1<UInt16>
 //CHECK-NEXT:[@ {{.*}}] GetGlobalObject 1<Reg8>
-//CHECK-NEXT:[@ {{.*}}] PutByIdLoose 1<Reg8>, 0<Reg8>, 1<UInt8>, 4<UInt16>
-//CHECK-NEXT:[@ {{.*}}] NewObjectWithBuffer 0<Reg8>, 3<UInt16>, 3<UInt16>, 0<UInt16>, 0<UInt16>
-//CHECK-NEXT:[@ {{.*}}] PutByIdLoose 0<Reg8>, 1<Reg8>, 2<UInt8>, 5<UInt16>
+//CHECK-NEXT:[@ {{.*}}] PutByIdLoose 1<Reg8>, 2<Reg8>, 1<UInt8>, 5<UInt16>
+//CHECK-NEXT:[@ {{.*}}] CreateClosure 1<Reg8>, 0<Reg8>, 2<UInt16>
+//CHECK-NEXT:[@ {{.*}}] LoadConstUndefined 0<Reg8>
+//CHECK-NEXT:[@ {{.*}}] Call1 0<Reg8>, 1<Reg8>, 0<Reg8>
 //CHECK-NEXT:[@ {{.*}}] Ret 0<Reg8>
 
 //CHECK-LABEL:Function<foo>(2 params, 1 registers, 0 symbols):
-//CHECK-NEXT:[@ {{.*}}] NewObjectWithBuffer 0<Reg8>, 2<UInt16>, 2<UInt16>, 4<UInt16>, 8<UInt16>
+//CHECK-NEXT:[@ {{.*}}] NewObjectWithBuffer 0<Reg8>, 2<UInt16>, 2<UInt16>, 0<UInt16>, 0<UInt16>
+//CHECK-NEXT:[@ {{.*}}] Ret 0<Reg8>
+
+//CHECK-LABEL:Function<>(1 params, 2 registers, 0 symbols):
+//CHECK-NEXT:Offset in debug table: source 0x000a, lexical 0x0000
+//CHECK-NEXT:[@ {{.*}}] NewObjectWithBuffer 0<Reg8>, 3<UInt16>, 3<UInt16>, 3<UInt16>, 9<UInt16>
+//CHECK-NEXT:[@ {{.*}}] GetGlobalObject 1<Reg8>
+//CHECK-NEXT:[@ {{.*}}] PutByIdLoose 0<Reg8>, 1<Reg8>, 1<UInt8>, 6<UInt16>
 //CHECK-NEXT:[@ {{.*}}] Ret 0<Reg8>

--- a/test/Optimizer/auto-inline.js
+++ b/test/Optimizer/auto-inline.js
@@ -8,6 +8,7 @@
 // RUN: %hermesc -target=HBC -O -dump-ir %s | %FileCheckOrRegen --match-full-lines %s
 
 function foo1(a) {
+    'use strict';
     var add = function() {
         return 100;
     }
@@ -15,6 +16,7 @@ function foo1(a) {
 }
 
 function foo2(a) {
+    'use strict';
     var add = function(a, b) {
         return a + b;
     }
@@ -22,6 +24,7 @@ function foo2(a) {
 }
 
 function foo3(a) {
+    'use strict';
     var add = function(a, b) {
         return a ? a : b;
     }
@@ -29,6 +32,7 @@ function foo3(a) {
 }
 
 function foo4(a) {
+    'use strict';
     var add = function(a, b) {
         if (a < 0)
             return -1;

--- a/test/Optimizer/callee.js
+++ b/test/Optimizer/callee.js
@@ -48,7 +48,7 @@ function load_store_multiple_test() {
 
 // Auto-generated content below. Please do not modify manually.
 
-// CHECK:function global() : string
+// CHECK:function global() : string [allCallsitesKnown]
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = DeclareGlobalVarInst "fuzz" : string
@@ -70,7 +70,7 @@ function load_store_multiple_test() {
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = CreateFunctionInst %foo() : number
-// CHECK-NEXT:  %1 = CallInst %0 : closure, empty, empty, undefined : undefined, 12 : number
+// CHECK-NEXT:  %1 = CallInst %0 : closure, %foo() : number, empty, undefined : undefined, 12 : number
 // CHECK-NEXT:  %2 = ReturnInst 12 : number
 // CHECK-NEXT:function_end
 
@@ -80,7 +80,7 @@ function load_store_multiple_test() {
 // CHECK-NEXT:  %0 = CreateFunctionInst %"foo 1#"() : number
 // CHECK-NEXT:  %1 = LoadPropertyInst %0 : closure, "prototype" : string
 // CHECK-NEXT:  %2 = CreateThisInst %1, %0 : closure
-// CHECK-NEXT:  %3 = ConstructInst %0 : closure, empty, empty, undefined : undefined, 12 : number
+// CHECK-NEXT:  %3 = ConstructInst %0 : closure, %"foo 1#"() : number, empty, undefined : undefined, 12 : number
 // CHECK-NEXT:  %4 = GetConstructedObjectInst %2 : object, %3 : number
 // CHECK-NEXT:  %5 = ReturnInst %4 : object
 // CHECK-NEXT:function_end
@@ -91,7 +91,7 @@ function load_store_multiple_test() {
 // CHECK-NEXT:  %0 = CreateFunctionInst %ping() : number
 // CHECK-NEXT:  %1 = CreateFunctionInst %k() : number
 // CHECK-NEXT:  %2 = StoreFrameInst %1 : closure, [k] : closure
-// CHECK-NEXT:  %3 = CallInst %0 : closure, empty, empty, undefined : undefined
+// CHECK-NEXT:  %3 = CallInst %0 : closure, %ping() : number, empty, undefined : undefined
 // CHECK-NEXT:  %4 = ReturnInst 123 : number
 // CHECK-NEXT:function_end
 
@@ -101,49 +101,49 @@ function load_store_multiple_test() {
 // CHECK-NEXT:  %0 = CreateFunctionInst %"foo 2#"() : number
 // CHECK-NEXT:  %1 = StoreFrameInst %0 : closure, [foo] : closure
 // CHECK-NEXT:  %2 = CreateFunctionInst %bar() : number
-// CHECK-NEXT:  %3 = CallInst %2 : closure, empty, empty, undefined : undefined
+// CHECK-NEXT:  %3 = CallInst %2 : closure, %bar() : number, empty, undefined : undefined
 // CHECK-NEXT:  %4 = ReturnInst %3 : number
 // CHECK-NEXT:function_end
 
-// CHECK:function foo(k : number) : number
+// CHECK:function foo(k : number) : number [allCallsitesKnown]
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = ReturnInst 12 : number
 // CHECK-NEXT:function_end
 
-// CHECK:function "foo 1#"(k : number) : number
+// CHECK:function "foo 1#"(k : number) : number [allCallsitesKnown]
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = ReturnInst 12 : number
 // CHECK-NEXT:function_end
 
-// CHECK:function ping() : number
+// CHECK:function ping() : number [allCallsitesKnown]
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = LoadFrameInst [k@load_store_test] : closure
-// CHECK-NEXT:  %1 = CallInst %0 : closure, empty, empty, undefined : undefined, 123 : number
+// CHECK-NEXT:  %1 = CallInst %0 : closure, %k() : number, empty, undefined : undefined, 123 : number
 // CHECK-NEXT:  %2 = ReturnInst 123 : number
 // CHECK-NEXT:function_end
 
-// CHECK:function k(k : number) : number
+// CHECK:function k(k : number) : number [allCallsitesKnown]
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = ReturnInst 123 : number
 // CHECK-NEXT:function_end
 
-// CHECK:function "foo 2#"(cond : boolean, val : number) : number
+// CHECK:function "foo 2#"(cond : boolean, val : number) : number [allCallsitesKnown]
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = LoadParamInst %val : number
 // CHECK-NEXT:  %1 = ReturnInst %0 : number
 // CHECK-NEXT:function_end
 
-// CHECK:function bar() : number
+// CHECK:function bar() : number [allCallsitesKnown]
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = LoadFrameInst [foo@load_store_multiple_test] : closure
-// CHECK-NEXT:  %1 = CallInst %0 : closure, empty, empty, undefined : undefined, true : boolean, 7 : number
-// CHECK-NEXT:  %2 = CallInst %0 : closure, empty, empty, undefined : undefined, true : boolean, 8 : number
+// CHECK-NEXT:  %1 = CallInst %0 : closure, %"foo 2#"() : number, empty, undefined : undefined, true : boolean, 7 : number
+// CHECK-NEXT:  %2 = CallInst %0 : closure, %"foo 2#"() : number, empty, undefined : undefined, true : boolean, 8 : number
 // CHECK-NEXT:  %3 = BinaryOperatorInst '+', %1 : number, %2 : number
 // CHECK-NEXT:  %4 = ReturnInst %3 : number
 // CHECK-NEXT:function_end

--- a/test/Optimizer/callgraph-escape-arg.js
+++ b/test/Optimizer/callgraph-escape-arg.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermesc -dump-ir %s -O | %FileCheckOrRegen %s
+
+// bar2 isn't inlined because CallGraph infers that it escapes,
+// but bar1 can be inlined.
+function foo() {
+  'use strict';
+  function bar1(x) {
+    return x;
+  }
+  function bar2() {
+    return 2;
+  }
+  return bar1(bar2);
+}
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:function global() : undefined
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = DeclareGlobalVarInst "foo" : string
+// CHECK-NEXT:  %1 = CreateFunctionInst %foo() : closure
+// CHECK-NEXT:  %2 = StorePropertyLooseInst %1 : closure, globalObject : object, "foo" : string
+// CHECK-NEXT:  %3 = ReturnInst undefined : undefined
+// CHECK-NEXT:function_end
+
+// CHECK:function foo() : closure
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = CreateFunctionInst %bar2() : number
+// CHECK-NEXT:  %1 = ReturnInst %0 : closure
+// CHECK-NEXT:function_end
+
+// CHECK:function bar2() : number
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = ReturnInst 2 : number
+// CHECK-NEXT:function_end

--- a/test/Optimizer/cant-inline.js
+++ b/test/Optimizer/cant-inline.js
@@ -30,7 +30,7 @@ function outer1() {
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = CreateFunctionInst %dontInline()
-// CHECK-NEXT:  %1 = CallInst %0 : closure, empty, empty, undefined : undefined, 1 : number
+// CHECK-NEXT:  %1 = CallInst %0 : closure, %dontInline(), empty, undefined : undefined, 1 : number
 // CHECK-NEXT:  %2 = ReturnInst %1
 // CHECK-NEXT:function_end
 

--- a/test/Optimizer/constructor_callee.js
+++ b/test/Optimizer/constructor_callee.js
@@ -32,7 +32,7 @@ function ctor_load_store_test() {
 
 // Auto-generated content below. Please do not modify manually.
 
-// CHECK:function global() : string
+// CHECK:function global() : string [allCallsitesKnown]
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = DeclareGlobalVarInst "ctor_this_test" : string
@@ -50,7 +50,7 @@ function ctor_load_store_test() {
 // CHECK-NEXT:  %0 = CreateFunctionInst %use_this() : object
 // CHECK-NEXT:  %1 = LoadPropertyInst %0 : closure, "prototype" : string
 // CHECK-NEXT:  %2 = CreateThisInst %1, %0 : closure
-// CHECK-NEXT:  %3 = ConstructInst %0 : closure, empty, empty, %2 : object, 12 : number
+// CHECK-NEXT:  %3 = ConstructInst %0 : closure, %use_this() : object, empty, %2 : object, 12 : number
 // CHECK-NEXT:  %4 = GetConstructedObjectInst %2 : object, %3 : object
 // CHECK-NEXT:  %5 = ReturnInst %4 : object
 // CHECK-NEXT:function_end
@@ -61,11 +61,11 @@ function ctor_load_store_test() {
 // CHECK-NEXT:  %0 = CreateFunctionInst %"use_this 1#"() : undefined
 // CHECK-NEXT:  %1 = StoreFrameInst %0 : closure, [use_this] : closure
 // CHECK-NEXT:  %2 = CreateFunctionInst %construct_use_this() : object
-// CHECK-NEXT:  %3 = CallInst %2 : closure, empty, empty, undefined : undefined
+// CHECK-NEXT:  %3 = CallInst %2 : closure, %construct_use_this() : object, empty, undefined : undefined
 // CHECK-NEXT:  %4 = ReturnInst %3 : object
 // CHECK-NEXT:function_end
 
-// CHECK:function use_this(k : number) : object
+// CHECK:function use_this(k : number) : object [allCallsitesKnown]
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = LoadParamInst %this : object
@@ -81,13 +81,13 @@ function ctor_load_store_test() {
 // CHECK-NEXT:  %2 = ReturnInst undefined : undefined
 // CHECK-NEXT:function_end
 
-// CHECK:function construct_use_this() : object
+// CHECK:function construct_use_this() : object [allCallsitesKnown]
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = LoadFrameInst [use_this@ctor_load_store_test] : closure
 // CHECK-NEXT:  %1 = LoadPropertyInst %0 : closure, "prototype" : string
 // CHECK-NEXT:  %2 = CreateThisInst %1, %0 : closure
-// CHECK-NEXT:  %3 = ConstructInst %0 : closure, empty, empty, %2 : object, 12 : number
+// CHECK-NEXT:  %3 = ConstructInst %0 : closure, %"use_this 1#"() : undefined, empty, %2 : object, 12 : number
 // CHECK-NEXT:  %4 = GetConstructedObjectInst %2 : object, %3 : undefined
 // CHECK-NEXT:  %5 = ReturnInst %4 : object
 // CHECK-NEXT:function_end

--- a/test/Optimizer/func_sig_opts.js
+++ b/test/Optimizer/func_sig_opts.js
@@ -58,7 +58,7 @@ function test_async() {
 
 // Auto-generated content below. Please do not modify manually.
 
-// CHECK:function global() : string
+// CHECK:function global() : string [allCallsitesKnown]
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = DeclareGlobalVarInst "main" : string
@@ -89,8 +89,8 @@ function test_async() {
 // CHECK-NEXT:  %1 = CreateFunctionInst %foo() : number
 // CHECK-NEXT:  %2 = CreateFunctionInst %bar() : string|number|bigint
 // CHECK-NEXT:  %3 = StorePropertyStrictInst %2 : closure, %0, "p" : string
-// CHECK-NEXT:  %4 = CallInst %1 : closure, empty, empty, undefined : undefined, 1 : number, 2 : number
-// CHECK-NEXT:  %5 = CallInst %2 : closure, empty, empty, undefined : undefined, 1 : number, 2 : number
+// CHECK-NEXT:  %4 = CallInst %1 : closure, %foo() : number, empty, undefined : undefined, 1 : number, 2 : number
+// CHECK-NEXT:  %5 = CallInst %2 : closure, %bar() : string|number|bigint, empty, undefined : undefined, 1 : number, 2 : number
 // CHECK-NEXT:  %6 = BinaryOperatorInst '+', %4 : number, %5 : string|number|bigint
 // CHECK-NEXT:  %7 = ReturnInst %6 : string|number
 // CHECK-NEXT:function_end
@@ -99,8 +99,8 @@ function test_async() {
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = CreateFunctionInst %builder() : number
-// CHECK-NEXT:  %1 = CallInst %0 : closure, empty, empty, undefined : undefined
-// CHECK-NEXT:  %2 = CallInst %0 : closure, empty, empty, undefined : undefined
+// CHECK-NEXT:  %1 = CallInst %0 : closure, %builder() : number, empty, undefined : undefined
+// CHECK-NEXT:  %2 = CallInst %0 : closure, %builder() : number, empty, undefined : undefined
 // CHECK-NEXT:  %3 = BinaryOperatorInst '+', %1 : number, %2 : number
 // CHECK-NEXT:  %4 = ReturnInst %3 : number
 // CHECK-NEXT:function_end
@@ -122,7 +122,7 @@ function test_async() {
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = CreateFunctionInst %baz()
-// CHECK-NEXT:  %1 = CallInst %0 : closure, empty, empty, undefined : undefined, 100 : number
+// CHECK-NEXT:  %1 = CallInst %0 : closure, %baz(), empty, undefined : undefined, 100 : number
 // CHECK-NEXT:  %2 = ReturnInst %1
 // CHECK-NEXT:function_end
 
@@ -130,7 +130,7 @@ function test_async() {
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = CreateFunctionInst %gen() : object
-// CHECK-NEXT:  %1 = CallInst %0 : closure, empty, empty, undefined : undefined, 1 : number
+// CHECK-NEXT:  %1 = CallInst %0 : closure, %gen() : object, empty, undefined : undefined, 1 : number
 // CHECK-NEXT:  %2 = ReturnInst %1 : object
 // CHECK-NEXT:function_end
 
@@ -138,11 +138,11 @@ function test_async() {
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = CreateFunctionInst %asyncFn()
-// CHECK-NEXT:  %1 = CallInst %0 : closure, empty, empty, undefined : undefined, 1 : number
+// CHECK-NEXT:  %1 = CallInst %0 : closure, %asyncFn(), empty, undefined : undefined, 1 : number
 // CHECK-NEXT:  %2 = ReturnInst %1
 // CHECK-NEXT:function_end
 
-// CHECK:function foo(x : number, y : number) : number
+// CHECK:function foo(x : number, y : number) : number [allCallsitesKnown]
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = BinaryOperatorInst '+', 1 : number, 2 : number
@@ -158,7 +158,7 @@ function test_async() {
 // CHECK-NEXT:  %3 = ReturnInst %2 : string|number|bigint
 // CHECK-NEXT:function_end
 
-// CHECK:function builder() : number
+// CHECK:function builder() : number [allCallsitesKnown]
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = TryLoadGlobalPropertyInst globalObject : object, "k" : string
@@ -166,7 +166,7 @@ function test_async() {
 // CHECK-NEXT:  %2 = ReturnInst %1 : number
 // CHECK-NEXT:function_end
 
-// CHECK:function foo2(a, b : number, c : number, d : undefined) : string|number
+// CHECK:function foo2(a, b : number, c : number, d : undefined) : string|number [allCallsitesKnown]
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = LoadParamInst %a
@@ -181,7 +181,7 @@ function test_async() {
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = LoadParamInst %e
 // CHECK-NEXT:  %1 = LoadFrameInst [foo2@test_unused_and_duplicate_params] : closure
-// CHECK-NEXT:  %2 = CallInst %1 : closure, empty, empty, undefined : undefined, %0, 2 : number, 1 : number, undefined : undefined, undefined : undefined, undefined : undefined
+// CHECK-NEXT:  %2 = CallInst %1 : closure, %foo2() : string|number, empty, undefined : undefined, %0, 2 : number, 1 : number, undefined : undefined, undefined : undefined, undefined : undefined
 // CHECK-NEXT:  %3 = ReturnInst undefined : undefined
 // CHECK-NEXT:function_end
 
@@ -190,25 +190,25 @@ function test_async() {
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = LoadParamInst %e
 // CHECK-NEXT:  %1 = LoadFrameInst [foo2@test_unused_and_duplicate_params] : closure
-// CHECK-NEXT:  %2 = CallInst %1 : closure, empty, empty, undefined : undefined, %0, 2 : number, 3 : number, undefined : undefined, undefined : undefined
+// CHECK-NEXT:  %2 = CallInst %1 : closure, %foo2() : string|number, empty, undefined : undefined, %0, 2 : number, 3 : number, undefined : undefined, undefined : undefined
 // CHECK-NEXT:  %3 = ReturnInst undefined : undefined
 // CHECK-NEXT:function_end
 
-// CHECK:function baz()
+// CHECK:function baz() [allCallsitesKnown]
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = CallBuiltinInst [HermesBuiltin.copyRestArgs] : number, empty, empty, undefined : undefined, 0 : number
 // CHECK-NEXT:  %1 = ReturnInst %0
 // CHECK-NEXT:function_end
 
-// CHECK:function gen() : object
+// CHECK:function gen() : object [allCallsitesKnown]
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = CreateGeneratorInst %?anon_0_gen()
 // CHECK-NEXT:  %1 = ReturnInst %0 : object
 // CHECK-NEXT:function_end
 
-// CHECK:function asyncFn()
+// CHECK:function asyncFn() [allCallsitesKnown]
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = CreateArgumentsInst

--- a/test/Optimizer/function-analysis-call-arg.js
+++ b/test/Optimizer/function-analysis-call-arg.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermesc -fno-inline -dump-ir %s -O | %FileCheckOrRegen %s --match-full-lines
+
+'use strict';
+
+// Function leaks as an arg to its own call.
+function main() {
+  var x;
+  x = function f() {
+    sink();
+  };
+  return x(x);
+}
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:function global() : string [allCallsitesKnown]
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = DeclareGlobalVarInst "main" : string
+// CHECK-NEXT:  %1 = CreateFunctionInst %main() : undefined
+// CHECK-NEXT:  %2 = StorePropertyStrictInst %1 : closure, globalObject : object, "main" : string
+// CHECK-NEXT:  %3 = ReturnInst "use strict" : string
+// CHECK-NEXT:function_end
+
+// CHECK:function main() : undefined
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = CreateFunctionInst %f() : undefined
+// CHECK-NEXT:  %1 = CallInst %0 : closure, %f() : undefined, empty, undefined : undefined, %0 : closure
+// CHECK-NEXT:  %2 = ReturnInst undefined : undefined
+// CHECK-NEXT:function_end
+
+// CHECK:function f() : undefined
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = TryLoadGlobalPropertyInst globalObject : object, "sink" : string
+// CHECK-NEXT:  %1 = CallInst %0, empty, empty, undefined : undefined
+// CHECK-NEXT:  %2 = ReturnInst undefined : undefined
+// CHECK-NEXT:function_end

--- a/test/Optimizer/function-analysis-call-closure.js
+++ b/test/Optimizer/function-analysis-call-closure.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermesc -fno-inline -dump-ir %s -O | %FileCheckOrRegen %s --match-full-lines
+
+'use strict';
+
+// Call the closure without a variable.
+function main() {
+  function f() {}
+  return f();
+}
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:function global() : string [allCallsitesKnown]
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = DeclareGlobalVarInst "main" : string
+// CHECK-NEXT:  %1 = CreateFunctionInst %main() : undefined
+// CHECK-NEXT:  %2 = StorePropertyStrictInst %1 : closure, globalObject : object, "main" : string
+// CHECK-NEXT:  %3 = ReturnInst "use strict" : string
+// CHECK-NEXT:function_end
+
+// CHECK:function main() : undefined
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = CreateFunctionInst %f() : undefined
+// CHECK-NEXT:  %1 = CallInst %0 : closure, %f() : undefined, empty, undefined : undefined
+// CHECK-NEXT:  %2 = ReturnInst undefined : undefined
+// CHECK-NEXT:function_end
+
+// CHECK:function f() : undefined [allCallsitesKnown]
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = ReturnInst undefined : undefined
+// CHECK-NEXT:function_end

--- a/test/Optimizer/function-analysis-construction-store.js
+++ b/test/Optimizer/function-analysis-construction-store.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermesc -fno-inline -dump-ir %s -O | %FileCheckOrRegen %s --match-full-lines
+
+'use strict';
+
+// Resolve construction through a variable.
+function main() {
+  var x;
+  x = function f() {};
+  return new x();
+}
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:function global() : string [allCallsitesKnown]
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = DeclareGlobalVarInst "main" : string
+// CHECK-NEXT:  %1 = CreateFunctionInst %main() : object
+// CHECK-NEXT:  %2 = StorePropertyStrictInst %1 : closure, globalObject : object, "main" : string
+// CHECK-NEXT:  %3 = ReturnInst "use strict" : string
+// CHECK-NEXT:function_end
+
+// CHECK:function main() : object
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = CreateFunctionInst %f() : undefined
+// CHECK-NEXT:  %1 = LoadPropertyInst %0 : closure, "prototype" : string
+// CHECK-NEXT:  %2 = CreateThisInst %1, %0 : closure
+// CHECK-NEXT:  %3 = ConstructInst %0 : closure, %f() : undefined, empty, undefined : undefined
+// CHECK-NEXT:  %4 = GetConstructedObjectInst %2 : object, %3 : undefined
+// CHECK-NEXT:  %5 = ReturnInst %4 : object
+// CHECK-NEXT:function_end
+
+// CHECK:function f() : undefined [allCallsitesKnown]
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = ReturnInst undefined : undefined
+// CHECK-NEXT:function_end

--- a/test/Optimizer/function-analysis-construction.js
+++ b/test/Optimizer/function-analysis-construction.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermesc -fno-inline -dump-ir %s -O | %FileCheckOrRegen %s --match-full-lines
+
+'use strict';
+
+// Resolve construction through a variable.
+function main() {
+  function f() {};
+  return new f();
+}
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:function global() : string [allCallsitesKnown]
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = DeclareGlobalVarInst "main" : string
+// CHECK-NEXT:  %1 = CreateFunctionInst %main() : object
+// CHECK-NEXT:  %2 = StorePropertyStrictInst %1 : closure, globalObject : object, "main" : string
+// CHECK-NEXT:  %3 = ReturnInst "use strict" : string
+// CHECK-NEXT:function_end
+
+// CHECK:function main() : object
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = CreateFunctionInst %f() : undefined
+// CHECK-NEXT:  %1 = LoadPropertyInst %0 : closure, "prototype" : string
+// CHECK-NEXT:  %2 = CreateThisInst %1, %0 : closure
+// CHECK-NEXT:  %3 = ConstructInst %0 : closure, %f() : undefined, empty, undefined : undefined
+// CHECK-NEXT:  %4 = GetConstructedObjectInst %2 : object, %3 : undefined
+// CHECK-NEXT:  %5 = ReturnInst %4 : object
+// CHECK-NEXT:function_end
+
+// CHECK:function f() : undefined [allCallsitesKnown]
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = ReturnInst undefined : undefined
+// CHECK-NEXT:function_end

--- a/test/Optimizer/function-analysis-multiple-store.js
+++ b/test/Optimizer/function-analysis-multiple-store.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermesc -fno-inline -dump-ir %s -O | %FileCheckOrRegen %s --match-full-lines
+
+'use strict';
+
+// Multiple variable stores.
+// Can't resolve the call.
+function main() {
+  var x;
+  x = function f() {};
+  if (flag) x = function g() {};
+  x();
+}
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:function global() : string [allCallsitesKnown]
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = DeclareGlobalVarInst "main" : string
+// CHECK-NEXT:  %1 = CreateFunctionInst %main() : undefined
+// CHECK-NEXT:  %2 = StorePropertyStrictInst %1 : closure, globalObject : object, "main" : string
+// CHECK-NEXT:  %3 = ReturnInst "use strict" : string
+// CHECK-NEXT:function_end
+
+// CHECK:function main() : undefined
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = CreateFunctionInst %f() : undefined
+// CHECK-NEXT:  %1 = TryLoadGlobalPropertyInst globalObject : object, "flag" : string
+// CHECK-NEXT:  %2 = CondBranchInst %1, %BB1, %BB2
+// CHECK-NEXT:%BB1:
+// CHECK-NEXT:  %3 = CreateFunctionInst %g() : undefined
+// CHECK-NEXT:  %4 = BranchInst %BB2
+// CHECK-NEXT:%BB2:
+// CHECK-NEXT:  %5 = PhiInst %3 : closure, %BB1, %0 : closure, %BB0
+// CHECK-NEXT:  %6 = CallInst %5 : closure, empty, empty, undefined : undefined
+// CHECK-NEXT:  %7 = ReturnInst undefined : undefined
+// CHECK-NEXT:function_end
+
+// CHECK:function f() : undefined
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = ReturnInst undefined : undefined
+// CHECK-NEXT:function_end
+
+// CHECK:function g() : undefined
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = ReturnInst undefined : undefined
+// CHECK-NEXT:function_end

--- a/test/Optimizer/function-analysis-new-target.js
+++ b/test/Optimizer/function-analysis-new-target.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermesc -fno-inline -dump-ir %s -O | %FileCheckOrRegen %s --match-full-lines
+
+'use strict';
+
+// Function leaks by usage of new.target.
+function main() {
+  var x;
+  x = function f() {
+    sink(new.target);
+  };
+  return x();
+}
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:function global() : string [allCallsitesKnown]
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = DeclareGlobalVarInst "main" : string
+// CHECK-NEXT:  %1 = CreateFunctionInst %main() : undefined
+// CHECK-NEXT:  %2 = StorePropertyStrictInst %1 : closure, globalObject : object, "main" : string
+// CHECK-NEXT:  %3 = ReturnInst "use strict" : string
+// CHECK-NEXT:function_end
+
+// CHECK:function main() : undefined
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = CreateFunctionInst %f() : undefined
+// CHECK-NEXT:  %1 = CallInst %0 : closure, %f() : undefined, empty, undefined : undefined
+// CHECK-NEXT:  %2 = ReturnInst undefined : undefined
+// CHECK-NEXT:function_end
+
+// CHECK:function f() : undefined
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = TryLoadGlobalPropertyInst globalObject : object, "sink" : string
+// CHECK-NEXT:  %1 = GetNewTargetInst %new.target
+// CHECK-NEXT:  %2 = CallInst %0, empty, empty, undefined : undefined, %1
+// CHECK-NEXT:  %3 = ReturnInst undefined : undefined
+// CHECK-NEXT:function_end

--- a/test/Optimizer/function-analysis-single-store.js
+++ b/test/Optimizer/function-analysis-single-store.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermesc -fno-inline -dump-ir %s -O | %FileCheckOrRegen %s --match-full-lines
+
+'use strict';
+
+// Single variable store.
+function main(x) {
+  x = function f() {};
+  x();
+}
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:function global() : string [allCallsitesKnown]
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = DeclareGlobalVarInst "main" : string
+// CHECK-NEXT:  %1 = CreateFunctionInst %main() : undefined
+// CHECK-NEXT:  %2 = StorePropertyStrictInst %1 : closure, globalObject : object, "main" : string
+// CHECK-NEXT:  %3 = ReturnInst "use strict" : string
+// CHECK-NEXT:function_end
+
+// CHECK:function main(x) : undefined
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = CreateFunctionInst %f() : undefined
+// CHECK-NEXT:  %1 = CallInst %0 : closure, %f() : undefined, empty, undefined : undefined
+// CHECK-NEXT:  %2 = ReturnInst undefined : undefined
+// CHECK-NEXT:function_end
+
+// CHECK:function f() : undefined [allCallsitesKnown]
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = ReturnInst undefined : undefined
+// CHECK-NEXT:function_end

--- a/test/Optimizer/global_props.js
+++ b/test/Optimizer/global_props.js
@@ -34,7 +34,7 @@ process = null;
 // CHECK-NEXT:  %12 = ReturnInst %11
 // CHECK-NEXT:function_end
 
-// OPT-CHECK:function global() : null
+// OPT-CHECK:function global() : null [allCallsitesKnown]
 // OPT-CHECK-NEXT:frame = []
 // OPT-CHECK-NEXT:%BB0:
 // OPT-CHECK-NEXT:  %0 = DeclareGlobalVarInst "a" : string

--- a/test/Optimizer/inline-new-target.js
+++ b/test/Optimizer/inline-new-target.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermesc -O -dump-ir %s | %FileCheckOrRegen --match-full-lines %s
+
+function outer(a, b) {
+    'use strict'
+    function f1() {
+        // new.target is an inlining barrier.
+        return new.target;
+    }
+    return f1();
+}
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:function global() : undefined
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = DeclareGlobalVarInst "outer" : string
+// CHECK-NEXT:  %1 = CreateFunctionInst %outer()
+// CHECK-NEXT:  %2 = StorePropertyLooseInst %1 : closure, globalObject : object, "outer" : string
+// CHECK-NEXT:  %3 = ReturnInst undefined : undefined
+// CHECK-NEXT:function_end
+
+// CHECK:function outer(a, b)
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = CreateFunctionInst %f1()
+// CHECK-NEXT:  %1 = CallInst %0 : closure, %f1(), empty, undefined : undefined
+// CHECK-NEXT:  %2 = ReturnInst %1
+// CHECK-NEXT:function_end
+
+// CHECK:function f1()
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = GetNewTargetInst %new.target
+// CHECK-NEXT:  %1 = ReturnInst %0
+// CHECK-NEXT:function_end

--- a/test/Optimizer/inline-recursive.js
+++ b/test/Optimizer/inline-recursive.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermesc -O -dump-ir %s | %FileCheckOrRegen --match-full-lines %s
+
+// Don't inline recursive functions.
+
+'use strict'
+(function main() {
+  function f() {
+    return f();
+  }
+});
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:function global() : closure [allCallsitesKnown]
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = CreateFunctionInst %main() : undefined
+// CHECK-NEXT:  %1 = ReturnInst %0 : closure
+// CHECK-NEXT:function_end
+
+// CHECK:function main() : undefined
+// CHECK-NEXT:frame = [f : closure]
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = CreateFunctionInst %f()
+// CHECK-NEXT:  %1 = StoreFrameInst %0 : closure, [f] : closure
+// CHECK-NEXT:  %2 = ReturnInst undefined : undefined
+// CHECK-NEXT:function_end
+
+// CHECK:function f() [allCallsitesKnown]
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = LoadFrameInst [f@main] : closure
+// CHECK-NEXT:  %1 = CallInst %0 : closure, %f(), empty, undefined : undefined
+// CHECK-NEXT:  %2 = ReturnInst %1
+// CHECK-NEXT:function_end

--- a/test/Optimizer/inline-sibling.js
+++ b/test/Optimizer/inline-sibling.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermesc -O -dump-ir %s | %FileCheckOrRegen --match-full-lines %s
+
+function outer(a, b) {
+    'use strict'
+    function f1() {
+        return f2() + 1;
+    }
+    function f2() {
+        return a;
+    }
+    return f1();
+}
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:function global() : undefined
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = DeclareGlobalVarInst "outer" : string
+// CHECK-NEXT:  %1 = CreateFunctionInst %outer() : string|number
+// CHECK-NEXT:  %2 = StorePropertyLooseInst %1 : closure, globalObject : object, "outer" : string
+// CHECK-NEXT:  %3 = ReturnInst undefined : undefined
+// CHECK-NEXT:function_end
+
+// CHECK:function outer(a, b) : string|number
+// CHECK-NEXT:frame = [a]
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = LoadParamInst %a
+// CHECK-NEXT:  %1 = StoreFrameInst %0, [a]
+// CHECK-NEXT:  %2 = CreateFunctionInst %f2()
+// CHECK-NEXT:  %3 = BinaryOperatorInst '+', %0, 1 : number
+// CHECK-NEXT:  %4 = ReturnInst %3 : string|number
+// CHECK-NEXT:function_end
+
+// CHECK:function f2() [allCallsitesKnown]
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = LoadFrameInst [a@outer]
+// CHECK-NEXT:  %1 = ReturnInst %0
+// CHECK-NEXT:function_end

--- a/test/Optimizer/load_store_capture_vars.js
+++ b/test/Optimizer/load_store_capture_vars.js
@@ -108,7 +108,7 @@ function postponed_store_in_use_block(x) {
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = CreateFunctionInst %"foo 1#"() : undefined
-// CHECK-NEXT:  %1 = CallInst %0 : closure, empty, empty, undefined : undefined
+// CHECK-NEXT:  %1 = CallInst %0 : closure, %"foo 1#"() : undefined, empty, undefined : undefined
 // CHECK-NEXT:  %2 = ReturnInst 9 : number
 // CHECK-NEXT:function_end
 
@@ -116,7 +116,7 @@ function postponed_store_in_use_block(x) {
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = CreateFunctionInst %"foo 2#"() : undefined
-// CHECK-NEXT:  %1 = CallInst %0 : closure, empty, empty, undefined : undefined
+// CHECK-NEXT:  %1 = CallInst %0 : closure, %"foo 2#"() : undefined, empty, undefined : undefined
 // CHECK-NEXT:  %2 = ReturnInst 9 : number
 // CHECK-NEXT:function_end
 
@@ -124,7 +124,7 @@ function postponed_store_in_use_block(x) {
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = CreateFunctionInst %"foo 3#"() : undefined
-// CHECK-NEXT:  %1 = CallInst %0 : closure, empty, empty, undefined : undefined
+// CHECK-NEXT:  %1 = CallInst %0 : closure, %"foo 3#"() : undefined, empty, undefined : undefined
 // CHECK-NEXT:  %2 = ReturnInst 4 : number
 // CHECK-NEXT:function_end
 
@@ -133,7 +133,7 @@ function postponed_store_in_use_block(x) {
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = StoreFrameInst 4 : number, [x] : number
 // CHECK-NEXT:  %1 = CreateFunctionInst %"foo 4#"() : undefined
-// CHECK-NEXT:  %2 = CallInst %1 : closure, empty, empty, undefined : undefined
+// CHECK-NEXT:  %2 = CallInst %1 : closure, %"foo 4#"() : undefined, empty, undefined : undefined
 // CHECK-NEXT:  %3 = LoadFrameInst [x] : number
 // CHECK-NEXT:  %4 = ReturnInst %3 : number
 // CHECK-NEXT:function_end
@@ -142,7 +142,7 @@ function postponed_store_in_use_block(x) {
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = CreateFunctionInst %"foo 5#"() : undefined
-// CHECK-NEXT:  %1 = CallInst %0 : closure, empty, empty, undefined : undefined
+// CHECK-NEXT:  %1 = CallInst %0 : closure, %"foo 5#"() : undefined, empty, undefined : undefined
 // CHECK-NEXT:  %2 = ReturnInst 4 : number
 // CHECK-NEXT:function_end
 

--- a/test/Optimizer/loadstore.js
+++ b/test/Optimizer/loadstore.js
@@ -32,7 +32,7 @@ function test2(p1, p2) {
 
 // Auto-generated content below. Please do not modify manually.
 
-// OPT-CHECK:function global()
+// OPT-CHECK:function global() [allCallsitesKnown]
 // OPT-CHECK-NEXT:frame = []
 // OPT-CHECK-NEXT:%BB0:
 // OPT-CHECK-NEXT:  %0 = DeclareGlobalVarInst "foo" : string

--- a/test/Optimizer/non-strict-opts.js
+++ b/test/Optimizer/non-strict-opts.js
@@ -33,7 +33,7 @@ function main()  {
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = CreateFunctionInst %foo() : string
-// CHECK-NEXT:  %1 = CallInst %0 : closure, empty, empty, undefined : undefined, 2 : number
+// CHECK-NEXT:  %1 = CallInst %0 : closure, %foo() : string, empty, undefined : undefined, 2 : number
 // CHECK-NEXT:  %2 = ReturnInst undefined : undefined
 // CHECK-NEXT:function_end
 

--- a/test/Optimizer/simplify-this.js
+++ b/test/Optimizer/simplify-this.js
@@ -8,6 +8,7 @@
 // RUN: %hermesc -target=HBC -dump-ir -O %s | %FileCheckOrRegen --match-full-lines %s
 
 function thisUndefined () {
+    'use strict';
     function inner() {
         return this;
     }
@@ -20,13 +21,13 @@ function thisUndefined () {
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = DeclareGlobalVarInst "thisUndefined" : string
-// CHECK-NEXT:  %1 = CreateFunctionInst %thisUndefined() : object
+// CHECK-NEXT:  %1 = CreateFunctionInst %thisUndefined() : undefined
 // CHECK-NEXT:  %2 = StorePropertyLooseInst %1 : closure, globalObject : object, "thisUndefined" : string
 // CHECK-NEXT:  %3 = ReturnInst undefined : undefined
 // CHECK-NEXT:function_end
 
-// CHECK:function thisUndefined() : object
+// CHECK:function thisUndefined() : undefined
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
-// CHECK-NEXT:  %0 = ReturnInst globalObject : object
+// CHECK-NEXT:  %0 = ReturnInst undefined : undefined
 // CHECK-NEXT:function_end

--- a/test/Optimizer/single_store_optz.js
+++ b/test/Optimizer/single_store_optz.js
@@ -31,11 +31,11 @@ function g12(z) {
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = LoadParamInst %z
 // CHECK-NEXT:  %1 = CreateFunctionInst %w() : number
-// CHECK-NEXT:  %2 = CallInst %1 : closure, empty, empty, undefined : undefined
+// CHECK-NEXT:  %2 = CallInst %1 : closure, %w() : number, empty, undefined : undefined
 // CHECK-NEXT:  %3 = BinaryOperatorInst '>', %0, 0 : number
 // CHECK-NEXT:  %4 = CondBranchInst %3 : boolean, %BB1, %BB2
 // CHECK-NEXT:%BB1:
-// CHECK-NEXT:  %5 = CallInst %1 : closure, empty, empty, undefined : undefined
+// CHECK-NEXT:  %5 = CallInst %1 : closure, %w() : number, empty, undefined : undefined
 // CHECK-NEXT:  %6 = BranchInst %BB2
 // CHECK-NEXT:%BB2:
 // CHECK-NEXT:  %7 = ReturnInst undefined : undefined

--- a/test/Optimizer/stack-after-inline.js
+++ b/test/Optimizer/stack-after-inline.js
@@ -9,6 +9,7 @@
 // Perform stack promotion after inlining
 
 function f1(num) {
+    'use strict';
     function bar() {
         return num;
     }

--- a/test/Optimizer/type_infer_fun_returns.js
+++ b/test/Optimizer/type_infer_fun_returns.js
@@ -32,7 +32,7 @@ function g14(z) {
 // CHECK-NEXT:  %0 = LoadParamInst %z
 // CHECK-NEXT:  %1 = CreateFunctionInst %w() : number
 // CHECK-NEXT:  %2 = StoreFrameInst %1 : closure, [w] : closure
-// CHECK-NEXT:  %3 = CallInst %1 : closure, empty, empty, undefined : undefined
+// CHECK-NEXT:  %3 = CallInst %1 : closure, %w() : number, empty, undefined : undefined
 // CHECK-NEXT:  %4 = BinaryOperatorInst '>', %0, %3 : number
 // CHECK-NEXT:  %5 = CondBranchInst %4 : boolean, %BB1, %BB2
 // CHECK-NEXT:%BB1:

--- a/test/SourceMap/cjs-map/symbolicator-modules-test.sh
+++ b/test/SourceMap/cjs-map/symbolicator-modules-test.sh
@@ -15,7 +15,8 @@ HBC_FILE="$TMPDIR/out.hbc"
 RAW_TRACE="$TMPDIR/raw_trace.txt"
 SYM_TRACE="$TMPDIR/symbolicated_trace.txt"
 
-"$HERMES" -gc-sanitize-handles=0 -commonjs -output-source-map \
+# Disable inlining to make sure the stack trace is stable.
+"$HERMES" -gc-sanitize-handles=0 -commonjs -output-source-map -fno-inline \
   -emit-binary -out "$HBC_FILE" \
   "$SRCDIR"
 

--- a/test/hermes/cjs/subdir-segments-deltamode/base/foo/cjs-subdir-foo.js
+++ b/test/hermes/cjs/subdir-segments-deltamode/base/foo/cjs-subdir-foo.js
@@ -6,6 +6,7 @@
  */
 
 // RUN: true
+'use strict'
 
 print('foo: init');
 

--- a/test/hermes/cjs/subdir-segments-deltamode/update/foo/cjs-subdir-foo.js
+++ b/test/hermes/cjs/subdir-segments-deltamode/update/foo/cjs-subdir-foo.js
@@ -6,6 +6,7 @@
  */
 
 // RUN: true
+'use strict'
 
 print('foo: init');
 

--- a/test/hermes/cjs/subdir-segments/foo/cjs-subdir-foo.js
+++ b/test/hermes/cjs/subdir-segments/foo/cjs-subdir-foo.js
@@ -6,6 +6,7 @@
  */
 
 // RUN: true
+'use strict';
 
 print('foo: init');
 

--- a/unittests/IR/CMakeLists.txt
+++ b/unittests/IR/CMakeLists.txt
@@ -6,6 +6,7 @@
 set(IRSources
   BasicBlockTest.cpp
   BuilderTest.cpp
+  FunctionTest.cpp
   InstrTest.cpp
   IRUtilsTest.cpp
   IRVerifierTest.cpp

--- a/unittests/IR/FunctionTest.cpp
+++ b/unittests/IR/FunctionTest.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "hermes/AST/Context.h"
+#include "hermes/IR/CFG.h"
+#include "hermes/IR/IR.h"
+#include "hermes/IR/IRBuilder.h"
+#include "hermes/IR/Instrs.h"
+#include "hermes/Utils/Dumper.h"
+
+#include "gtest/gtest.h"
+
+using namespace hermes;
+
+namespace {
+
+TEST(FunctionTest, AttributesTest) {
+  Function::Attributes attr;
+  EXPECT_EQ("", attr.getDescriptionStr());
+  EXPECT_TRUE(attr.isEmpty());
+  attr.allCallsitesKnown = true;
+  EXPECT_EQ("[allCallsitesKnown]", attr.getDescriptionStr());
+  EXPECT_FALSE(attr.isEmpty());
+  attr.pure = true;
+  EXPECT_EQ("[allCallsitesKnown,pure]", attr.getDescriptionStr());
+  EXPECT_FALSE(attr.isEmpty());
+  attr.clear();
+  EXPECT_EQ("", attr.getDescriptionStr());
+  EXPECT_TRUE(attr.isEmpty());
+}
+
+} // end anonymous namespace


### PR DESCRIPTION
Summary:
Use the generated CallGraph to create an ordering to visit functions
in the inlining pass.

We start at any functions we can find which we don't think have any
known callsites, and seed the search with that first.
Using those as a starting point,
we use the postorder visitor from each function to try and ensure that
functions are visited before the callees for those functions,
which will be conducive to inlining.
This enables inlining sibling functions, as demonstrated in the test.

Then, we reorganize the pass itself to use the call graph and the
derived ordering on `Function`s, delete the code for figuring out
callsites ad-hoc, and preserve semantics by checking for `CallInst`
instead of some other instruction, and explicitly checking for recursion
because the call graph itself will register the callee (it is correct
to register the target operand, we just can't inline it, and technically
it's dead code anyway).

Differential Revision: D40962637

