### PR TITLE
Add missing cstdint includes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ android/intltest/java/com/facebook/hermes/test/assets/**
 # VS Code and Visual Studio
 .vs
 .vscode
+
+# clangd cache
+.cache/

--- a/include/hermes/Support/SHA1.h
+++ b/include/hermes/Support/SHA1.h
@@ -9,6 +9,7 @@
 #define HERMES_SUPPORT_SHA1_H
 
 #include <array>
+#include <cstdint>
 #include <string>
 
 namespace hermes {

--- a/public/hermes/Public/DebuggerTypes.h
+++ b/public/hermes/Public/DebuggerTypes.h
@@ -8,6 +8,7 @@
 #ifndef HERMES_PUBLIC_DEBUGGERTYPES_H
 #define HERMES_PUBLIC_DEBUGGERTYPES_H
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #pragma GCC diagnostic push


### PR DESCRIPTION
I added the missing <cstdint> includes to fix build errors when using uint*_t with clang 16. I also added .cache to gitignore so I don't acidentally commit the clangd LSP cache directory.

The errors that this PR fixes look like this:
```
          ^
/home/theo/dev/hermes/public/hermes/Public/../../hermes/Public/DebuggerTypes.h:40:11: error: unknown type name 'uint64_t'
constexpr uint64_t kInvalidBreakpoint = 0;
```