### PR TITLE
Eval Loose Equality Checks Between Compile Time Null And Undefined Values

### DIFF
--- a/lib/IR/IREval.cpp
+++ b/lib/IR/IREval.cpp
@@ -172,6 +172,9 @@ Literal *hermes::evalBinaryOperator(
   auto leftNaN = isNaN(lhs);
   auto rightNaN = isNaN(rhs);
 
+  auto leftIsNullOrUndef = leftNull || leftUndef;
+  auto rightIsNullOrUndef = rightNull || rightUndef;
+
   auto &ctx = builder.getModule()->getContext();
 
   using OpKind = BinaryOperatorInst::OpKind;
@@ -246,6 +249,12 @@ Literal *hermes::evalBinaryOperator(
         return builder.getLiteralBool(true);
       }
 
+      // `null` and `undefined` are only equal to themselves.
+      if (leftIsNullOrUndef || rightIsNullOrUndef) {
+        return builder.getLiteralBool(
+            leftIsNullOrUndef && rightIsNullOrUndef);
+      }
+
       // Handle numeric comparisons:
       if (numericOrder.hasValue()) {
         switch (numericOrder.getValue()) {
@@ -271,6 +280,12 @@ Literal *hermes::evalBinaryOperator(
       // Identical operands can't be non-equal.
       if (lhs == rhs) {
         return builder.getLiteralBool(false);
+      }
+
+      // `null` and `undefined` are only equal to themselves.
+      if (leftIsNullOrUndef || rightIsNullOrUndef) {
+        return builder.getLiteralBool(
+            !(leftIsNullOrUndef && rightIsNullOrUndef));
       }
 
       // Handle numeric comparisons:

--- a/test/Optimizer/simplify.js
+++ b/test/Optimizer/simplify.js
@@ -316,6 +316,27 @@ function undef_test(x, y) {
   var sink = print;
   sink(undefined >= undefined)
   sink(undefined == undefined)
+  sink(undefined != undefined)
+  sink(undefined == null)
+  sink(null == undefined)
+  sink(undefined != null)
+  sink(null != undefined)
+  sink(undefined == 0)
+  sink(null == 0)
+  sink("" == null)
+  sink("" == undefined)
+  sink(undefined == false)
+  sink(null == false)
+  sink(true == undefined)
+  sink(true == null)
+  sink(undefined != 0)
+  sink(null != 0)
+  sink("" != undefined)
+  sink("" != null)
+  sink(undefined != false)
+  sink(null != false)
+  sink(true != undefined)
+  sink(true != null)
 }
 
 function foo(y) {
@@ -851,7 +872,28 @@ function objectCond() {
 // CHECK-NEXT:  %2 = BinaryOperatorInst '>=', undefined : undefined, undefined : undefined
 // CHECK-NEXT:  %3 = CallInst %1, undefined : undefined, undefined : undefined, %2 : boolean
 // CHECK-NEXT:  %4 = CallInst %1, undefined : undefined, undefined : undefined, true : boolean
-// CHECK-NEXT:  %5 = ReturnInst undefined : undefined
+// CHECK-NEXT:  %5 = CallInst %1, undefined : undefined, undefined : undefined, false : boolean
+// CHECK-NEXT:  %6 = CallInst %1, undefined : undefined, undefined : undefined, true : boolean
+// CHECK-NEXT:  %7 = CallInst %1, undefined : undefined, undefined : undefined, true : boolean
+// CHECK-NEXT:  %8 = CallInst %1, undefined : undefined, undefined : undefined, false : boolean
+// CHECK-NEXT:  %9 = CallInst %1, undefined : undefined, undefined : undefined, false : boolean
+// CHECK-NEXT:  %10 = CallInst %1, undefined : undefined, undefined : undefined, false : boolean
+// CHECK-NEXT:  %11 = CallInst %1, undefined : undefined, undefined : undefined, false : boolean
+// CHECK-NEXT:  %12 = CallInst %1, undefined : undefined, undefined : undefined, false : boolean
+// CHECK-NEXT:  %13 = CallInst %1, undefined : undefined, undefined : undefined, false : boolean
+// CHECK-NEXT:  %14 = CallInst %1, undefined : undefined, undefined : undefined, false : boolean
+// CHECK-NEXT:  %15 = CallInst %1, undefined : undefined, undefined : undefined, false : boolean
+// CHECK-NEXT:  %16 = CallInst %1, undefined : undefined, undefined : undefined, false : boolean
+// CHECK-NEXT:  %17 = CallInst %1, undefined : undefined, undefined : undefined, false : boolean
+// CHECK-NEXT:  %18 = CallInst %1, undefined : undefined, undefined : undefined, true : boolean
+// CHECK-NEXT:  %19 = CallInst %1, undefined : undefined, undefined : undefined, true : boolean
+// CHECK-NEXT:  %20 = CallInst %1, undefined : undefined, undefined : undefined, true : boolean
+// CHECK-NEXT:  %21 = CallInst %1, undefined : undefined, undefined : undefined, true : boolean
+// CHECK-NEXT:  %22 = CallInst %1, undefined : undefined, undefined : undefined, true : boolean
+// CHECK-NEXT:  %23 = CallInst %1, undefined : undefined, undefined : undefined, true : boolean
+// CHECK-NEXT:  %24 = CallInst %1, undefined : undefined, undefined : undefined, true : boolean
+// CHECK-NEXT:  %25 = CallInst %1, undefined : undefined, undefined : undefined, true : boolean
+// CHECK-NEXT:  %26 = ReturnInst undefined : undefined
 // CHECK-NEXT:function_end
 
 // CHECK:function foo#0#1(y)#25 : number


### PR DESCRIPTION
## Summary

Looking to make some optimizations to Hermes compiler, specifically for opportunities with the handling of `null` and `undefined`.

First thing I noticed was that `null` and `undefined` were not optimized away in loose equality checks.

- [x] Fork [the repository](https://github.com/facebook/hermes) and create your branch from `main`.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Ensure it builds and the test suite passes.
- [x] Format your code with `.../hermes/utils/format.sh`
- [x] If you haven't already, complete the CLA.

## Test Plan

```
$ cmake --build ../build --target check-hermes all -j 4              
[30/31] Running the Hermes regression tests
Testing Time: 19.97s
  Expected Passes    : 1681
  Unsupported Tests  : 62
```

More specifically, this function...

```
function undef_test(x, y) {
    var sink = print;
    sink(undefined >= undefined)
    sink(undefined == undefined)
    sink(undefined != undefined)
    sink(undefined == null)
    sink(null == undefined)
    sink(undefined != null)
    sink(null != undefined)
    sink(undefined == 0)
    sink(null == 0)
    sink("" == null)
    sink("" == undefined)
    sink(undefined == false)
    sink(null == false)
    sink(true == undefined)
    sink(true == null)
    sink(undefined != 0)
    sink(null != 0)
    sink("" != undefined)
    sink("" != null)
    sink(undefined != false)
    sink(null != false)
    sink(true != undefined)
    sink(true != null)
  }
```
...would compile to the following byte-code:
```
Function<undef_test>(3 params, 16 registers, 0 symbols):
Offset in debug table: source 0x0009, scope 0x0000, textified callees 0x0000
    GetGlobalObject   r0
    TryGetById        r2, r0, 1, "print"
    LoadConstUndefined r0
    GreaterEq         r1, r0, r0
    Call2             r1, r2, r0, r1
    LoadConstTrue     r3
    Call2             r1, r2, r0, r3
    LoadConstFalse    r4
    Call2             r1, r2, r0, r4
    LoadConstNull     r1
    Eq                r5, r0, r1
    Call2             r5, r2, r0, r5
    Eq                r5, r1, r0
    Call2             r5, r2, r0, r5
    Neq               r5, r0, r1
    Call2             r5, r2, r0, r5
    Neq               r5, r1, r0
    Call2             r5, r2, r0, r5
    LoadConstZero     r6
    Eq                r5, r0, r6
    Call2             r5, r2, r0, r5
    Eq                r5, r1, r6
    Call2             r5, r2, r0, r5
    LoadConstString   r5, ""
    Eq                r7, r5, r1
    Call2             r7, r2, r0, r7
    Eq                r7, r5, r0
    Call2             r7, r2, r0, r7
    Eq                r7, r0, r4
    Call2             r7, r2, r0, r7
    Eq                r7, r1, r4
    Call2             r7, r2, r0, r7
    Eq                r7, r3, r0
    Call2             r7, r2, r0, r7
    Eq                r7, r3, r1
    Call2             r7, r2, r0, r7
    Neq               r7, r0, r6
    Call2             r7, r2, r0, r7
    Neq               r6, r1, r6
    Call2             r6, r2, r0, r6
    Neq               r6, r5, r0
    Call2             r6, r2, r0, r6
    Neq               r5, r5, r1
    Call2             r5, r2, r0, r5
    Neq               r5, r0, r4
    Call2             r5, r2, r0, r5
    Neq               r4, r1, r4
    Call2             r4, r2, r0, r4
    Neq               r4, r3, r0
    Call2             r4, r2, r0, r4
    Neq               r1, r3, r1
    Call2             r1, r2, r0, r1
    Ret               r0
```

After this change, the function compiles to...

```
Function<undef_test>(3 params, 13 registers, 0 symbols):
Offset in debug table: source 0x0009, scope 0x0000, textified callees 0x0000
    GetGlobalObject   r0
    TryGetById        r2, r0, 1, "print"
    LoadConstUndefined r0
    GreaterEq         r1, r0, r0
    Call2             r1, r2, r0, r1
    LoadConstTrue     r1
    Call2             r3, r2, r0, r1
    LoadConstFalse    r3
    Call2             r4, r2, r0, r3
    Call2             r4, r2, r0, r1
    Call2             r4, r2, r0, r1
    Call2             r4, r2, r0, r3
    Call2             r4, r2, r0, r3
    Call2             r4, r2, r0, r3
    Call2             r4, r2, r0, r3
    Call2             r4, r2, r0, r3
    Call2             r4, r2, r0, r3
    Call2             r4, r2, r0, r3
    Call2             r4, r2, r0, r3
    Call2             r4, r2, r0, r3
    Call2             r3, r2, r0, r3
    Call2             r3, r2, r0, r1
    Call2             r3, r2, r0, r1
    Call2             r3, r2, r0, r1
    Call2             r3, r2, r0, r1
    Call2             r3, r2, r0, r1
    Call2             r3, r2, r0, r1
    Call2             r3, r2, r0, r1
    Call2             r1, r2, r0, r1
    Ret               r0
```
Also confirming that the execution is the same for both:
```
false
true
false
true
true
false
false
false
false
false
false
false
false
false
false
true
true
true
true
true
true
true
true
```