### PR TITLE
Remove exceptions from synthTraceParser

### DIFF
--- a/API/hermes/CMakeLists.txt
+++ b/API/hermes/CMakeLists.txt
@@ -12,13 +12,10 @@ if(HERMES_ENABLE_DEBUGGER)
   set(INSPECTOR_DEPS hermesInspector_rtti_exception)
 endif()
 
-set(HERMES_ENABLE_EH ON)
-
-# synthTraceParser uses exceptions but not RTTI.
-# TODO(T127739425): Switch it to either use both exceptions and RTTI or neither.
 add_hermes_library(synthTraceParser SynthTraceParser.cpp LINK_LIBS hermesSupport hermesParser synthTrace)
 
 # All remaining targets in this file use both exceptions and RTTI.
+set(HERMES_ENABLE_EH ON)
 set(HERMES_ENABLE_RTTI ON)
 
 # List the files that define exported functions explicitly, and they can link

--- a/unittests/API/SynthTraceParserTest.cpp
+++ b/unittests/API/SynthTraceParserTest.cpp
@@ -112,7 +112,7 @@ TEST_F(SynthTraceParserTest, SynthVersionMismatch) {
   "trace": []
 }
   )";
-  ASSERT_THROW(parseSynthTrace(bufFromStr(src)), std::invalid_argument);
+  EXPECT_DEATH_IF_SUPPORTED(parseSynthTrace(bufFromStr(src)), "");
 }
 
 TEST_F(SynthTraceParserTest, ParsePropID) {
@@ -178,7 +178,7 @@ TEST_F(SynthTraceParserTest, SynthVersionInvalidKind) {
   "trace": []
 }
   )";
-  ASSERT_THROW(parseSynthTrace(bufFromStr(src)), std::invalid_argument);
+  EXPECT_DEATH_IF_SUPPORTED(parseSynthTrace(bufFromStr(src)), "");
 }
 
 TEST_F(SynthTraceParserTest, SynthMissingVersion) {
@@ -193,7 +193,7 @@ TEST_F(SynthTraceParserTest, SynthMissingVersion) {
   "trace": []
 }
   )";
-  EXPECT_NO_THROW(parseSynthTrace(bufFromStr(src)));
+  parseSynthTrace(bufFromStr(src));
 }
 
 TEST_F(SynthTraceParserTest, CreateBigIntRecord) {
@@ -223,103 +223,7 @@ TEST_F(SynthTraceParserTest, CreateBigIntRecord) {
   ]
 }
   )";
-  EXPECT_NO_THROW(parseSynthTrace(bufFromStr(src)));
-}
-
-TEST_F(SynthTraceParserTest, CreateBigIntRecordFailures) {
-  auto createBigIntRecord = [](const char *record) -> std::string {
-    std::stringstream src;
-
-    src << R"(
-{
-  "globalObjID": 258,
-  "runtimeConfig": {
-  },
-  "env": {
-    "callsToHermesInternalGetInstrumentedStats": [],
-  },
-  "trace": [
-)" << record
-        << R"(
-  ]
-}
-  )";
-
-    return src.str();
-  };
-
-  struct Test {
-    const char *description;
-    const char *createBigIntRecord;
-  } shouldThrowInvalidArgument[] = {
-      {"missing bits field",
-       R"(
-        {
-          "type": "CreateBigIntRecord",
-          "time": 0,
-          "objID": 0,
-          "method": "FromUint64"
-        }
-        )"},
-      {"bits field is not a string",
-       R"(
-        {
-          "type": "CreateBigIntRecord",
-          "time": 0,
-          "objID": 0,
-          "method": "FromUint64",
-          "bits": 123456
-        }
-        )"},
-      {"bits has non-digit charaters",
-       R"(
-        {
-          "type": "CreateBigIntRecord",
-          "time": 0,
-          "objID": 0,
-          "method": "FromUint64",
-          "bits": "123456!"
-        })"},
-      {"bits field is empty",
-       R"(
-        {
-          "type": "CreateBigIntRecord",
-          "time": 0,
-          "objID": 0,
-          "method": "FromUint64",
-          "bits": ""
-        }
-        )"},
-      {"bits is not a number",
-       R"(
-        {
-          "type": "CreateBigIntRecord",
-          "time": 0,
-          "objID": 0,
-          "method": "FromUint64",
-          "bits": "I am not a number"
-        })"},
-  };
-
-  for (const auto &test : shouldThrowInvalidArgument) {
-    // TODO(T127739425): Enforce the type of this exception after we fix RTTI in
-    // SynthTraceParser.
-    EXPECT_ANY_THROW(parseSynthTrace(
-        bufFromStr(createBigIntRecord(test.createBigIntRecord))))
-        << test.description;
-  }
-
-  EXPECT_THROW(
-      parseSynthTrace(bufFromStr(createBigIntRecord(R"(
-        {
-          "type": "CreateBigIntRecord",
-          "time": 0,
-          "objID": 0,
-          "method": "FromUint64",
-          "bits": "9999999999999999999999999999999999999999999"
-        })"))),
-      std::out_of_range)
-      << "bits is out-of-range";
+  parseSynthTrace(bufFromStr(src));
 }
 
 TEST_F(SynthTraceParserTest, BigIntToStringRecord) {
@@ -342,7 +246,7 @@ TEST_F(SynthTraceParserTest, BigIntToStringRecord) {
   ]
 }
   )";
-  EXPECT_NO_THROW(parseSynthTrace(bufFromStr(src)));
+  parseSynthTrace(bufFromStr(src));
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
The synth trace parser has had a longstanding problem where it uses
exceptions to report errors, but also needs to depend on the Hermes
JSON parser, which means it needs to be compiled without RTTI. This
causes problems in executables that link against this library, because
it contains its own copy of type information for exception types. As a
result, `std::exception`s thrown across shared library boundaries may
not be catchable when one side of the boundary links against
synthTraceParser.

To avoid this, remove the use of exceptions in the synth trace parser
and replace them with fatals. The parser is only ever used to parse
generated traces, and the errors it reports are not recoverable in a
meaningful way, so exceptions are not particularly useful.

Differential Revision: D50294404


