### PR TITLE
RegAlloc: replace allocated operands with SHLocal

### DIFF
--- a/include/hermes/AST/Context.h
+++ b/include/hermes/AST/Context.h
@@ -27,8 +27,8 @@ struct CodeGenerationSettings {
   bool test262{false};
   /// Whether we should emit TDZ checks.
   bool enableTDZ{false};
-  /// Dump registers assigned to instruction operands.
-  bool dumpOperandRegisters{false};
+  /// Dump register liveness intervals.
+  bool dumpRegisterInterval{false};
   /// Print source location information in IR dumps.
   bool dumpSourceLocation{false};
   /// Print the use list if the instruction has any users.

--- a/include/hermes/IR/IRVisitor.h
+++ b/include/hermes/IR/IRVisitor.h
@@ -10,6 +10,7 @@
 
 #include "hermes/IR/IR.h"
 #include "hermes/IR/Instrs.h"
+#include "hermes/IR/SH/SHModule.h"
 
 #define INCLUDE_ALL_INSTRS
 

--- a/include/hermes/IR/SH/SHModule.h
+++ b/include/hermes/IR/SH/SHModule.h
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef HERMES_IR_SH_SHMODULE_H
+#define HERMES_IR_SH_SHMODULE_H
+
+#include "hermes/IR/IR.h"
+
+#include "llvh/ADT/DenseMap.h"
+
+namespace hermes::sh {
+
+/// A register class identifies a set of registers with similar properties.
+enum class RegClass : uint8_t {
+  /// A native local that may be a pointer.
+  LocalPtr,
+  /// A native local that is guaranteed to not be a pointer.
+  LocalNonPtr,
+  /// An entry in the VM register stack.
+  RegStack,
+  /// The last entry.
+  _last,
+};
+
+/// An alias to make it explicit that a value is a register index.
+using RegIndex = uint32_t;
+
+/// This is an instance of a register. It contains a register class and an index
+/// within the class. Register is passed by value and must remain a small
+/// wrapper around an integer.
+class Register {
+  /// Marks unused/invalid register.
+  static constexpr uint32_t kInvalidRegister = ~(uint32_t)0;
+  /// A tombstone used by llvh::DenseMap.
+  static constexpr uint32_t kTombstoneRegister = kInvalidRegister - 1;
+
+  /// Bits reserved for the register class.
+  static constexpr unsigned kClassWidth = 4;
+  /// Remaining bits for the register index.
+  static constexpr unsigned kIndexWidth = 32 - kClassWidth;
+
+  static_assert(
+      (unsigned)RegClass::_last <= 1u << kClassWidth,
+      "not enough bits for RegClass");
+
+  /// The class and the index are packed inside a 32-bit word. We use a union
+  /// and a bitfield struct for convenient access.
+  union {
+    struct {
+      /// The register class.
+      uint32_t class_ : kClassWidth;
+      /// The index withing the register class.
+      uint32_t index_ : kIndexWidth;
+    };
+    /// An opaque 32-bit value holding both the index and the class.
+    uint32_t value_;
+  };
+
+  explicit constexpr Register(uint32_t value) : value_(value) {}
+
+ public:
+  /// Create an invalid register.
+  explicit constexpr Register() : Register(kInvalidRegister) {}
+
+  /// Create a register with class and index.
+  explicit constexpr Register(RegClass cls, RegIndex index)
+      : class_((uint32_t)cls), index_(index) {
+    assert(index < (1u << kIndexWidth) && "register index too large");
+  }
+
+  /// Create a tombstone register for used by llvh::DenseMap.
+  static constexpr Register getTombstoneKey() {
+    return Register(kTombstoneRegister);
+  }
+
+  /// \returns true if this is a valid result.
+  bool isValid() const {
+    return value_ != kInvalidRegister;
+  }
+
+  /// \returns an opaque value containing all information stored in the
+  /// register:
+  ///     the index and the class.
+  uint32_t getOpaqueValue() const {
+    return value_;
+  }
+
+  /// \returns the register class.
+  RegClass getClass() const {
+    assert(isValid());
+    return static_cast<RegClass>(class_);
+  }
+
+  /// \returns the index within the register class.
+  RegIndex getIndex() const {
+    assert(isValid());
+    return index_;
+  }
+
+  bool operator==(Register RHS) const {
+    return value_ == RHS.value_;
+  }
+  bool operator!=(Register RHS) const {
+    return !(*this == RHS);
+  }
+
+  /// \returns true if the register RHS comes right after this one.
+  /// For example, R5 comes after R4.
+  bool isConsecutive(Register RHS) const {
+    assert(isValid() && RHS.isValid());
+    return getClass() == RHS.getClass() && getIndex() + 1 == RHS.getIndex();
+  }
+
+  /// \return the n'th consecutive register after the current register.
+  Register getConsecutive(uint32_t count = 1) {
+    assert(isValid());
+    return Register(getClass(), getIndex() + count);
+  }
+
+  /// Impose an arbitrary ordering between registers.
+  static bool less(Register a, Register b) {
+    return a.value_ < b.value_;
+  }
+};
+
+// Print Register to llvm debug/error streams.
+llvh::raw_ostream &operator<<(llvh::raw_ostream &OS, Register reg);
+
+/// An IR representation of a local and the type used to access it.
+class SHLocal : public Value {
+  Register reg_;
+
+ public:
+  SHLocal(Register reg, Type type) : Value(ValueKind::SHLocalKind), reg_(reg) {
+    setType(type);
+  }
+
+  static bool classof(const Value *v) {
+    return v->getKind() == ValueKind::SHLocalKind;
+  }
+
+  Register reg() const {
+    return reg_;
+  }
+};
+
+/// All SH-specific IR data is owned by this class.
+class SHModule {
+  /// A map from register and type to local.
+  llvh::DenseMap<std::pair<Register, Type>, SHLocal *> locals_{};
+
+ public:
+  SHModule();
+  ~SHModule();
+
+  /// \returns a local with the given register and type, creating one if it
+  ///     doesn't exist.
+  SHLocal *getLocal(Register reg, Type type);
+};
+
+} // namespace hermes::sh
+
+namespace llvh {
+template <>
+struct DenseMapInfo<hermes::sh::Register> {
+  static inline hermes::sh::Register getEmptyKey() {
+    return hermes::sh::Register();
+  }
+  static inline hermes::sh::Register getTombstoneKey() {
+    return hermes::sh::Register::getTombstoneKey();
+  }
+  static unsigned getHashValue(hermes::sh::Register val) {
+    return val.getOpaqueValue();
+  }
+  static bool isEqual(hermes::sh::Register LHS, hermes::sh::Register RHS) {
+    return LHS == RHS;
+  }
+};
+
+template <>
+struct DenseMapInfo<std::pair<hermes::sh::Register, hermes::Type>> {
+  using T = std::pair<hermes::sh::Register, hermes::Type>;
+  using Info = DenseMapInfo<hermes::sh::Register>;
+
+  static inline T getEmptyKey() {
+    return T(Info::getEmptyKey(), hermes::Type::createNoType());
+  }
+  static inline T getTombstoneKey() {
+    return T(Info::getTombstoneKey(), hermes::Type::createNoType());
+  }
+  static unsigned getHashValue(const T &Val) {
+    return llvh::hash_combine(Info::getHashValue(Val.first), Val.second);
+  }
+  static bool isEqual(const T &LHS, const T &RHS) {
+    return Info::isEqual(LHS.first, RHS.first) && LHS.second == RHS.second;
+  }
+};
+} // namespace llvh
+
+#endif

--- a/include/hermes/IR/ValueKinds.def
+++ b/include/hermes/IR/ValueKinds.def
@@ -58,6 +58,8 @@ MARK_LAST(Function)
 
 DEF_VALUE(Module, Value)
 
+DEF_VALUE(SHLocal, Value)
+
 #undef DEF_VALUE
 #undef MARK_FIRST
 #undef MARK_LAST

--- a/lib/BCGen/RegAlloc.cpp
+++ b/lib/BCGen/RegAlloc.cpp
@@ -861,6 +861,7 @@ struct LivenessRegAllocIRPrinter : IRPrinter {
   void printValueLabel(Instruction *I, Value *V, unsigned opIndex) override {
     if (allocator.isAllocated(V)) {
       os << "$" << allocator.getRegister(V);
+      printTypeLabel(V);
     } else {
       IRPrinter::printValueLabel(I, V, opIndex);
     }

--- a/lib/BCGen/RegAlloc.cpp
+++ b/lib/BCGen/RegAlloc.cpp
@@ -846,7 +846,7 @@ struct LivenessRegAllocIRPrinter : IRPrinter {
       os << "$" << allocator.getRegister(I);
     }
 
-    if (!codeGenOpts.dumpOperandRegisters) {
+    if (codeGenOpts.dumpRegisterInterval) {
       os << " ";
       if (allocator.hasInstructionNumber(I)) {
         auto idx = allocator.getInstructionNumber(I);
@@ -855,14 +855,11 @@ struct LivenessRegAllocIRPrinter : IRPrinter {
       } else {
         os << "          \t";
       }
-
-      IRPrinter::printInstructionDestination(I);
     }
   }
 
   void printValueLabel(Instruction *I, Value *V, unsigned opIndex) override {
-    auto codeGenOpts = I->getContext().getCodeGenerationSettings();
-    if (codeGenOpts.dumpOperandRegisters && allocator.isAllocated(V)) {
+    if (allocator.isAllocated(V)) {
       os << "$" << allocator.getRegister(V);
     } else {
       IRPrinter::printValueLabel(I, V, opIndex);

--- a/lib/BCGen/SH/SHRegAlloc.cpp
+++ b/lib/BCGen/SH/SHRegAlloc.cpp
@@ -914,28 +914,6 @@ unsigned RegisterAllocator::getInstructionNumber(Instruction *I) {
   return newIdx;
 }
 
-llvh::raw_ostream &operator<<(llvh::raw_ostream &OS, Register reg) {
-  if (!reg.isValid()) {
-    OS << "invalid";
-  } else {
-    switch (reg.getClass()) {
-      case RegClass::LocalPtr:
-        OS << "loc" << reg.getIndex();
-        break;
-      case RegClass::LocalNonPtr:
-        OS << "np" << reg.getIndex();
-        break;
-      case RegClass::RegStack:
-        OS << "stack[" << reg.getIndex() << ']';
-        break;
-      case RegClass::_last:
-        llvm_unreachable("invalid register class");
-    }
-  }
-
-  return OS;
-}
-
 llvh::raw_ostream &operator<<(llvh::raw_ostream &OS, const Segment &segment) {
   if (segment.empty()) {
     OS << "[empty]";

--- a/lib/BCGen/SH/SHRegAlloc.cpp
+++ b/lib/BCGen/SH/SHRegAlloc.cpp
@@ -837,7 +837,7 @@ struct LivenessRegAllocIRPrinter : IRPrinter {
           llvh::fmt_align(allocator.getRegister(I), llvh::AlignStyle::Left, 9));
     }
 
-    if (!codeGenOpts.dumpOperandRegisters) {
+    if (codeGenOpts.dumpRegisterInterval) {
       os << " ";
       if (allocator.hasInstructionNumber(I)) {
         auto idx = allocator.getInstructionNumber(I);
@@ -846,14 +846,11 @@ struct LivenessRegAllocIRPrinter : IRPrinter {
       } else {
         os << "          \t";
       }
-
-      IRPrinter::printInstructionDestination(I);
     }
   }
 
   void printValueLabel(Instruction *I, Value *V, unsigned opIndex) override {
-    auto codeGenOpts = I->getContext().getCodeGenerationSettings();
-    if (codeGenOpts.dumpOperandRegisters && allocator.isAllocated(V)) {
+    if (allocator.isAllocated(V)) {
       os << "$" << allocator.getRegister(V);
     } else {
       IRPrinter::printValueLabel(I, V, opIndex);

--- a/lib/BCGen/SH/SHRegAlloc.h
+++ b/lib/BCGen/SH/SHRegAlloc.h
@@ -8,6 +8,8 @@
 #ifndef HERMES_BCGEN_SHREGALLOC_H
 #define HERMES_BCGEN_SHREGALLOC_H
 
+#include "hermes/IR/SH/SHModule.h"
+
 #include "hermes/BCGen/HBC/StackFrameLayout.h"
 #include "hermes/IR/Instrs.h"
 
@@ -17,119 +19,6 @@
 #include "llvh/ADT/DenseSet.h"
 
 namespace hermes::sh {
-
-/// A register class identifies a set of registers with similar properties.
-enum class RegClass : uint8_t {
-  /// A native local that may be a pointer.
-  LocalPtr,
-  /// A native local that is guaranteed to not be a pointer.
-  LocalNonPtr,
-  /// An entry in the VM register stack.
-  RegStack,
-  /// The last entry.
-  _last,
-};
-
-/// An alias to make it explicit that a value is a register index.
-using RegIndex = uint32_t;
-
-/// This is an instance of a register. It contains a register class and an index
-/// within the class. Register is passed by value and must remain a small
-/// wrapper around an integer.
-class Register {
-  /// Marks unused/invalid register.
-  static constexpr uint32_t kInvalidRegister = ~(uint32_t)0;
-  /// A tombstone used by llvh::DenseMap.
-  static constexpr uint32_t kTombstoneRegister = kInvalidRegister - 1;
-
-  /// Bits reserved for the register class.
-  static constexpr unsigned kClassWidth = 4;
-  /// Remaining bits for the register index.
-  static constexpr unsigned kIndexWidth = 32 - kClassWidth;
-
-  static_assert(
-      (unsigned)RegClass::_last <= 1u << kClassWidth,
-      "not enough bits for RegClass");
-
-  /// The class and the index are packed inside a 32-bit word. We use a union
-  /// and a bitfield struct for convenient access.
-  union {
-    struct {
-      /// The register class.
-      uint32_t class_ : kClassWidth;
-      /// The index withing the register class.
-      uint32_t index_ : kIndexWidth;
-    };
-    /// An opaque 32-bit value holding both the index and the class.
-    uint32_t value_;
-  };
-
-  explicit constexpr Register(uint32_t value) : value_(value) {}
-
- public:
-  /// Create an invalid register.
-  explicit constexpr Register() : Register(kInvalidRegister) {}
-
-  /// Create a register with class and index.
-  explicit constexpr Register(RegClass cls, RegIndex index)
-      : class_((uint32_t)cls), index_(index) {
-    assert(index < (1u << kIndexWidth) && "register index too large");
-  }
-
-  /// Create a tombstone register for used by llvh::DenseMap.
-  static constexpr Register getTombstoneKey() {
-    return Register(kTombstoneRegister);
-  }
-
-  /// \returns true if this is a valid result.
-  bool isValid() const {
-    return value_ != kInvalidRegister;
-  }
-
-  /// \returns an opaque value containing all information stored in the
-  /// register:
-  ///     the index and the class.
-  uint32_t getOpaqueValue() const {
-    return value_;
-  }
-
-  /// \returns the register class.
-  RegClass getClass() const {
-    assert(isValid());
-    return static_cast<RegClass>(class_);
-  }
-
-  /// \returns the index within the register class.
-  RegIndex getIndex() const {
-    assert(isValid());
-    return index_;
-  }
-
-  bool operator==(Register RHS) const {
-    return value_ == RHS.value_;
-  }
-  bool operator!=(Register RHS) const {
-    return !(*this == RHS);
-  }
-
-  /// \returns true if the register RHS comes right after this one.
-  /// For example, R5 comes after R4.
-  bool isConsecutive(Register RHS) const {
-    assert(isValid() && RHS.isValid());
-    return getClass() == RHS.getClass() && getIndex() + 1 == RHS.getIndex();
-  }
-
-  /// \return the n'th consecutive register after the current register.
-  Register getConsecutive(uint32_t count = 1) {
-    assert(isValid());
-    return Register(getClass(), getIndex() + count);
-  }
-
-  /// Impose an arbitrary ordering between registers.
-  static bool less(Register a, Register b) {
-    return a.value_ < b.value_;
-  }
-};
 
 /// This class represents the register file. In keeps track of the currently
 /// live registers and knows how to recycle registers.
@@ -529,28 +418,9 @@ class SHRegisterAllocator : public RegisterAllocator {
 };
 
 // Print Register to llvm debug/error streams.
-llvh::raw_ostream &operator<<(llvh::raw_ostream &OS, Register reg);
 llvh::raw_ostream &operator<<(llvh::raw_ostream &OS, const Interval &interval);
 llvh::raw_ostream &operator<<(llvh::raw_ostream &OS, const Segment &segment);
 
 } // namespace hermes::sh
-
-namespace llvh {
-template <>
-struct DenseMapInfo<hermes::sh::Register> {
-  static inline hermes::sh::Register getEmptyKey() {
-    return hermes::sh::Register();
-  }
-  static inline hermes::sh::Register getTombstoneKey() {
-    return hermes::sh::Register::getTombstoneKey();
-  }
-  static unsigned getHashValue(hermes::sh::Register val) {
-    return val.getOpaqueValue();
-  }
-  static bool isEqual(hermes::sh::Register LHS, hermes::sh::Register RHS) {
-    return LHS == RHS;
-  }
-};
-} // namespace llvh
 
 #endif

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -41,6 +41,7 @@ add_hermes_library(hermesFrontend
   IR/IRBuilder.cpp
   IR/IRVerifier.cpp
   IR/Instrs.cpp
+  IR/SH/SHModule.cpp
   Utils/Dumper.cpp
   LINK_OBJLIBS hermesSupport hermesFrontEndDefs hermesAST hermesSema hermesParser
 )

--- a/lib/CompilerDriver/CompilerDriver.cpp
+++ b/lib/CompilerDriver/CompilerDriver.cpp
@@ -357,11 +357,11 @@ static opt<bool> OutputSourceMap(
     desc("Emit a source map to the output filename with .map extension"),
     cat(CompilerCategory));
 
-static opt<bool> DumpOperandRegisters(
-    "dump-operand-registers",
-    desc("Dump registers assigned to instruction operands"),
-    init(true),
-    cat(CompilerCategory));
+cl::opt<bool> DumpRegisterInterval(
+    "dump-register-interval",
+    cl::desc("Dump the liveness interval of allocated registers"),
+    cl::init(false),
+    cl::cat(CompilerCategory));
 
 static opt<bool> DumpUseList(
     "dump-instr-uselist",
@@ -1012,7 +1012,7 @@ std::shared_ptr<Context> createContext(
     std::vector<uint32_t> segments) {
   CodeGenerationSettings codeGenOpts;
   codeGenOpts.enableTDZ = cl::EnableTDZ;
-  codeGenOpts.dumpOperandRegisters = cl::DumpOperandRegisters;
+  codeGenOpts.dumpRegisterInterval = cl::DumpRegisterInterval;
   codeGenOpts.dumpUseList = cl::DumpUseList;
   codeGenOpts.dumpSourceLocation =
       cl::DumpSourceLocation != LocationDumpMode::None;

--- a/lib/IR/IR.cpp
+++ b/lib/IR/IR.cpp
@@ -5,16 +5,18 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include "hermes/IR/IR.h"
+
+#include "hermes/AST/Context.h"
+#include "hermes/IR/Instrs.h"
+#include "hermes/IR/SH/SHModule.h"
+#include "hermes/Utils/Dumper.h"
+
 #include "llvh/ADT/SetVector.h"
 #include "llvh/ADT/SmallString.h"
 #include "llvh/Support/Casting.h"
 #include "llvh/Support/ErrorHandling.h"
 #include "llvh/Support/raw_ostream.h"
-
-#include "hermes/AST/Context.h"
-#include "hermes/IR/IR.h"
-#include "hermes/IR/Instrs.h"
-#include "hermes/Utils/Dumper.h"
 
 #include <set>
 #include <type_traits>

--- a/lib/IR/SH/SHModule.cpp
+++ b/lib/IR/SH/SHModule.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "hermes/IR/SH/SHModule.h"
+
+#define DEBUG_TYPE "shmodule"
+
+namespace hermes::sh {
+
+llvh::raw_ostream &operator<<(llvh::raw_ostream &OS, Register reg) {
+  if (!reg.isValid()) {
+    OS << "invalid";
+  } else {
+    switch (reg.getClass()) {
+      case RegClass::LocalPtr:
+        OS << "loc" << reg.getIndex();
+        break;
+      case RegClass::LocalNonPtr:
+        OS << "np" << reg.getIndex();
+        break;
+      case RegClass::RegStack:
+        OS << "stack[" << reg.getIndex() << ']';
+        break;
+      case RegClass::_last:
+        llvm_unreachable("invalid register class");
+    }
+  }
+
+  return OS;
+}
+
+SHModule::SHModule() = default;
+
+SHModule::~SHModule() {
+  for (auto &pair : locals_)
+    Value::destroy(pair.second);
+}
+
+SHLocal *SHModule::getLocal(hermes::sh::Register reg, hermes::Type type) {
+  auto [it, inserted] = locals_.try_emplace(std::make_pair(reg, type), nullptr);
+  if (inserted)
+    it->second = new SHLocal(reg, type);
+  return it->second;
+}
+
+} // namespace hermes::sh
+
+#undef DEBUG_TYPE

--- a/lib/Utils/Dumper.cpp
+++ b/lib/Utils/Dumper.cpp
@@ -190,6 +190,8 @@ void IRPrinter::printValueLabel(Instruction *I, Value *V, unsigned opIndex) {
     if (ne->declared())
       os << " /*declared*/";
     os << ")";
+  } else if (auto *shLocal = llvh::dyn_cast<sh::SHLocal>(V)) {
+    os << '$' << shLocal->reg();
   } else {
     llvm_unreachable("Invalid value");
   }

--- a/test/BCGen/SH/RA/phi_swap.js
+++ b/test/BCGen/SH/RA/phi_swap.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// RUN: %shermes -O -dump-ra -dump-operand-registers %s | %FileCheckOrRegen --match-full-lines %s
+// RUN: %shermes -O -dump-ra %s | %FileCheckOrRegen --match-full-lines %s
 // Ensure that the register allocator correctly handles cycles between Phi-nodes.
 
 function foo (a, b) {

--- a/test/BCGen/SH/call-and-new-args.js
+++ b/test/BCGen/SH/call-and-new-args.js
@@ -29,15 +29,15 @@ function test_builtin(a) {
 // CHECK-NEXT:  $loc1      = DeclareGlobalVarInst "test_call": string
 // CHECK-NEXT:  $loc1      = DeclareGlobalVarInst "test_new": string
 // CHECK-NEXT:  $loc1      = DeclareGlobalVarInst "test_builtin": string
-// CHECK-NEXT:  $loc2      = HBCCreateFunctionInst (:object) %test_call(): any, $loc0
+// CHECK-NEXT:  $loc2      = HBCCreateFunctionInst (:object) %test_call(): any, $loc0: environment
 // CHECK-NEXT:  $loc1      = HBCGetGlobalObjectInst (:object)
-// CHECK-NEXT:  $loc2      = StorePropertyLooseInst $loc2, $loc1, "test_call": string
-// CHECK-NEXT:  $loc2      = HBCCreateFunctionInst (:object) %test_new(): object, $loc0
-// CHECK-NEXT:  $loc2      = StorePropertyLooseInst $loc2, $loc1, "test_new": string
-// CHECK-NEXT:  $loc0      = HBCCreateFunctionInst (:object) %test_builtin(): number, $loc0
-// CHECK-NEXT:  $loc0      = StorePropertyLooseInst $loc0, $loc1, "test_builtin": string
+// CHECK-NEXT:  $loc2      = StorePropertyLooseInst $loc2: object, $loc1: object, "test_call": string
+// CHECK-NEXT:  $loc2      = HBCCreateFunctionInst (:object) %test_new(): object, $loc0: environment
+// CHECK-NEXT:  $loc2      = StorePropertyLooseInst $loc2: object, $loc1: object, "test_new": string
+// CHECK-NEXT:  $loc0      = HBCCreateFunctionInst (:object) %test_builtin(): number, $loc0: environment
+// CHECK-NEXT:  $loc0      = StorePropertyLooseInst $loc0: object, $loc1: object, "test_builtin": string
 // CHECK-NEXT:  $np0       = HBCLoadConstInst (:undefined) undefined: undefined
-// CHECK-NEXT:  $loc0      = ReturnInst $np0
+// CHECK-NEXT:  $loc0      = ReturnInst $np0: undefined
 // CHECK-NEXT:function_end
 
 // CHECK:function test_call(bar: any): any
@@ -51,26 +51,26 @@ function test_builtin(a) {
 // CHECK-NEXT:  $stack[0]  = HBCLoadConstInst (:number) 13: number
 // CHECK-NEXT:  $stack[6]  = HBCLoadConstInst (:undefined) undefined: undefined
 // CHECK-NEXT:  $stack[4]  = HBCLoadConstInst (:undefined) undefined: undefined
-// CHECK-NEXT:  $loc0      = CallInst (:any) $stack[5], empty: any, empty: any, $np4, $stack[4], $stack[3], $stack[2], $stack[1], $stack[0]
-// CHECK-NEXT:  $loc0      = ReturnInst $loc0
+// CHECK-NEXT:  $loc0      = CallInst (:any) $stack[5]: any, empty: any, empty: any, $np4: undefined, $stack[4]: undefined, $stack[3]: number, $stack[2]: number, $stack[1]: number, $stack[0]: number
+// CHECK-NEXT:  $loc0      = ReturnInst $loc0: any
 // CHECK-NEXT:function_end
 
 // CHECK:function test_new(bar: any): object
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  $loc0      = LoadParamInst (:any) %bar: any
-// CHECK-NEXT:  $loc1      = LoadPropertyInst (:any) $loc0, "prototype": string
-// CHECK-NEXT:  $loc1      = CreateThisInst (:object) $loc1, $loc0
+// CHECK-NEXT:  $loc1      = LoadPropertyInst (:any) $loc0: any, "prototype": string
+// CHECK-NEXT:  $loc1      = CreateThisInst (:object) $loc1: any, $loc0: any
 // CHECK-NEXT:  $stack[3]  = HBCLoadConstInst (:number) 10: number
 // CHECK-NEXT:  $stack[2]  = HBCLoadConstInst (:number) 11: number
 // CHECK-NEXT:  $stack[1]  = HBCLoadConstInst (:number) 12: number
 // CHECK-NEXT:  $stack[0]  = HBCLoadConstInst (:number) 13: number
-// CHECK-NEXT:  $stack[6]  = MovInst (:any) $loc0
-// CHECK-NEXT:  $stack[5]  = MovInst (:any) $loc0
-// CHECK-NEXT:  $stack[4]  = MovInst (:object) $loc1
-// CHECK-NEXT:  $loc0      = CallInst (:any) $stack[5], empty: any, empty: any, $loc0, $stack[4], $stack[3], $stack[2], $stack[1], $stack[0]
-// CHECK-NEXT:  $loc0      = GetConstructedObjectInst (:object) $loc1, $loc0
-// CHECK-NEXT:  $loc0      = ReturnInst $loc0
+// CHECK-NEXT:  $stack[6]  = MovInst (:any) $loc0: any
+// CHECK-NEXT:  $stack[5]  = MovInst (:any) $loc0: any
+// CHECK-NEXT:  $stack[4]  = MovInst (:object) $loc1: object
+// CHECK-NEXT:  $loc0      = CallInst (:any) $stack[5]: any, empty: any, empty: any, $loc0: any, $stack[4]: object, $stack[3]: number, $stack[2]: number, $stack[1]: number, $stack[0]: number
+// CHECK-NEXT:  $loc0      = GetConstructedObjectInst (:object) $loc1: object, $loc0: any
+// CHECK-NEXT:  $loc0      = ReturnInst $loc0: object
 // CHECK-NEXT:function_end
 
 // CHECK:function test_builtin(a: any): number
@@ -81,6 +81,6 @@ function test_builtin(a) {
 // CHECK-NEXT:  $stack[4]  = ImplicitMovInst (:undefined) undefined: undefined
 // CHECK-NEXT:  $stack[3]  = ImplicitMovInst (:empty) empty: empty
 // CHECK-NEXT:  $stack[2]  = ImplicitMovInst (:undefined) undefined: undefined
-// CHECK-NEXT:  $loc0      = CallBuiltinInst (:any) [HermesBuiltin.exponentiationOperator]: number, empty: any, empty: any, undefined: undefined, undefined: undefined, $stack[1], $stack[0]
-// CHECK-NEXT:  $loc0      = ReturnInst $loc0
+// CHECK-NEXT:  $loc0      = CallBuiltinInst (:any) [HermesBuiltin.exponentiationOperator]: number, empty: any, empty: any, undefined: undefined, undefined: undefined, $stack[1]: any, $stack[0]: number
+// CHECK-NEXT:  $loc0      = ReturnInst $loc0: any
 // CHECK-NEXT:function_end

--- a/test/BCGen/SH/call-and-new-args.js
+++ b/test/BCGen/SH/call-and-new-args.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// RUN: %shermes -O -dump-lra -dump-operand-registers %s | %FileCheckOrRegen --match-full-lines %s
+// RUN: %shermes -O -dump-lra %s | %FileCheckOrRegen --match-full-lines %s
 
 // Check that call and new arguments, including the calleee and new.target, are
 // correctly lowered into stack registers.

--- a/test/BCGen/SH/call-builtin-clobber-callee.js
+++ b/test/BCGen/SH/call-builtin-clobber-callee.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// RUN: %shermes -O -dump-lra -dump-operand-registers %s | %FileCheckOrRegen --match-full-lines %s
+// RUN: %shermes -O -dump-lra %s | %FileCheckOrRegen --match-full-lines %s
 
 /// Ensure that the callee stack entry is clobbered by the builtin call.
 function test_call_after_builtin() {

--- a/test/BCGen/SH/call-builtin-clobber-callee.js
+++ b/test/BCGen/SH/call-builtin-clobber-callee.js
@@ -19,39 +19,39 @@ function test_call_after_builtin() {
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  $loc0      = DeclareGlobalVarInst "test_call_after_builtin": string
 // CHECK-NEXT:  $loc0      = HBCCreateEnvironmentInst (:environment)
-// CHECK-NEXT:  $loc1      = HBCCreateFunctionInst (:object) %test_call_after_builtin(): undefined, $loc0
+// CHECK-NEXT:  $loc1      = HBCCreateFunctionInst (:object) %test_call_after_builtin(): undefined, $loc0: environment
 // CHECK-NEXT:  $loc0      = HBCGetGlobalObjectInst (:object)
-// CHECK-NEXT:  $loc0      = StorePropertyLooseInst $loc1, $loc0, "test_call_after_builtin": string
+// CHECK-NEXT:  $loc0      = StorePropertyLooseInst $loc1: object, $loc0: object, "test_call_after_builtin": string
 // CHECK-NEXT:  $np0       = HBCLoadConstInst (:undefined) undefined: undefined
-// CHECK-NEXT:  $loc0      = ReturnInst $np0
+// CHECK-NEXT:  $loc0      = ReturnInst $np0: undefined
 // CHECK-NEXT:function_end
 
 // CHECK:function test_call_after_builtin(): undefined
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  $loc0      = HBCGetGlobalObjectInst (:object)
-// CHECK-NEXT:  $loc1      = TryLoadGlobalPropertyInst (:any) $loc0, "print": string
+// CHECK-NEXT:  $loc1      = TryLoadGlobalPropertyInst (:any) $loc0: object, "print": string
 // CHECK-NEXT:  $loc0      = HBCAllocObjectFromBufferInst (:object) 1: number, "valueOf": string, null: null
 // CHECK-NEXT:  $loc2      = HBCCreateEnvironmentInst (:environment)
-// CHECK-NEXT:  $loc2      = HBCCreateFunctionInst (:object) %valueOf(): number, $loc2
-// CHECK-NEXT:  $loc2      = StorePropertyLooseInst $loc2, $loc0, "valueOf": string
+// CHECK-NEXT:  $loc2      = HBCCreateFunctionInst (:object) %valueOf(): number, $loc2: environment
+// CHECK-NEXT:  $loc2      = StorePropertyLooseInst $loc2: object, $loc0: object, "valueOf": string
 // CHECK-NEXT:  $stack[0]  = HBCLoadConstInst (:number) 3: number
 // CHECK-NEXT:  $stack[4]  = ImplicitMovInst (:undefined) undefined: undefined
 // CHECK-NEXT:  $stack[3]  = ImplicitMovInst (:empty) empty: empty
 // CHECK-NEXT:  $stack[2]  = ImplicitMovInst (:undefined) undefined: undefined
-// CHECK-NEXT:  $stack[1]  = MovInst (:object) $loc0
-// CHECK-NEXT:  $stack[1]  = CallBuiltinInst (:any) [HermesBuiltin.exponentiationOperator]: number, empty: any, empty: any, undefined: undefined, undefined: undefined, $stack[1], $stack[0]
+// CHECK-NEXT:  $stack[1]  = MovInst (:object) $loc0: object
+// CHECK-NEXT:  $stack[1]  = CallBuiltinInst (:any) [HermesBuiltin.exponentiationOperator]: number, empty: any, empty: any, undefined: undefined, undefined: undefined, $stack[1]: object, $stack[0]: number
 // CHECK-NEXT:  $np0       = HBCLoadConstInst (:undefined) undefined: undefined
 // CHECK-NEXT:  $stack[4]  = HBCLoadConstInst (:undefined) undefined: undefined
-// CHECK-NEXT:  $stack[3]  = MovInst (:any) $loc1
+// CHECK-NEXT:  $stack[3]  = MovInst (:any) $loc1: any
 // CHECK-NEXT:  $stack[2]  = HBCLoadConstInst (:undefined) undefined: undefined
-// CHECK-NEXT:  $loc0      = CallInst (:any) $stack[3], empty: any, empty: any, $np0, $stack[2], $stack[1]
-// CHECK-NEXT:  $loc0      = ReturnInst $np0
+// CHECK-NEXT:  $loc0      = CallInst (:any) $stack[3]: any, empty: any, empty: any, $np0: undefined, $stack[2]: undefined, $stack[1]: any
+// CHECK-NEXT:  $loc0      = ReturnInst $np0: undefined
 // CHECK-NEXT:function_end
 
 // CHECK:arrow valueOf(): number
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  $np0       = HBCLoadConstInst (:number) 2: number
-// CHECK-NEXT:  $loc0      = ReturnInst $np0
+// CHECK-NEXT:  $loc0      = ReturnInst $np0: number
 // CHECK-NEXT:function_end

--- a/tools/shermes/shermes.cpp
+++ b/tools/shermes/shermes.cpp
@@ -342,10 +342,10 @@ cl::opt<bool> VerifyIR(
     cl::desc("Verify the IR after each pass."),
     cl::cat(CompilerCategory));
 
-cl::opt<bool> DumpOperandRegisters(
-    "dump-operand-registers",
-    cl::desc("Dump registers for operands instead of instruction numbers"),
-    cl::init(true),
+cl::opt<bool> DumpRegisterInterval(
+    "dump-register-interval",
+    cl::desc("Dump the liveness interval of allocated registers"),
+    cl::init(false),
     cl::cat(CompilerCategory));
 
 cl::opt<bool> DumpUseList(
@@ -464,7 +464,7 @@ std::shared_ptr<Context> createContext() {
   codeGenOpts.enableTDZ = cli::Test262 && !cli::EnableTDZ.getNumOccurrences()
       ? true
       : cli::EnableTDZ;
-  codeGenOpts.dumpOperandRegisters = cli::DumpOperandRegisters;
+  codeGenOpts.dumpRegisterInterval = cli::DumpRegisterInterval;
   codeGenOpts.dumpUseList = cli::DumpUseList;
   codeGenOpts.dumpSourceLocation =
       cli::DumpSourceLocation != LocationDumpMode::None;


### PR DESCRIPTION
Summary:
Replace operands referring to instructions with an instance of SHLocal
with the corresponding register and type. This breaks the usage
dependency between operands and instructions, which was logically
inconsistent after RegAlloc, since at that point the IR is no longer
SSA.

This now allows registers and types to be freely updated in individual
instructions.

PhiInst and AllocStackInst are removed.

This all happens after the lowering passes, since those passes still
need the dependency information left overt from SSA.

Differential Revision: D49221051

