### PR TITLE
Rename oscompat::thread_id to global_thread_id()

### DIFF
--- a/include/hermes/Support/OSCompat.h
+++ b/include/hermes/Support/OSCompat.h
@@ -189,8 +189,10 @@ bool num_context_switches(long &voluntary, long &involuntary);
 /// \return OS process id of the current process.
 uint64_t process_id();
 
-/// \return OS thread id of current thread.
-uint64_t thread_id();
+/// \return the OS thread id of current thread, uniquely identifying the thread
+///   in the system among all processes. This does \b NOT correspond to
+///   \c pthread_self().
+uint64_t global_thread_id();
 
 /// Set the thread name for the current thread. This can be viewed in various
 /// debuggers and profilers.

--- a/lib/Support/OSCompatEmscripten.cpp
+++ b/lib/Support/OSCompatEmscripten.cpp
@@ -211,7 +211,7 @@ bool num_context_switches(long &voluntary, long &involuntary) {
   return false;
 }
 
-uint64_t thread_id() {
+uint64_t global_thread_id() {
   return 0;
 }
 

--- a/lib/Support/OSCompatPosix.cpp
+++ b/lib/Support/OSCompatPosix.cpp
@@ -583,10 +583,10 @@ uint64_t process_id() {
   return getpid();
 }
 
-// Platform-specific implementations of thread_id
+// Platform-specific implementations of global_thread_id
 #if defined(__APPLE__) && defined(__MACH__)
 
-uint64_t thread_id() {
+uint64_t global_thread_id() {
   uint64_t tid = 0;
   auto ret = pthread_threadid_np(nullptr, &tid);
   assert(ret == 0 && "pthread_threadid_np shouldn't fail for current thread");
@@ -596,13 +596,13 @@ uint64_t thread_id() {
 
 #elif defined(__ANDROID__)
 
-uint64_t thread_id() {
+uint64_t global_thread_id() {
   return gettid();
 }
 
 #elif defined(__linux__)
 
-uint64_t thread_id() {
+uint64_t global_thread_id() {
   return syscall(__NR_gettid);
 }
 

--- a/lib/Support/OSCompatWindows.cpp
+++ b/lib/Support/OSCompatWindows.cpp
@@ -391,7 +391,7 @@ uint64_t process_id() {
   return GetCurrentProcessId();
 }
 
-uint64_t thread_id() {
+uint64_t global_thread_id() {
   return GetCurrentThreadId();
 }
 

--- a/lib/Support/SemaphorePosix.cpp
+++ b/lib/Support/SemaphorePosix.cpp
@@ -35,9 +35,9 @@ bool Semaphore::open(const char *semaphorePrefix) {
   llvh::SmallVector<char, 64> semaphoreName;
   llvh::raw_svector_ostream OS(semaphoreName);
 
-  // oscompat::thread_id returns the OS level thread ID, and is thus system
-  // unique.
-  OS << semaphorePrefix << oscompat::thread_id();
+  // oscompat::global_thread_id returns the OS level thread ID, and is thus
+  // system unique.
+  OS << semaphorePrefix << oscompat::global_thread_id();
 
   // Create a named semaphore with read/write. Use O_EXCL as an extra protection
   // layer -- sem_open will fail if semaphoreName is not unique.

--- a/lib/VM/Profiler/SamplingProfiler.cpp
+++ b/lib/VM/Profiler/SamplingProfiler.cpp
@@ -121,13 +121,13 @@ uint32_t SamplingProfiler::walkRuntimeStack(
       }
     }
   }
-  sampleStorage.tid = oscompat::thread_id();
+  sampleStorage.tid = oscompat::global_thread_id();
   sampleStorage.timeStamp = std::chrono::steady_clock::now();
   return count;
 }
 
 SamplingProfiler::SamplingProfiler(Runtime &runtime) : runtime_{runtime} {
-  threadNames_[oscompat::thread_id()] = oscompat::thread_name();
+  threadNames_[oscompat::global_thread_id()] = oscompat::thread_name();
   sampling_profiler::Sampler::get()->registerRuntime(this);
 }
 


### PR DESCRIPTION
Summary:
Original Author: avp@meta.com
Original Git: b837b9beb019d0d2a14fbc143d2a4b83d8b28218

oscompat::thread_id is a bit misleading, since it sounds more
universally useful than it actually is. Rename it to avoid confusion and
add some more doc-comment.

Original Reviewed By: neildhar

Original Revision: D41601037

Reviewed By: tmikov

Differential Revision: D47875958

