### PR TITLE
Run DCE after SimplifyCFG to remove unused local functions.

### DIFF
--- a/lib/Optimizer/PassManager/Pipeline.cpp
+++ b/lib/Optimizer/PassManager/Pipeline.cpp
@@ -52,6 +52,9 @@ void hermes::runFullOptimizationPasses(Module &M) {
   PM.addDCE();
 
   PM.addSimplifyCFG();
+  // SimplifyCFG may remove all callsites of a particular local function.
+  // Run DCE after SimplifyCFG to remove such functions if any.
+  PM.addDCE();
   PM.addStackPromotion();
   PM.addMem2Reg();
   PM.addStackPromotion();


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `main`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/HEAD/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.
-->

## Summary

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
-->

SimplifyCFG may result in unused local functions by optimising out all their callsites. TypeInference may not be able to finish analysing such functions because their captured variables will remain NoType.

Here is an example excerpted and abbreviated from https://github.com/facebook/react-native/blob/0.70-stable/Libraries/StyleSheet/processTransform.js

```
function moduleFactory(module) {
  function processTransform(list) {
    // To be simplified by SimplifyCFG.
    // Any code following this if statement is unreachable.
    if (true === true) {
      return list;
    }

    // Although `list.forEach()` gets removed,
    // the anonymous function itself still remains.
    list.forEach(function (item) {
      switch (item.key) {
        case "foo":
          foo(item.value); // TypeInference cannot find where foo comes from
          break;
        case "bar":
          bar(item.value); // The same for bar
          break;
        default:
          throw new Error("Invalid key: " + key);
      }
    });
  }

  function foo(value) {
    console.log("This is foo(): " + value);
  }

  function bar(value) {
    console.log("This is bar(): " + value);
  }

  module.exports = processTransform;
}
```

TypeInference will keep re-trying to infer `LoadFrameInst` for `foo` and `bar`.

```
Inferring LoadFrameInst
Missing type for operand 0 of LoadFrameInst(Variable)
Inferring LoadPropertyInst
Inferring CallInst
Missing type for operand 0 of CallInst(LoadFrameInst)
```

We might want to look into TypeInference so it can handle such cases, but running DCE after SimplifyCFG is anyway beneficial, hence this PR.

## Test Plan

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes the user interface.
-->

Tested with the above example, along with the unittests.