### PR TITLE
fix: specify currency in locale identifier when formatting currency plural

### DIFF
--- a/lib/Platform/Intl/PlatformIntlApple.mm
+++ b/lib/Platform/Intl/PlatformIntlApple.mm
@@ -2468,10 +2468,8 @@ void NumberFormatApple::initializeNSFormatters() noexcept {
   // - compactDisplay is not supported.
   // - signDisplay is not supported.
   // - NSNumberFormatter has maximumIntegerDigits, which is 42 by default
-  auto nsLocale =
-      [NSLocale localeWithLocaleIdentifier:u16StringToNSString(dataLocale_)];
+  std::u16string nsLocaleStr = dataLocale_;
   nsNumberFormatter_ = [NSNumberFormatter new];
-  nsNumberFormatter_.locale = nsLocale;
   if (style_ == u"decimal") {
     nsNumberFormatter_.numberStyle = NSNumberFormatterDecimalStyle;
     if (notation_ == u"scientific") {
@@ -2479,7 +2477,7 @@ void NumberFormatApple::initializeNSFormatters() noexcept {
     }
   } else if (style_ == u"currency") {
     nsNumberFormatter_.numberStyle = NSNumberFormatterCurrencyStyle;
-    nsNumberFormatter_.currencyCode = u16StringToNSString(*currency_);
+    nsLocaleStr.append(u"@currency=").append(*currency_);
     if (currencyDisplay_ == u"code") {
       nsNumberFormatter_.numberStyle = NSNumberFormatterCurrencyISOCodeStyle;
     } else if (currencyDisplay_ == u"symbol") {
@@ -2507,6 +2505,9 @@ void NumberFormatApple::initializeNSFormatters() noexcept {
     nsNumberFormatter_.maximumSignificantDigits = significantDigits_->maximum;
   }
   nsNumberFormatter_.usesGroupingSeparator = useGrouping_;
+  auto nsLocale =
+      [NSLocale localeWithLocaleIdentifier:u16StringToNSString(nsLocaleStr)];
+  nsNumberFormatter_.locale = nsLocale;
   if (style_ == u"unit") {
     nsMeasurementFormatter_ = [NSMeasurementFormatter new];
     nsMeasurementFormatter_.numberFormatter = nsNumberFormatter_;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `main`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/HEAD/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.
-->

## Summary
Intl.NumberFormat does not respect the currency input when currencyDisplay is "name". Without currencyDisplay, currency is correctly taken into account.

Resolves https://github.com/facebook/hermes/issues/914

## Test Plan
Build Hermes and installed on RN application, tested against multiple currency/locale pairs. 

```
new Intl.NumberFormat('de-DE', {
  style: 'currency',
  currency,
  currencyDisplay: 'name',
}).format(2)
```

