### PR TITLE
Add failing parser test for `yield of()`

### DIFF
--- a/test/Parser/regress/yield-of.js
+++ b/test/Parser/regress/yield-of.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -dump-ast --pretty-json %s | %FileCheck %s --match-full-lines
+"use strict";
+
+function of() {}
+function* foo() {
+  yield of();
+}


### PR DESCRIPTION

## Summary

Failing test for https://github.com/facebook/hermes/issues/1028

## Test Plan

- [ ] CI
