### PR TITLE
Remove register stack size override in hermes.cpp

### DIFF
--- a/API/hermes/hermes.cpp
+++ b/API/hermes/hermes.cpp
@@ -137,15 +137,6 @@ void hermesFatalErrorHandler(
 
 namespace {
 
-// Max size of the runtime's register stack.
-// The runtime register stack needs to be small enough to be allocated on the
-// native thread stack in Android (1MiB) and on MacOS's thread stack (512 KiB)
-// Calculated by: (thread stack size - size of runtime -
-// 8 memory pages for other stuff in the thread)
-static constexpr unsigned kMaxNumRegisters =
-    (512 * 1024 - sizeof(::hermes::vm::Runtime) - 4096 * 8) /
-    sizeof(::hermes::vm::PinnedHermesValue);
-
 void raw_ostream_append(llvh::raw_ostream &os) {}
 
 template <typename Arg0, typename... Args>
@@ -191,11 +182,7 @@ class HermesRuntimeImpl final : public HermesRuntime,
   HermesRuntimeImpl(const vm::RuntimeConfig &runtimeConfig)
       : hermesValues_(runtimeConfig.getGCConfig().getOccupancyTarget()),
         weakHermesValues_(runtimeConfig.getGCConfig().getOccupancyTarget()),
-        rt_(::hermes::vm::Runtime::create(
-            runtimeConfig.rebuild()
-                .withRegisterStack(nullptr)
-                .withMaxNumRegisters(kMaxNumRegisters)
-                .build())),
+        rt_(::hermes::vm::Runtime::create(runtimeConfig)),
         runtime_(*rt_),
         vmExperimentFlags_(runtimeConfig.getVMExperimentFlags()) {
 #ifdef HERMES_ENABLE_DEBUGGER

--- a/public/hermes/Public/RuntimeConfig.h
+++ b/public/hermes/Public/RuntimeConfig.h
@@ -35,7 +35,7 @@ class PinnedHermesValue;
   F(constexpr, PinnedHermesValue *, RegisterStack, nullptr)            \
                                                                        \
   /* Register Stack Size */                                            \
-  F(constexpr, unsigned, MaxNumRegisters, 1024 * 1024)                 \
+  F(constexpr, unsigned, MaxNumRegisters, 64 * 1024)                   \
                                                                        \
   /* Whether or not the JIT is enabled */                              \
   F(constexpr, bool, EnableJIT, false)                                 \

--- a/public/hermes/Public/RuntimeConfig.h
+++ b/public/hermes/Public/RuntimeConfig.h
@@ -35,7 +35,7 @@ class PinnedHermesValue;
   F(constexpr, PinnedHermesValue *, RegisterStack, nullptr)            \
                                                                        \
   /* Register Stack Size */                                            \
-  F(constexpr, unsigned, MaxNumRegisters, 64 * 1024)                   \
+  F(constexpr, unsigned, MaxNumRegisters, 128 * 1024)                  \
                                                                        \
   /* Whether or not the JIT is enabled */                              \
   F(constexpr, bool, EnableJIT, false)                                 \

--- a/tools/hermes/hermes.cpp
+++ b/tools/hermes/hermes.cpp
@@ -114,6 +114,7 @@ static int executeHBCBytecodeFromCL(
           .withEnableHermesInternal(cl::EnableHermesInternal)
           .withEnableHermesInternalTestMethods(
               cl::EnableHermesInternalTestMethods)
+          .withMaxNumRegisters(1024 * 1024)
           .build();
 
   options.basicBlockProfiling = cl::BasicBlockProfiling;

--- a/tools/hvm/hvm.cpp
+++ b/tools/hvm/hvm.cpp
@@ -128,6 +128,7 @@ int main(int argc, char **argv) {
           .withEnableHermesInternal(cl::EnableHermesInternal)
           .withEnableHermesInternalTestMethods(
               cl::EnableHermesInternalTestMethods)
+          .withMaxNumRegisters(1024 * 1024)
           .build();
 
   options.stabilizeInstructionCount = cl::StableInstructionCount;


### PR DESCRIPTION
Picks of 
* https://github.com/facebook/hermes/commit/03f2dffc1d0ef8b2360a6790ad425ce4013e4de3
* https://github.com/facebook/hermes/commit/1b759f40bd2f6bb72b2a353f0d9856fcbdbb981c

As per discussion here: https://github.com/reactwg/react-native-releases/discussions/62#discussioncomment-5597099