### PR TITLE
Add thread stack limit function to OSCompat

### DIFF
--- a/include/hermes/Support/OSCompat.h
+++ b/include/hermes/Support/OSCompat.h
@@ -189,8 +189,10 @@ bool num_context_switches(long &voluntary, long &involuntary);
 /// \return OS process id of the current process.
 uint64_t process_id();
 
-/// \return OS thread id of current thread.
-uint64_t thread_id();
+/// \return the OS thread id of current thread, uniquely identifying the thread
+///   in the system among all processes. This does \b NOT correspond to
+///   \c pthread_self().
+uint64_t global_thread_id();
 
 /// Set the thread name for the current thread. This can be viewed in various
 /// debuggers and profilers.

--- a/include/hermes/Support/OSCompat.h
+++ b/include/hermes/Support/OSCompat.h
@@ -194,6 +194,16 @@ uint64_t process_id();
 ///   \c pthread_self().
 uint64_t global_thread_id();
 
+/// \param gap if provided, the number of bytes to subtract from the total size
+///   of the stack bounds. If the stack grows to high address, will subtract
+///   from the higher bound.
+/// \return (higher stack bound, size) of the current thread.
+///   The stack overflows when an address is no longer within
+///   the bounds [high - size, high).
+///   Will return (nullptr, 0) if the platform doesn't support checking the
+///   stack bounds.
+std::pair<const void *, size_t> thread_stack_bounds(unsigned gap = 0);
+
 /// Set the thread name for the current thread. This can be viewed in various
 /// debuggers and profilers.
 /// NOTE: Is a no-op on some platforms.

--- a/lib/Support/OSCompatEmscripten.cpp
+++ b/lib/Support/OSCompatEmscripten.cpp
@@ -215,6 +215,11 @@ uint64_t global_thread_id() {
   return 0;
 }
 
+std::pair<const void *, size_t> thread_stack_bounds(unsigned) {
+  // Native stack checking unsupported on Emscripten.
+  return {nullptr, 0};
+}
+
 void set_thread_name(const char *name) {
   // Intentionally does nothing
 }

--- a/lib/Support/OSCompatEmscripten.cpp
+++ b/lib/Support/OSCompatEmscripten.cpp
@@ -211,7 +211,7 @@ bool num_context_switches(long &voluntary, long &involuntary) {
   return false;
 }
 
