### PR TITLE
Create prettier-plugin-hermes-parser package

### DIFF
--- a/tools/hermes-parser/js/.prettierignore
+++ b/tools/hermes-parser/js/.prettierignore
@@ -1,1 +1,2 @@
 dist
+jest.config.js

--- a/tools/hermes-parser/js/flow-api-translator/__tests__/flowToFlowDef-test.js
+++ b/tools/hermes-parser/js/flow-api-translator/__tests__/flowToFlowDef-test.js
@@ -410,27 +410,27 @@ describe('flowToFlowDef', () => {
     it('basic type parameter', async () => {
       await expectTranslate(
         `export const foo: number = 1;`,
-        `declare export var foo: number;`,
+        `declare export const foo: number;`,
       );
     });
     it('basic typecast', async () => {
       await expectTranslate(
         `export const foo = (1: number);`,
-        `declare export var foo: number;`,
+        `declare export const foo: number;`,
       );
     });
     it('prefer type parameter', async () => {
       await expectTranslate(
         `export const foo: number = (1: any);`,
-        `declare export var foo: number;`,
+        `declare export const foo: number;`,
       );
     });
     it('with dependency', async () => {
       await expectTranslate(
         `const foo: number = 1;
          export const bar: typeof foo = 1;`,
-        `declare var foo: number;
-         declare export var bar: typeof foo;`,
+        `declare const foo: number;
+         declare export const bar: typeof foo;`,
       );
     });
   });
