### PR TITLE
Use newer cmake for windows CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,7 +350,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            choco install --no-progress cmake --version 3.14.7 --installargs 'ADD_CMAKE_TO_PATH=System'
+            choco install --no-progress cmake --version 3.24.3 --installargs 'ADD_CMAKE_TO_PATH=System'
             if (-not $?) { throw "Failed to install CMake" }
             choco install --no-progress python3
             if (-not $?) { throw "Failed to install Python" }


### PR DESCRIPTION
Summary: cmake 3.14.7 was available back in end of 2019. Updating to a newer version so that we can start coding to newer cmake capabilities.

Differential Revision: D48526115

