### PR TITLE
Allow VisitCaller to send parents to the Node overload of visit

### DIFF
--- a/include/hermes/AST/RecursiveVisitor.h
+++ b/include/hermes/AST/RecursiveVisitor.h
@@ -33,7 +33,11 @@ template <typename V, typename N>
 struct VisitCaller<
     V,
     N,
-    decltype((void)static_cast<void (V::*)(N *, Node *)>(&V::visit))> {
+    std::enable_if_t<std::is_same<
+        void,
+        decltype(std::declval<V>().visit(
+            std::declval<N *>(),
+            std::declval<Node *>()))>::value>> {
   static void call(V &v, N *node, Node *parent) {
     v.visit(node, parent);
   }

--- a/unittests/AST/CMakeLists.txt
+++ b/unittests/AST/CMakeLists.txt
@@ -7,6 +7,7 @@ set(ASTSources
   JSONTest.cpp
   ESTreeTest.cpp
   ResolverTest.cpp
+  VisitorTest.cpp
   )
 
 add_hermes_unittest(HermesASTTests

--- a/unittests/AST/VisitorTest.cpp
+++ b/unittests/AST/VisitorTest.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "llvh/Support/Casting.h"
+#include "llvh/Support/SourceMgr.h"
+#include "llvh/Support/YAMLParser.h"
+
+#include "hermes/AST/ASTBuilder.h"
+#include "hermes/AST/ESTreeVisitors.h"
+#include "hermes/AST/RecursiveVisitor.h"
+#include "hermes/Parser/JSONParser.h"
+
+#include "gtest/gtest.h"
+using llvh::cast;
+using llvh::dyn_cast;
+
+using namespace hermes;
+
+namespace {
+
+TEST(VisitorTest, NodeParentTest) {
+  Context context;
+
+  auto *statement = new (context)
+      ESTree::AwaitExpressionNode(new (context) ESTree::NullLiteralNode());
+
+  class Visitor {
+   public:
+    bool foundNull = false;
+
+    bool incRecursionDepth(ESTree::Node *) {
+      return true;
+    }
+    void decRecursionDepth() {}
+
+    void visit(ESTree::Node *node, ESTree::Node *parent) {
+      if (llvh::isa<ESTree::NullLiteralNode>(node)) {
+        foundNull = true;
+        ASSERT_TRUE(llvh::isa<ESTree::AwaitExpressionNode>(parent));
+      }
+      visitESTreeChildren(*this, node);
+    }
+  };
+
+  Visitor v{};
+  visitESTreeNode(v, statement);
+  ASSERT_TRUE(v.foundNull);
+}
+
+} // end anonymous namespace


### PR DESCRIPTION
Summary:
If the user only had the
```
void visit(Node *node, Node *parent);
```
overload in the visitor, it couldn't be called from the RecursiveVisitor
because the RecursiveVisitor was only looking for overloads for each
specific `NodeKind`.

Switch from using `static_cast` to `std::declval` and attempting to just
call the `visit` function directly inside `decltype`.

This allows the full overload resolution to take place.

Reviewed By: tmikov

Differential Revision: D48665671

