### PR TITLE
Remove --dump-operand-registers

### DIFF
--- a/include/hermes/AST/Context.h
+++ b/include/hermes/AST/Context.h
@@ -27,8 +27,8 @@ struct CodeGenerationSettings {
   bool test262{false};
   /// Whether we should emit TDZ checks.
   bool enableTDZ{false};
-  /// Dump registers assigned to instruction operands.
-  bool dumpOperandRegisters{false};
+  /// Dump register liveness intervals.
+  bool dumpRegisterInterval{false};
   /// Print source location information in IR dumps.
   bool dumpSourceLocation{false};
   /// Print the use list if the instruction has any users.

--- a/lib/BCGen/RegAlloc.cpp
+++ b/lib/BCGen/RegAlloc.cpp
@@ -846,7 +846,7 @@ struct LivenessRegAllocIRPrinter : IRPrinter {
       os << "$" << allocator.getRegister(I);
     }
 
-    if (!codeGenOpts.dumpOperandRegisters) {
+    if (codeGenOpts.dumpRegisterInterval) {
       os << " ";
       if (allocator.hasInstructionNumber(I)) {
         auto idx = allocator.getInstructionNumber(I);
@@ -855,14 +855,11 @@ struct LivenessRegAllocIRPrinter : IRPrinter {
       } else {
         os << "          \t";
       }
-
-      IRPrinter::printInstructionDestination(I);
     }
   }
 
   void printValueLabel(Instruction *I, Value *V, unsigned opIndex) override {
-    auto codeGenOpts = I->getContext().getCodeGenerationSettings();
-    if (codeGenOpts.dumpOperandRegisters && allocator.isAllocated(V)) {
+    if (allocator.isAllocated(V)) {
       os << "$" << allocator.getRegister(V);
     } else {
       IRPrinter::printValueLabel(I, V, opIndex);

--- a/lib/BCGen/SH/SHRegAlloc.cpp
+++ b/lib/BCGen/SH/SHRegAlloc.cpp
@@ -837,7 +837,7 @@ struct LivenessRegAllocIRPrinter : IRPrinter {
           llvh::fmt_align(allocator.getRegister(I), llvh::AlignStyle::Left, 9));
     }
 
-    if (!codeGenOpts.dumpOperandRegisters) {
+    if (codeGenOpts.dumpRegisterInterval) {
       os << " ";
       if (allocator.hasInstructionNumber(I)) {
         auto idx = allocator.getInstructionNumber(I);
@@ -846,14 +846,11 @@ struct LivenessRegAllocIRPrinter : IRPrinter {
       } else {
         os << "          \t";
       }
-
-      IRPrinter::printInstructionDestination(I);
     }
   }
 
   void printValueLabel(Instruction *I, Value *V, unsigned opIndex) override {
-    auto codeGenOpts = I->getContext().getCodeGenerationSettings();
-    if (codeGenOpts.dumpOperandRegisters && allocator.isAllocated(V)) {
+    if (allocator.isAllocated(V)) {
       os << "$" << allocator.getRegister(V);
     } else {
       IRPrinter::printValueLabel(I, V, opIndex);

--- a/lib/CompilerDriver/CompilerDriver.cpp
+++ b/lib/CompilerDriver/CompilerDriver.cpp
@@ -357,11 +357,11 @@ static opt<bool> OutputSourceMap(
     desc("Emit a source map to the output filename with .map extension"),
     cat(CompilerCategory));
 
-static opt<bool> DumpOperandRegisters(
-    "dump-operand-registers",
-    desc("Dump registers assigned to instruction operands"),
-    init(true),
-    cat(CompilerCategory));
+cl::opt<bool> DumpRegisterInterval(
+    "dump-register-interval",
+    cl::desc("Dump the liveness interval of allocated registers"),
+    cl::init(false),
+    cl::cat(CompilerCategory));
 
 static opt<bool> DumpUseList(
     "dump-instr-uselist",
@@ -1012,7 +1012,7 @@ std::shared_ptr<Context> createContext(
     std::vector<uint32_t> segments) {
   CodeGenerationSettings codeGenOpts;
   codeGenOpts.enableTDZ = cl::EnableTDZ;
-  codeGenOpts.dumpOperandRegisters = cl::DumpOperandRegisters;
+  codeGenOpts.dumpRegisterInterval = cl::DumpRegisterInterval;
   codeGenOpts.dumpUseList = cl::DumpUseList;
   codeGenOpts.dumpSourceLocation =
       cl::DumpSourceLocation != LocationDumpMode::None;

--- a/test/BCGen/SH/RA/phi_swap.js
+++ b/test/BCGen/SH/RA/phi_swap.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// RUN: %shermes -O -dump-ra -dump-operand-registers %s | %FileCheckOrRegen --match-full-lines %s
+// RUN: %shermes -O -dump-ra %s | %FileCheckOrRegen --match-full-lines %s
 // Ensure that the register allocator correctly handles cycles between Phi-nodes.
 
 function foo (a, b) {

--- a/test/BCGen/SH/call-and-new-args.js
+++ b/test/BCGen/SH/call-and-new-args.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// RUN: %shermes -O -dump-lra -dump-operand-registers %s | %FileCheckOrRegen --match-full-lines %s
+// RUN: %shermes -O -dump-lra %s | %FileCheckOrRegen --match-full-lines %s
 
 // Check that call and new arguments, including the calleee and new.target, are
 // correctly lowered into stack registers.

--- a/test/BCGen/SH/call-builtin-clobber-callee.js
+++ b/test/BCGen/SH/call-builtin-clobber-callee.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// RUN: %shermes -O -dump-lra -dump-operand-registers %s | %FileCheckOrRegen --match-full-lines %s
+// RUN: %shermes -O -dump-lra %s | %FileCheckOrRegen --match-full-lines %s
 
 /// Ensure that the callee stack entry is clobbered by the builtin call.
 function test_call_after_builtin() {

--- a/tools/shermes/shermes.cpp
+++ b/tools/shermes/shermes.cpp
@@ -342,10 +342,10 @@ cl::opt<bool> VerifyIR(
     cl::desc("Verify the IR after each pass."),
     cl::cat(CompilerCategory));
 
-cl::opt<bool> DumpOperandRegisters(
-    "dump-operand-registers",
-    cl::desc("Dump registers for operands instead of instruction numbers"),
-    cl::init(true),
+cl::opt<bool> DumpRegisterInterval(
+    "dump-register-interval",
+    cl::desc("Dump the liveness interval of allocated registers"),
+    cl::init(false),
     cl::cat(CompilerCategory));
 
 cl::opt<bool> DumpUseList(
@@ -464,7 +464,7 @@ std::shared_ptr<Context> createContext() {
   codeGenOpts.enableTDZ = cli::Test262 && !cli::EnableTDZ.getNumOccurrences()
       ? true
       : cli::EnableTDZ;
-  codeGenOpts.dumpOperandRegisters = cli::DumpOperandRegisters;
+  codeGenOpts.dumpRegisterInterval = cli::DumpRegisterInterval;
   codeGenOpts.dumpUseList = cli::DumpUseList;
   codeGenOpts.dumpSourceLocation =
       cli::DumpSourceLocation != LocationDumpMode::None;


### PR DESCRIPTION
Summary:
Dumping operand registers after regalloc should not be optional, so
always enable it and remove the CLI flag. Add a new flag
"--dump-register-interval" to print the liveness information which was
previously printed with --dump-operand-registers=0.

Differential Revision: D49221052

