### PR TITLE
Increase default max stack size

### DIFF
--- a/public/hermes/Public/RuntimeConfig.h
+++ b/public/hermes/Public/RuntimeConfig.h
@@ -35,7 +35,7 @@ class PinnedHermesValue;
   F(constexpr, PinnedHermesValue *, RegisterStack, nullptr)            \
                                                                        \
   /* Register Stack Size */                                            \
-  F(constexpr, unsigned, MaxNumRegisters, 64 * 1024)                   \
+  F(constexpr, unsigned, MaxNumRegisters, 128 * 1024)                  \
                                                                        \
   /* Whether to allow eval and Function ctor */                        \
   F(constexpr, bool, EnableEval, true)                                 \


### PR DESCRIPTION
## Summary

As discussed in #135, the default stack size doesn't work for all use cases. In particular, when very large and complex bundles are loaded in dev mode.

This PR bumps the default stack size from `64*1024` (512kB) to `128*1024` (1MB). As suggested by @tmikov in this comment - https://github.com/facebook/hermes/issues/135#issuecomment-1444984528.

