### PR TITLE
Replace isSimpleSideEffectFreeInstruction with canReorderAndMerge

### DIFF
--- a/include/hermes/IR/IR.h
+++ b/include/hermes/IR/IR.h
@@ -432,6 +432,25 @@ class SideEffect {
     return createExecute();
   }
 
+  /// Determine whether the given instruction modifies the state of the world in
+  /// any an observable way.
+  bool hasSideEffect() const {
+    // Note that we do not check ExecuteJS here because any observable
+    // side-effect of a call requires one of these other bits to be set.
+    return getWriteStack() || getWriteHeap() || getWriteFrame() || getThrow();
+  }
+
+  /// Determine if the instruction is pure. That is, whether separate
+  /// invocations of the instruction with the same operands will always yield
+  /// the same result, and will not modify the state of the world in any
+  /// observable way. Note that this excludes instructions that allocate (e.g.
+  /// AllocObject, CreateFunction) since they produce a different reference each
+  /// time.
+  bool isPure() const {
+    return !hasSideEffect() && !getReadStack() && !getReadHeap() &&
+        !getReadFrame() && getIdempotent();
+  }
+
   /// Helper functions to expose the SideEffectKind interface.
   /// TODO: Delete these once all instructions are migrated off SideEffectKind.
   bool mayExecute() const {

--- a/include/hermes/Optimizer/Scalar/Utils.h
+++ b/include/hermes/Optimizer/Scalar/Utils.h
@@ -63,10 +63,5 @@ bool deleteUnusedVariables(Module *M);
 /// remaining uses.
 /// \return true if anything was deleted, false otherwise.
 bool deleteUnusedFunctionsAndVariables(Module *M);
-
-/// \returns True if the instruction \p I has no side effects, can be combined
-/// with identical instructions or duplicated without changing semantics, and
-/// can be placed anywhere in the middle of a basic block.
-bool isSimpleSideEffectFreeInstruction(Instruction *I);
 } // namespace hermes
 #endif // HERMES_OPTIMIZER_SCALAR_UTILS_H

--- a/lib/Optimizer/Scalar/CSE.cpp
+++ b/lib/Optimizer/Scalar/CSE.cpp
@@ -45,7 +45,10 @@ struct CSEValue {
 
   /// Return true if we know how to CSE this instruction.
   static bool canHandle(Instruction *Inst) {
-    return isSimpleSideEffectFreeInstruction(Inst);
+    // Check that the instruction can be freely reordered and deduplicated, and
+    // that it is not a terminator.
+    return !llvh::isa<TerminatorInst>(Inst) && Inst->getSideEffect().isPure() &&
+        !Inst->getSideEffect().getFirstInBlock();
   }
 };
 } // end anonymous namespace

--- a/lib/Optimizer/Scalar/CodeMotion.cpp
+++ b/lib/Optimizer/Scalar/CodeMotion.cpp
@@ -115,7 +115,10 @@ static bool canHoistFromLoop(
     Instruction *inst,
     Instruction *branchInst,
     const DominanceInfo &dominance) {
-  if (!isSimpleSideEffectFreeInstruction(inst)) {
+  // Check whether the instruction is pure, and whether it has restrictions on
+  // where it can be placed within a block.
+  if (llvh::isa<TerminatorInst>(inst) || !inst->getSideEffect().isPure() ||
+      inst->getSideEffect().getFirstInBlock()) {
     return false;
   }
   for (int i = 0, e = inst->getNumOperands(); i < e; ++i) {

--- a/lib/Optimizer/Scalar/DCE.cpp
+++ b/lib/Optimizer/Scalar/DCE.cpp
@@ -40,13 +40,9 @@ static bool performFunctionDCE(Function *F) {
       // allow us to delete the current instruction.
       ++it;
 
-      // If the instruction writes to memory then we can't remove it. Notice
-      // that it is okay to delete instructions that only read memory and are
-      // unused.
-      auto se = I->getSideEffect();
-      bool observable = se.getWriteStack() || se.getWriteHeap() ||
-          se.getWriteFrame() || se.getThrow();
-      if (observable || llvh::isa<TerminatorInst>(I))
+      // Skip if the instruction has side effects that prevent us from deleting
+      // it, or if it is a terminator.
+      if (I->getSideEffect().hasSideEffect() || llvh::isa<TerminatorInst>(I))
         continue;
 
       // If some other instruction is using the result of this instruction then

--- a/lib/Optimizer/Scalar/Utils.cpp
+++ b/lib/Optimizer/Scalar/Utils.cpp
@@ -238,24 +238,4 @@ bool hermes::deleteUnusedFunctionsAndVariables(Module *M) {
   return changed;
 }
 
-bool hermes::isSimpleSideEffectFreeInstruction(Instruction *I) {
-  if (I->getSideEffect().mayReadOrWorse()) {
-    return false;
-  }
-  if (llvh::isa<UnaryOperatorInst>(I))
-    return true;
-  if (llvh::isa<BinaryOperatorInst>(I))
-    return true;
-  switch (I->getKind()) {
-    case ValueKind::GetNewTargetInstKind:
-    case ValueKind::HBCResolveEnvironmentKind:
-    case ValueKind::HBCLoadConstInstKind:
-    case ValueKind::HBCGetGlobalObjectInstKind:
-      return true;
-    default:
-      return false;
-  }
-  llvm_unreachable("unreachable");
-}
-
 #undef DEBUG_TYPE


### PR DESCRIPTION
Summary:
Replace the explicit list of instructions in
`isSimpleSideEffectFreeInstruction` with a check against the side
effects of a given instruction.

This results in three additional instructions being eligible for
optimisation:

`GetConstructedObjectInstKind`
`UnionNarrowTrustedInstKind`
`GetBuiltinClosureInstKind`

Differential Revision: D45022332

