### PR TITLE
Update keys in Android CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,7 @@ jobs:
             yes | sdkmanager "cmake;3.18.1" &
             mkdir -p "$HERMES_WS_DIR" "$HERMES_WS_DIR/output"
             ln -sf "$PWD" "$HERMES_WS_DIR/hermes"
+            curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
             sudo apt-get update
             sudo apt-get install -y cmake ninja-build libicu-dev
             wait


### PR DESCRIPTION
Summary:
The image we are using no longer has up-to-date keys for fetching dependencies, breaking the Android build. Update the keys in the script.

Fixes this failure: https://app.circleci.com/pipelines/github/facebook/hermes/3871/workflows/5ed8c799-10b7-4e0d-8438-43d533ba7ee9/jobs/37104

Differential Revision: D42610931

