### PR TITLE
Limit stack size for native stack overflow test

### DIFF
--- a/test/shermes/regress-error-stack-native-stack-overflow.js
+++ b/test/shermes/regress-error-stack-native-stack-overflow.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// RUN: %shermes -exec %s  | %FileCheck --match-full-lines %s
+// RUN: ulimit -s 512 && %shermes -exec %s  | %FileCheck --match-full-lines %s
 
 "use strict";
 


### PR DESCRIPTION
Summary:
On  macOS under lit, I have observed the stack being as large as 64MB.
This makes this test extremely slow. Limit the stack so it completes
faster.

Looking at CircleCI runs, it looks like running check-hermes became
~3x slower in CI as well after adding this test.

Differential Revision: D50438267