@@ -441,7 +441,7 @@ describe('flowToFlowDef', () => {
     it('local', async () => {
       await expectTranslateUnchanged(
         `enum Foo {}
-         declare export var bar: Foo;`,
+         declare export const bar: Foo;`,
       );
     });
   });
@@ -449,7 +449,7 @@ describe('flowToFlowDef', () => {
     it('basic', async () => {
       await expectTranslateUnchanged(
         `declare class Foo {}
-         declare export var bar: Foo;`,
+         declare export const bar: Foo;`,
       );
     });
     it('complex', async () => {
@@ -474,7 +474,7 @@ describe('flowToFlowDef', () => {
     ): Promise<void> {
       await expectTranslate(
         `export const expr = ${expectExprCode};`,
-        `declare export var expr: ${toBeExprCode};`,
+        `declare export const expr: ${toBeExprCode};`,
       );
     }
     describe('Identifier', () => {

--- a/tools/hermes-parser/js/flow-api-translator/package.json
+++ b/tools/hermes-parser/js/flow-api-translator/package.json
@@ -18,7 +18,7 @@
     "hermes-transform": "0.11.1"
   },
   "peerDependencies": {
-    "prettier": "^2.7.1"
+    "prettier": "^3.0.0 || ^2.7.1"
   },
   "files": [
     "dist",

--- a/tools/hermes-parser/js/flow-typed/prettier.js
+++ b/tools/hermes-parser/js/flow-typed/prettier.js
@@ -840,3 +840,18 @@ declare module 'prettier' {
     },
   };
 }
+
+declare module 'prettier/plugins/flow' {
+  declare type AST = any;
+
+  declare export var parsers: {
+    flow: {
+      astFormat: string,
+      parse(text: string, parsers: any, options: any): AST,
+      hasPragma?: ((text: string) => boolean) | void,
+      locStart: (node: AST) => number,
+      locEnd: (node: AST) => number,
+      preprocess?: ((text: string, options: any) => string) | void,
+    },
+  };
+}

--- a/tools/hermes-parser/js/hermes-parser/src/index.js
+++ b/tools/hermes-parser/js/hermes-parser/src/index.js
@@ -90,3 +90,4 @@ export * from './traverse/getVisitorKeys';
 export {FlowVisitorKeys};
 export * as astArrayMutationHelpers from './transform/astArrayMutationHelpers';
 export * as astNodeMutationHelpers from './transform/astNodeMutationHelpers';
+export {default as mutateESTreeASTForPrettier} from './utils/mutateESTreeASTForPrettier';

--- a/tools/hermes-parser/js/hermes-parser/src/transform/SimpleTransform.js
+++ b/tools/hermes-parser/js/hermes-parser/src/transform/SimpleTransform.js
@@ -74,6 +74,7 @@ export class SimpleTransform {
         }
       },
       leave(_node: ESNode) {},
+      visitorKeys: options.visitorKeys,
     });
     return resultRootNode;
   }

--- a/tools/hermes-parser/js/hermes-parser/src/utils/mutateESTreeASTForPrettier.js
+++ b/tools/hermes-parser/js/hermes-parser/src/utils/mutateESTreeASTForPrettier.js
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+'use strict';
+
+import type {ESNode, Program} from 'hermes-estree';
+import type {VisitorKeysType} from '../traverse/getVisitorKeys';
+import {SimpleTransform} from '../transform/SimpleTransform';
+
+// https://github.com/prettier/prettier/blob/d962466a828f8ef51435e3e8840178d90b7ec6cd/src/language-js/parse/postprocess/index.js#L161-L182
+function transformChainExpression(node: ESNode): ESNode {
+  switch (node.type) {
+    case 'CallExpression':
+      // $FlowExpectedError[cannot-spread-interface]
+      return {
+        ...node,
+        type: 'OptionalCallExpression',
+        callee: transformChainExpression(node.callee),
+      };
+
+    case 'MemberExpression':
+      // $FlowExpectedError[cannot-spread-interface]
+      return {
+        ...node,
+        type: 'OptionalMemberExpression',
+        object: transformChainExpression(node.object),
+      };
+    // No default
+  }
+
+  return node;
+}
+
+export default function mutate(
+  rootNode: Program,
+  visitorKeys: ?VisitorKeysType,
+): void {
+  // Since we don't return the result of `transform` we need to be careful not to replace the Program root node.
+  SimpleTransform.transform(rootNode, {
+    transform(node): ESNode | null {
+      // prettier fully expects the parent pointers are NOT set and
+      // certain cases can crash due to prettier infinite-looping
+      // whilst naively traversing the parent property
+      // https://github.com/prettier/prettier/issues/11793
+      if (node.parent) {
+        // $FlowExpectedError[cannot-write]
+        delete node.parent;
+      }
+
+      // prettier currently relies on the AST being in the old-school, deprecated AST format for optional chaining
+      // so we have to apply their transform to our AST so it can actually format it.
+      // Note: Only needed for prettier V2, this is supported in V3
+      if (node.type === 'ChainExpression') {
+        return transformChainExpression(node.expression);
+      }
+
+      // Prettier currently relies on comparing the `node` vs `node.value` start positions to know if an
+      // `ObjectTypeProperty` is a method or not (instead of using the `node.method` boolean). To correctly print
+      // the node when its not a method we need the start position to be different from the `node.value`s start
+      // position.
+      if (node.type === 'ObjectTypeProperty') {
+        if (
+          node.method === false &&
+          node.kind === 'init' &&
+          node.range[0] === 1 &&
+          node.value.range[0] === 1
+        ) {
+          // $FlowExpectedError[cannot-write]
+          // $FlowExpectedError[cannot-spread-interface]
+          node.value = {
+            ...node.value,
+            range: [2, node.value.range[1]],
+          };
+        }
+        return node;
+      }
+
+      // Prettier currently relies on comparing the the start positions to know if the import/export specifier should have a
+      // rename (eg `Name` vs `Name as Name`) when the name is exactly the same
+      // So we need to ensure that the range is always the same to avoid the useless code printing
+      if (node.type === 'ImportSpecifier') {
+        if (node.local.name === node.imported.name) {
+          if (node.local.range == null) {
+            // for our TS-ast printing which has no locs
+            // $FlowExpectedError[cannot-write]
+            node.local.range = [0, 0];
+          }
+          // $FlowExpectedError[cannot-write]
+          node.imported.range = [...node.local.range];
+        }
+        return node;
+      }
+
+      if (node.type === 'ExportSpecifier') {
+        if (node.local.name === node.exported.name) {
+          if (node.local.range == null) {
+            // for our TS-ast printing which has no locs
+            // $FlowExpectedError[cannot-write]
+            node.local.range = [0, 0];
+          }
+          // $FlowExpectedError[cannot-write]
+          node.exported.range = [...node.local.range];
+        }
+        return node;
+      }
+
+      return node;
+    },
+    visitorKeys,
+  });
+}

--- a/tools/hermes-parser/js/hermes-transform/package.json
+++ b/tools/hermes-parser/js/hermes-transform/package.json
@@ -17,7 +17,7 @@
     "hermes-parser": "0.11.1"
   },
   "peerDependencies": {
-    "prettier": "^2.7.1"
+    "prettier": "^3.0.0 || ^2.7.1"
   },
   "files": [
     "dist",

--- a/tools/hermes-parser/js/hermes-transform/src/transform/print.js
+++ b/tools/hermes-parser/js/hermes-transform/src/transform/print.js
@@ -11,9 +11,9 @@
 'use strict';
 
 import type {MaybeDetachedNode} from '../detachedNode';
-import type {Program, ESNode} from 'hermes-estree';
+import type {Program} from 'hermes-estree';
 
-import {SimpleTraverser} from 'hermes-parser';
+import {mutateESTreeASTForPrettier} from 'hermes-parser';
 import * as prettier from 'prettier';
 import {
   addCommentsToNode,
@@ -44,7 +44,7 @@ export async function print(
   }
 
   // Fix up the AST to match what prettier expects.
-  mutateASTForPrettier(program, visitorKeys);
+  mutateESTreeASTForPrettier(program, visitorKeys);
 
   // we need to delete the comments prop or else prettier will do
   // its own attachment pass after the mutation and duplicate the
@@ -99,93 +99,6 @@ export async function print(
   }
 }
 
-function mutateASTForPrettier(
-  rootNode: ESNode,
-  visitorKeys: ?VisitorKeysType,
-): void {
-  SimpleTraverser.traverse(rootNode, {
-    enter(node) {
-      // prettier fully expects the parent pointers are NOT set and
-      // certain cases can crash due to prettier infinite-looping
-      // whilst naively traversing the parent property
-      // https://github.com/prettier/prettier/issues/11793
-      // $FlowExpectedError[cannot-write]
-      delete node.parent;
-
-      // prettier currently relies on the AST being in the old-school, deprecated AST format for optional chaining
-      // so we have to apply their transform to our AST so it can actually format it.
-      if (node.type === 'ChainExpression') {
-        const newNode = transformChainExpression(node.expression);
-
-        // Clear out existing properties
-        for (const k of Object.keys(node)) {
-          // $FlowExpectedError[prop-missing]
-          delete node[k];
-        }
-
-        // Traverse `newNode` and its children.
-        mutateASTForPrettier(newNode, visitorKeys);
-
-        // Overwrite `node` to match `newNode` while retaining the reference.
-        // $FlowExpectedError[prop-missing]
-        // $FlowExpectedError[cannot-write]
-        Object.assign(node, newNode);
-
-        // Skip traversing the existing nodes since we are replacing them.
-        throw SimpleTraverser.Skip;
-      }
-
-      // Prettier currently relies on comparing the `node` vs `node.value` start positions to know if an
-      // `ObjectTypeProperty` is a method or not (instead of using the `node.method` boolean). To correctly print
-      // the node when its not a method we need the start position to be different from the `node.value`s start
-      // position.
-      if (node.type === 'ObjectTypeProperty') {
-        if (
-          node.method === false &&
-          node.kind === 'init' &&
-          node.range[0] === 1 &&
-          node.value.range[0] === 1
-        ) {
-          // $FlowExpectedError[cannot-write]
-          // $FlowExpectedError[cannot-spread-interface]
-          node.value = {
-            ...node.value,
-            range: [2, node.value.range[1]],
-          };
-        }
-      }
-
-      // Prettier currently relies on comparing the the start positions to know if the import/export specifier should have a
-      // rename (eg `Name` vs `Name as Name`) when the name is exactly the same
-      // So we need to ensure that the range is always the same to avoid the useless code printing
-      if (node.type === 'ImportSpecifier') {
-        if (node.local.name === node.imported.name) {
-          if (node.local.range == null) {
-            // for our TS-ast printing which has no locs
-            // $FlowExpectedError[cannot-write]
-            node.local.range = [0, 0];
-          }
-          // $FlowExpectedError[cannot-write]
-          node.imported.range = [...node.local.range];
-        }
-      }
-      if (node.type === 'ExportSpecifier') {
-        if (node.local.name === node.exported.name) {
-          if (node.local.range == null) {
-            // for our TS-ast printing which has no locs
-            // $FlowExpectedError[cannot-write]
-            node.local.range = [0, 0];
-          }
-          // $FlowExpectedError[cannot-write]
-          node.exported.range = [...node.local.range];
-        }
-      }
-    },
-    leave() {},
-    visitorKeys,
-  });
-}
-
 function getPrettierMajorVersion(): '3' | '2' | 'UNSUPPORTED' {
   const {version} = prettier;
 
@@ -198,28 +111,4 @@ function getPrettierMajorVersion(): '3' | '2' | 'UNSUPPORTED' {
   }
 
   return 'UNSUPPORTED';
-}
-
-// https://github.com/prettier/prettier/blob/d962466a828f8ef51435e3e8840178d90b7ec6cd/src/language-js/parse/postprocess/index.js#L161-L182
-function transformChainExpression(node: ESNode): ESNode {
-  switch (node.type) {
-    case 'CallExpression':
-      // $FlowExpectedError[cannot-spread-interface]
-      return {
-        ...node,
-        type: 'OptionalCallExpression',
-        callee: transformChainExpression(node.callee),
-      };
-
-    case 'MemberExpression':
-      // $FlowExpectedError[cannot-spread-interface]
-      return {
-        ...node,
-        type: 'OptionalMemberExpression',
-        object: transformChainExpression(node.object),
-      };
-    // No default
-  }
-
-  return node;
 }

--- a/tools/hermes-parser/js/jest.config.js
+++ b/tools/hermes-parser/js/jest.config.js
@@ -27,6 +27,8 @@ module.exports = {
   // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
   transformIgnorePatterns: ['/node_modules/', '/dist/'],
 
+  setupFiles: ['<rootDir>/scripts/jest-config/setup-mocks.js'],
+
   // These mappings tell jest how to find the source files directly instead of using the built `dist` files.
   // This allows us to run tests without first doing a build.
   //

--- a/tools/hermes-parser/js/package.json
+++ b/tools/hermes-parser/js/package.json
@@ -16,14 +16,14 @@
     "eslint-plugin-fb-flow": "^0.0.4",
     "eslint-plugin-flowtype": "^8.0.3",
     "eslint-plugin-jest": "^25.2.4",
-    "eslint-plugin-prettier": "^4.0.0",
+    "eslint-plugin-prettier": "5.0.0-alpha.1",
     "flow-bin": "^0.206.0",
     "glob": "^8.0.3",
     "jest": "^29.2.2",
     "jest-specific-snapshot": "^5.0.0",
     "mkdirp": "^1.0.4",
     "patch-package": "^6.5.0",
-    "prettier": "2.7.1"
+    "prettier": "3.0.0-alpha.11"
   },
   "resolutions": {
     "jest-snapshot": "^29.2.2"

--- a/tools/hermes-parser/js/prettier-plugin-hermes-parser/LICENSE
+++ b/tools/hermes-parser/js/prettier-plugin-hermes-parser/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tools/hermes-parser/js/prettier-plugin-hermes-parser/README.md
+++ b/tools/hermes-parser/js/prettier-plugin-hermes-parser/README.md
@@ -1,0 +1,26 @@
+# prettier-plugin-hermes-parser
+
+Hermes parser plugin for [Prettier](https://prettier.io/). This plugin enables Prettier to use `hermes-parser` as it's parser. Since Hermes parser uses C++ compiled to WASM it is significantly faster than alternatives such as `flow` or `babel-flow` by as much as 10x.
+
+## Usage
+
+Prettier will automatically load this plugin if you install it in the same `node_modules` directory where Prettier is located.
+
+More details on using Prettier plugins: https://prettier.io/docs/en/plugins.html#using-plugins
+
+To then use the parser you will need to instruct Prettier to use `hermes` as the parser for your required files:
+
+```
+// .prettierrc
+{
+  "overrides": [
+    {
+      "files": ["*.js", "*.jsx", "*.flow"],
+      "options": {
+        "parser": "hermes"
+      }
+    }
+  ]
+}
+```
+More details on configuring Prettier parsers: https://prettier.io/docs/en/configuration.html#setting-the-parserdocsenoptionshtmlparser-option

--- a/tools/hermes-parser/js/prettier-plugin-hermes-parser/__tests__/prettier-plugin-hermes-parser-test.js
+++ b/tools/hermes-parser/js/prettier-plugin-hermes-parser/__tests__/prettier-plugin-hermes-parser-test.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+// $FlowExpectedError[cannot-resolve-module]
+import prettierConfig from '../../.prettierrc.json';
+
+import * as prettier from 'prettier';
+import * as prettierPluginHermesParser from '../src/index.js';
+
+describe('prettier-plugin-hermes-parser', () => {
+  it('uses plugin', async () => {
+    const code = `const A: number = 1;`;
+    const parseSpy = jest.spyOn(
+      prettierPluginHermesParser.parsers.hermes,
+      'parse',
+    );
+    const output = await prettier.format(code, {
+      ...prettierConfig,
+      parser: 'hermes',
+      requirePragma: false,
+      plugins: [prettierPluginHermesParser],
+    });
+    expect(parseSpy).toHaveBeenCalledTimes(1);
+    expect(output).toBe(output);
+  });
+});

--- a/tools/hermes-parser/js/prettier-plugin-hermes-parser/package.json
+++ b/tools/hermes-parser/js/prettier-plugin-hermes-parser/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "prettier-plugin-hermes-parser",
+  "version": "0.11.1",
+  "description": "Hermes parser plugin for Prettier.",
+  "main": "dist/index.js",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:facebook/hermes.git"
+  },
+  "dependencies": {
+    "hermes-parser": "0.11.1"
+  },
+  "peerDependencies": {
+    "prettier": "^3.0.0"
+  },
+  "files": [
+    "dist",
+    "LICENCE",
+    "README.md"
+  ]
+}

--- a/tools/hermes-parser/js/prettier-plugin-hermes-parser/src/index.js
+++ b/tools/hermes-parser/js/prettier-plugin-hermes-parser/src/index.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+import type {Program} from 'hermes-estree';
+
+import {parse, mutateESTreeASTForPrettier} from 'hermes-parser';
+
+import {parsers as flowPluginParsers} from 'prettier/plugins/flow';
+
+// copied from https://github.com/prettier/prettier/blob/20ab6d6f1c5bd774621230b493a3b71d39383a2c/src/language-js/parse/utils/replace-hashbang.js
+function replaceHashbang(text: string): string {
+  if (text.charAt(0) === '#' && text.charAt(1) === '!') {
+    return '//' + text.slice(2);
+  }
+
+  return text;
+}
+
+export const parsers = {
+  hermes: {
+    ...flowPluginParsers.flow,
+    parse(originalText: string): Program {
+      const textToParse = replaceHashbang(originalText);
+
+      const result = parse(textToParse, {
+        allowReturnOutsideFunction: true,
+        enableExperimentalComponentSyntax: true,
+        flow: 'all',
+        sourceType: 'module',
+        tokens: true,
+      });
+
+      mutateESTreeASTForPrettier(result);
+
+      return result;
+    },
+  },
+};

--- a/tools/hermes-parser/js/scripts/build.sh
+++ b/tools/hermes-parser/js/scripts/build.sh
@@ -8,7 +8,7 @@ set -xe -o pipefail
 
 THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-PACKAGES=(hermes-estree hermes-parser hermes-eslint hermes-transform flow-api-translator)
+PACKAGES=(hermes-estree hermes-parser hermes-eslint hermes-transform prettier-plugin-hermes-parser)
 
 # Yarn install all packages
 yarn install

--- a/tools/hermes-parser/js/scripts/jest-config/setup-mocks.js
+++ b/tools/hermes-parser/js/scripts/jest-config/setup-mocks.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
+/**
+ * Prettier v3 uses import (cjs/mjs) file formats that jest-runtime does not
+ * support. To work around this we need to bypass the jest module system by
+ * using the orginal node `require` function.
+ */
+jest.mock('prettier', () => {
+  const module = jest.requireActual('module');
+  return module.prototype.require(require.resolve('prettier'));
+});

--- a/tools/hermes-parser/js/scripts/utils/scriptUtils.js
+++ b/tools/hermes-parser/js/scripts/utils/scriptUtils.js
@@ -93,7 +93,8 @@ type Package =
   | 'hermes-estree'
   | 'hermes-parser'
   | 'hermes-transform'
-  | 'flow-api-translator';
+  | 'flow-api-translator'
+  | 'prettier-plugin-hermes-parser';
 
 type ArtifactOptions = $ReadOnly<{
   code: string,

--- a/tools/hermes-parser/js/scripts/utils/scriptUtils.js
+++ b/tools/hermes-parser/js/scripts/utils/scriptUtils.js
@@ -103,30 +103,34 @@ type ArtifactOptions = $ReadOnly<{
   file: string,
 }>;
 
-export function formatAndWriteDistArtifact(opts: ArtifactOptions): void {
-  formatAndWriteArtifact({
+export async function formatAndWriteDistArtifact(
+  opts: ArtifactOptions,
+): Promise<void> {
+  await formatAndWriteArtifact({
     ...opts,
     file: path.join('dist', opts.file),
   });
 }
-export function formatAndWriteSrcArtifact(opts: ArtifactOptions): void {
-  formatAndWriteArtifact({
+export async function formatAndWriteSrcArtifact(
+  opts: ArtifactOptions,
+): Promise<void> {
+  await formatAndWriteArtifact({
     ...opts,
     file: path.join('src', opts.file),
   });
 }
 
-function formatAndWriteArtifact({
+async function formatAndWriteArtifact({
   code: code_,
   flow = 'loose',
   package: pkg,
   file,
-}: ArtifactOptions): void {
+}: ArtifactOptions): Promise<void> {
   // make sure the code has a header
   const code = code_.slice(0, 3) === '/**' ? code_ : HEADER(flow) + code_;
 
   // Format the file
-  const formattedContents = prettier.format(code, {
+  const formattedContents = await prettier.format(code, {
     ...prettierConfig,
     parser: 'flow',
   });

--- a/tools/hermes-parser/js/yarn.lock
+++ b/tools/hermes-parser/js/yarn.lock
@@ -1631,6 +1631,18 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@pkgr/utils@^2.3.1":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@pkgr/utils/-/utils-2.4.0.tgz#b6373d2504aedaf2fc7cdf2d13ab1f48fa5f12d5"
+  integrity sha512-2OCURAmRtdlL8iUDTypMrrxfwe8frXTeXaxGsVOaYtc/wrUyk8Z/0OBetM7cdlsy7ZFWlMX72VogKeh+A4Xcjw==
+  dependencies:
+    cross-spawn "^7.0.3"
+    fast-glob "^3.2.12"
+    is-glob "^4.0.3"
+    open "^9.1.0"
+    picocolors "^1.0.0"
+    tslib "^2.5.0"
+
 "@sinclair/typebox@^0.24.1":
   version "0.24.51"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.51.tgz#645f33fe4e02defe26f2f5c0410e1c094eac7f5f"
@@ -2004,10 +2016,22 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+big-integer@^1.6.44:
+  version "1.6.51"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
+  integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
+
 binary-extensions@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.1.0.tgz#30fa40c9e7fe07dbc895678cd287024dea241dd9"
   integrity sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==
+
+bplist-parser@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/bplist-parser/-/bplist-parser-0.2.0.tgz#43a9d183e5bf9d545200ceac3e712f79ebbe8d0e"
+  integrity sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==
+  dependencies:
+    big-integer "^1.6.44"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -2074,6 +2098,13 @@ buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
+bundle-name@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/bundle-name/-/bundle-name-3.0.0.tgz#ba59bcc9ac785fb67ccdbf104a2bf60c099f0e1a"
+  integrity sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==
+  dependencies:
+    run-applescript "^5.0.0"
 
 call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
@@ -2292,6 +2323,29 @@ deepmerge@^4.2.2:
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
 
+default-browser-id@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/default-browser-id/-/default-browser-id-3.0.0.tgz#bee7bbbef1f4e75d31f98f4d3f1556a14cea790c"
+  integrity sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==
+  dependencies:
+    bplist-parser "^0.2.0"
+    untildify "^4.0.0"
+
+default-browser@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/default-browser/-/default-browser-4.0.0.tgz#53c9894f8810bf86696de117a6ce9085a3cbc7da"
+  integrity sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==
+  dependencies:
+    bundle-name "^3.0.0"
+    default-browser-id "^3.0.0"
+    execa "^7.1.1"
+    titleize "^3.0.0"
+
+define-lazy-prop@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz#dbb19adfb746d7fc6d734a06b72f4a00d021255f"
+  integrity sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==
+
 define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
@@ -2450,12 +2504,13 @@ eslint-plugin-jest@^25.2.4:
   dependencies:
     "@typescript-eslint/experimental-utils" "^5.0.0"
 
-eslint-plugin-prettier@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz#8b99d1e4b8b24a762472b4567992023619cb98e0"
-  integrity sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==
+eslint-plugin-prettier@5.0.0-alpha.1:
+  version "5.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0-alpha.1.tgz#fc81f9041497b2ee79b777a3ae52006622624097"
+  integrity sha512-VB20LzLKsHC19yRtxyr73OFJexGaIm8dkODwtUB5qwFrqRhswr/J624dMxCSBe6Dyx3993dbm2jr+rwJ9yoPhA==
   dependencies:
     prettier-linter-helpers "^1.0.0"
+    synckit "^0.8.5"
 
 eslint-scope@^5.1.1:
   version "5.1.1"
@@ -2612,6 +2667,21 @@ execa@^5.0.0:
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
 
+execa@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-7.1.1.tgz#3eb3c83d239488e7b409d48e8813b76bb55c9c43"
+  integrity sha512-wH0eMf/UXckdUYnO21+HDztteVv05rq2GXksxT4fCGeHkBhw1DROXh40wcjMcRqDOWE7iPJ4n3M7e2+YFP+76Q==
+  dependencies:
+    cross-spawn "^7.0.3"
+    get-stream "^6.0.1"
+    human-signals "^4.3.0"
+    is-stream "^3.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^5.1.0"
+    onetime "^6.0.0"
+    signal-exit "^3.0.7"
+    strip-final-newline "^3.0.0"
+
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
@@ -2642,6 +2712,17 @@ fast-glob@^3.1.1:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
   integrity sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
+fast-glob@^3.2.12:
+  version "3.2.12"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
+  integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -2804,7 +2885,7 @@ get-package-type@^0.1.0:
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
 
-get-stream@^6.0.0:
+get-stream@^6.0.0, get-stream@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
@@ -2927,6 +3008,11 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
+human-signals@^4.3.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-4.3.1.tgz#ab7f811e851fca97ffbd2c1fe9a958964de321b2"
+  integrity sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==
+
 ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
@@ -3045,6 +3131,11 @@ is-docker@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
   integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
 
+is-docker@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-3.0.0.tgz#90093aa3106277d8a77a5910dbae71747e15a200"
+  integrity sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -3066,6 +3157,13 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-inside-container@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-inside-container/-/is-inside-container-1.0.0.tgz#e81fba699662eb31dbdaf26766a61d4814717ea4"
+  integrity sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==
+  dependencies:
+    is-docker "^3.0.0"
 
 is-negative-zero@^2.0.1:
   version "2.0.1"
@@ -3109,6 +3207,11 @@ is-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
   integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
 
+is-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-3.0.0.tgz#e6bfd7aa6bef69f4f472ce9bb681e3e57b4319ac"
+  integrity sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==
+
 is-string@^1.0.5, is-string@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.7.tgz#0dd12bf2006f255bb58f695110eff7491eebc0fd"
@@ -3130,7 +3233,7 @@ is-weakref@^1.0.1:
   dependencies:
     call-bind "^1.0.0"
 
-is-wsl@^2.1.1:
+is-wsl@^2.1.1, is-wsl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
@@ -3754,6 +3857,11 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
+mimic-fn@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-4.0.0.tgz#60a90550d5cb0b239cca65d893b1a53b29871ecc"
+  integrity sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==
+
 minimatch@^3.0.4:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
@@ -3843,6 +3951,13 @@ npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
+npm-run-path@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-5.1.0.tgz#bc62f7f3f6952d9894bd08944ba011a6ee7b7e00"
+  integrity sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==
+  dependencies:
+    path-key "^4.0.0"
+
 object-inspect@^1.11.0, object-inspect@^1.9.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.11.0.tgz#9dceb146cedd4148a0d9e51ab88d34cf509922b1"
@@ -3886,6 +4001,13 @@ onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
+onetime@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-6.0.0.tgz#7c24c18ed1fd2e9bca4bd26806a33613c77d34b4"
+  integrity sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==
+  dependencies:
+    mimic-fn "^4.0.0"
+
 open@^7.4.2:
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
@@ -3893,6 +4015,16 @@ open@^7.4.2:
   dependencies:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
+
+open@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-9.1.0.tgz#684934359c90ad25742f5a26151970ff8c6c80b6"
+  integrity sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==
+  dependencies:
+    default-browser "^4.0.0"
+    define-lazy-prop "^3.0.0"
+    is-inside-container "^1.0.0"
+    is-wsl "^2.2.0"
 
 optionator@^0.9.1:
   version "0.9.1"
@@ -4011,6 +4143,11 @@ path-key@^3.0.0, path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
+path-key@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-4.0.0.tgz#295588dc3aee64154f877adb9d780b81c554bf18"
+  integrity sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==
+
 path-parse@^1.0.6, path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
@@ -4079,10 +4216,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
-  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
+prettier@3.0.0-alpha.11:
+  version "3.0.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.0-alpha.11.tgz#fb6f9c7b4495fcc8c70b6633de885bf38b8585af"
+  integrity sha512-/x61/kcsjjU8kUEDKnn8PtqRzMXROg68KbUOtRC09oOQ3Vs6Bjwz7tabF98xu/K/RP/jZzWIvxphWr881DaokQ==
 
 pretty-format@^29.2.1:
   version "29.2.1"
@@ -4248,6 +4385,13 @@ rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
+
+run-applescript@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/run-applescript/-/run-applescript-5.0.0.tgz#e11e1c932e055d5c6b40d98374e0268d9b11899c"
+  integrity sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==
+  dependencies:
+    execa "^5.0.0"
 
 run-parallel@^1.1.9:
   version "1.2.0"
@@ -4445,6 +4589,11 @@ strip-final-newline@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
+strip-final-newline@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-3.0.0.tgz#52894c313fbff318835280aed60ff71ebf12b8fd"
+  integrity sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==
+
 strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
@@ -4476,6 +4625,14 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+synckit@^0.8.5:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.8.5.tgz#b7f4358f9bb559437f9f167eb6bc46b3c9818fa3"
+  integrity sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==
+  dependencies:
+    "@pkgr/utils" "^2.3.1"
+    tslib "^2.5.0"
+
 table@^6.0.9:
   version "6.7.3"
   resolved "https://registry.yarnpkg.com/table/-/table-6.7.3.tgz#255388439715a738391bd2ee4cbca89a4d05a9b7"
@@ -4500,6 +4657,11 @@ text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+
+titleize@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/titleize/-/titleize-3.0.0.tgz#71c12eb7fdd2558aa8a44b0be83b8a76694acd53"
+  integrity sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==
 
 tmp@^0.0.33:
   version "0.0.33"
@@ -4529,6 +4691,11 @@ tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
+  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -4596,6 +4763,11 @@ universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+untildify@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/untildify/-/untildify-4.0.0.tgz#2bc947b953652487e4600949fb091e3ae8cd919b"
+  integrity sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==
 
 update-browserslist-db@^1.0.9:
   version "1.0.10"


### PR DESCRIPTION
Summary: Create a simple package that exposes `hermes-parser` as a Prettier plugin. This will allow the easy use of `hermes-parser` without needing to merge the parser into upstream prettier. The limitation is we have no control of printing logic but this package is already constrained to what the Flow parser supports anyway so it shouldn't be an issue.

Differential Revision: D45965450

