### PR TITLE
Fix intl build

### DIFF
--- a/lib/VM/JSLib/Intl.cpp
+++ b/lib/VM/JSLib/Intl.cpp
@@ -277,7 +277,7 @@ constexpr OptionData kDTFOptions[] = {
     {u"month",
      platform_intl::Option::Kind::String,
      kDateRequired | kDateDefault},
-    {u"dayPeriod", platform_intl::Option::Kind::String},
+    {u"dayPeriod", platform_intl::Option::Kind::String, 0},
     {u"day", platform_intl::Option::Kind::String, kDateRequired | kDateDefault},
     {u"hour",
      platform_intl::Option::Kind::String,


### PR DESCRIPTION
Summary:
Build is failing due to:
```
stderr: xplat/hermes/lib/VM/JSLib/Intl.cpp:280:55: error: missing field 'flags' initializer [-Werror,-Wmissing-field-initializers]
    {u"dayPeriod", platform_intl::Option::Kind::String},
```

This line is brought in via GitHub Pull Request: D45185307

Reviewed By: neildhar

Differential Revision: D46750063

