### PR TITLE
Build OBJECT libraries for debugger files

### DIFF
--- a/API/hermes/CMakeLists.txt
+++ b/API/hermes/CMakeLists.txt
@@ -6,8 +6,10 @@
 # compileJS uses neither exceptions nor RTTI
 add_hermes_library(compileJS CompileJS.cpp LINK_LIBS hermesPublic)
 
-add_subdirectory(inspector)
-add_subdirectory(jsinspector)
+if(HERMES_ENABLE_DEBUGGER)
+  add_subdirectory(inspector)
+  add_subdirectory(jsinspector)
+endif()
 
 set(HERMES_ENABLE_EH ON)
 
@@ -46,7 +48,20 @@ add_hermes_library(traceInterpreter TraceInterpreter.cpp
 
 set(HERMES_LINK_COMPONENTS LLVHSupport)
 
-add_library(libhermes SHARED ${api_sources})
+set(LIBHERMES_INSPECTOR_OBJS)
+if(HERMES_ENABLE_DEBUGGER)
+  set(LIBHERMES_INSPECTOR_OBJS
+    $<TARGET_OBJECTS:hermesInspector_no_rtti_no_exception_obj>
+    $<TARGET_OBJECTS:hermesInspector_rtti_exception_obj>
+    $<TARGET_OBJECTS:jsinspector_obj>
+  )
+endif()
+
+add_library(libhermes
+  SHARED
+  ${api_sources}
+  ${LIBHERMES_INSPECTOR_OBJS}
+)
 
 # This is configured using a cmake flag instead of a separate target, because
 # we need the output to be named "libhermes.so".

--- a/API/hermes/inspector/CMakeLists.txt
+++ b/API/hermes/inspector/CMakeLists.txt
@@ -13,7 +13,9 @@ set(no_rtti_no_exception_SRC
   chrome/MessageTypes.cpp
   )
 
-add_hermes_library(hermesInspector_no_rtti_no_exception ${no_rtti_no_exception_SRC} LINK_LIBS jsi hermesapi)
+add_hermes_library(hermesInspector_no_rtti_no_exception OBJECT
+  ${no_rtti_no_exception_SRC}
+  LINK_LIBS jsi hermesapi)
 
 set(HERMES_ENABLE_EH ON)
 set(HERMES_ENABLE_RTTI ON)
@@ -25,9 +27,10 @@ set(rtti_exception_SRC
   chrome/RemoteObjectsTable.cpp
   )
 
-add_hermes_library(hermesInspector_rtti_exception
-        ${rtti_exception_SRC}
-        LINK_LIBS hermesInspector_no_rtti_no_exception hermesapi)
+add_hermes_library(hermesInspector_rtti_exception OBJECT
+  ${rtti_exception_SRC}
+  LINK_OBJLIBS hermesInspector_no_rtti_no_exception
+  LINK_LIBS hermesapi)
 
 if(HERMES_ENABLE_TOOLS AND NOT WIN32)
   add_subdirectory(chrome/cli)

--- a/API/hermes/jsinspector/CMakeLists.txt
+++ b/API/hermes/jsinspector/CMakeLists.txt
@@ -6,9 +6,11 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -std=c++17)
+set(HERMES_ENABLE_EH ON)
+set(HERMES_ENABLE_RTTI ON)
+set(jsinspector_SRC
+  InspectorInterfaces.cpp
+  )
 
