### PR TITLE
Flow API Translator - Fix variables that have identifiers as values

### DIFF
--- a/tools/hermes-parser/js/flow-api-translator/__tests__/flowToFlowDef-test.js
+++ b/tools/hermes-parser/js/flow-api-translator/__tests__/flowToFlowDef-test.js
@@ -210,7 +210,7 @@ describe('flowToFlowDef', () => {
         `function foo() {}
          export default foo;`,
         `declare function foo(): void;
-         declare export default foo;`,
+         declare export default typeof foo;`,
       );
     });
   });
@@ -433,6 +433,14 @@ describe('flowToFlowDef', () => {
          declare export const bar: typeof foo;`,
       );
     });
+    it('with imported value', async () => {
+      await expectTranslate(
+        `import {foo} from 'foo';
+         export const bar = foo;`,
+        `import {foo} from 'foo';
+         declare export const bar: typeof foo;`,
+      );
+    });
   });
   describe('EnumDeclaration', () => {
     it('basic', async () => {
@@ -479,7 +487,7 @@ describe('flowToFlowDef', () => {
     }
     describe('Identifier', () => {
       it('basic', async () => {
-        await expectTranslateExpression(`foo`, `foo`);
+        await expectTranslateExpression(`foo`, `typeof foo`);
       });
     });
     describe('ObjectExpression', () => {

--- a/tools/hermes-parser/js/flow-api-translator/src/flowToFlowDef.js
+++ b/tools/hermes-parser/js/flow-api-translator/src/flowToFlowDef.js
@@ -744,6 +744,20 @@ function convertExportDefaultDeclaration(
   stmt: ExportDefaultDeclaration,
   context: TranslationContext,
 ): TranslatedResult<ProgramStatement> {
+  const expr = stmt.declaration;
+  if (isExpression(expr) && (expr: Expression).type === 'Identifier') {
+    const name = ((expr: $FlowFixMe): Identifier).name;
+    const [declDecl, deps] = [
+      t.TypeofTypeAnnotation({argument: t.Identifier({name})}),
+      analyzeTypeDependencies(expr, context),
+    ];
+    return [
+      t.DeclareExportDefaultDeclaration({
+        declaration: declDecl,
+      }),
+      deps,
+    ];
+  }
   return convertExportDeclaration(stmt.declaration, {default: true}, context);
 }
 
@@ -811,6 +825,13 @@ function convertVariableDeclaration(
           context,
         ),
         [],
+      ];
+    }
+
+    if (init.type === 'Identifier') {
+      return [
+        t.TypeofTypeAnnotation({argument: t.Identifier({name: init.name})}),
+        analyzeTypeDependencies(init, context),
       ];
     }
 


### PR DESCRIPTION
Summary: ...to Use `typeof` for values.

Differential Revision: D46993719

