### PR TITLE
Remove uses of the LOCATION target property

### DIFF
--- a/API/hermes/CMakeLists.txt
+++ b/API/hermes/CMakeLists.txt
@@ -119,16 +119,16 @@ install(DIRECTORY "${PROJECT_SOURCE_DIR}/API/hermes" DESTINATION include
   PATTERN "synthtest" EXCLUDE)
 
 # Create debug symbols (dSYM) bundle for Apple platform dylibs/frameworks
-# Largely inspired by https://github.com/llvm/llvm-project/blob/6701993027f8af172d7ba697884459261b00e3c6/llvm/cmake/modules/AddLLVM.cmake#L1934-L1986
+# Largely inspired by https://github.com/llvm/llvm-project/blob/9a708855daeb6f70bbde7c2bc63e061ebaf072df/llvm/cmake/modules/AddLLVM.cmake#L2218-L2242
 if(HERMES_BUILD_APPLE_DSYM)
   if(CMAKE_CXX_FLAGS MATCHES "-flto")
     set(lto_object ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/libhermes-lto.o)
     set_property(TARGET libhermes APPEND_STRING PROPERTY LINK_FLAGS " -Wl,-object_path_lto,${lto_object}")
   endif()
 
-  get_target_property(DSYM_PATH libhermes LOCATION)
+  set(DSYM_PATH $<TARGET_FILE:libhermes>)
   if(HERMES_BUILD_APPLE_FRAMEWORK)
-    get_filename_component(DSYM_PATH ${DSYM_PATH} DIRECTORY)
+    set(DSYM_PATH $<TARGET_FILE_DIR:libhermes>)
   endif()
   set(DSYM_PATH "${DSYM_PATH}.dSYM")
 
@@ -137,7 +137,6 @@ if(HERMES_BUILD_APPLE_DSYM)
   endif()
   add_custom_command(TARGET libhermes POST_BUILD
     COMMAND ${CMAKE_DSYMUTIL} $<TARGET_FILE:libhermes> --out ${DSYM_PATH}
-    BYPRODUCTS ${DSYM_PATH}
   )
 
   if(HERMES_BUILD_APPLE_FRAMEWORK)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,13 +35,6 @@ if(POLICY CMP0022)
   cmake_policy(SET CMP0022 NEW)
 endif()
 
-# Allow reading the LOCATION property of a target to determine the eventual
-# location of build targets. This is needed when building the debugging symbols
-# bundles for Apple platforms.
-if (POLICY CMP0026)
-  cmake_policy(SET CMP0026 OLD)
-endif()
-
 # Has to be set before `project` as per documentation
 # https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_SYSROOT.html
 set(CMAKE_OSX_SYSROOT ${HERMES_APPLE_TARGET_PLATFORM})


### PR DESCRIPTION
Summary: Replace the use of the LOCATION target property with generator expressions. Also remove setting the ```CMP0026```  policy.

Reviewed By: cortinico

Differential Revision: D43155905

