### PR TITLE
Move Impl class out of CDPHandler

### DIFF
--- a/API/hermes/inspector/chrome/CDPHandler.h
+++ b/API/hermes/inspector/chrome/CDPHandler.h
@@ -25,6 +25,8 @@ namespace chrome {
 using CDPMessageCallbackFunction = std::function<void(const std::string &)>;
 using OnUnregisterFunction = std::function<void()>;
 
+class CDPHandlerImpl;
+
 /// CDPHandler processes CDP messages between the client and the debugger.
 /// It performs no networking or connection logic itself.
 /// The CDP Handler is invoked from multiple threads. The locking strategy is
@@ -81,8 +83,7 @@ class INSPECTOR_EXPORT CDPHandler {
   void handle(std::string str);
 
  private:
-  class Impl;
-  std::shared_ptr<Impl> impl_;
+  std::shared_ptr<CDPHandlerImpl> impl_;
 };
 
 } // namespace chrome

--- a/cmake/modules/Hermes.cmake
+++ b/cmake/modules/Hermes.cmake
@@ -28,12 +28,6 @@ if (EMSCRIPTEN AND EMSCRIPTEN_FASTCOMP)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -s BINARYEN_TRAP_MODE=clamp")
 endif()
 
-# For compatibility, CMake adds /EHsc by default for MSVC. We want to set that
-# flag per target, so remove it.
-if (MSVC)
-  string(REPLACE "/EHsc" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-endif (MSVC)
-
 # set stack reserved size to ~10MB
 if (MSVC)
   # CMake previously automatically set this value for MSVC builds, but the


### PR DESCRIPTION
Summary:
Defining the `CDPHandler` class as `INSPECTOR_EXPORT` also causes any
nested classes to be exported.

This means that symbols for functions in `CDPHandler::Impl` also get
exported, even though they aren't supposed to be.

To avoid this, move the class out.

Differential Revision: D50294402

