### PR TITLE
Avoid recursion in JSError construction

### DIFF
--- a/API/hermes/hermes.cpp
+++ b/API/hermes/hermes.cpp
@@ -2220,16 +2220,6 @@ void HermesRuntimeImpl::checkStatus(vm::ExecutionStatus status) {
     return;
   }
 
-  // Here, we increment the depth to detect recursion in error handling.
-  vm::ScopedNativeDepthTracker depthTracker{runtime_};
-  if (LLVM_LIKELY(!depthTracker.overflowed()))
-    throwPendingError();
-
-  (void)runtime_.raiseStackOverflow(
-      vm::Runtime::StackOverflowKind::NativeStack);
-  // Here, we give us a little more room so we can call into JS to
-  // populate the JSError members.
-  vm::ScopedNativeDepthReducer reducer(runtime_);
   throwPendingError();
 }
 
@@ -2253,10 +2243,64 @@ vm::HermesValue HermesRuntimeImpl::stringHVFromUtf8(
 }
 
 void HermesRuntimeImpl::throwPendingError() {
-  // Convert the thrown value to a jsi::Value and construct a JSError from it.
-  jsi::Value exception = valueFromHermesValue(runtime_.getThrownValue());
+  vm::GCScope scope{runtime_};
+
+  // Retrieve the exception value and clear as we will rethrow it as a C++
+  // exception.
+  auto hv = runtime_.getThrownValue();
   runtime_.clearThrownValue();
-  throw jsi::JSError(*this, std::move(exception));
+  auto jsiVal = valueFromHermesValue(hv);
+  auto hnd = vmHandleFromValue(jsiVal);
+
+  std::string msg = "No message";
+  std::string stack = "No stack";
+  if (auto str = vm::Handle<vm::StringPrimitive>::dyn_vmcast(hnd)) {
+    // If the exception is a string, use it as the message.
+    msg = utf8FromStringView(
+        vm::StringPrimitive::createStringView(runtime_, str));
+  } else if (auto obj = vm::Handle<vm::JSObject>::dyn_vmcast(hnd)) {
+    // If the exception is an object try to retrieve its message and stack
+    // properties.
+
+    /// Attempt to retrieve a string property \p sym from \c obj and store it
+    /// in \p out. Ignore any catchable errors and non-string properties.
+    auto getStrProp = [this, obj](vm::SymbolID sym, std::string &out) {
+      auto propRes = vm::JSObject::getNamed_RJS(obj, runtime_, sym);
+      if (LLVM_UNLIKELY(propRes == vm::ExecutionStatus::EXCEPTION)) {
+        // An exception was thrown while retrieving the property, if it is
+        // catchable, suppress it. Otherwise, rethrow this exception without
+        // trying to invoke any more JavaScript.
+        auto propExHv = runtime_.getThrownValue();
+        runtime_.clearThrownValue();
+
+        if (!vm::isUncatchableError(propExHv))
+          return;
+
+        // An uncatchable error occurred, it is unsafe to do anything that might
+        // execute more JavaScript.
+        throw jsi::JSError(
+            valueFromHermesValue(propExHv),
+            "Uncatchable exception thrown while creating error",
+            "No stack");
+      }
+
+      // If the property is a string, update out. Otherwise ignore it.
+      auto prop = propRes->get();
+      if (prop.isString()) {
+        auto view = vm::StringPrimitive::createStringView(
+            runtime_, runtime_.makeHandle(prop.getString()));
+        out = utf8FromStringView(view);
+      }
+    };
+
+    getStrProp(vm::Predefined::getSymbolID(vm::Predefined::message), msg);
+    getStrProp(vm::Predefined::getSymbolID(vm::Predefined::stack), stack);
+  }
+
+  // Use the constructor of jsi::JSError that cannot run additional
+  // JS, since that may then result in additional exceptions and infinite
+  // recursion.
+  throw jsi::JSError(std::move(jsiVal), msg, stack);
 }
 
 template <typename... Args>


### PR DESCRIPTION
Summary:
The `jsi::JSError` constructor currently makes further JSI calls to
populate the message and stack values. These JSI calls may throw, which
may then lead to the `JSError` constructor being recursively invoked.

This is especially a problem because our stack overflow detection
itself reports an exception on overflow, but producing that exception
requires retrieving those properties, which will then attempt to throw
another exception because the stack has already overflowed. This
continues until the native stack is exhausted and the program crashes.

To address this, use Hermes internal APIs to retrieve the value of
those properties. If this fail, we can simply suppress the exception
without constructing another `JSError`.

Reviewed By: avp

Differential Revision: D49211075


