### PR TITLE
Update CMake version in E2E test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -562,7 +562,7 @@ jobs:
       - run:
           name: Setup dependencies
           command: |
-            (yes | sdkmanager "cmake;3.18.1" --verbose) || true
+            (yes | sdkmanager "cmake;3.22.1" --verbose) || true
       - checkout:
           path: hermes
       - run:


### PR DESCRIPTION
Summary: The RN build in the E2E test is lookign for a newer version of CMake. Update the version being installed.

Differential Revision: D42611110

