### PR TITLE
Use a large register stack when testing for native overflow

### DIFF
--- a/lib/Support/OSCompatPosix.cpp
+++ b/lib/Support/OSCompatPosix.cpp
@@ -640,7 +640,7 @@ std::pair<const void *, size_t> thread_stack_bounds(unsigned gap) {
 
   // origin is now the lowest addressable byte.
   unsigned adjustedSize = gap < size ? size - gap : 0;
-  return {origin + adjustedSize, adjustedSize};
+  return {(char *)origin + size, adjustedSize};
 }
 
 #endif

--- a/test/shermes/native-overflow.js
+++ b/test/shermes/native-overflow.js
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// RUN: (! %shermes -fcheck-native-stack -exec %s 2>&1) | %FileCheck --match-full-lines %s
+// Restrict the native stack to ensure it overflows before the register stack.
+// RUN: (ulimit -s 512 && ! %shermes -fcheck-native-stack -exec %s 2>&1) | %FileCheck --match-full-lines %s
 // REQUIRES: check_native_stack
 
 function foo() {


### PR DESCRIPTION
Summary:
This test is flaky because the register stack will sometimes overflow
first. Add an option to configure the register stack size, and make it
very large so it no longer does so.

I also looked at setting the stack size via a linker flag, but it turns
out that the method we use for obtaining the stack size on the main
thread on macOS does not reflect that value. This seems to be a problem
for other language implementations as well. JSC does what we're doing,
and OpenJDK has some extra logic that falls back to a hard coded value.
So it seems wise not to tamper with the linker stack size for now.

Differential Revision: D44859336

