### PR TITLE
Complete support for timeZoneName on Android (#1001)

### DIFF
--- a/lib/Platform/Intl/java/com/facebook/hermes/intl/DateTimeFormat.java
+++ b/lib/Platform/Intl/java/com/facebook/hermes/intl/DateTimeFormat.java
@@ -368,7 +368,9 @@ public class DateTimeFormat {
             options,
             "timeZoneName",
             OptionHelpers.OptionType.STRING,
-            new String[] {"long", "short"},
+            new String[] {
+              "long", "longOffset", "longGeneric", "short", "shortOffset", "shortGeneric"
+            },
             JSObjects.Undefined());
     mTimeZoneName =
         OptionHelpers.searchEnum(IPlatformDateTimeFormatter.TimeZoneName.class, timeZoneName);

--- a/lib/Platform/Intl/java/com/facebook/hermes/intl/IPlatformDateTimeFormatter.java
+++ b/lib/Platform/Intl/java/com/facebook/hermes/intl/IPlatformDateTimeFormatter.java
@@ -357,7 +357,11 @@ public interface IPlatformDateTimeFormatter {
 
   enum TimeZoneName {
     LONG,
+    LONGOFFSET,
+    LONGGENERIC,
     SHORT,
+    SHORTOFFSET,
+    SHORTGENERIC,
     UNDEFINED;
 
     @Override
@@ -365,8 +369,16 @@ public interface IPlatformDateTimeFormatter {
       switch (this) {
         case LONG:
           return "long";
+        case LONGOFFSET:
+          return "longOffset";
+        case LONGGENERIC:
+          return "longGeneric";
         case SHORT:
           return "short";
+        case SHORTOFFSET:
+          return "shortOffset";
+        case SHORTGENERIC:
+          return "shortGeneric";
         case UNDEFINED:
           return "";
         default:
@@ -377,9 +389,17 @@ public interface IPlatformDateTimeFormatter {
     public String getSkeleonSymbol() {
       switch (this) {
         case LONG:
-          return "VV";
+          return "zzzz";
+        case LONGOFFSET:
+          return "OOOO";
+        case LONGGENERIC:
+          return "vvvv";
         case SHORT:
+          return "z";
+        case SHORTOFFSET:
           return "O";
+        case SHORTGENERIC:
+          return "v";
         case UNDEFINED:
           return "";
         default:


### PR DESCRIPTION
Summary:
Our support for the `timeZoneName` option on Android is incomplete,
since it only  supports `short` and `long`, and its behaviour is
inconsistent with our iOS implementation, and with other engines. Add
support for the other options.

Closes #1001

Reviewed By: mattbfb

Differential Revision: D46011723