-file(GLOB jsinspector_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(jsinspector SHARED ${jsinspector_SRC})
+add_hermes_library(jsinspector OBJECT
+  ${jsinspector_SRC})

--- a/API/hermes/jsinspector/InspectorInterfaces.h
+++ b/API/hermes/jsinspector/InspectorInterfaces.h
@@ -84,7 +84,7 @@ class JSINSPECTOR_EXPORT IInspector : public IDestructible {
 
 /// getInspectorInstance retrieves the singleton inspector that tracks all
 /// debuggable pages in this process.
-extern IInspector &getInspectorInstance();
+extern JSINSPECTOR_EXPORT IInspector &getInspectorInstance();
 
 /// makeTestInspectorInstance creates an independent inspector instance that
 /// should only be used in tests.

--- a/cmake/modules/Hermes.cmake
+++ b/cmake/modules/Hermes.cmake
@@ -119,14 +119,48 @@ function(hermes_update_compile_flags name)
 endfunction()
 
 function(add_hermes_library name)
-  cmake_parse_arguments(ARG "" "" "LINK_LIBS" ${ARGN})
-  add_library(${name} STATIC ${ARG_UNPARSED_ARGUMENTS})
-  target_link_libraries(${name} ${ARG_LINK_LIBS} ${HERMES_LINK_COMPONENTS})
-  set_property(TARGET ${name} PROPERTY POSITION_INDEPENDENT_CODE ON)
-  hermes_update_compile_flags(${name})
-  if (HERMES_ENABLE_BITCODE)
-    target_compile_options(${name} PUBLIC "-fembed-bitcode")
-  endif ()
+  cmake_parse_arguments(ARG "OBJECT;STATIC;SHARED" "" "LINK_OBJLIBS;LINK_LIBS" ${ARGN})
+
+  if(NOT ARG_OBJECT)
+    if(ARG_SHARED)
+      add_library(${name} SHARED ${ARG_UNPARSED_ARGUMENTS})
+    else()
+      add_library(${name} STATIC ${ARG_UNPARSED_ARGUMENTS})
+    endif()
+    target_link_libraries(${name} ${ARG_LINK_LIBS} ${HERMES_LINK_COMPONENTS})
+    set_property(TARGET ${name} PROPERTY POSITION_INDEPENDENT_CODE ON)
+    hermes_update_compile_flags(${name})
+    if (HERMES_ENABLE_BITCODE)
+      target_compile_options(${name} PUBLIC "-fembed-bitcode")
+    endif ()
+  else()
+    # When asking to link an OBJECT library, we create an OBJECT library with a
+    # suffix _obj, which depends on all object libraries in LINK_OBJLIBS with
+    # added suffixes and the static libraries in LINK_LIBS. Then we create a
+    # static library which depends on name_obj and the libraries in
+    # LINK_OBJLIBS, but without the suffixes.
+    #
+    # In this way, "name_obj" pulls in all interface settings from the other _obj
+    # libraries, while "name.a" contains the files from "name_obj" and depends
+    # on the other *static* libraries.
+    #
+    # The static library "name.a" can be used as before. Note that all this
+    # avoids compiling an object file more than once (ordinarily an object file
+    # is compiled for every target that includes it).
+    add_library(${name}_obj OBJECT ${ARG_UNPARSED_ARGUMENTS})
+    foreach(lib ${ARG_LINK_OBJLIBS})
+      target_link_libraries(${name}_obj ${lib}_obj)
+    endforeach(lib)
+    target_link_libraries(${name}_obj ${ARG_LINK_LIBS})
+    set_property(TARGET ${name}_obj PROPERTY POSITION_INDEPENDENT_CODE ON)
+    hermes_update_compile_flags(${name}_obj)
+    if (HERMES_ENABLE_BITCODE)
+      target_compile_options(${name}_obj PUBLIC "-fembed-bitcode")
+    endif ()
+
+    add_library(${name} STATIC ${PROJECT_SOURCE_DIR}/lib/dummy.cpp)
+    target_link_libraries(${name} ${name}_obj ${ARG_LINK_OBJLIBS})
+  endif()
 endfunction(add_hermes_library)
 
 function(add_hermes_executable name)

--- a/lib/dummy.cpp
+++ b/lib/dummy.cpp
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// CMake requires libraries to have at least one associated source file. This
+// file is intentionally left empty so that it can be used to create libraries
+// that otherwise do not have any associated source files.


### PR DESCRIPTION
Summary:
Earlier diff that included CDP debugger symbols in libhermes broke GitHub CI jobs for windows and one using gcc v8.3.0. Other jobs are fine and internal CI didn't catch the failures.

Fixing the issue by building OBJECT libraries like the error message asks.

Differential Revision: D48459319

