### PR TITLE
Test test262 tests with computed-property-names feature

### DIFF
--- a/utils/testsuite/testsuite_skiplist.py
+++ b/utils/testsuite/testsuite_skiplist.py
@@ -46,7 +46,6 @@ SKIP_LIST = [
     "mjsunit/regress/regress-deopt-in-array-literal-spread.js",
     "mjsunit/regress/regress-crbug-621816.js",
     "mjsunit/computed-property-names-deopt.js",
-    "test262/test/language/expressions/object/computed-property-evaluation-order.js",
     "test262/test/language/module-code/eval-export-dflt-expr-err-eval.js",
     "test262/test/language/module-code/eval-export-dflt-expr-err-get-value.js",
     # Defines __proto__ multiple times in literal and expects it to throw.
@@ -217,6 +216,7 @@ SKIP_LIST = [
     "test262/test/language/expressions/dynamic-import/",
     "test262/test/language/expressions/import.meta/",
     "test262/test/language/expressions/new.target/",
+    "test262/test/language/expressions/object/cpn-obj-lit-computed-property-name-from-async-arrow-function-expression.js",
     "test262/test/language/expressions/object/method-definition/",
     "test262/test/language/expressions/super/",
     "test262/test/language/module-code/",
@@ -2009,7 +2009,6 @@ UNSUPPORTED_FEATURES = [
     "class-static-methods-private",
     "class-static-block",
     "class-methods-private",
-    "computed-property-names",
     "const",
     "destructuring-binding",
     "dynamic-import",


### PR DESCRIPTION

## Summary

Computed properties are part of the [officially supported features](https://hermesengine.dev/docs/language-features) so the corresponding test262 tests should be tested.

```diff
 | Results              |   FAIL   |
 |----------------------+----------|
 | Total                |    48692 |
-| Pass                 |    18716 |
+| Pass                 |    18809 |
 | Fail                 |      211 |
-| Skipped              |    26347 |
-| Permanently Skipped  |     3418 |
+| Skipped              |    26241 |
+| Permanently Skipped  |     3431 |
 | Pass Rate            |   98.89% |
 -----------------------------------
 | Failures             |          |
```


## Test Plan

1. Followed https://hermesengine.dev/docs/building-and-running#release-build
1. `hermes/utils/testsuite/run_testsuite.py -b hermes-release/bin/ test262/test/ > result.baseline.log`
1. checkout this branch
1. rebuild  
1. `hermes/utils/testsuite/run_testsuite.py -b hermes-release/bin/ test262/test/ > result.reference.log`