### PR TITLE
Add restricted properties to function prototype

### DIFF
--- a/include/hermes/VM/RuntimeFlags.h
+++ b/include/hermes/VM/RuntimeFlags.h
@@ -98,7 +98,7 @@ struct VMOnlyRuntimeFlags {
       llvh::cl::cat(GCCategory),
       llvh::cl::init(MemorySize{vm::GCConfig::getDefaultMaxHeapSize()})};
 
-  llvh::cl::opt<uint64_t> MaxNumRegisters{
+  llvh::cl::opt<unsigned> MaxNumRegisters{
       "max-register-stack",
       llvh::cl::desc("Max number of registers in the register stack."),
       llvh::cl::cat(RuntimeCategory),

--- a/lib/VM/Callable.cpp
+++ b/lib/VM/Callable.cpp
@@ -160,20 +160,6 @@ ExecutionStatus Callable::defineNameLengthAndPrototype(
   auto nameHandle = runtime.makeHandle(runtime.getStringPrimFromSymbolID(name));
   DEFINE_PROP(selfHandle, P::name, nameHandle);
 
-  if (strictMode) {
-    // Define .callee and .arguments properties: throw always in strict mode.
-    auto accessor =
-        Handle<PropertyAccessor>::vmcast(&runtime.throwTypeErrorAccessor);
-
-    pf.clear();
-    pf.enumerable = 0;
-    pf.configurable = 0;
-    pf.accessor = 1;
-
-    DEFINE_PROP(selfHandle, P::caller, accessor);
-    DEFINE_PROP(selfHandle, P::arguments, accessor);
-  }
-
   if (prototypeObjectHandle) {
     // Set its 'prototype' property.
     pf.clear();
@@ -613,35 +599,6 @@ ExecutionStatus BoundFunction::initializeLengthAndName_RJS(
               Predefined::getSymbolID(Predefined::name),
               dpf,
               boundNameHandle) == ExecutionStatus::EXCEPTION)) {
-    return ExecutionStatus::EXCEPTION;
-  }
-
-  // Define .callee and .arguments properties: throw always in bound functions.
-  auto accessor =
-      Handle<PropertyAccessor>::vmcast(&runtime.throwTypeErrorAccessor);
-
-  pf.clear();
-  pf.enumerable = 0;
-  pf.configurable = 0;
-  pf.accessor = 1;
-
-  if (LLVM_UNLIKELY(
-          JSObject::defineNewOwnProperty(
-              selfHandle,
-              runtime,
-              Predefined::getSymbolID(Predefined::caller),
-              pf,
-              accessor) == ExecutionStatus::EXCEPTION)) {
-    return ExecutionStatus::EXCEPTION;
-  }
-
-  if (LLVM_UNLIKELY(
-          JSObject::defineNewOwnProperty(
-              selfHandle,
-              runtime,
-              Predefined::getSymbolID(Predefined::arguments),
-              pf,
-              accessor) == ExecutionStatus::EXCEPTION)) {
     return ExecutionStatus::EXCEPTION;
   }
 

--- a/test/shermes/function-non-strict.js
+++ b/test/shermes/function-non-strict.js
@@ -18,8 +18,10 @@ print('function properties');
 // CHECK-LABEL: function properties
 print(typeof strict, typeof nonStrict);
 // CHECK-NEXT: function function
-print(nonStrict.caller, nonStrict.arguments);
-// CHECK-NEXT: undefined undefined
+try { print(nonStrict.caller); } catch(e) { print('caught', e.name, e.message); }
+// CHECK-NEXT: caught TypeError Restricted in strict mode
+try { print(nonStrict.arguments); } catch(e) { print('caught', e.name, e.message); }
+// CHECK-NEXT: caught TypeError Restricted in strict mode
 try { print(strict.caller); } catch(e) { print('caught', e.name, e.message); }
 // CHECK-NEXT: caught TypeError Restricted in strict mode
 try { print(strict.arguments); } catch(e) { print('caught', e.name, e.message); }
@@ -29,4 +31,9 @@ var bound = nonStrict.bind(42);
 try { print(bound.caller); } catch(e) { print('caught', e.name, e.message); }
 // CHECK-NEXT: caught TypeError Restricted in strict mode
 try { print(bound.arguments); } catch(e) { print('caught', e.name, e.message); }
+// CHECK-NEXT: caught TypeError Restricted in strict mode
+
+try { print(Function.prototype.caller); } catch(e) { print('caught', e.name, e.message); }
+// CHECK-NEXT: caught TypeError Restricted in strict mode
+try { print(Function.prototype.arguments); } catch(e) { print('caught', e.name, e.message); }
 // CHECK-NEXT: caught TypeError Restricted in strict mode


### PR DESCRIPTION
Summary:
Move `caller` and `arguments` throwing accessors onto
Function.prototype. Define these unconditionally, not just in strict
mode. This is in accordance with [AddRestrictedFunctionProperties](https://tc39.es/ecma262/#sec-addrestrictedfunctionproperties).

Reviewed By: avp

Differential Revision: D48205935

