### PR TITLE
Reject non-enumerable properties in LowerAllocObject

### DIFF
--- a/include/hermes/BCGen/HBC/Passes.h
+++ b/include/hermes/BCGen/HBC/Passes.h
@@ -29,15 +29,10 @@ class LoadConstants : public FunctionPass {
   bool operandMustBeLiteral(Instruction *Inst, unsigned opIndex);
 
  public:
-  explicit LoadConstants(bool optimizationEnabled)
-      : FunctionPass("LoadConstants"),
-        optimizationEnabled_(optimizationEnabled) {}
+  explicit LoadConstants() : FunctionPass("LoadConstants") {}
   ~LoadConstants() override = default;
 
   bool runOnFunction(Function *F) override;
-
- private:
-  bool const optimizationEnabled_;
 };
 
 /// Lower LoadFrameInst, StoreFrameInst and CreateFunctionInst.

--- a/include/hermes/BCGen/Lowering.h
+++ b/include/hermes/BCGen/Lowering.h
@@ -52,9 +52,17 @@ class LowerAllocObject : public FunctionPass {
  private:
   /// Define a type for managing lists of StoreNewOwnPropertyInsts.
   using StoreList = llvh::SmallVector<StoreNewOwnPropertyInst *, 4>;
+  /// Define a type for mapping a given basic block to the users of a given
+  /// AllocObjectInst in that basic block.
+  using BlockUserMap =
+      llvh::DenseMap<BasicBlock *, llvh::DenseSet<Instruction *>>;
 
-  /// Perform a series of lowerings for a given allocInst.
-  bool lowerAlloc(AllocObjectInst *allocInst);
+  /// Construct an ordered list of stores to \p allocInst that are known to
+  /// always execute without any other intervening users.
+  StoreList collectStores(
+      AllocObjectInst *allocInst,
+      const BlockUserMap &userBasicBlockMap,
+      const DominanceInfo &DI);
   /// Serialize AllocObjects with literal property and value sets into object
   /// buffer; non-literals values could also be set as placeholders and later
   /// overwritten by PutByIds.

--- a/include/hermes/BCGen/Lowering.h
+++ b/include/hermes/BCGen/Lowering.h
@@ -50,6 +50,9 @@ class LowerAllocObject : public FunctionPass {
   bool runOnFunction(Function *F) override;
 
  private:
+  /// Define a type for managing lists of StoreNewOwnPropertyInsts.
+  using StoreList = llvh::SmallVector<StoreNewOwnPropertyInst *, 4>;
+
   /// Perform a series of lowerings for a given allocInst.
   bool lowerAlloc(AllocObjectInst *allocInst);
   /// Serialize AllocObjects with literal property and value sets into object
@@ -57,12 +60,11 @@ class LowerAllocObject : public FunctionPass {
   /// overwritten by PutByIds.
   bool lowerAllocObjectBuffer(
       AllocObjectInst *allocInst,
-      llvh::SmallVectorImpl<StoreNewOwnPropertyInst *> &users,
+      const StoreList &users,
       uint32_t maxSize);
   /// Estimate best number of elements to serialize into the buffer.
   /// Try optimizing for max bytecode size saving.
-  uint32_t estimateBestNumElemsToSerialize(
-      llvh::SmallVectorImpl<StoreNewOwnPropertyInst *> &users);
+  uint32_t estimateBestNumElemsToSerialize(const StoreList &users);
 };
 
 /// Lowers AllocObjectLiterals which target object literals with

--- a/include/hermes/BCGen/Lowering.h
+++ b/include/hermes/BCGen/Lowering.h
@@ -52,10 +52,9 @@ class LowerAllocObject : public FunctionPass {
  private:
   /// Define a type for managing lists of StoreNewOwnPropertyInsts.
   using StoreList = llvh::SmallVector<StoreNewOwnPropertyInst *, 4>;
-  /// Define a type for mapping a given basic block to the users of a given
+  /// Define a type for mapping a given basic block to the stores to a given
   /// AllocObjectInst in that basic block.
-  using BlockUserMap =
-      llvh::DenseMap<BasicBlock *, llvh::DenseSet<Instruction *>>;
+  using BlockUserMap = llvh::DenseMap<BasicBlock *, StoreList>;
 
   /// Construct an ordered list of stores to \p allocInst that are known to
   /// always execute without any other intervening users.

--- a/include/hermes/BCGen/Lowering.h
+++ b/include/hermes/BCGen/Lowering.h
@@ -71,7 +71,9 @@ class LowerAllocObject : public FunctionPass {
       uint32_t maxSize);
   /// Estimate best number of elements to serialize into the buffer.
   /// Try optimizing for max bytecode size saving.
-  uint32_t estimateBestNumElemsToSerialize(const StoreList &users);
+  uint32_t estimateBestNumElemsToSerialize(
+      const StoreList &users,
+      bool hasParent);
 };
 
 /// Lowers AllocObjectLiterals which target object literals with

--- a/lib/BCGen/HBC/HBC.cpp
+++ b/lib/BCGen/HBC/HBC.cpp
@@ -76,7 +76,7 @@ void lowerIR(Module *M, const BytecodeGenerationOptions &options) {
   PM.addPass(new DedupReifyArguments());
   PM.addPass(new LowerSwitchIntoJumpTables());
   PM.addPass(new SwitchLowering());
-  PM.addPass(new LoadConstants(options.optimizationEnabled));
+  PM.addPass(new LoadConstants());
   if (options.optimizationEnabled) {
     // Lowers AllocObjects and its sequential literal properties into a single
     // HBCAllocObjectFromBufferInst

--- a/lib/BCGen/HBC/Passes.cpp
+++ b/lib/BCGen/HBC/Passes.cpp
@@ -242,46 +242,43 @@ bool LoadConstants::runOnFunction(Function *F) {
   IRBuilder builder(F);
   bool changed = false;
 
-  llvh::SmallDenseMap<Literal *, Instruction *, 8> constMap{};
-
-  // This is a bit counter-intuitive because the logic appears reversed.
-  // We only want to unique the generated literals if optimization is disabled.
-  // That is the case when it causes too many registers to be generated (one
-  // per literal).
-  // If optimization is enabled, that is not necessary because of CSE and
-  // because doing this now interefers with code motion.
-  const bool uniqueLiterals = !optimizationEnabled_;
-
-  auto createLoadLiteral = [&builder](Literal *literal) -> Instruction * {
+  /// Inserts and returns a load instruction for \p literal before \p where.
+  auto createLoadLiteral = [&builder](Literal *literal, Instruction *where) {
+    builder.setInsertionPoint(where);
     return llvh::isa<GlobalObject>(literal)
         ? cast<Instruction>(builder.createHBCGetGlobalObjectInst())
         : cast<Instruction>(builder.createHBCLoadConstInst(literal));
   };
 
-  updateToEntryInsertionPoint(builder, F);
-
-  for (BasicBlock &bbit : F->getBasicBlockList()) {
-    for (auto &it : bbit.getInstList()) {
-      for (unsigned i = 0, n = it.getNumOperands(); i < n; i++) {
-        if (operandMustBeLiteral(&it, i))
-          continue;
-
-        auto *operand = llvh::dyn_cast<Literal>(it.getOperand(i));
-        if (!operand)
-          continue;
-
-        Instruction *load = nullptr;
-        if (uniqueLiterals) {
-          auto &entry = constMap[operand];
-          if (!entry)
-            entry = createLoadLiteral(operand);
-          load = entry;
-        } else {
-          load = createLoadLiteral(operand);
+  for (BasicBlock &BB : *F) {
+    for (auto &I : BB) {
+      if (auto *phi = llvh::dyn_cast<PhiInst>(&I)) {
+        // Since PhiInsts must always be at the start of a basic block, we have
+        // to insert the load instruction in the predecessor. This lowering is
+        // sub-optimal: for conditional branches, the load constant operation
+        // will be performed before the branch decides which path to take.
+        for (unsigned i = 0, e = phi->getNumEntries(); i < e; ++i) {
+          auto [val, bb] = phi->getEntry(i);
+          if (auto *literal = llvh::dyn_cast<Literal>(val)) {
+            auto *load = createLoadLiteral(literal, bb->getTerminator());
+            phi->updateEntry(i, load, bb);
+            changed = true;
+          }
         }
-
-        it.setOperand(load, i);
-        changed = true;
+        continue;
+      }
+      // For all other instructions, insert load constants right before the they
+      // are needed. This minimizes their live range and therefore reduces
+      // register pressure. CodeMotion and CSE can later hoist and deduplicate
+      // them.
+      for (unsigned i = 0, e = I.getNumOperands(); i < e; ++i) {
+        if (auto *literal = llvh::dyn_cast<Literal>(I.getOperand(i))) {
+          if (!operandMustBeLiteral(&I, i)) {
+            auto *load = createLoadLiteral(literal, &I);
+            I.setOperand(load, i);
+            changed = true;
+          }
+        }
       }
     }
   }

--- a/lib/BCGen/Lowering.cpp
+++ b/lib/BCGen/Lowering.cpp
@@ -243,7 +243,7 @@ bool LowerAllocObject::runOnFunction(Function *F) {
     if (!stores.empty() && !stores.back())
       return;
     auto *SI = llvh::dyn_cast<StoreNewOwnPropertyInst>(U);
-    if (!SI || SI->getStoredValue() == A) {
+    if (!SI || SI->getStoredValue() == A || !SI->getIsEnumerable()) {
       // A user that's not a StoreNewOwnPropertyInst storing into the object
       // created by allocInst. We have to stop processing here. Note that we
       // check the stored value instead of the target object so that we omit

--- a/lib/BCGen/Lowering.cpp
+++ b/lib/BCGen/Lowering.cpp
@@ -244,12 +244,20 @@ LowerAllocObjectFuncContext::collectInstructions() const {
         continue;
       }
       auto *SI = llvh::dyn_cast<StoreNewOwnPropertyInst>(&I);
-      if (!SI || SI->getObject() != allocInst_) {
+      if (!SI || SI->getStoredValue() == allocInst_) {
         // A user that's not a StoreNewOwnPropertyInst storing into the object
-        // created by allocInst_. We have to stop processing here.
+        // created by allocInst_. We have to stop processing here. Note that we
+        // check the stored value instead of the target object so that we omit
+        // the case where an object is stored into itself. While it should
+        // technically be safe, this maintains the invariant that stop as soon
+        // the allocated object is used as something other than the target of a
+        // StoreNewOwnPropertyInst.
         terminate = true;
         break;
       }
+      assert(
+          SI->getObject() == allocInst_ &&
+          "SNOP using allocInst_ must use it as object or value");
       instrs.push_back(SI);
     }
     if (terminate) {

--- a/lib/BCGen/Lowering.cpp
+++ b/lib/BCGen/Lowering.cpp
@@ -320,7 +320,7 @@ static bool canSerialize(Value *V) {
 }
 
 uint32_t LowerAllocObject::estimateBestNumElemsToSerialize(
-    llvh::SmallVectorImpl<StoreNewOwnPropertyInst *> &users) {
+    const StoreList &users) {
   // We want to track curSaving to avoid serializing too many place holders
   // which ends up causing a big size regression.
   // We set curSaving to be the delta of the size of two instructions to avoid
@@ -372,7 +372,7 @@ uint32_t LowerAllocObject::estimateBestNumElemsToSerialize(
 
 bool LowerAllocObject::lowerAllocObjectBuffer(
     AllocObjectInst *allocInst,
-    llvh::SmallVectorImpl<StoreNewOwnPropertyInst *> &users,
+    const StoreList &users,
     uint32_t maxSize) {
   auto size = estimateBestNumElemsToSerialize(users);
   if (size == 0) {

--- a/lib/BCGen/Lowering.cpp
+++ b/lib/BCGen/Lowering.cpp
@@ -219,52 +219,62 @@ LowerAllocObject::StoreList LowerAllocObject::collectStores(
       });
 
   // Iterate over the sorted blocks to collect StoreNewOwnPropertyInst users
-  // until we encounter the first user that is not a StoreNewOwnPropertyInst.
+  // until we encounter a nullptr indicating we should stop.
   StoreList instrs;
   for (BasicBlock *BB : sortedBlocks) {
-    for (Instruction &I : *BB) {
-      if (!userBasicBlockMap.find(BB)->second.count(&I)) {
-        // I is not a user of allocInst, ignore it.
-        continue;
-      }
-      auto *SI = llvh::dyn_cast<StoreNewOwnPropertyInst>(&I);
-      if (!SI || SI->getStoredValue() == allocInst) {
-        // A user that's not a StoreNewOwnPropertyInst storing into the object
-        // created by allocInst. We have to stop processing here. Note that we
-        // check the stored value instead of the target object so that we omit
-        // the case where an object is stored into itself. While it should
-        // technically be safe, this maintains the invariant that stop as soon
-        // the allocated object is used as something other than the target of a
-        // StoreNewOwnPropertyInst.
+    for (StoreNewOwnPropertyInst *I : userBasicBlockMap.find(BB)->second) {
+      // If I is null, we cannot consider additional stores.
+      if (!I)
         return instrs;
-      }
-      assert(
-          SI->getObject() == allocInst &&
-          "SNOP using allocInst must use it as object or value");
-      instrs.push_back(SI);
+      instrs.push_back(I);
     }
   }
   return instrs;
 }
 
 bool LowerAllocObject::runOnFunction(Function *F) {
-  bool changed = false;
-  llvh::SmallVector<AllocObjectInst *, 4> allocs;
-  // Collect all AllocObject instructions.
-  for (BasicBlock &BB : *F)
-    for (auto &it : BB) {
-      if (auto *A = llvh::dyn_cast<AllocObjectInst>(&it))
-        if (llvh::isa<EmptySentinel>(A->getParentObject()))
-          allocs.push_back(A);
+  /// If we can still append to \p stores, check if the user \p U is an eligible
+  /// store to \p A. If so, append it to \p stores, if not, append nullptr to
+  /// indicate that subsequent users in the basic block should not be
+  /// considered.
+  auto tryAdd = [](AllocObjectInst *A, Instruction *U, StoreList &stores) {
+    // If the store list has been terminated by a nullptr, we have already
+    // encountered a non-SNOP user of A in this block. Ignore this user.
+    if (!stores.empty() && !stores.back())
+      return;
+    auto *SI = llvh::dyn_cast<StoreNewOwnPropertyInst>(U);
+    if (!SI || SI->getStoredValue() == A) {
+      // A user that's not a StoreNewOwnPropertyInst storing into the object
+      // created by allocInst. We have to stop processing here. Note that we
+      // check the stored value instead of the target object so that we omit
+      // the case where an object is stored into itself. While it should
+      // technically be safe, this maintains the invariant that stop as soon
+      // the allocated object is used as something other than the target of a
+      // StoreNewOwnPropertyInst.
+      stores.push_back(nullptr);
+    } else {
+      assert(
+          SI->getObject() == A &&
+          "SNOP using allocInst must use it as object or value");
+      stores.push_back(SI);
     }
+  };
 
+  // For each basic block, collect an ordered list of stores into
+  // AllocObjectInsts that should be considered for lowering into a buffer.
+  llvh::DenseMap<AllocObjectInst *, BlockUserMap> allocUsers;
+  for (BasicBlock &BB : *F)
+    for (Instruction &I : BB)
+      for (size_t i = 0; i < I.getNumOperands(); ++i)
+        if (auto *A = llvh::dyn_cast<AllocObjectInst>(I.getOperand(i)))
+          if (llvh::isa<EmptySentinel>(A->getParentObject()))
+            tryAdd(A, &I, allocUsers[A][&BB]);
+
+  bool changed = false;
   DominanceInfo DI(F);
-  for (auto *A : allocs) {
-    // A map containing the set of instructions that use A for each basic block.
-    BlockUserMap userBasicBlockMap;
-    for (Instruction *I : A->getUsers())
-      userBasicBlockMap[I->getParent()].insert(I);
-
+  for (const auto &[A, userBasicBlockMap] : allocUsers) {
+    // Collect the stores that are guaranteed to execute before any other user
+    // of this object.
     auto stores = collectStores(A, userBasicBlockMap, DI);
     changed |= lowerAllocObjectBuffer(A, stores, UINT16_MAX);
   }

--- a/lib/BCGen/SH/SH.cpp
+++ b/lib/BCGen/SH/SH.cpp
@@ -2287,7 +2287,7 @@ void lowerModuleIR(Module *M, bool optimize) {
   PM.addPass(new hbc::DedupReifyArguments());
   // TODO Consider supporting LowerSwitchIntoJumpTables for optimization
   PM.addPass(new SwitchLowering());
-  PM.addPass(new hbc::LoadConstants(true));
+  PM.addPass(new hbc::LoadConstants());
   PM.addPass(new hbc::LowerLoadStoreFrameInst());
   if (optimize) {
     PM.addTypeInference();

--- a/lib/IRGen/ESTreeIRGen-expr.cpp
+++ b/lib/IRGen/ESTreeIRGen-expr.cpp
@@ -1072,13 +1072,9 @@ Value *ESTreeIRGen::genObjectExpr(ESTree::ObjectExpressionNode *Expr) {
   ESTree::PropertyNode *protoProperty = nullptr;
 
   uint32_t numComputed = 0;
-  bool hasSpread = false;
-  bool hasAccessor = false;
-  bool hasDuplicateProperty = false;
 
   for (auto &P : Expr->_properties) {
     if (llvh::isa<ESTree::SpreadElementNode>(&P)) {
-      hasSpread = true;
       continue;
     }
 
@@ -1115,10 +1111,8 @@ Value *ESTreeIRGen::genObjectExpr(ESTree::ObjectExpressionNode *Expr) {
     PropertyValue *propValue = &propMap[propName];
     if (prop->_kind->str() == "get") {
       propValue->setGetter(cast<ESTree::FunctionExpressionNode>(prop->_value));
-      hasAccessor = true;
     } else if (prop->_kind->str() == "set") {
       propValue->setSetter(cast<ESTree::FunctionExpressionNode>(prop->_value));
-      hasAccessor = true;
     } else {
       assert(prop->_kind->str() == "init" && "invalid PropertyNode kind");
       // We record the propValue if this is a regular property
@@ -1128,7 +1122,6 @@ Value *ESTreeIRGen::genObjectExpr(ESTree::ObjectExpressionNode *Expr) {
     std::string key = (prop->_kind->str() + propName).str();
     auto iterAndSuccess = firstLocMap.try_emplace(key, prop->getSourceRange());
     if (!iterAndSuccess.second) {
-      hasDuplicateProperty = true;
       Builder.getModule()->getContext().getSourceErrorManager().warning(
           prop->getSourceRange(),
           Twine("the property \"") + propName +
@@ -1137,38 +1130,6 @@ Value *ESTreeIRGen::genObjectExpr(ESTree::ObjectExpressionNode *Expr) {
       Builder.getModule()->getContext().getSourceErrorManager().note(
           iterAndSuccess.first->second, "The first definition was here.");
     }
-  }
-
-  // Heuristically determine if we emit AllocObjectLiteral.
-  // We do so if there is no computed key, no __proto__, no spread element
-  // node, no duplicate properties, no accessors, and object literal is not
-  // empty.
-  if (numComputed == 0 && !protoProperty && !hasSpread &&
-      !hasDuplicateProperty && !hasAccessor && propMap.size()) {
-    AllocObjectLiteralInst::ObjectPropertyMap objPropMap;
-    // It is safe to assume that there is no computed keys, and
-    // no __proto__.
-    for (auto &P : Expr->_properties) {
-      auto *prop = cast<ESTree::PropertyNode>(&P);
-      assert(
-          !prop->_computed &&
-          "Cannot handle computed key in AllocObjectLiteral");
-
-      // We are reusing the storage, so make sure it is cleared at every
-      // iteration.
-      stringStorage.clear();
-
-      llvh::StringRef keyStr = propertyKeyAsString(stringStorage, prop->_key);
-      auto *Key = Builder.getLiteralString(keyStr);
-      assert(
-          propMap[keyStr].valueNode == prop->_value &&
-          "Should only have one value for each property.");
-      auto value =
-          genExpression(prop->_value, Builder.createIdentifier(keyStr));
-      objPropMap.push_back(std::pair<LiteralString *, Value *>(Key, value));
-    }
-
-    return Builder.createAllocObjectLiteralInst(objPropMap);
   }
 
   /// Attempt to determine whether we can directly use the value of the

--- a/lib/IRGen/ESTreeIRGen.cpp
+++ b/lib/IRGen/ESTreeIRGen.cpp
@@ -7,6 +7,7 @@
 
 #include "ESTreeIRGen.h"
 
+#include "llvh/ADT/SetVector.h"
 #include "llvh/ADT/StringSet.h"
 #include "llvh/Support/Debug.h"
 #include "llvh/Support/SaveAndRestore.h"
@@ -800,23 +801,21 @@ void ESTreeIRGen::emitRestProperty(
   auto lref = createLRef(rest->_argument, declInit);
 
   // Construct the excluded items.
-  AllocObjectLiteralInst::ObjectPropertyMap exMap{};
   llvh::SmallVector<Value *, 4> computedExcludedItems{};
-  // Keys need de-duping so we don't create a dummy exclusion object with
-  // duplicate keys.
-  llvh::DenseSet<Literal *> keyDeDupeSet;
+  // Keys must be deduplicated so we don't create StoreNewOwnProperty with the
+  // same key twice. Use a SetVector for deterministic ordering.
+  llvh::SetVector<Literal *> literalExcludedItems;
   auto *zeroValue = Builder.getLiteralPositiveZero();
 
   for (Value *key : excludedItems) {
     if (auto *lit = llvh::dyn_cast<LiteralString>(key)) {
-      // If the key is a literal string, we can place it in the
-      // AllocObjectLiteralInst buffer.
-      if (keyDeDupeSet.insert(lit).second) {
-        exMap.emplace_back(std::make_pair(lit, zeroValue));
-      }
+      // If the key is a literal string, we can use StoreNewOwnProperty which
+      // will allow us to create the object with a single instruction after
+      // optimization.
+      literalExcludedItems.insert(lit);
     } else {
       // If the key is not a supported literal, then we have to dynamically
-      // populate the excluded object with it after creation from the buffer.
+      // populate the excluded object with regular stores.
       computedExcludedItems.push_back(key);
     }
   }
@@ -827,18 +826,17 @@ void ESTreeIRGen::emitRestProperty(
   } else {
     // This size is only a hint as the true size may change if there are
     // duplicates when computedExcludedItems is processed at run-time.
-    auto excludedSizeHint = exMap.size() + computedExcludedItems.size();
+    auto excludedSizeHint =
+        literalExcludedItems.size() + computedExcludedItems.size();
     // Explicitly set the prototype for the object created here so it isn't
     // initialized to Object.prototype, which may be modified by the user.
-    if (exMap.empty()) {
-      excludedObj = Builder.createAllocObjectInst(
-          excludedSizeHint, Builder.getLiteralNull());
-    } else {
-      excludedObj = Builder.createAllocObjectLiteralInst(exMap);
-      genBuiltinCall(
-          BuiltinMethod::HermesBuiltin_silentSetPrototypeOf,
-          {excludedObj, Builder.getLiteralNull()});
-    }
+    excludedObj = Builder.createAllocObjectInst(
+        excludedSizeHint, Builder.getLiteralNull());
+
+    for (Literal *key : literalExcludedItems)
+      Builder.createStoreNewOwnPropertyInst(
+          zeroValue, excludedObj, key, IRBuilder::PropEnumerable::Yes);
+
     for (Value *key : computedExcludedItems) {
       Builder.createStorePropertyInst(zeroValue, excludedObj, key);
     }

--- a/test/BCGen/SH/RA/interp-dispatch.js
+++ b/test/BCGen/SH/RA/interp-dispatch.js
@@ -50,25 +50,25 @@ print(bench(4e6, 100))
 // CHINT:function bench(lc: any, fc: any): string|number
 // CHINT-NEXT:frame = []
 // CHINT-NEXT:%BB0:
-// CHINT-NEXT:  {np1}     %0 [1...33)   = HBCLoadConstInst (:number) 0: number
-// CHINT-NEXT:  {np0}     %1 [2...33)   = HBCLoadConstInst (:number) 1: number
-// CHINT-NEXT:  {loc3}    %2 [3...33)   = LoadParamInst (:any) %fc: any
-// CHINT-NEXT:  {loc0}    %3 [4...5)    = LoadParamInst (:any) %lc: any
-// CHINT-NEXT:  {loc2}    %4 [5...7)    = UnaryDecInst (:number|bigint) %3: any
-// CHINT-NEXT:  {loc1}    %5 [6...11)   = MovInst (:number) %0: number
-// CHINT-NEXT:  {loc2}    %6 [7...10)   = MovInst (:number|bigint) %4: number|bigint
+// CHINT-NEXT:  {loc3}    %0 [1...33)   = LoadParamInst (:any) %fc: any
+// CHINT-NEXT:  {loc0}    %1 [2...3)    = LoadParamInst (:any) %lc: any
+// CHINT-NEXT:  {loc2}    %2 [3...7)    = UnaryDecInst (:number|bigint) %1: any
+// CHINT-NEXT:  {np1}     %3 [4...33)   = HBCLoadConstInst (:number) 0: number
+// CHINT-NEXT:  {np0}     %4 [5...33)   = HBCLoadConstInst (:number) 1: number
+// CHINT-NEXT:  {loc1}    %5 [6...11)   = MovInst (:number) %3: number
+// CHINT-NEXT:  {loc2}    %6 [7...10)   = MovInst (:number|bigint) %2: number|bigint
 // CHINT-NEXT:  {loc0}    %7 [8...34)   = MovInst (:number) %5: number
 // CHINT-NEXT:            %8            = CmpBrGreaterThanOrEqualInst %6: number|bigint, %7: number, %BB1, %BB2
 // CHINT-NEXT:%BB1:
-// CHINT-NEXT:  {loc2}    %9 [5...13) [32...33)  = PhiInst (:number|bigint) %6: number|bigint, %BB0, %31: number|bigint, %BB3
+// CHINT-NEXT:  {loc2}    %9 [3...13) [32...33)  = PhiInst (:number|bigint) %6: number|bigint, %BB0, %31: number|bigint, %BB3
 // CHINT-NEXT:  {loc1}   %10 [6...14) [30...33)  = PhiInst (:string|number) %5: number, %BB0, %29: string|number, %BB3
-// CHINT-NEXT:  {loc6}   %11 [12...17)  = UnaryDecInst (:number|bigint) %2: any
-// CHINT-NEXT:  {loc2}   %12 [5...33)   = MovInst (:number|bigint) %9: number|bigint
+// CHINT-NEXT:  {loc6}   %11 [12...17)  = UnaryDecInst (:number|bigint) %0: any
+// CHINT-NEXT:  {loc2}   %12 [3...33)   = MovInst (:number|bigint) %9: number|bigint
 // CHINT-NEXT:  {loc1}   %13 [6...28) [30...33)  = MovInst (:string|number) %10: string|number
-// CHINT-NEXT:  {loc5}   %14 [15...20)  = MovInst (:any) %2: any
+// CHINT-NEXT:  {loc5}   %14 [15...20)  = MovInst (:any) %0: any
 // CHINT-NEXT:  {loc4}   %15 [16...27)  = MovInst (:any) %14: any
 // CHINT-NEXT:  {loc6}   %16 [17...19)  = MovInst (:number|bigint) %11: number|bigint
-// CHINT-NEXT:           %17            = CmpBrGreaterThanInst %16: number|bigint, %1: number, %BB4, %BB3
+// CHINT-NEXT:           %17            = CmpBrGreaterThanInst %16: number|bigint, %4: number, %BB4, %BB3
 // CHINT-NEXT:%BB4:
 // CHINT-NEXT:  {loc6}   %18 [12...26)  = PhiInst (:number|bigint) %16: number|bigint, %BB1, %24: number|bigint, %BB4
 // CHINT-NEXT:  {loc5}   %19 [15...21) [23...26)  = PhiInst (:any) %14: any, %BB1, %22: number|bigint, %BB4
@@ -77,7 +77,7 @@ print(bench(4e6, 100))
 // CHINT-NEXT:  {loc5}   %22 [23...25)  = MovInst (:number|bigint) %20: number|bigint
 // CHINT-NEXT:  {loc4}   %23 [24...27)  = MovInst (:number|bigint) %22: number|bigint
 // CHINT-NEXT:  {loc6}   %24 [25...26)  = MovInst (:number|bigint) %21: number|bigint
-// CHINT-NEXT:           %25            = CmpBrGreaterThanInst %24: number|bigint, %1: number, %BB4, %BB3
+// CHINT-NEXT:           %25            = CmpBrGreaterThanInst %24: number|bigint, %4: number, %BB4, %BB3
 // CHINT-NEXT:%BB3:
 // CHINT-NEXT:  {loc4}   %26 [16...28)  = PhiInst (:any) %15: any, %BB1, %23: number|bigint, %BB4
 // CHINT-NEXT:  {loc4}   %27 [28...31)  = BinaryAddInst (:string|number) %13: string|number, %26: any
@@ -85,7 +85,7 @@ print(bench(4e6, 100))
 // CHINT-NEXT:  {loc1}   %29 [30...33)  = MovInst (:string|number) %27: string|number
 // CHINT-NEXT:  {loc0}   %30 [31...34)  = MovInst (:string|number) %29: string|number
 // CHINT-NEXT:  {loc2}   %31 [32...33)  = MovInst (:number|bigint) %28: number|bigint
-// CHINT-NEXT:           %32            = CmpBrGreaterThanOrEqualInst %31: number|bigint, %0: number, %BB1, %BB2
+// CHINT-NEXT:           %32            = CmpBrGreaterThanOrEqualInst %31: number|bigint, %3: number, %BB1, %BB2
 // CHINT-NEXT:%BB2:
 // CHINT-NEXT:  {loc0}   %33 [8...35)   = PhiInst (:string|number) %7: number, %BB0, %30: string|number, %BB3
 // CHINT-NEXT:  {loc0}   %34 [8...36)   = MovInst (:string|number) %33: string|number
@@ -113,25 +113,25 @@ print(bench(4e6, 100))
 // CHECK:function bench(lc: any, fc: any): string|number
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
-// CHECK-NEXT:  {np1}     %0 = HBCLoadConstInst (:number) 0: number
-// CHECK-NEXT:  {np0}     %1 = HBCLoadConstInst (:number) 1: number
-// CHECK-NEXT:  {loc3}    %2 = LoadParamInst (:any) %fc: any
-// CHECK-NEXT:  {loc0}    %3 = LoadParamInst (:any) %lc: any
-// CHECK-NEXT:  {loc2}    %4 = UnaryDecInst (:number|bigint) {loc0} %3: any
-// CHECK-NEXT:  {loc1}    %5 = MovInst (:number) {np1} %0: number
-// CHECK-NEXT:  {loc2}    %6 = MovInst (:number|bigint) {loc2} %4: number|bigint
+// CHECK-NEXT:  {loc3}    %0 = LoadParamInst (:any) %fc: any
+// CHECK-NEXT:  {loc0}    %1 = LoadParamInst (:any) %lc: any
+// CHECK-NEXT:  {loc2}    %2 = UnaryDecInst (:number|bigint) {loc0} %1: any
+// CHECK-NEXT:  {np1}     %3 = HBCLoadConstInst (:number) 0: number
+// CHECK-NEXT:  {np0}     %4 = HBCLoadConstInst (:number) 1: number
+// CHECK-NEXT:  {loc1}    %5 = MovInst (:number) {np1} %3: number
+// CHECK-NEXT:  {loc2}    %6 = MovInst (:number|bigint) {loc2} %2: number|bigint
 // CHECK-NEXT:  {loc0}    %7 = MovInst (:number) {loc1} %5: number
 // CHECK-NEXT:                 CmpBrGreaterThanOrEqualInst {loc2} %6: number|bigint, {loc0} %7: number, %BB1, %BB2
 // CHECK-NEXT:%BB1:
 // CHECK-NEXT:  {loc2}    %9 = PhiInst (:number|bigint) {loc2} %6: number|bigint, %BB0, {loc2} %31: number|bigint, %BB3
 // CHECK-NEXT:  {loc1}   %10 = PhiInst (:string|number) {loc1} %5: number, %BB0, {loc1} %29: string|number, %BB3
-// CHECK-NEXT:  {loc6}   %11 = UnaryDecInst (:number|bigint) {loc3} %2: any
+// CHECK-NEXT:  {loc6}   %11 = UnaryDecInst (:number|bigint) {loc3} %0: any
 // CHECK-NEXT:  {loc2}   %12 = MovInst (:number|bigint) {loc2} %9: number|bigint
 // CHECK-NEXT:  {loc1}   %13 = MovInst (:string|number) {loc1} %10: string|number
-// CHECK-NEXT:  {loc5}   %14 = MovInst (:any) {loc3} %2: any
+// CHECK-NEXT:  {loc5}   %14 = MovInst (:any) {loc3} %0: any
 // CHECK-NEXT:  {loc4}   %15 = MovInst (:any) {loc5} %14: any
 // CHECK-NEXT:  {loc6}   %16 = MovInst (:number|bigint) {loc6} %11: number|bigint
-// CHECK-NEXT:                 CmpBrGreaterThanInst {loc6} %16: number|bigint, {np0} %1: number, %BB4, %BB3
+// CHECK-NEXT:                 CmpBrGreaterThanInst {loc6} %16: number|bigint, {np0} %4: number, %BB4, %BB3
 // CHECK-NEXT:%BB4:
 // CHECK-NEXT:  {loc6}   %18 = PhiInst (:number|bigint) {loc6} %16: number|bigint, %BB1, {loc6} %24: number|bigint, %BB4
 // CHECK-NEXT:  {loc5}   %19 = PhiInst (:any) {loc5} %14: any, %BB1, {loc5} %22: number|bigint, %BB4
@@ -140,7 +140,7 @@ print(bench(4e6, 100))
 // CHECK-NEXT:  {loc5}   %22 = MovInst (:number|bigint) {loc7} %20: number|bigint
 // CHECK-NEXT:  {loc4}   %23 = MovInst (:number|bigint) {loc5} %22: number|bigint
 // CHECK-NEXT:  {loc6}   %24 = MovInst (:number|bigint) {loc6} %21: number|bigint
-// CHECK-NEXT:                 CmpBrGreaterThanInst {loc6} %24: number|bigint, {np0} %1: number, %BB4, %BB3
+// CHECK-NEXT:                 CmpBrGreaterThanInst {loc6} %24: number|bigint, {np0} %4: number, %BB4, %BB3
 // CHECK-NEXT:%BB3:
 // CHECK-NEXT:  {loc4}   %26 = PhiInst (:any) {loc4} %15: any, %BB1, {loc4} %23: number|bigint, %BB4
 // CHECK-NEXT:  {loc4}   %27 = BinaryAddInst (:string|number) {loc1} %13: string|number, {loc4} %26: any
@@ -148,7 +148,7 @@ print(bench(4e6, 100))
 // CHECK-NEXT:  {loc1}   %29 = MovInst (:string|number) {loc4} %27: string|number
 // CHECK-NEXT:  {loc0}   %30 = MovInst (:string|number) {loc1} %29: string|number
 // CHECK-NEXT:  {loc2}   %31 = MovInst (:number|bigint) {loc2} %28: number|bigint
-// CHECK-NEXT:                 CmpBrGreaterThanOrEqualInst {loc2} %31: number|bigint, {np1} %0: number, %BB1, %BB2
+// CHECK-NEXT:                 CmpBrGreaterThanOrEqualInst {loc2} %31: number|bigint, {np1} %3: number, %BB1, %BB2
 // CHECK-NEXT:%BB2:
 // CHECK-NEXT:  {loc0}   %33 = PhiInst (:string|number) {loc0} %7: number, %BB0, {loc0} %30: string|number, %BB3
 // CHECK-NEXT:  {loc0}   %34 = MovInst (:string|number) {loc0} %33: string|number

--- a/test/BCGen/SH/call-builtin-clobber-callee.js
+++ b/test/BCGen/SH/call-builtin-clobber-callee.js
@@ -31,10 +31,10 @@ function test_call_after_builtin() {
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  {loc0}    %0 = HBCGetGlobalObjectInst (:object)
 // CHECK-NEXT:  {loc1}    %1 = TryLoadGlobalPropertyInst (:any) {loc0} %0: object, "print": string
-// CHECK-NEXT:  {loc0}    %2 = HBCAllocObjectFromBufferInst (:object) 1: number, "valueOf": string, null: null
+// CHECK-NEXT:  {loc0}    %2 = AllocObjectInst (:object) 1: number, empty: any
 // CHECK-NEXT:  {loc2}    %3 = HBCCreateEnvironmentInst (:environment)
 // CHECK-NEXT:  {loc2}    %4 = HBCCreateFunctionInst (:object) %valueOf(): number, {loc2} %3: environment
-// CHECK-NEXT:                 StorePropertyLooseInst {loc2} %4: object, {loc0} %2: object, "valueOf": string
+// CHECK-NEXT:                 StoreNewOwnPropertyInst {loc2} %4: object, {loc0} %2: object, "valueOf": string, true: boolean
 // CHECK-NEXT:  {stack[0]}  %6 = HBCLoadConstInst (:number) 3: number
 // CHECK-NEXT:  {stack[4]}  %7 = ImplicitMovInst (:undefined) undefined: undefined
 // CHECK-NEXT:  {stack[3]}  %8 = ImplicitMovInst (:empty) empty: empty

--- a/test/BCGen/SH/switch_default_regress.js
+++ b/test/BCGen/SH/switch_default_regress.js
@@ -56,18 +56,18 @@ function foo(i) {
 // CHKLIR:function foo(i: any): any
 // CHKLIR-NEXT:frame = []
 // CHKLIR-NEXT:%BB0:
-// CHKLIR-NEXT:  %0 = HBCLoadConstInst (:number) 2: number
-// CHKLIR-NEXT:  %1 = LoadParamInst (:any) %i: any
+// CHKLIR-NEXT:  %0 = LoadParamInst (:any) %i: any
 // CHKLIR-NEXT:       BranchInst %BB1
 // CHKLIR-NEXT:%BB2:
-// CHKLIR-NEXT:  %3 = PhiInst (:any) %0: number, %BB3, %1: any, %BB4
-// CHKLIR-NEXT:       ReturnInst %3: any
+// CHKLIR-NEXT:  %2 = PhiInst (:any) %4: number, %BB3, %0: any, %BB4
+// CHKLIR-NEXT:       ReturnInst %2: any
 // CHKLIR-NEXT:%BB3:
+// CHKLIR-NEXT:  %4 = HBCLoadConstInst (:number) 2: number
 // CHKLIR-NEXT:       BranchInst %BB2
 // CHKLIR-NEXT:%BB4:
 // CHKLIR-NEXT:  %6 = HBCLoadConstInst (:number) 1: number
-// CHKLIR-NEXT:       CmpBrStrictlyEqualInst %6: number, %1: any, %BB2, %BB2
+// CHKLIR-NEXT:       CmpBrStrictlyEqualInst %6: number, %0: any, %BB2, %BB2
 // CHKLIR-NEXT:%BB1:
 // CHKLIR-NEXT:  %8 = HBCLoadConstInst (:number) 0: number
-// CHKLIR-NEXT:       CmpBrStrictlyEqualInst %8: number, %1: any, %BB3, %BB4
+// CHKLIR-NEXT:       CmpBrStrictlyEqualInst %8: number, %0: any, %BB3, %BB4
 // CHKLIR-NEXT:function_end

--- a/test/BCGen/SH/tdz-unionnarrow.js
+++ b/test/BCGen/SH/tdz-unionnarrow.js
@@ -100,16 +100,16 @@ function f2() {
 // CHKLIR-NEXT:frame = [x: empty|undefined]
 // CHKLIR-NEXT:%BB0:
 // CHKLIR-NEXT:  %0 = HBCCreateEnvironmentInst (:environment)
-// CHKLIR-NEXT:  %1 = HBCLoadConstInst (:undefined) undefined: undefined
-// CHKLIR-NEXT:  %2 = HBCLoadConstInst (:empty) empty: empty
-// CHKLIR-NEXT:       HBCStoreToEnvironmentInst %0: environment, %2: empty, [x]: empty|undefined
-// CHKLIR-NEXT:  %4 = ThrowIfEmptyInst (:any) %2: empty
-// CHKLIR-NEXT:  %5 = UnionNarrowTrustedInst (:any) %2: empty
-// CHKLIR-NEXT:  %6 = HBCLoadConstInst (:number) 1: number
-// CHKLIR-NEXT:  %7 = BinaryAddInst (:string|number) %5: any, %6: number
-// CHKLIR-NEXT:       ReturnInst %7: string|number
+// CHKLIR-NEXT:  %1 = HBCLoadConstInst (:empty) empty: empty
+// CHKLIR-NEXT:       HBCStoreToEnvironmentInst %0: environment, %1: empty, [x]: empty|undefined
+// CHKLIR-NEXT:  %3 = ThrowIfEmptyInst (:any) %1: empty
+// CHKLIR-NEXT:  %4 = UnionNarrowTrustedInst (:any) %1: empty
+// CHKLIR-NEXT:  %5 = HBCLoadConstInst (:number) 1: number
+// CHKLIR-NEXT:  %6 = BinaryAddInst (:string|number) %4: any, %5: number
+// CHKLIR-NEXT:       ReturnInst %6: string|number
 // CHKLIR-NEXT:%BB1:
-// CHKLIR-NEXT:       HBCStoreToEnvironmentInst %0: environment, %1: undefined, [x]: empty|undefined
+// CHKLIR-NEXT:  %8 = HBCLoadConstInst (:undefined) undefined: undefined
+// CHKLIR-NEXT:       HBCStoreToEnvironmentInst %0: environment, %8: undefined, [x]: empty|undefined
 // CHKLIR-NEXT:        UnreachableInst
 // CHKLIR-NEXT:function_end
 

--- a/test/IRGen/__proto__-shorthand.js
+++ b/test/IRGen/__proto__-shorthand.js
@@ -66,11 +66,14 @@ function protoShorthandMix2(func) {
 // CHECK-NEXT:       StoreFrameInst %0: any, [func]: any
 // CHECK-NEXT:       StoreFrameInst undefined: undefined, [__proto__]: any
 // CHECK-NEXT:       StoreFrameInst 42: number, [__proto__]: any
-// CHECK-NEXT:  %4 = LoadFrameInst (:any) [__proto__]: any
-// CHECK-NEXT:  %5 = AllocObjectLiteralInst (:object) "__proto__": string, %4: any, "a": string, 2: number, "b": string, 3: number
-// CHECK-NEXT:       ReturnInst %5: object
+// CHECK-NEXT:  %4 = AllocObjectInst (:object) 3: number, empty: any
+// CHECK-NEXT:  %5 = LoadFrameInst (:any) [__proto__]: any
+// CHECK-NEXT:       StoreNewOwnPropertyInst %5: any, %4: object, "__proto__": string, true: boolean
+// CHECK-NEXT:       StoreNewOwnPropertyInst 2: number, %4: object, "a": string, true: boolean
+// CHECK-NEXT:       StoreNewOwnPropertyInst 3: number, %4: object, "b": string, true: boolean
+// CHECK-NEXT:       ReturnInst %4: object
 // CHECK-NEXT:%BB1:
-// CHECK-NEXT:       UnreachableInst
+// CHECK-NEXT:        UnreachableInst
 // CHECK-NEXT:function_end
 
 // CHECK:function protoShorthandDup(func: any): any

--- a/test/IRGen/array_object.js
+++ b/test/IRGen/array_object.js
@@ -39,16 +39,18 @@ function foo(param) {
 // CHECK-NEXT:       StoreFrameInst %0: any, [param]: any
 // CHECK-NEXT:       StoreFrameInst undefined: undefined, [obj]: any
 // CHECK-NEXT:       StoreFrameInst undefined: undefined, [foo]: any
-// CHECK-NEXT:  %4 = LoadFrameInst (:any) [param]: any
-// CHECK-NEXT:  %5 = AllocObjectLiteralInst (:object) "1": string, 2: number, "key": string, %4: any
-// CHECK-NEXT:       StoreFrameInst %5: object, [obj]: any
-// CHECK-NEXT:  %7 = AllocArrayInst (:object) 4: number, 1: number, 2: number, 3: number, 4: number
-// CHECK-NEXT:       StoreFrameInst %7: object, [foo]: any
-// CHECK-NEXT:  %9 = LoadFrameInst (:any) [obj]: any
-// CHECK-NEXT:  %10 = LoadFrameInst (:any) [foo]: any
-// CHECK-NEXT:        StorePropertyLooseInst %10: any, %9: any, "field": string
+// CHECK-NEXT:  %4 = AllocObjectInst (:object) 2: number, empty: any
+// CHECK-NEXT:       StoreNewOwnPropertyInst 2: number, %4: object, "1": string, true: boolean
+// CHECK-NEXT:  %6 = LoadFrameInst (:any) [param]: any
+// CHECK-NEXT:       StoreNewOwnPropertyInst %6: any, %4: object, "key": string, true: boolean
+// CHECK-NEXT:       StoreFrameInst %4: object, [obj]: any
+// CHECK-NEXT:  %9 = AllocArrayInst (:object) 4: number, 1: number, 2: number, 3: number, 4: number
+// CHECK-NEXT:        StoreFrameInst %9: object, [foo]: any
+// CHECK-NEXT:  %11 = LoadFrameInst (:any) [obj]: any
 // CHECK-NEXT:  %12 = LoadFrameInst (:any) [foo]: any
-// CHECK-NEXT:  %13 = LoadFrameInst (:any) [obj]: any
-// CHECK-NEXT:        StorePropertyLooseInst %13: any, %12: any, 5: number
+// CHECK-NEXT:        StorePropertyLooseInst %12: any, %11: any, "field": string
+// CHECK-NEXT:  %14 = LoadFrameInst (:any) [foo]: any
+// CHECK-NEXT:  %15 = LoadFrameInst (:any) [obj]: any
+// CHECK-NEXT:        StorePropertyLooseInst %15: any, %14: any, 5: number
 // CHECK-NEXT:        ReturnInst undefined: undefined
 // CHECK-NEXT:function_end

--- a/test/IRGen/es6/object-computed-destructuring.js
+++ b/test/IRGen/es6/object-computed-destructuring.js
@@ -31,8 +31,8 @@ var {} = x;
 // CHECK-NEXT:  %8 = TryLoadGlobalPropertyInst (:any) globalObject: object, "x": string
 // CHECK-NEXT:  %9 = LoadPropertyInst (:any) %8: any, "a": string
 // CHECK-NEXT:        StorePropertyLooseInst %9: any, globalObject: object, "b": string
-// CHECK-NEXT:  %11 = AllocObjectLiteralInst (:object) "a": string, 0: number
-// CHECK-NEXT:  %12 = CallBuiltinInst (:any) [HermesBuiltin.silentSetPrototypeOf]: number, empty: any, empty: any, undefined: undefined, undefined: undefined, %11: object, null: null
+// CHECK-NEXT:  %11 = AllocObjectInst (:object) 1: number, null: null
+// CHECK-NEXT:        StoreNewOwnPropertyInst 0: number, %11: object, "a": string, true: boolean
 // CHECK-NEXT:  %13 = AllocObjectInst (:object) 0: number, empty: any
 // CHECK-NEXT:  %14 = CallBuiltinInst (:any) [HermesBuiltin.copyDataProperties]: number, empty: any, empty: any, undefined: undefined, undefined: undefined, %13: object, %8: any, %11: object
 // CHECK-NEXT:        StorePropertyLooseInst %14: any, globalObject: object, "rest": string
@@ -43,8 +43,8 @@ var {} = x;
 // CHECK-NEXT:        StorePropertyLooseInst %19: any, globalObject: object, "b": string
 // CHECK-NEXT:  %21 = LoadPropertyInst (:any) %16: any, "c": string
 // CHECK-NEXT:        StorePropertyLooseInst %21: any, globalObject: object, "d": string
-// CHECK-NEXT:  %23 = AllocObjectLiteralInst (:object) "c": string, 0: number
-// CHECK-NEXT:  %24 = CallBuiltinInst (:any) [HermesBuiltin.silentSetPrototypeOf]: number, empty: any, empty: any, undefined: undefined, undefined: undefined, %23: object, null: null
+// CHECK-NEXT:  %23 = AllocObjectInst (:object) 2: number, null: null
+// CHECK-NEXT:        StoreNewOwnPropertyInst 0: number, %23: object, "c": string, true: boolean
 // CHECK-NEXT:        StorePropertyLooseInst 0: number, %23: object, %18: any
 // CHECK-NEXT:  %26 = AllocObjectInst (:object) 0: number, empty: any
 // CHECK-NEXT:  %27 = CallBuiltinInst (:any) [HermesBuiltin.copyDataProperties]: number, empty: any, empty: any, undefined: undefined, undefined: undefined, %26: object, %16: any, %23: object

--- a/test/IRGen/es6/rest-property.js
+++ b/test/IRGen/es6/rest-property.js
@@ -92,13 +92,14 @@ function f5(o) {
 // CHECK-NEXT:       StoreFrameInst %6: any, [a]: any
 // CHECK-NEXT:  %8 = LoadPropertyInst (:any) %5: any, "b": string
 // CHECK-NEXT:       StoreFrameInst %8: any, [b]: any
-// CHECK-NEXT:  %10 = AllocObjectLiteralInst (:object) "a": string, 0: number, "b": string, 0: number
-// CHECK-NEXT:  %11 = CallBuiltinInst (:any) [HermesBuiltin.silentSetPrototypeOf]: number, empty: any, empty: any, undefined: undefined, undefined: undefined, %10: object, null: null
-// CHECK-NEXT:  %12 = AllocObjectInst (:object) 0: number, empty: any
-// CHECK-NEXT:  %13 = CallBuiltinInst (:any) [HermesBuiltin.copyDataProperties]: number, empty: any, empty: any, undefined: undefined, undefined: undefined, %12: object, %5: any, %10: object
-// CHECK-NEXT:        StoreFrameInst %13: any, [rest]: any
-// CHECK-NEXT:  %15 = LoadFrameInst (:any) [rest]: any
-// CHECK-NEXT:        ReturnInst %15: any
+// CHECK-NEXT:  %10 = AllocObjectInst (:object) 2: number, null: null
+// CHECK-NEXT:        StoreNewOwnPropertyInst 0: number, %10: object, "a": string, true: boolean
+// CHECK-NEXT:        StoreNewOwnPropertyInst 0: number, %10: object, "b": string, true: boolean
+// CHECK-NEXT:  %13 = AllocObjectInst (:object) 0: number, empty: any
+// CHECK-NEXT:  %14 = CallBuiltinInst (:any) [HermesBuiltin.copyDataProperties]: number, empty: any, empty: any, undefined: undefined, undefined: undefined, %13: object, %5: any, %10: object
+// CHECK-NEXT:        StoreFrameInst %14: any, [rest]: any
+// CHECK-NEXT:  %16 = LoadFrameInst (:any) [rest]: any
+// CHECK-NEXT:        ReturnInst %16: any
 // CHECK-NEXT:%BB1:
 // CHECK-NEXT:        UnreachableInst
 // CHECK-NEXT:function_end
@@ -113,8 +114,8 @@ function f5(o) {
 // CHECK-NEXT:  %4 = LoadFrameInst (:any) [t]: any
 // CHECK-NEXT:  %5 = LoadPropertyInst (:any) %4: any, "a": string
 // CHECK-NEXT:       StoreFrameInst %5: any, [a]: any
-// CHECK-NEXT:  %7 = AllocObjectLiteralInst (:object) "a": string, 0: number
-// CHECK-NEXT:  %8 = CallBuiltinInst (:any) [HermesBuiltin.silentSetPrototypeOf]: number, empty: any, empty: any, undefined: undefined, undefined: undefined, %7: object, null: null
+// CHECK-NEXT:  %7 = AllocObjectInst (:object) 1: number, null: null
+// CHECK-NEXT:       StoreNewOwnPropertyInst 0: number, %7: object, "a": string, true: boolean
 // CHECK-NEXT:  %9 = AllocObjectInst (:object) 0: number, empty: any
 // CHECK-NEXT:  %10 = CallBuiltinInst (:any) [HermesBuiltin.copyDataProperties]: number, empty: any, empty: any, undefined: undefined, undefined: undefined, %9: object, %4: any, %7: object
 // CHECK-NEXT:        StoreFrameInst %10: any, [rest]: any
@@ -133,8 +134,8 @@ function f5(o) {
 // CHECK-NEXT:  %6 = LoadPropertyInst (:any) %5: any, "a": string
 // CHECK-NEXT:       StoreFrameInst %6: any, [a]: any
 // CHECK-NEXT:  %8 = LoadFrameInst (:any) [o]: any
-// CHECK-NEXT:  %9 = AllocObjectLiteralInst (:object) "a": string, 0: number
-// CHECK-NEXT:  %10 = CallBuiltinInst (:any) [HermesBuiltin.silentSetPrototypeOf]: number, empty: any, empty: any, undefined: undefined, undefined: undefined, %9: object, null: null
+// CHECK-NEXT:  %9 = AllocObjectInst (:object) 1: number, null: null
+// CHECK-NEXT:        StoreNewOwnPropertyInst 0: number, %9: object, "a": string, true: boolean
 // CHECK-NEXT:  %11 = AllocObjectInst (:object) 0: number, empty: any
 // CHECK-NEXT:  %12 = CallBuiltinInst (:any) [HermesBuiltin.copyDataProperties]: number, empty: any, empty: any, undefined: undefined, undefined: undefined, %11: object, %5: any, %9: object
 // CHECK-NEXT:        StorePropertyLooseInst %12: any, %8: any, "rest": string
@@ -153,8 +154,8 @@ function f5(o) {
 // CHECK-NEXT:       StoreFrameInst %5: any, [a]: any
 // CHECK-NEXT:  %7 = LoadPropertyInst (:any) %4: any, "a": string
 // CHECK-NEXT:       StoreFrameInst %7: any, [a]: any
-// CHECK-NEXT:  %9 = AllocObjectLiteralInst (:object) "a": string, 0: number
-// CHECK-NEXT:  %10 = CallBuiltinInst (:any) [HermesBuiltin.silentSetPrototypeOf]: number, empty: any, empty: any, undefined: undefined, undefined: undefined, %9: object, null: null
+// CHECK-NEXT:  %9 = AllocObjectInst (:object) 1: number, null: null
+// CHECK-NEXT:        StoreNewOwnPropertyInst 0: number, %9: object, "a": string, true: boolean
 // CHECK-NEXT:  %11 = AllocObjectInst (:object) 0: number, empty: any
 // CHECK-NEXT:  %12 = CallBuiltinInst (:any) [HermesBuiltin.copyDataProperties]: number, empty: any, empty: any, undefined: undefined, undefined: undefined, %11: object, %4: any, %9: object
 // CHECK-NEXT:        StoreFrameInst %12: any, [rest]: any

--- a/test/IRGen/es6/tagged-template.js
+++ b/test/IRGen/es6/tagged-template.js
@@ -171,16 +171,17 @@ function helloWorld() {
 // CHECK-NEXT:frame = [obj: any]
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:       StoreFrameInst undefined: undefined, [obj]: any
-// CHECK-NEXT:  %1 = LoadPropertyInst (:any) globalObject: object, "dummy": string
-// CHECK-NEXT:  %2 = AllocObjectLiteralInst (:object) "func": string, %1: any
-// CHECK-NEXT:       StoreFrameInst %2: object, [obj]: any
-// CHECK-NEXT:  %4 = GetTemplateObjectInst (:any) 5: number, true: boolean, "hello world!": string
-// CHECK-NEXT:  %5 = LoadFrameInst (:any) [obj]: any
-// CHECK-NEXT:  %6 = LoadPropertyInst (:any) %5: any, "func": string
-// CHECK-NEXT:  %7 = CallInst (:any) %6: any, empty: any, empty: any, undefined: undefined, %5: any, %4: any
-// CHECK-NEXT:       ReturnInst %7: any
+// CHECK-NEXT:  %1 = AllocObjectInst (:object) 1: number, empty: any
+// CHECK-NEXT:  %2 = LoadPropertyInst (:any) globalObject: object, "dummy": string
+// CHECK-NEXT:       StoreNewOwnPropertyInst %2: any, %1: object, "func": string, true: boolean
+// CHECK-NEXT:       StoreFrameInst %1: object, [obj]: any
+// CHECK-NEXT:  %5 = GetTemplateObjectInst (:any) 5: number, true: boolean, "hello world!": string
+// CHECK-NEXT:  %6 = LoadFrameInst (:any) [obj]: any
+// CHECK-NEXT:  %7 = LoadPropertyInst (:any) %6: any, "func": string
+// CHECK-NEXT:  %8 = CallInst (:any) %7: any, empty: any, empty: any, undefined: undefined, %6: any, %5: any
+// CHECK-NEXT:       ReturnInst %8: any
 // CHECK-NEXT:%BB1:
-// CHECK-NEXT:       UnreachableInst
+// CHECK-NEXT:        UnreachableInst
 // CHECK-NEXT:function_end
 
 // CHECK:function callExpr(): any

--- a/test/IRGen/json.js
+++ b/test/IRGen/json.js
@@ -41,14 +41,29 @@ var json = {
 // CHECK-NEXT:       DeclareGlobalVarInst "json": string
 // CHECK-NEXT:  %1 = AllocStackInst (:any) $?anon_0_ret: any
 // CHECK-NEXT:       StoreStackInst undefined: undefined, %1: any
-// CHECK-NEXT:  %3 = AllocArrayInst (:object) 2: number, "GML": string, "XML": string
-// CHECK-NEXT:  %4 = AllocObjectLiteralInst (:object) "para": string, "A meta-markup language, used to create markup languages such as DocBook.": string, "GlossSeeAlso": string, %3: object
-// CHECK-NEXT:  %5 = AllocObjectLiteralInst (:object) "ID": string, "SGML": string, "SortAs": string, "SGML": string, "GlossTerm": string, "Standard Generalized Markup Language": string, "Acronym": string, "SGML": string, "Abbrev": string, "ISO 8879:1986": string, "GlossDef": string, %4: object, "GlossSee": string, "markup": string
-// CHECK-NEXT:  %6 = AllocObjectLiteralInst (:object) "GlossEntry": string, %5: object
-// CHECK-NEXT:  %7 = AllocObjectLiteralInst (:object) "title": string, "S": string, "GlossList": string, %6: object
-// CHECK-NEXT:  %8 = AllocObjectLiteralInst (:object) "title": string, "example glossary": string, "GlossDiv": string, %7: object
-// CHECK-NEXT:  %9 = AllocObjectLiteralInst (:object) "glossary": string, %8: object
-// CHECK-NEXT:        StorePropertyLooseInst %9: object, globalObject: object, "json": string
-// CHECK-NEXT:  %11 = LoadStackInst (:any) %1: any
-// CHECK-NEXT:        ReturnInst %11: any
+// CHECK-NEXT:  %3 = AllocObjectInst (:object) 1: number, empty: any
+// CHECK-NEXT:  %4 = AllocObjectInst (:object) 2: number, empty: any
+// CHECK-NEXT:       StoreNewOwnPropertyInst "example glossary": string, %4: object, "title": string, true: boolean
+// CHECK-NEXT:  %6 = AllocObjectInst (:object) 2: number, empty: any
+// CHECK-NEXT:       StoreNewOwnPropertyInst "S": string, %6: object, "title": string, true: boolean
+// CHECK-NEXT:  %8 = AllocObjectInst (:object) 1: number, empty: any
+// CHECK-NEXT:  %9 = AllocObjectInst (:object) 7: number, empty: any
+// CHECK-NEXT:        StoreNewOwnPropertyInst "SGML": string, %9: object, "ID": string, true: boolean
+// CHECK-NEXT:        StoreNewOwnPropertyInst "SGML": string, %9: object, "SortAs": string, true: boolean
+// CHECK-NEXT:        StoreNewOwnPropertyInst "Standard Generalized Markup Language": string, %9: object, "GlossTerm": string, true: boolean
+// CHECK-NEXT:        StoreNewOwnPropertyInst "SGML": string, %9: object, "Acronym": string, true: boolean
+// CHECK-NEXT:        StoreNewOwnPropertyInst "ISO 8879:1986": string, %9: object, "Abbrev": string, true: boolean
+// CHECK-NEXT:  %15 = AllocObjectInst (:object) 2: number, empty: any
+// CHECK-NEXT:        StoreNewOwnPropertyInst "A meta-markup language, used to create markup languages such as DocBook.": string, %15: object, "para": string, true: boolean
+// CHECK-NEXT:  %17 = AllocArrayInst (:object) 2: number, "GML": string, "XML": string
+// CHECK-NEXT:        StoreNewOwnPropertyInst %17: object, %15: object, "GlossSeeAlso": string, true: boolean
+// CHECK-NEXT:        StoreNewOwnPropertyInst %15: object, %9: object, "GlossDef": string, true: boolean
+// CHECK-NEXT:        StoreNewOwnPropertyInst "markup": string, %9: object, "GlossSee": string, true: boolean
+// CHECK-NEXT:        StoreNewOwnPropertyInst %9: object, %8: object, "GlossEntry": string, true: boolean
+// CHECK-NEXT:        StoreNewOwnPropertyInst %8: object, %6: object, "GlossList": string, true: boolean
+// CHECK-NEXT:        StoreNewOwnPropertyInst %6: object, %4: object, "GlossDiv": string, true: boolean
+// CHECK-NEXT:        StoreNewOwnPropertyInst %4: object, %3: object, "glossary": string, true: boolean
+// CHECK-NEXT:        StorePropertyLooseInst %3: object, globalObject: object, "json": string
+// CHECK-NEXT:  %26 = LoadStackInst (:any) %1: any
+// CHECK-NEXT:        ReturnInst %26: any
 // CHECK-NEXT:function_end

--- a/test/IRGen/object_literals.js
+++ b/test/IRGen/object_literals.js
@@ -112,8 +112,10 @@ function accessorObjectLiteral2(func) {
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = LoadParamInst (:any) %func: any
 // CHECK-NEXT:       StoreFrameInst %0: any, [func]: any
-// CHECK-NEXT:  %2 = AllocObjectLiteralInst (:object) "prop1": string, 10: number
-// CHECK-NEXT:  %3 = AllocObjectLiteralInst (:object) "prop1": string, 10: number
+// CHECK-NEXT:  %2 = AllocObjectInst (:object) 1: number, empty: any
+// CHECK-NEXT:       StoreNewOwnPropertyInst 10: number, %2: object, "prop1": string, true: boolean
+// CHECK-NEXT:  %4 = AllocObjectInst (:object) 1: number, empty: any
+// CHECK-NEXT:       StoreNewOwnPropertyInst 10: number, %4: object, "prop1": string, true: boolean
 // CHECK-NEXT:       ReturnInst undefined: undefined
 // CHECK-NEXT:function_end
 
@@ -122,10 +124,16 @@ function accessorObjectLiteral2(func) {
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = LoadParamInst (:any) %func: any
 // CHECK-NEXT:       StoreFrameInst %0: any, [func]: any
-// CHECK-NEXT:  %2 = AllocObjectLiteralInst (:object) "a": string, 1: number, "b": string, 2: number, "c": string, 3: number, "d": string, 4: number, "5": string, 5: number, "6": string, 6: number
+// CHECK-NEXT:  %2 = AllocObjectInst (:object) 6: number, empty: any
+// CHECK-NEXT:       StoreNewOwnPropertyInst 1: number, %2: object, "a": string, true: boolean
+// CHECK-NEXT:       StoreNewOwnPropertyInst 2: number, %2: object, "b": string, true: boolean
+// CHECK-NEXT:       StoreNewOwnPropertyInst 3: number, %2: object, "c": string, true: boolean
+// CHECK-NEXT:       StoreNewOwnPropertyInst 4: number, %2: object, "d": string, true: boolean
+// CHECK-NEXT:       StoreNewOwnPropertyInst 5: number, %2: object, "5": string, true: boolean
+// CHECK-NEXT:       StoreNewOwnPropertyInst 6: number, %2: object, "6": string, true: boolean
 // CHECK-NEXT:       ReturnInst %2: object
 // CHECK-NEXT:%BB1:
-// CHECK-NEXT:       UnreachableInst
+// CHECK-NEXT:        UnreachableInst
 // CHECK-NEXT:function_end
 
 // CHECK:function nestedAllocObjectLiteral(func: any): any
@@ -133,11 +141,17 @@ function accessorObjectLiteral2(func) {
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = LoadParamInst (:any) %func: any
 // CHECK-NEXT:       StoreFrameInst %0: any, [func]: any
-// CHECK-NEXT:  %2 = AllocObjectLiteralInst (:object) "1": string, 100: number, "2": string, 200: number
-// CHECK-NEXT:  %3 = AllocObjectLiteralInst (:object) "a": string, 10: number, "b": string, %2: object, "c": string, "hello": string, "d": string, null: null
-// CHECK-NEXT:       ReturnInst %3: object
+// CHECK-NEXT:  %2 = AllocObjectInst (:object) 4: number, empty: any
+// CHECK-NEXT:       StoreNewOwnPropertyInst 10: number, %2: object, "a": string, true: boolean
+// CHECK-NEXT:  %4 = AllocObjectInst (:object) 2: number, empty: any
+// CHECK-NEXT:       StoreNewOwnPropertyInst 100: number, %4: object, "1": string, true: boolean
+// CHECK-NEXT:       StoreNewOwnPropertyInst 200: number, %4: object, "2": string, true: boolean
+// CHECK-NEXT:       StoreNewOwnPropertyInst %4: object, %2: object, "b": string, true: boolean
+// CHECK-NEXT:       StoreNewOwnPropertyInst "hello": string, %2: object, "c": string, true: boolean
+// CHECK-NEXT:       StoreNewOwnPropertyInst null: null, %2: object, "d": string, true: boolean
+// CHECK-NEXT:        ReturnInst %2: object
 // CHECK-NEXT:%BB1:
-// CHECK-NEXT:       UnreachableInst
+// CHECK-NEXT:        UnreachableInst
 // CHECK-NEXT:function_end
 
 // CHECK:function duplicatedObjectLiteral(func: any): any
@@ -219,13 +233,15 @@ function accessorObjectLiteral2(func) {
 // CHECK-NEXT:  %0 = LoadParamInst (:any) %func: any
 // CHECK-NEXT:       StoreFrameInst %0: any, [func]: any
 // CHECK-NEXT:       StoreFrameInst undefined: undefined, [obj]: any
-// CHECK-NEXT:  %3 = AllocObjectLiteralInst (:object) "a": string, 10: number, "b": string, 20: number
+// CHECK-NEXT:  %3 = AllocObjectInst (:object) 2: number, empty: any
+// CHECK-NEXT:       StoreNewOwnPropertyInst 10: number, %3: object, "a": string, true: boolean
+// CHECK-NEXT:       StoreNewOwnPropertyInst 20: number, %3: object, "b": string, true: boolean
 // CHECK-NEXT:       StoreFrameInst %3: object, [obj]: any
-// CHECK-NEXT:  %5 = AllocObjectInst (:object) 1: number, empty: any
-// CHECK-NEXT:  %6 = LoadFrameInst (:any) [obj]: any
-// CHECK-NEXT:  %7 = CallBuiltinInst (:any) [HermesBuiltin.copyDataProperties]: number, empty: any, empty: any, undefined: undefined, undefined: undefined, %5: object, %6: any
-// CHECK-NEXT:       StoreOwnPropertyInst 42: number, %5: object, "c": string, true: boolean
-// CHECK-NEXT:       ReturnInst %5: object
+// CHECK-NEXT:  %7 = AllocObjectInst (:object) 1: number, empty: any
+// CHECK-NEXT:  %8 = LoadFrameInst (:any) [obj]: any
+// CHECK-NEXT:  %9 = CallBuiltinInst (:any) [HermesBuiltin.copyDataProperties]: number, empty: any, empty: any, undefined: undefined, undefined: undefined, %7: object, %8: any
+// CHECK-NEXT:        StoreOwnPropertyInst 42: number, %7: object, "c": string, true: boolean
+// CHECK-NEXT:        ReturnInst %7: object
 // CHECK-NEXT:%BB1:
 // CHECK-NEXT:        UnreachableInst
 // CHECK-NEXT:function_end

--- a/test/Optimizer/type_infer_fun_returns.js
+++ b/test/Optimizer/type_infer_fun_returns.js
@@ -41,9 +41,10 @@ function g14(z) {
 // CHECK-NEXT:  %8 = CallInst (:any) %7: object, empty: any, empty: any, undefined: undefined, undefined: undefined
 // CHECK-NEXT:  %9 = BinaryAddInst (:string|number) %8: any, 1: number
 // CHECK-NEXT:  %10 = CallInst (:any) %6: any, empty: any, empty: any, undefined: undefined, undefined: undefined, %9: string|number
-// CHECK-NEXT:  %11 = CreateFunctionInst (:object) %m(): undefined
-// CHECK-NEXT:  %12 = AllocObjectLiteralInst (:object) "m": string, %11: object
-// CHECK-NEXT:        ReturnInst %12: object
+// CHECK-NEXT:  %11 = AllocObjectInst (:object) 1: number, empty: any
+// CHECK-NEXT:  %12 = CreateFunctionInst (:object) %m(): undefined
+// CHECK-NEXT:        StoreNewOwnPropertyInst %12: object, %11: object, "m": string, true: boolean
+// CHECK-NEXT:        ReturnInst %11: object
 // CHECK-NEXT:%BB2:
 // CHECK-NEXT:        ReturnInst undefined: undefined
 // CHECK-NEXT:function_end

--- a/test/shermes/regress-error-stack-native-stack-overflow.js
+++ b/test/shermes/regress-error-stack-native-stack-overflow.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// RUN: %shermes -exec %s  | %FileCheck --match-full-lines %s
+// RUN: ulimit -s 512 && %shermes -exec %s  | %FileCheck --match-full-lines %s
 
 "use strict";
 


### PR DESCRIPTION
Summary:
Original Author: neildhar@meta.com
Original Git: 005cea0e232b1feb0f16be32a02fd0b90921c84c

Even though we don't currently have code that does so,
`StoreNewOwnPropertyInst` can define a non-enumerable property, which
cannot be represented in the buffer. Reject such properties.

Original Reviewed By: avp

Original Revision: D48658152

Differential Revision: D50460152


