### PR TITLE
Update publish-tag React Native version description

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       rnVersion:
-        description: "The RN version that triggered this tagging"
+        description: "The React Native version that will use this tag"
         required: true
       targetSha:
         description: "The SHA you want to tag. If not specified it will tag the HEAD of main"


### PR DESCRIPTION
## Summary

When working on React Native releases and needing to do a Hermes bump, we need to run the the publish-tag workflow. It requires the React Native version that will use the Hermes tag that this workflow will publish. 

The current phrasing doesn't make this clear. This is my attempt to make this version description clearer.

## Test Plan

N/A