### PR TITLE
Update BuildingAndRunning.md

### DIFF
--- a/doc/BuildingAndRunning.md
+++ b/doc/BuildingAndRunning.md
@@ -71,7 +71,7 @@ The primary binary is the `hermes` tool, which will be found at `build/bin/herme
 
 To run the Hermes test suite:
 
-    ninja check-hermes
+    cmake --build ./build --target check-hermes
 
 To run Hermes against the test262 suite, you need to have a Hermes binary built
 already and a clone of the [test262 repo](https://github.com/tc39/test262/):


### PR DESCRIPTION
As far as I can tell, `ninja check-hermes` does not work, or at least not without extra steps not mentioned in the docs

```
$ ninja check-hermes
ninja: error: loading 'build.ninja': No such file or directory
```

However this works:

```
cmake --build ./build --target check-hermes
```