### PR TITLE
Add native stack checking to Runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,6 +217,15 @@ set(HERMES_USE_STATIC_ICU OFF CACHE BOOL
 set(HERMES_UNICODE_LITE OFF CACHE BOOL
   "Enable to use internal no-op unicode functionality instead of relying on underlying system libraries")
 
+if(WIN32 OR EMSCRIPTEN)
+  set(DEFAULT_HERMES_CHECK_NATIVE_STACK OFF)
+else()
+  set(DEFAULT_HERMES_CHECK_NATIVE_STACK ON)
+endif()
+
+set(HERMES_CHECK_NATIVE_STACK ${DEFAULT_HERMES_CHECK_NATIVE_STACK} CACHE BOOL
+  "Check the native stack for stack overflow")
+
 set(HERMES_ENABLE_DEBUGGER ON CACHE BOOL
   "Build with debugger support")
 
@@ -283,6 +292,16 @@ set(HERMES_BUILD_SHARED_JSI OFF CACHE BOOL "Build JSI as a shared library.")
 
 if (HERMES_IS_ANDROID)
   add_definitions(-DHERMES_PLATFORM_UNICODE=HERMES_PLATFORM_UNICODE_JAVA)
+endif()
+
+if(HERMES_CHECK_NATIVE_STACK)
+  if (WIN32 OR EMSCRIPTEN)
+    message(
+      FATAL_ERROR
+      "Native stack checking not supported on Windows or EMSCRIPTEN"
+    )
+  endif()
+  add_definitions(-DHERMES_CHECK_NATIVE_STACK)
 endif()
 
 if(HERMES_BUILD_APPLE_DSYM)

--- a/include/hermes/Support/OSCompat.h
+++ b/include/hermes/Support/OSCompat.h
@@ -189,8 +189,10 @@ bool num_context_switches(long &voluntary, long &involuntary);
 /// \return OS process id of the current process.
 uint64_t process_id();
 
-/// \return OS thread id of current thread.
-uint64_t thread_id();
+/// \return the OS thread id of current thread, uniquely identifying the thread
+///   in the system among all processes. This does \b NOT correspond to
+///   \c pthread_self().
+uint64_t global_thread_id();
 
 /// Set the thread name for the current thread. This can be viewed in various
 /// debuggers and profilers.

--- a/include/hermes/Support/OSCompat.h
+++ b/include/hermes/Support/OSCompat.h
@@ -194,6 +194,16 @@ uint64_t process_id();
 ///   \c pthread_self().
 uint64_t global_thread_id();
 
+/// \param gap if provided, the number of bytes to subtract from the total size
+///   of the stack bounds. If the stack grows to high address, will subtract
+///   from the higher bound.
+/// \return (higher stack bound, size) of the current thread.
+///   The stack overflows when an address is no longer within
+///   the bounds [high - size, high).
+///   Will return (nullptr, 0) if the platform doesn't support checking the
+///   stack bounds.
+std::pair<const void *, size_t> thread_stack_bounds(unsigned gap = 0);
+
 /// Set the thread name for the current thread. This can be viewed in various
 /// debuggers and profilers.
 /// NOTE: Is a no-op on some platforms.

--- a/include/hermes/VM/Runtime.h
+++ b/include/hermes/VM/Runtime.h
@@ -544,6 +544,17 @@ class HERMES_EMPTY_BASES Runtime : public PointerBase,
   /// helper method intended to be called from a debugger.
   void dumpCallFrames();
 
+  /// \return true if the native stack is overflowing the bounds of the
+  ///   current thread. Updates the stack bounds if the thread which Runtime
+  ///   is executing on changes. Will use nativeCallFrameDepth_ if Runtime
+  ///   has been compiled without \c HERMES_CHECK_NATIVE_STACK.
+  inline bool isNativeStackOverflowing();
+
+#ifdef HERMES_CHECK_NATIVE_STACK
+  /// Clear the native stack bounds and force recomputation.
+  inline void clearStackBounds();
+#endif
+
   /// \return `thrownValue`.
   HermesValue getThrownValue() const {
     return thrownValue_;
@@ -1116,6 +1127,13 @@ class HERMES_EMPTY_BASES Runtime : public PointerBase,
   /// Write a JS stack trace as part of a \c crashCallback() run.
   void crashWriteCallStack(JSONEmitter &json);
 
+  /// Out-of-line slow path for \c isNativeStackOverflowing.
+  /// Sets \c stackLow_ \c stackHigh_.
+  /// \return true if the native stack is overflowing the bounds of the
+  ///   current thread. Will always return false when Runtime
+  ///   has been compiled without \c HERMES_CHECK_NATIVE_STACK.
+  bool isNativeStackOverflowingSlowPath();
+
  private:
   GCStorage heapStorage_;
 
@@ -1231,9 +1249,22 @@ class HERMES_EMPTY_BASES Runtime : public PointerBase,
   /// including \c stackPointer_.
   StackFramePtr currentFrame_{nullptr};
 
+#ifdef HERMES_CHECK_NATIVE_STACK
+  /// Native stack remaining before assuming overflow.
+  unsigned nativeStackGap_;
+
+  /// Upper bound on the stack, nullptr if currently unknown.
+  const void *nativeStackHigh_{nullptr};
+
+  /// This has already taken \c nativeStackGap_ into account,
+  /// so any stack outside [nativeStackHigh_-nativeStackSize_, nativeStackHigh_]
+  /// is overflowing.
+  size_t nativeStackSize_{0};
+#else
   /// Current depth of native call frames, including recursive interpreter
   /// calls.
   unsigned nativeCallFrameDepth_{0};
+#endif
 
   /// rootClazzes_[i] is a PinnedHermesValue pointing to a hidden class with
   /// its i first slots pre-reserved.
@@ -1553,19 +1584,26 @@ static_assert(
 /// An RAII class for automatically tracking the native call frame depth.
 class ScopedNativeDepthTracker {
   Runtime &runtime_;
+  /// Whether the stack overflowed when the tracker was constructed.
+  bool overflowed_;
 
  public:
   explicit ScopedNativeDepthTracker(Runtime &runtime) : runtime_(runtime) {
+    (void)runtime_;
+#ifndef HERMES_CHECK_NATIVE_STACK
     ++runtime.nativeCallFrameDepth_;
+#endif
+    overflowed_ = runtime.isNativeStackOverflowing();
   }
   ~ScopedNativeDepthTracker() {
+#ifndef HERMES_CHECK_NATIVE_STACK
     --runtime_.nativeCallFrameDepth_;
+#endif
   }
 
   /// \return whether we overflowed the native call frame depth.
   bool overflowed() const {
-    return runtime_.nativeCallFrameDepth_ >
-        Runtime::MAX_NATIVE_CALL_FRAME_DEPTH;
+    return overflowed_;
   }
 };
 
@@ -1575,11 +1613,40 @@ class ScopedNativeDepthTracker {
 /// cascade of exceptions could occur, overflowing the C++ stack.
 class ScopedNativeDepthReducer {
   Runtime &runtime_;
+#ifdef HERMES_CHECK_NATIVE_STACK
+  unsigned nativeStackGapOld;
+  // This is empirically good enough.
+  static constexpr int kReducedNativeStackGap =
+#if LLVM_ADDRESS_SANITIZER_BUILD
+      256 * 1024;
+#else
+      32 * 1024;
+#endif
+#else
   bool undo = false;
   // This is empirically good enough.
   static constexpr int kDepthAdjustment = 3;
+#endif
 
  public:
+#ifdef HERMES_CHECK_NATIVE_STACK
+  explicit ScopedNativeDepthReducer(Runtime &runtime)
+      : runtime_(runtime), nativeStackGapOld(runtime.nativeStackGap_) {
+    // Temporarily reduce the gap to use that headroom for gathering the error.
+    // If overflow is detected, the recomputation of the stack bounds will
+    // result in no gap for the duration of the ScopedNativeDepthReducer's
+    // lifetime.
+    runtime_.nativeStackGap_ = kReducedNativeStackGap;
+  }
+  ~ScopedNativeDepthReducer() {
+    assert(
+        runtime_.nativeStackGap_ == kReducedNativeStackGap &&
+        "ScopedNativeDepthReducer gap was overridden");
+    runtime_.nativeStackGap_ = nativeStackGapOld;
+    // Force the bounds to be recomputed the next time.
+    runtime_.clearStackBounds();
+  }
+#else
   explicit ScopedNativeDepthReducer(Runtime &runtime) : runtime_(runtime) {
     if (runtime.nativeCallFrameDepth_ >= kDepthAdjustment) {
       runtime.nativeCallFrameDepth_ -= kDepthAdjustment;
@@ -1591,6 +1658,11 @@ class ScopedNativeDepthReducer {
       runtime_.nativeCallFrameDepth_ += kDepthAdjustment;
     }
   }
+#endif
+
+ private:
+  /// Unused function for static asserts that use internal information.
+  static void staticAsserts();
 };
 
 /// A ScopedNativeCallFrame is an RAII class that manipulates the Runtime
@@ -1627,7 +1699,7 @@ class ScopedNativeCallFrame {
       Runtime &runtime,
       uint32_t registersNeeded) {
     return runtime.checkAvailableStack(registersNeeded) &&
-        runtime.nativeCallFrameDepth_ <= Runtime::MAX_NATIVE_CALL_FRAME_DEPTH;
+        !runtime.isNativeStackOverflowing();
   }
 
  public:
@@ -1648,7 +1720,9 @@ class ScopedNativeCallFrame {
       HermesValue newTarget,
       HermesValue thisArg)
       : runtime_(runtime), savedSP_(runtime.getStackPointer()) {
+#ifndef HERMES_CHECK_NATIVE_STACK
     runtime.nativeCallFrameDepth_++;
+#endif
     uint32_t registersNeeded =
         StackFrameLayout::callerOutgoingRegisters(argCount);
     overflowed_ = !runtimeCanAllocateFrame(runtime, registersNeeded);
@@ -1702,7 +1776,9 @@ class ScopedNativeCallFrame {
   ~ScopedNativeCallFrame() {
     // Note that we unconditionally increment the native call frame depth and
     // save the SP to avoid branching in the dtor.
+#ifndef HERMES_CHECK_NATIVE_STACK
     runtime_.nativeCallFrameDepth_--;
+#endif
     runtime_.popToSavedStackPointer(savedSP_);
 #ifndef NDEBUG
     // Clear the frame to detect use-after-free.
@@ -2031,6 +2107,42 @@ inline llvh::iterator_range<ConstStackFrameIterator> Runtime::getStackFrames()
       ConstStackFrameIterator{currentFrame_},
       ConstStackFrameIterator{registerStackStart_}};
 };
+
+inline bool Runtime::isNativeStackOverflowing() {
+#ifdef HERMES_CHECK_NATIVE_STACK
+  // Check for overflow by subtracting the sp from the high pointer.
+  // If the sp is outside the valid stack range, the difference will
+  // be greater than the known stack size.
+  // This is clearly true when 0 < sp < nativeStackHigh_ - size.
+  // If nativeStackHigh_ < sp, then the subtraction will wrap around.
+  // We know that nativeStackSize_ <= nativeStackHigh_
+  // (because otherwise the stack wouldn't fit in the memory),
+  // so the overflowed difference will be greater than nativeStackSize_.
+  bool overflowing =
+      (uintptr_t)nativeStackHigh_ - (uintptr_t)__builtin_frame_address(0) >
+      nativeStackSize_;
+  if (LLVM_LIKELY(!overflowing)) {
+    // Fast path: quickly check the stored stack bounds.
+    // NOTE: It is possible to have a false negative here (highly unlikely).
+    // If the program creates many threads and destroys them, a new
+    // thread's stack could overlap the saved stack so we'd be checking
+    // against the wrong bounds.
+    return false;
+  }
+  // Slow path: might be overflowing, but update the stack bounds first
+  // in case execution has changed threads.
+  return isNativeStackOverflowingSlowPath();
+#else
+  return nativeCallFrameDepth_ > Runtime::MAX_NATIVE_CALL_FRAME_DEPTH;
+#endif
+}
+
+#ifdef HERMES_CHECK_NATIVE_STACK
+inline void Runtime::clearStackBounds() {
+  nativeStackHigh_ = nullptr;
+  nativeStackSize_ = 0;
+}
+#endif
 
 inline ExecutionStatus Runtime::setThrownValue(HermesValue value) {
   thrownValue_ = value;

--- a/lib/Support/OSCompatEmscripten.cpp
+++ b/lib/Support/OSCompatEmscripten.cpp
@@ -215,6 +215,11 @@ uint64_t global_thread_id() {
   return 0;
 }
 
+std::pair<const void *, size_t> thread_stack_bounds(unsigned) {
+  // Native stack checking unsupported on Emscripten.
+  return {nullptr, 0};
+}
+
 void set_thread_name(const char *name) {
   // Intentionally does nothing
 }

--- a/lib/Support/OSCompatEmscripten.cpp
+++ b/lib/Support/OSCompatEmscripten.cpp
@@ -211,7 +211,7 @@ bool num_context_switches(long &voluntary, long &involuntary) {
   return false;
 }
 
-uint64_t thread_id() {
+uint64_t global_thread_id() {
   return 0;
 }
 

--- a/lib/Support/OSCompatPosix.cpp
+++ b/lib/Support/OSCompatPosix.cpp
@@ -583,10 +583,10 @@ uint64_t process_id() {
   return getpid();
 }
 
-// Platform-specific implementations of thread_id
+// Platform-specific implementations of global_thread_id
 #if defined(__APPLE__) && defined(__MACH__)
 
-uint64_t thread_id() {
+uint64_t global_thread_id() {
   uint64_t tid = 0;
   auto ret = pthread_threadid_np(nullptr, &tid);
   assert(ret == 0 && "pthread_threadid_np shouldn't fail for current thread");
@@ -596,13 +596,13 @@ uint64_t thread_id() {
 
 #elif defined(__ANDROID__)
 
-uint64_t thread_id() {
+uint64_t global_thread_id() {
   return gettid();
 }
 
 #elif defined(__linux__)
 
-uint64_t thread_id() {
+uint64_t global_thread_id() {
   return syscall(__NR_gettid);
 }
 

--- a/lib/Support/OSCompatPosix.cpp
+++ b/lib/Support/OSCompatPosix.cpp
@@ -25,15 +25,12 @@
 #endif
 #endif // __linux__
 
+#include <pthread.h>
 #include <sys/types.h>
 #include <unistd.h>
 
 #ifdef __MACH__
 #include <mach/mach.h>
-
-#ifdef __APPLE__
-#include <pthread.h>
-#endif // __APPLE__
 
 #endif // __MACH__
 
@@ -608,6 +605,47 @@ uint64_t global_thread_id() {
 
 #else
 #error "Thread ID not supported on this platform"
+#endif
+
+#if defined(__APPLE__) && defined(__MACH__)
+
+std::pair<const void *, size_t> thread_stack_bounds(unsigned gap) {
+  pthread_t tid = pthread_self();
+  void *origin = pthread_get_stackaddr_np(tid);
+  rlim_t size = 0;
+  if (pthread_main_np()) {
+    // According to
+    // https://opensource.apple.com/source/WTFEmbedded/WTFEmbedded-95.23/wtf/StackBounds.cpp.auto.html
+    // pthread_get_size lies to us when we're the main thread, use get_rlimit
+    // instead
+    struct rlimit limit;
+    getrlimit(RLIMIT_STACK, &limit);
+    size = limit.rlim_cur;
+  } else {
+    size = pthread_get_stacksize_np(tid);
+  }
+
+  return {origin, gap < size ? size - gap : 0};
+}
+
+#else
+
+std::pair<const void *, size_t> thread_stack_bounds(unsigned gap) {
+  pthread_attr_t attr;
+  pthread_attr_init(&attr);
+  pthread_getattr_np(pthread_self(), &attr);
+
+  void *origin;
+  size_t size;
+  pthread_attr_getstack(&attr, &origin, &size);
+
+  pthread_attr_destroy(&attr);
+
+  // origin is now the lowest addressable byte.
+  unsigned adjustedSize = gap < size ? size - gap : 0;
+  return {(char *)origin + size, adjustedSize};
+}
+
 #endif
 
 void set_thread_name(const char *name) {

--- a/lib/Support/OSCompatWindows.cpp
+++ b/lib/Support/OSCompatWindows.cpp
@@ -395,6 +395,11 @@ uint64_t global_thread_id() {
   return GetCurrentThreadId();
 }
 
+std::pair<const void *, size_t> thread_stack_bounds(unsigned) {
+  // Native stack checking unsupported on Windows.
+  return {nullptr, 0};
+}
+
 void set_thread_name(const char *name) {
   // Set the thread name for TSAN. It doesn't share the same name mapping as the
   // OS does. This macro expands to nothing if TSAN isn't on.

--- a/lib/Support/OSCompatWindows.cpp
+++ b/lib/Support/OSCompatWindows.cpp
@@ -391,7 +391,7 @@ uint64_t process_id() {
   return GetCurrentProcessId();
 }
 
-uint64_t thread_id() {
+uint64_t global_thread_id() {
   return GetCurrentThreadId();
 }
 

--- a/lib/Support/SemaphorePosix.cpp
+++ b/lib/Support/SemaphorePosix.cpp
@@ -35,9 +35,9 @@ bool Semaphore::open(const char *semaphorePrefix) {
   llvh::SmallVector<char, 64> semaphoreName;
   llvh::raw_svector_ostream OS(semaphoreName);
 
-  // oscompat::thread_id returns the OS level thread ID, and is thus system
-  // unique.
-  OS << semaphorePrefix << oscompat::thread_id();
+  // oscompat::global_thread_id returns the OS level thread ID, and is thus
+  // system unique.
+  OS << semaphorePrefix << oscompat::global_thread_id();
 
   // Create a named semaphore with read/write. Use O_EXCL as an extra protection
   // layer -- sem_open will fail if semaphoreName is not unique.

--- a/lib/VM/Profiler/SamplingProfiler.cpp
+++ b/lib/VM/Profiler/SamplingProfiler.cpp
@@ -121,13 +121,13 @@ uint32_t SamplingProfiler::walkRuntimeStack(
       }
     }
   }
-  sampleStorage.tid = oscompat::thread_id();
+  sampleStorage.tid = oscompat::global_thread_id();
   sampleStorage.timeStamp = std::chrono::steady_clock::now();
   return count;
 }
 
 SamplingProfiler::SamplingProfiler(Runtime &runtime) : runtime_{runtime} {
-  threadNames_[oscompat::thread_id()] = oscompat::thread_name();
+  threadNames_[oscompat::global_thread_id()] = oscompat::thread_name();
   sampling_profiler::Sampler::get()->registerRuntime(this);
 }
 

--- a/public/hermes/Public/RuntimeConfig.h
+++ b/public/hermes/Public/RuntimeConfig.h
@@ -37,6 +37,9 @@ class PinnedHermesValue;
   /* Register Stack Size */                                            \
   F(constexpr, unsigned, MaxNumRegisters, 128 * 1024)                  \
                                                                        \
+  /* Native stack remaining before assuming overflow */                \
+  F(constexpr, unsigned, NativeStackGap, 64 * 1024)                    \
+                                                                       \
   /* Whether to allow eval and Function ctor */                        \
   F(constexpr, bool, EnableEval, true)                                 \
                                                                        \

--- a/test/hermes/array-flat-recursion.js
+++ b/test/hermes/array-flat-recursion.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//RUN: ulimit -s 512 && %hermes -O %s -gc-sanitize-handles=0 | %FileCheck --match-full-lines %s
+
+var a = [1];
+for (var i = 0; i < 1000; ++i) {
+  a = [a];
+}
+try { a.flat(Infinity); } catch(e) { print('caught', e.name) }
+// CHECK: caught RangeError

--- a/test/hermes/array-functions.js
+++ b/test/hermes/array-functions.js
@@ -1078,12 +1078,6 @@ print(arrayEquals([1,[2,[3,[4]]]].flat(2), [1,2,3,[4]]));
 // CHECK-NEXT: true
 print(arrayEquals([1,[2,[3,[4]]]].flat(Infinity), [1,2,3,4]));
 // CHECK-NEXT: true
-var a = [1];
-for (var i = 0; i < 1000; ++i) {
-  a = [a];
-}
-try { a.flat(Infinity); } catch(e) { print('caught', e.name) }
-// CHECK-NEXT: caught RangeError
 
 print('flatMap');
 // CHECK-LABEL: flatMap

--- a/test/hermes/proxy-recursion-exception.js
+++ b/test/hermes/proxy-recursion-exception.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//RUN: %hermes -O -target=HBC %s -gc-sanitize-handles=0 | %FileCheck --match-full-lines %s
+//RUN: ulimit -s 1024 && %hermes -O -target=HBC %s -gc-sanitize-handles=0 | %FileCheck --match-full-lines %s
 
 try {
   var proxy = new Proxy(function() {}, {});

--- a/test/hermes/proxy.js
+++ b/test/hermes/proxy.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// RUN: %hermes -Xhermes-internal-test-methods -Xes6-proxy -non-strict -O -target=HBC %s | %FileCheck --match-full-lines %s
+// RUN: ulimit -s 2048 && %hermes -Xhermes-internal-test-methods -Xes6-proxy -non-strict -O -target=HBC %s | %FileCheck --match-full-lines %s
 
 let isStrictMode = (function() { return this === undefined; })();
 

--- a/test/hermes/regress-error-stack-native-stack-overflow.js
+++ b/test/hermes/regress-error-stack-native-stack-overflow.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// RUN: %hermes -O0 %s | %FileCheck --match-full-lines %s
-// RUN: %hermes -O %s  | %FileCheck --match-full-lines %s
+// RUN: ulimit -s 4096 && %hermes -O0 %s | %FileCheck --match-full-lines %s
+// RUN: ulimit -s 4096 && %hermes -O %s  | %FileCheck --match-full-lines %s
 
 "use strict";
 

--- a/unittests/Support/OSCompatTest.cpp
+++ b/unittests/Support/OSCompatTest.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "hermes/Support/OSCompat.h"
+
 #include "gtest/gtest.h"
 
 namespace {
@@ -138,4 +139,15 @@ TEST(OSCompatTest, GetProtections) {
   }
 }
 #endif
+
+#if !defined(_WINDOWS) && !defined(__EMSCRIPTEN__)
+
+TEST(OSCompatTest, ThreadStackBounds) {
+  auto [high, size] = oscompat::thread_stack_bounds();
+  ASSERT_TRUE(size > 0);
+  ASSERT_FALSE((uintptr_t)high - (uintptr_t)__builtin_frame_address(0) > size);
+}
+
+#endif
+
 } // namespace

--- a/unittests/VMRuntime/NativeFrameTest.cpp
+++ b/unittests/VMRuntime/NativeFrameTest.cpp
@@ -33,10 +33,13 @@ using NativeFrameTest = RuntimeTestFixture;
 
 TEST_F(NativeFrameTest, OverflowTest) {
   unsigned maxDepth = makeFramesUntilOverflow(runtime, nullptr);
+  (void)maxDepth;
+#ifndef HERMES_CHECK_NATIVE_STACK
   // Save into a local variable in order to avoid linker errors when passed
   // to gtest.
   auto expectedMaxDepth = Runtime::MAX_NATIVE_CALL_FRAME_DEPTH;
   EXPECT_EQ(maxDepth, expectedMaxDepth);
+#endif
 }
 
 #if HERMES_SLOW_DEBUG


### PR DESCRIPTION
Summary:
NOTE: This is a port of two diffs,
because the first one alone would cause errors.

Original Author: avp@meta.com
Original Git: 7a1a615c614100fc661cee4e016e51012a75e79a

Add a flag to control whether the true native stack checking is enabled.
This controls the VM behavior, defaulted to on but it'll error when
trying to compile for Windows.

Add a function to `Runtime` to check for native stack overflow.
The function is split:
* a fast inline check which does two simple comparisons
* a slow check that resets the stack bounds if the fast check fails

The fast inline check may erroneously return `false`,
but that will only happen if a new thread overlaps the old saved stack.

The amount of gap we're allowed at the end of the stack is configured
via `RuntimeConfig`.

This new mechanism will replace the `nativeCallFrameDepth_` mechanism,
which was in use until now but was conservative by design.
The RAII classes for using it are updated to use the true check,
if it is possible.

Some tests were checking for native stack overflow.
They need to be updated to grow the stack larger and actually cause an
overflow.

Original Reviewed By: neildhar

Original Revision: D41601035

=====

Original Revision: D47921011

Reviewed By: tmikov

Differential Revision: D47875957

