### PR TITLE
Optimize the Math.random implementation

### DIFF
--- a/include/hermes/VM/JSLib/RuntimeCommonStorage.h
+++ b/include/hermes/VM/JSLib/RuntimeCommonStorage.h
@@ -37,9 +37,9 @@ struct RuntimeCommonStorage {
   /// results of calls to functions).
   MockedEnvironment tracedEnv;
 
-  /// PRNG used by Math.random()
-  uint64_t randomState_;
-  bool randomEngineInited = false;
+  /// state for xoroshiro128+ PRNG used by Math.random()
+  uint64_t randomEngineState_[2];
+  bool randomEngineSeeded_ = false;
 };
 
 } // namespace vm

--- a/include/hermes/VM/JSLib/RuntimeCommonStorage.h
+++ b/include/hermes/VM/JSLib/RuntimeCommonStorage.h
@@ -38,8 +38,8 @@ struct RuntimeCommonStorage {
   MockedEnvironment tracedEnv;
 
   /// PRNG used by Math.random()
-  std::minstd_rand randomEngine_;
-  bool randomEngineSeeded_ = false;
+  uint64_t randomState_;
+  bool randomEngineInited = false;
 };
 
 } // namespace vm

--- a/lib/VM/JSLib/Math.cpp
+++ b/lib/VM/JSLib/Math.cpp
@@ -242,10 +242,10 @@ CallResult<HermesValue> mathRandom(void *, Runtime &runtime, NativeArgs) {
     if (storage->randomState_ == 0) {
       storage->randomState_ = 1;
     }
-      storage->randomEngineInited = true;
-    }
-    uint64_t val = XorShift64(&storage->randomState_);
-    return HermesValue::encodeUntrustedNumberValue(ToDouble(val));
+    storage->randomEngineInited = true;
+  }
+  uint64_t val = XorShift64(&storage->randomState_);
+  return HermesValue::encodeUntrustedNumberValue(ToDouble(val));
 }
 
 CallResult<HermesValue> mathFround(void *, Runtime &runtime, NativeArgs args)


### PR DESCRIPTION
Summary: Fix [The Math.random implementation in Hermes is collision prone for the App use case](https://github.com/facebook/hermes/issues/1169)
