### PR TITLE
Fix Android Intl to clear needDefault flag correctly

### DIFF
--- a/lib/VM/JSLib/Intl.cpp
+++ b/lib/VM/JSLib/Intl.cpp
@@ -269,7 +269,7 @@ constexpr OptionData kDTFOptions[] = {
     {u"hourCycle", platform_intl::Option::Kind::String, 0},
     {u"timeZone", platform_intl::Option::Kind::String, 0},
     {u"formatMatcher", platform_intl::Option::Kind::String, 0},
-    {u"weekday", platform_intl::Option::Kind::String, 0},
+    {u"weekday", platform_intl::Option::Kind::String, kDateRequired},
     {u"era", platform_intl::Option::Kind::String, 0},
     {u"year",
      platform_intl::Option::Kind::String,


### PR DESCRIPTION
Fixed an issue where needDefault flag was not being cleared when the option `weekday` was set.

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `main`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/HEAD/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.
-->

## Summary
The current Intl implementation on Android does not correctly follow the RFC for Intl implementation. Specifying a value for the option `weekday`, `year`, `month`, or `day` should clear the `needDefaults` flag, which will prevent the auto-formatted date from automatically being appended to the formatted string (4a here: https://tc39.es/ecma402/#sec-todatetimeoptions).

Current implementation:
```
const date = new Date(Date.UTC(2012, 11, 20, 3, 0, 0, 200));
// request a narrow weekday format
let options = {
  weekday: "narrow"
};
console.log(new Intl.DateTimeFormat("en-US", options).format(date)); 
// outputs "W, 12/19/2012" which is wrong, this should just be "W" since using "weekday" negates the need for defaults.
```

With fix:
```
const date = new Date(Date.UTC(2012, 11, 20, 3, 0, 0, 200));
let options = {
  weekday: "narrow"
};
console.log(new Intl.DateTimeFormat("en-US", options).format(date)); 
// outputs "W" which is correct.
```