### PR TITLE
Refine needsWriteBarrier to consider HV types

### DIFF
--- a/include/hermes/VM/GCBase.h
+++ b/include/hermes/VM/GCBase.h
@@ -1014,7 +1014,13 @@ class GCBase {
   }
   virtual bool dbgContains(const void *ptr) const = 0;
   virtual void trackReachable(CellKind kind, unsigned sz) {}
-  virtual bool needsWriteBarrier(void *loc, GCCell *value) = 0;
+  virtual bool needsWriteBarrier(const GCHermesValue *loc, HermesValue value)
+      const = 0;
+  virtual bool needsWriteBarrier(
+      const GCSmallHermesValue *loc,
+      SmallHermesValue value) const = 0;
+  virtual bool needsWriteBarrier(const GCPointerBase *loc, GCCell *value)
+      const = 0;
   /// \}
 #endif
 

--- a/include/hermes/VM/HadesGC.h
+++ b/include/hermes/VM/HadesGC.h
@@ -331,7 +331,12 @@ class HadesGC final : public GCBase {
   /// found reachable in a full GC.
   void trackReachable(CellKind kind, unsigned sz) override;
 
-  bool needsWriteBarrier(void *loc, GCCell *value) override;
+  bool needsWriteBarrier(const GCHermesValue *loc, HermesValue value)
+      const override;
+  bool needsWriteBarrier(const GCSmallHermesValue *loc, SmallHermesValue value)
+      const override;
+  bool needsWriteBarrier(const GCPointerBase *loc, GCCell *value)
+      const override;
   /// \}
 #endif
 

--- a/include/hermes/VM/HermesValue-inline.h
+++ b/include/hermes/VM/HermesValue-inline.h
@@ -54,11 +54,8 @@ inline void GCHermesValueBase<HVType>::set(HVType hv, GC &gc) {
     HERMES_SLOW_ASSERT(
         gc.validPointer(hv.getPointer(gc.getPointerBase())) &&
         "Setting an invalid pointer into a GCHermesValue");
-    assert(
-        NeedsBarriers::value ||
-        !gc.needsWriteBarrier(
-            this, static_cast<GCCell *>(hv.getPointer(gc.getPointerBase()))));
   }
+  assert(NeedsBarriers::value || !gc.needsWriteBarrier(this, hv));
   if (NeedsBarriers::value)
     gc.writeBarrier(this, hv);
   HVType::setNoBarrier(hv);

--- a/include/hermes/VM/MallocGC.h
+++ b/include/hermes/VM/MallocGC.h
@@ -216,7 +216,12 @@ class MallocGC final : public GCBase {
   bool validPointer(const void *p) const override;
   bool dbgContains(const void *p) const override;
 
-  bool needsWriteBarrier(void *loc, GCCell *value) override;
+  bool needsWriteBarrier(const GCHermesValue *loc, HermesValue value)
+      const override;
+  bool needsWriteBarrier(const GCSmallHermesValue *loc, SmallHermesValue value)
+      const override;
+  bool needsWriteBarrier(const GCPointerBase *loc, GCCell *value)
+      const override;
 #endif
 
 #ifdef HERMES_MEMORY_INSTRUMENTATION

--- a/lib/VM/gcs/HadesGC.cpp
+++ b/lib/VM/gcs/HadesGC.cpp
@@ -2162,7 +2162,34 @@ bool HadesGC::dbgContains(const void *p) const {
 
 void HadesGC::trackReachable(CellKind kind, unsigned sz) {}
 
-bool HadesGC::needsWriteBarrier(void *loc, GCCell *value) {
+bool HadesGC::needsWriteBarrier(const GCHermesValue *loc, HermesValue value)
+    const {
+  // Values in the YG never need a barrier.
+  if (inYoungGen(loc))
+    return false;
+  // If the old value is a pointer or a symbol, a snapshot barrier is needed.
+  if (loc->isPointer() || loc->isSymbol())
+    return true;
+  // If the new value is a pointer, a relocation barrier is needed.
+  if (value.isPointer())
+    return true;
+  return false;
+}
+bool HadesGC::needsWriteBarrier(
+    const GCSmallHermesValue *loc,
+    SmallHermesValue value) const {
+  // Values in the YG never need a barrier.
+  if (inYoungGen(loc))
+    return false;
+  // If the old value is a pointer or a symbol, a snapshot barrier is needed.
+  if (loc->isPointer() || loc->isSymbol())
+    return true;
+  // If the new value is a pointer, a relocation barrier is needed.
+  if (value.isPointer())
+    return true;
+  return false;
+}
+bool HadesGC::needsWriteBarrier(const GCPointerBase *loc, GCCell *value) const {
   return !inYoungGen(loc);
 }
 #endif

--- a/lib/VM/gcs/MallocGC.cpp
+++ b/lib/VM/gcs/MallocGC.cpp
@@ -539,7 +539,17 @@ bool MallocGC::dbgContains(const void *p) const {
   return isValid;
 }
 
-bool MallocGC::needsWriteBarrier(void *loc, GCCell *value) {
+bool MallocGC::needsWriteBarrier(const GCHermesValue *loc, HermesValue value)
+    const {
+  return false;
+}
+bool MallocGC::needsWriteBarrier(
+    const GCSmallHermesValue *loc,
+    SmallHermesValue value) const {
+  return false;
+}
+bool MallocGC::needsWriteBarrier(const GCPointerBase *loc, GCCell *value)
+    const {
   return false;
 }
 #endif


### PR DESCRIPTION
Summary:
We assert that whenever `NeedsBarriers` is set to false,
`needsWriteBarrier` must be false. However, the current implementation
of `needsWriteBarrier` in Hades is fairly rudimentary, it returns true
for all locations in the OG.

In SH, we would like to elide write barriers when the before and after
type of a `HermesValue` is known to not be a pointer or symbol type.
Allow `needsWriteBarrier` to consider this distinction.

Differential Revision: D42589793