-uint64_t thread_id() {
+uint64_t global_thread_id() {
   return 0;
 }
 

--- a/lib/Support/OSCompatPosix.cpp
+++ b/lib/Support/OSCompatPosix.cpp
@@ -583,10 +583,10 @@ uint64_t process_id() {
   return getpid();
 }
 
-// Platform-specific implementations of thread_id
+// Platform-specific implementations of global_thread_id
 #if defined(__APPLE__) && defined(__MACH__)
 
-uint64_t thread_id() {
+uint64_t global_thread_id() {
   uint64_t tid = 0;
   auto ret = pthread_threadid_np(nullptr, &tid);
   assert(ret == 0 && "pthread_threadid_np shouldn't fail for current thread");
@@ -596,13 +596,13 @@ uint64_t thread_id() {
 
 #elif defined(__ANDROID__)
 
-uint64_t thread_id() {
+uint64_t global_thread_id() {
   return gettid();
 }
 
 #elif defined(__linux__)
 
-uint64_t thread_id() {
+uint64_t global_thread_id() {
   return syscall(__NR_gettid);
 }
 

--- a/lib/Support/OSCompatPosix.cpp
+++ b/lib/Support/OSCompatPosix.cpp
@@ -25,15 +25,12 @@
 #endif
 #endif // __linux__
 
+#include <pthread.h>
 #include <sys/types.h>
 #include <unistd.h>
 
 #ifdef __MACH__
 #include <mach/mach.h>
-
-#ifdef __APPLE__
-#include <pthread.h>
-#endif // __APPLE__
 
 #endif // __MACH__
 
@@ -608,6 +605,47 @@ uint64_t global_thread_id() {
 
 #else
 #error "Thread ID not supported on this platform"
+#endif
+
+#if defined(__APPLE__) && defined(__MACH__)
+
+std::pair<const void *, size_t> thread_stack_bounds(unsigned gap) {
+  pthread_t tid = pthread_self();
+  void *origin = pthread_get_stackaddr_np(tid);
+  rlim_t size = 0;
+  if (pthread_main_np()) {
+    // According to
+    // https://opensource.apple.com/source/WTFEmbedded/WTFEmbedded-95.23/wtf/StackBounds.cpp.auto.html
+    // pthread_get_size lies to us when we're the main thread, use get_rlimit
+    // instead
+    struct rlimit limit;
+    getrlimit(RLIMIT_STACK, &limit);
+    size = limit.rlim_cur;
+  } else {
+    size = pthread_get_stacksize_np(tid);
+  }
+
+  return {origin, gap < size ? size - gap : 0};
+}
+
+#else
+
+std::pair<const void *, size_t> thread_stack_bounds(unsigned gap) {
+  pthread_attr_t attr;
+  pthread_attr_init(&attr);
+  pthread_getattr_np(pthread_self(), &attr);
+
+  void *origin;
+  size_t size;
+  pthread_attr_getstack(&attr, &origin, &size);
+
+  pthread_attr_destroy(&attr);
+
+  // origin is now the lowest addressable byte.
+  unsigned adjustedSize = gap < size ? size - gap : 0;
+  return {(char *)origin + size, adjustedSize};
+}
+
 #endif
 
 void set_thread_name(const char *name) {

--- a/lib/Support/OSCompatWindows.cpp
+++ b/lib/Support/OSCompatWindows.cpp
@@ -395,6 +395,11 @@ uint64_t global_thread_id() {
   return GetCurrentThreadId();
 }
 
+std::pair<const void *, size_t> thread_stack_bounds(unsigned) {
+  // Native stack checking unsupported on Windows.
+  return {nullptr, 0};
+}
+
 void set_thread_name(const char *name) {
   // Set the thread name for TSAN. It doesn't share the same name mapping as the
   // OS does. This macro expands to nothing if TSAN isn't on.

--- a/lib/Support/OSCompatWindows.cpp
+++ b/lib/Support/OSCompatWindows.cpp
@@ -391,7 +391,7 @@ uint64_t process_id() {
   return GetCurrentProcessId();
 }
 
-uint64_t thread_id() {
+uint64_t global_thread_id() {
   return GetCurrentThreadId();
 }
 

--- a/lib/Support/SemaphorePosix.cpp
+++ b/lib/Support/SemaphorePosix.cpp
@@ -35,9 +35,9 @@ bool Semaphore::open(const char *semaphorePrefix) {
   llvh::SmallVector<char, 64> semaphoreName;
   llvh::raw_svector_ostream OS(semaphoreName);
 
-  // oscompat::thread_id returns the OS level thread ID, and is thus system
-  // unique.
-  OS << semaphorePrefix << oscompat::thread_id();
+  // oscompat::global_thread_id returns the OS level thread ID, and is thus
+  // system unique.
+  OS << semaphorePrefix << oscompat::global_thread_id();
 
   // Create a named semaphore with read/write. Use O_EXCL as an extra protection
   // layer -- sem_open will fail if semaphoreName is not unique.

--- a/lib/VM/Profiler/SamplingProfiler.cpp
+++ b/lib/VM/Profiler/SamplingProfiler.cpp
@@ -121,13 +121,13 @@ uint32_t SamplingProfiler::walkRuntimeStack(
       }
     }
   }
-  sampleStorage.tid = oscompat::thread_id();
+  sampleStorage.tid = oscompat::global_thread_id();
   sampleStorage.timeStamp = std::chrono::steady_clock::now();
   return count;
 }
 
 SamplingProfiler::SamplingProfiler(Runtime &runtime) : runtime_{runtime} {
-  threadNames_[oscompat::thread_id()] = oscompat::thread_name();
+  threadNames_[oscompat::global_thread_id()] = oscompat::thread_name();
   sampling_profiler::Sampler::get()->registerRuntime(this);
 }
 

--- a/unittests/Support/OSCompatTest.cpp
+++ b/unittests/Support/OSCompatTest.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "hermes/Support/OSCompat.h"
+
 #include "gtest/gtest.h"
 
 namespace {
@@ -138,4 +139,15 @@ TEST(OSCompatTest, GetProtections) {
   }
 }
 #endif
+
+#if !defined(_WINDOWS) && !defined(__EMSCRIPTEN__)
+
+TEST(OSCompatTest, ThreadStackBounds) {
+  auto [high, size] = oscompat::thread_stack_bounds();
+  ASSERT_TRUE(size > 0);
+  ASSERT_FALSE((uintptr_t)high - (uintptr_t)__builtin_frame_address(0) > size);
+}
+
+#endif
+
 } // namespace


### PR DESCRIPTION
Summary:
Original Author: avp@meta.com
Original Git: d5880fd3a255a150de7bcc3743c04c026909fdee

Add a function to retrieve the stack bounds on the current thread.
This can be used for checking the native stack for overflow.

Currently, the function is only supported on POSIX systems.
Otherwise, it'll just compile to return `nullptr`s.

Original Reviewed By: tmikov

Original Revision: D41601039

Reviewed By: tmikov

Differential Revision: D47875959

