### PR TITLE
Replace hermesapi with libhermes

### DIFF
--- a/API/hermes/CMakeLists.txt
+++ b/API/hermes/CMakeLists.txt
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # compileJS uses neither exceptions nor RTTI
-add_hermes_library(compileJS CompileJS.cpp LINK_LIBS hermesPublic)
+add_hermes_library(compileJS CompileJS.cpp LINK_LIBS hermesPublic hermesHBCBackend)
 
 if(HERMES_ENABLE_DEBUGGER)
   if(HERMES_ENABLE_TOOLS AND NOT WIN32)
@@ -59,11 +59,6 @@ set(api_sources
 file(GLOB api_headers ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
 file(GLOB api_public_headers ${PROJECT_SOURCE_DIR}/public/hermes/Public/*.h)
 
-add_hermes_library(hermesapi
-        ${api_sources}
-        LINK_LIBS jsi hermesVMRuntime ${INSPECTOR_DEPS})
-target_include_directories(hermesapi PUBLIC ..)
-
 if(HERMES_THREAD_SAFETY_ANALYSIS)
   if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
     set_property(SOURCE inspector/chrome/CDPHandler.cpp APPEND_STRING PROPERTY
@@ -71,21 +66,16 @@ if(HERMES_THREAD_SAFETY_ANALYSIS)
   endif()
 endif()
 
-add_hermes_library(hermesapiLean
-        ${api_sources}
-        LINK_LIBS jsi hermesVMRuntimeLean)
-target_include_directories(hermesapiLean PUBLIC ..)
-
 add_hermes_library(synthTrace hermes_tracing.cpp SynthTrace.cpp TracingRuntime.cpp
-  LINK_LIBS hermesapi)
+  LINK_LIBS libhermes hermesPlatform)
 
 add_hermes_library(timerStats TimerStats.cpp LINK_LIBS jsi hermesSupport)
 
 add_hermes_library(traceInterpreter TraceInterpreter.cpp
-  LINK_LIBS hermesapi hermesInstrumentation synthTrace synthTraceParser)
+  LINK_LIBS libhermes hermesInstrumentation synthTrace synthTraceParser)
 
 add_library(libhermes ${api_sources})
-target_link_libraries(libhermes PRIVATE jsi hermesVMRuntime ${INSPECTOR_DEPS})
+target_link_libraries(libhermes PUBLIC jsi PRIVATE hermesVMRuntime ${INSPECTOR_DEPS})
 target_link_options(libhermes PRIVATE ${HERMES_EXTRA_LINKER_FLAGS})
 
 # Export the required header directory
@@ -96,7 +86,7 @@ set_target_properties(libhermes PROPERTIES OUTPUT_NAME hermes)
 
 # Create a lean version of libhermes in the same way.
 add_library(libhermes_lean ${api_sources})
-target_link_libraries(libhermes_lean PRIVATE jsi hermesVMRuntimeLean ${INSPECTOR_DEPS})
+target_link_libraries(libhermes_lean PUBLIC jsi PRIVATE hermesVMRuntimeLean ${INSPECTOR_DEPS})
 target_link_options(libhermes_lean PRIVATE ${HERMES_EXTRA_LINKER_FLAGS})
 target_include_directories(libhermes_lean PUBLIC .. ../../public ${HERMES_JSI_DIR})
 set_target_properties(libhermes_lean PROPERTIES OUTPUT_NAME hermes_lean)

--- a/API/hermes/inspector/chrome/cli/CMakeLists.txt
+++ b/API/hermes/inspector/chrome/cli/CMakeLists.txt
@@ -9,7 +9,9 @@ add_hermes_tool(hcds
   ${ALL_HEADER_FILES}
   )
 
-target_link_libraries(hcds hermesapi)
+# TODO: Even though this does not use llvh at all, a quirk of our build is that
+#       pthread is found and provided by llvh.
+target_link_libraries(hcds libhermes LLVHSupport)
 
 install(TARGETS hcds
   RUNTIME DESTINATION bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,8 +286,6 @@ set(HERMES_BUILD_APPLE_DSYM OFF CACHE BOOL
 
 set(HERMES_BUILD_NODE_HERMES OFF CACHE BOOL "Whether to build node-hermes")
 
-set(HERMES_BUILD_SHARED_JSI OFF CACHE BOOL "Build JSI as a shared library.")
-
 # On Windows, produce static libraries by default so that tests and tools work
 # without needing to move DLLs around.
 # On Emscripten, there is no concept of a shared library.
@@ -296,6 +294,9 @@ if(WIN32 OR EMSCRIPTEN)
 else()
   set(DEFAULT_BUILD_SHARED_LIBS ON)
 endif()
+
+set(HERMES_BUILD_SHARED_JSI ${DEFAULT_BUILD_SHARED_LIBS} CACHE BOOL "Build JSI as a shared library.")
+
 set(BUILD_SHARED_LIBS ${DEFAULT_BUILD_SHARED_LIBS} CACHE BOOL "Prefer producing shared libraries.")
 
 if (HERMES_IS_ANDROID)
@@ -329,6 +330,7 @@ if (HERMES_STATIC_LINK)
   append("-static" CMAKE_EXE_LINKER_FLAGS)
   set(HERMES_USE_STATIC_ICU ON)
   set(CMAKE_FIND_LIBRARY_SUFFIXES "${CMAKE_STATIC_LIBRARY_SUFFIX}")
+  set(HERMES_BUILD_SHARED_JSI OFF)
   set(BUILD_SHARED_LIBS OFF)
 endif()
 

--- a/android/intltest/java/com/facebook/hermes/test/CMakeLists.txt
+++ b/android/intltest/java/com/facebook/hermes/test/CMakeLists.txt
@@ -25,7 +25,6 @@ if(HERMES_IS_ANDROID)
       ${jni_source_files}
       LINK_LIBS
       libhermes
-      hermesapi
       compileJS
       fbjni::fbjni
       jsi
@@ -36,7 +35,6 @@ if(HERMES_IS_ANDROID)
       ${epi_source_files}
       LINK_LIBS
       libhermes
-      hermesapi
       compileJS
       fbjni::fbjni
       jsi

--- a/tools/fuzzers/fuzzilli/CMakeLists.txt
+++ b/tools/fuzzers/fuzzilli/CMakeLists.txt
@@ -13,5 +13,5 @@ if(HERMES_ENABLE_FUZZILLI)
     )
 
     target_include_directories(fuzzilli PRIVATE ${HERMES_SOURCE_DIR}/API)
-    target_link_libraries(fuzzilli hermesapi)
+    target_link_libraries(fuzzilli libhermes)
 endif()

--- a/tools/fuzzers/libfuzzer/CMakeLists.txt
+++ b/tools/fuzzers/libfuzzer/CMakeLists.txt
@@ -17,6 +17,6 @@ if(HERMES_ENABLE_LIBFUZZER)
     target_include_directories(fuzzer-jsi-entry PRIVATE ${HERMES_SOURCE_DIR}/API)
     target_link_libraries(fuzzer-jsi-entry
       PRIVATE
-        hermesapi
+        libhermes
     )
 endif()

--- a/tools/hdb/CMakeLists.txt
+++ b/tools/hdb/CMakeLists.txt
@@ -9,14 +9,9 @@ add_hermes_tool(hdb
   ${ALL_HEADER_FILES}
   )
 
-set_target_properties(hdb PROPERTIES
-  CXX_STANDARD 14
-  CXX_STANDARD_REQUIRED ON
-  )
-
-target_link_libraries(hdb
-  hermesapi
-)
+# TODO: Even though this does not use llvh at all, a quirk of our build is that
+#       pthread is found and provided by llvh.
+target_link_libraries(hdb libhermes LLVHSupport)
 
 install(TARGETS hdb
   RUNTIME DESTINATION bin

--- a/tools/jsi/CMakeLists.txt
+++ b/tools/jsi/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CXX_STANDARD_REQUIRED ON)
 add_hermes_tool(hermes-jsi
   jsi.cpp
   ${ALL_HEADER_FILES}
-  LINK_LIBS hermesapi timerStats
+  LINK_LIBS libhermes timerStats
   )
 
 # TODO: We have to disable RTTI here because we use LLVM libraries compiled

--- a/tools/node-hermes/CMakeLists.txt
+++ b/tools/node-hermes/CMakeLists.txt
@@ -18,7 +18,7 @@ if(HERMES_BUILD_NODE_HERMES)
     InternalBindings/util.cpp InternalBindings/tty_wrap.cpp
     InternalBindings/pipe_wrap.cpp InternalBindings/stream_base.cpp
     ${ALL_HEADER_FILES}
-    LINK_LIBS hermesapi hermesNodeBytecode uv_a
+    LINK_LIBS libhermes hermesNodeBytecode uv_a
     )
   target_include_directories(node-hermes PRIVATE third-party/libuv/include/)
 endif()

--- a/tools/synth/CMakeLists.txt
+++ b/tools/synth/CMakeLists.txt
@@ -12,9 +12,8 @@ add_hermes_tool(synth
 )
 
 target_link_libraries(synth
-  hermesVMRuntime
   hermesConsoleHost
-  hermesapi
+  libhermes
   traceInterpreter
 )
 

--- a/unittests/API/APITest.cpp
+++ b/unittests/API/APITest.cpp
@@ -437,21 +437,6 @@ TEST(HermesWatchTimeLimitTest, WatchTimeLimit) {
         rt2->evaluateJavaScript(std::make_unique<StringBuffer>(forEver), ""),
         JSIException);
   }
-  {
-    auto timeLimitMonitor = hermes::vm::TimeLimitMonitor::getOrCreate();
-    const auto &watchedRuntimes = timeLimitMonitor->getWatchedRuntimes();
-
-    auto rt1 = makeHermesRuntime();
-    rt1->watchTimeLimit(Around20MinsMS);
-    auto rt2 = makeHermesRuntime();
-    rt2->watchTimeLimit(Around20MinsMS);
-    auto rt3 = makeHermesRuntime();
-    rt3->watchTimeLimit(Around20MinsMS);
-    EXPECT_EQ(watchedRuntimes.size(), 3);
-
-    rt2 = nullptr;
-    EXPECT_EQ(watchedRuntimes.size(), 2);
-  }
 }
 
 TEST(HermesTriggerAsyncTimeoutTest, TriggerAsyncTimeout) {

--- a/unittests/API/CMakeLists.txt
+++ b/unittests/API/CMakeLists.txt
@@ -32,7 +32,7 @@ set(LLVM_ENABLE_RTTI ON)
 
 add_hermes_unittest(APITests ${APITestsSources})
 
-target_link_libraries(APITests hermesapi compileJS SegmentTestCompile traceInterpreter timerStats)
+target_link_libraries(APITests libhermes compileJS SegmentTestCompile traceInterpreter timerStats)
 
 add_hermes_unittest(APILeanTests APILeanTest.cpp)
-target_link_libraries(APILeanTests hermesapiLean)
+target_link_libraries(APILeanTests libhermes_lean jsi)

--- a/utils/build-apple-framework.sh
+++ b/utils/build-apple-framework.sh
@@ -69,6 +69,7 @@ function configure_apple_framework {
     -DHERMES_ENABLE_TEST_SUITE:BOOLEAN=false \
     -DHERMES_ENABLE_BITCODE:BOOLEAN="$enable_bitcode" \
     -DHERMES_BUILD_APPLE_FRAMEWORK:BOOLEAN=true \
+    -DHERMES_BUILD_SHARED_JSI:BOOLEAN=false \
     -DHERMES_BUILD_APPLE_DSYM:BOOLEAN=true \
     -DHERMES_ENABLE_TOOLS:BOOLEAN="$build_cli_tools" \
     -DIMPORT_HERMESC:PATH="$PWD/build_host_hermesc/ImportHermesc.cmake" \


### PR DESCRIPTION
Summary:
Delete the hermesapi library, in favour of always using libhermes. This
ensures that we are always testing libhermes itself, which is what
integrators actually use, and reduces the potential for confusion and
ODR violations introduced by `hermesapi`.

This should also avoid us creating further problems with exceptions and
RTTI of the kind that were addressed earlier in this stack, which may
have been obscured by linking statically.

Differential Revision: D50294403

