### PR TITLE
[static_h] Switch Math.random() to faster 64-bit seeded implementation. (#1175)

### DIFF
--- a/include/hermes/VM/JSLib/RuntimeCommonStorage.h
+++ b/include/hermes/VM/JSLib/RuntimeCommonStorage.h
@@ -38,7 +38,7 @@ struct RuntimeCommonStorage {
   MockedEnvironment tracedEnv;
 
   /// PRNG used by Math.random()
-  std::minstd_rand randomEngine_;
+  std::mt19937_64 randomEngine_;
   bool randomEngineSeeded_ = false;
 };
 

--- a/lib/VM/JSLib/Math.cpp
+++ b/lib/VM/JSLib/Math.cpp
@@ -205,8 +205,19 @@ CallResult<HermesValue> mathPow(void *, Runtime &runtime, NativeArgs args) {
 CallResult<HermesValue> mathRandom(void *, Runtime &runtime, NativeArgs) {
   RuntimeCommonStorage *storage = runtime.getCommonStorage();
   if (!storage->randomEngineSeeded_) {
-    std::minstd_rand::result_type seed;
-    seed = std::random_device()();
+    std::random_device randDevice;
+
+    auto randValue = randDevice();
+    static_assert(
+        sizeof(randValue) == 4, "expecting 32 bits from std::random_device()");
+
+    // Create a 64-bit seed using two 32-bit random numbers.
+    uint64_t seed =
+        (uint64_t(randValue) << (8 * sizeof(randValue))) | randDevice();
+    static_assert(
+        sizeof(decltype(storage->randomEngine_)::result_type) >= 8,
+        "expecting at least 64-bit result_type for PRNG");
+
     storage->randomEngine_.seed(seed);
     storage->randomEngineSeeded_ = true;
   }


### PR DESCRIPTION
Cherry-picking https://github.com/facebook/hermes/pull/1175 for `static_h`.