### PR TITLE
Fix wasm optimization compilation errors

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -50,7 +50,6 @@ add_hermes_library(hermesFrontend
   IR/Instrs.cpp
   Utils/Dumper.cpp
   Optimizer/Wasm/WasmIntrinsics.cpp
-  Optimizer/Wasm/EmitWasmIntrinsics.cpp
   LINK_LIBS hermesSupport hermesFrontEndDefs hermesAST hermesParser
 )
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -20,6 +20,7 @@ add_hermes_library(hermesOptimizer
   Optimizer/Scalar/InstSimplify.cpp
   Optimizer/Scalar/Auditor.cpp
   Optimizer/Wasm/WasmSimplify.cpp
+  Optimizer/Wasm/EmitWasmIntrinsics.cpp
   Optimizer/Scalar/ScopeTransformations.cpp
   Optimizer/Scalar/ResolveStaticRequire.cpp
   Optimizer/Scalar/SimpleCallGraphProvider.cpp

--- a/lib/Optimizer/PassManager/Pipeline.cpp
+++ b/lib/Optimizer/PassManager/Pipeline.cpp
@@ -13,6 +13,8 @@
 #include "hermes/Optimizer/Scalar/ScopeTransformations.h"
 #include "hermes/Optimizer/Scalar/SimplifyCFG.h"
 #include "hermes/Optimizer/Scalar/TypeInference.h"
+#include "hermes/Optimizer/Wasm/WasmSimplify.h"
+#include "hermes/Optimizer/Wasm/EmitWasmIntrinsics.h"
 
 #include "llvh/Support/Debug.h"
 #include "llvh/Support/raw_ostream.h"
@@ -68,7 +70,7 @@ void hermes::runFullOptimizationPasses(Module &M) {
 #ifdef HERMES_RUN_WASM
   if (M.getContext().getUseUnsafeIntrinsics()) {
     PM.addTypeInference();
-    PM.addPass(new WasmSimplify());
+    PM.addPass<WasmSimplify>();
   }
 #endif // HERMES_RUN_WASM
 
@@ -92,7 +94,7 @@ void hermes::runFullOptimizationPasses(Module &M) {
 #ifdef HERMES_RUN_WASM
   // Emit Asm.js/Wasm unsafe compiler intrinsics, if enabled.
   if (M.getContext().getUseUnsafeIntrinsics()) {
-    PM.addPass(new EmitWasmIntrinsics());
+    PM.addPass<EmitWasmIntrinsics>();
   }
 #endif // HERMES_RUN_WASM
 
@@ -113,7 +115,7 @@ void hermes::runDebugOptimizationPasses(Module &M) {
 #ifdef HERMES_RUN_WASM
   // Emit Asm.js/Wasm unsafe compiler intrinsics, if enabled.
   if (M.getContext().getUseUnsafeIntrinsics()) {
-    PM.addPass(new EmitWasmIntrinsics());
+    PM.addPass<EmitWasmIntrinsics>();
   }
 #endif // HERMES_RUN_WASM
 
@@ -127,8 +129,8 @@ void hermes::runNoOptimizationPasses(Module &M) {
 
   // Emit Asm.js/Wasm unsafe compiler intrinsics, if enabled.
   if (M.getContext().getUseUnsafeIntrinsics()) {
-    PassManager PM;
-    PM.addPass(new EmitWasmIntrinsics());
+    PassManager PM{M.getContext().getCodeGenerationSettings()};
+    PM.addPass<EmitWasmIntrinsics>();
     PM.run(&M);
   }
 }


### PR DESCRIPTION
## Summary

For now enabling the HERMES_RUN_WASM flags causes compilation errors

