### PR TITLE
Maintain ordering of loaded scripts

### DIFF
--- a/API/hermes/inspector/chrome/tests/ConnectionTests.cpp
+++ b/API/hermes/inspector/chrome/tests/ConnectionTests.cpp
@@ -573,6 +573,43 @@ TEST_F(ConnectionTests, testScriptsOnEnable) {
   expectNotification<m::debugger::ScriptParsedNotification>(conn);
 }
 
+TEST_F(ConnectionTests, testScriptsOrdering) {
+  int msgId = 1;
+  std::vector<m::debugger::ScriptParsedNotification> notifications;
+
+  const int kNumScriptParsed = 10;
+
+  send<m::debugger::EnableRequest>(conn, msgId++);
+
+  // Trigger a bunch of scriptParsed notifications to later verify that they get
+  // re-sent in the same order
+  for (int i = 0; i < kNumScriptParsed; i++) {
+    asyncRuntime.executeScriptAsync(R"(
+      true
+    )");
+    auto notification =
+        expectNotification<m::debugger::ScriptParsedNotification>(conn);
+    notifications.push_back(notification);
+  }
+
+  // Make sure a new Debugger.enable will see the same ordering of scriptParsed
+  send<m::debugger::EnableRequest>(conn, msgId++);
+  for (int i = 0; i < kNumScriptParsed; i++) {
+    auto notification =
+        expectNotification<m::debugger::ScriptParsedNotification>(conn);
+    EXPECT_EQ(notifications[i].scriptId, notification.scriptId);
+  }
+
+  // Make sure the same ordering is retained after a disable request
+  send<m::debugger::DisableRequest>(conn, msgId++);
+  send<m::debugger::EnableRequest>(conn, msgId++);
+  for (int i = 0; i < kNumScriptParsed; i++) {
+    auto notification =
+        expectNotification<m::debugger::ScriptParsedNotification>(conn);
+    EXPECT_EQ(notifications[i].scriptId, notification.scriptId);
+  }
+}
+
 TEST_F(ConnectionTests, testRespondsErrorToUnknownRequests) {
   asyncRuntime.executeScriptAsync(R"(
     var a = 1 + 2;


### PR DESCRIPTION
Summary:
We used to keep track of the loaded scripts in an `unordered_map`. This means that when a client connects and sends us a Debugger.enable message, the scriptParsed notifications that we send are not the same order as when those loaded scripts appeared.

This is a problem because DevTools' [DebuggerModel.ts](https://github.com/ChromeDevTools/devtools-frontend/blob/main/front_end/core/sdk/DebuggerModel.ts#L756) treats the scriptParsed that appear later on as the newest version of the script.

For the React Native Fast Refresh scenario where the same script gets modified and loaded multiple times, we want DevTools to treat the last loaded version as the newest version.

Fixing this issue by switching to use a vector so that the behavior is more like we buffered the loaded scripts and then send the scriptParsed notifications in the order that they would have been sent if the debugger client was already connected.

Reviewed By: fbmal7

Differential Revision: D50236422


