### PR TITLE
Back out "Link inspector lib in libhermes"

### DIFF
--- a/API/hermes/CMakeLists.txt
+++ b/API/hermes/CMakeLists.txt
@@ -46,20 +46,7 @@ add_hermes_library(traceInterpreter TraceInterpreter.cpp
 
 set(HERMES_LINK_COMPONENTS LLVHSupport)
 
-set(LIBHERMES_INSPECTOR_OBJS)
-if(HERMES_ENABLE_DEBUGGER)
-  set(LIBHERMES_INSPECTOR_OBJS
-    $<TARGET_OBJECTS:hermesInspector_no_rtti_no_exception>
-    $<TARGET_OBJECTS:hermesInspector_rtti_exception>
-    $<TARGET_OBJECTS:jsinspector>
-  )
-endif()
-
-add_library(libhermes
-  SHARED
-  ${api_sources}
-  ${LIBHERMES_INSPECTOR_OBJS}
-)
+add_library(libhermes SHARED ${api_sources})
 
 # This is configured using a cmake flag instead of a separate target, because
 # we need the output to be named "libhermes.so".

--- a/API/hermes/inspector/CMakeLists.txt
+++ b/API/hermes/inspector/CMakeLists.txt
@@ -26,8 +26,8 @@ set(rtti_exception_SRC
   )
 
 add_hermes_library(hermesInspector_rtti_exception
-  ${rtti_exception_SRC}
-  LINK_LIBS hermesInspector_no_rtti_no_exception hermesapi)
+        ${rtti_exception_SRC}
+        LINK_LIBS hermesInspector_no_rtti_no_exception hermesapi)
 
 if(HERMES_ENABLE_TOOLS AND NOT WIN32)
   add_subdirectory(chrome/cli)

--- a/API/hermes/jsinspector/CMakeLists.txt
+++ b/API/hermes/jsinspector/CMakeLists.txt
@@ -6,11 +6,9 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-set(HERMES_ENABLE_EH ON)
-set(HERMES_ENABLE_RTTI ON)
-set(jsinspector_SRC
-  InspectorInterfaces.cpp
-  )
+add_compile_options(
+        -fexceptions
+        -std=c++17)
 
-add_hermes_library(jsinspector
-  ${jsinspector_SRC})
+file(GLOB jsinspector_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(jsinspector SHARED ${jsinspector_SRC})

--- a/API/hermes/jsinspector/InspectorInterfaces.h
+++ b/API/hermes/jsinspector/InspectorInterfaces.h
@@ -84,7 +84,7 @@ class JSINSPECTOR_EXPORT IInspector : public IDestructible {
 
 /// getInspectorInstance retrieves the singleton inspector that tracks all
 /// debuggable pages in this process.
-extern JSINSPECTOR_EXPORT IInspector &getInspectorInstance();
+extern IInspector &getInspectorInstance();
 
 /// makeTestInspectorInstance creates an independent inspector instance that
 /// should only be used in tests.


### PR DESCRIPTION
Summary:
This change broke some of the GitHub CI jobs including jobs in React Native. Backing out the change to unblock things.

Original commit changeset: 7e73e3a87cd4

Original Phabricator Diff: D48324876

Differential Revision: D48459707

