### PR TITLE
Update CMake to Build Debugger CLI

### DIFF
--- a/API/hermes/CMakeLists.txt
+++ b/API/hermes/CMakeLists.txt
@@ -6,6 +6,9 @@
 # compileJS uses neither exceptions nor RTTI
 add_hermes_library(compileJS CompileJS.cpp LINK_LIBS hermesPublic)
 
+add_subdirectory(inspector)
+add_subdirectory(jsinspector)
+
 set(HERMES_ENABLE_EH ON)
 
 # synthTraceParser uses exceptions but not RTTI.
@@ -143,6 +146,3 @@ if(HERMES_BUILD_APPLE_DSYM)
     install(DIRECTORY ${DSYM_PATH} DESTINATION lib)
   endif()
 endif()
-
-add_subdirectory(inspector)
-add_subdirectory(jsinspector)

--- a/API/hermes/inspector/CMakeLists.txt
+++ b/API/hermes/inspector/CMakeLists.txt
@@ -6,12 +6,29 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-file(GLOB hermesinspector_SRC CONFIGURE_DEPENDS *.cpp chrome/*.cpp)
+set(no_rtti_no_exception_SRC
+  chrome/JSONValueInterfaces.cpp
+  chrome/MessageConverters.cpp
+  chrome/MessageInterfaces.cpp
+  chrome/MessageTypes.cpp
+  )
 
-add_library(hermes_inspector
-        STATIC
-        ${hermesinspector_SRC})
+add_hermes_library(hermesInspector_no_rtti_no_exception ${no_rtti_no_exception_SRC} LINK_LIBS jsi hermesapi)
 
-target_link_libraries(hermes_inspector
-  hermesapi
-)
+set(HERMES_ENABLE_EH ON)
+set(HERMES_ENABLE_RTTI ON)
+set(rtti_exception_SRC
+  RuntimeAdapter.cpp
+  chrome/CDPHandler.cpp
+  chrome/CallbackOStream.cpp
+  chrome/RemoteObjectConverters.cpp
+  chrome/RemoteObjectsTable.cpp
+  )
+
+add_hermes_library(hermesInspector_rtti_exception
+        ${rtti_exception_SRC}
+        LINK_LIBS hermesInspector_no_rtti_no_exception hermesapi)
+
+if(HERMES_ENABLE_TOOLS AND NOT WIN32)
+  add_subdirectory(chrome/cli)
+endif()

--- a/API/hermes/inspector/chrome/cli/CMakeLists.txt
+++ b/API/hermes/inspector/chrome/cli/CMakeLists.txt
@@ -12,7 +12,7 @@ add_hermes_tool(hcds
 
 target_link_libraries(hcds
   hermesapi
-  hermes_inspector
+  hermesInspector_rtti_exception
   jsinspector
 )
 


### PR DESCRIPTION
Summary:
Restore building `chrome/cli` subdirectory after figuring out RTTI compilation.

CMake will now build certain files without RTTI & exception, but build others with RTTI & exception.

Reviewed By: mattbfb

Differential Revision: D48323701

