### PR TITLE
Stop using CDPHandler as a way to track page title

### DIFF
--- a/API/hermes/inspector/chrome/CDPHandler.cpp
+++ b/API/hermes/inspector/chrome/CDPHandler.cpp
@@ -105,13 +105,8 @@ class CDPHandlerImpl : public message::RequestHandler,
                        public debugger::EventObserver,
                        public std::enable_shared_from_this<CDPHandlerImpl> {
  public:
-  CDPHandlerImpl(
-      std::unique_ptr<RuntimeAdapter> adapter,
-      const std::string &title,
-      bool waitForDebugger);
+  CDPHandlerImpl(std::unique_ptr<RuntimeAdapter> adapter, bool waitForDebugger);
   ~CDPHandlerImpl() override;
-
-  std::string getTitle() const;
 
   bool registerCallbacks(
       CDPMessageCallbackFunction msgCallback,
@@ -336,7 +331,6 @@ class CDPHandlerImpl : public message::RequestHandler,
   /// inside the CDP Handler without requiring \p RuntimeAdapter::getRuntime
   /// to support use from arbitrary threads.
   HermesRuntime &runtime_;
-  const std::string title_;
 
   // preparedScripts_ stores user-entered scripts that have been prepared for
   // execution, and may be invoked by a later command.
@@ -428,11 +422,9 @@ class CDPHandlerImpl : public message::RequestHandler,
 
 CDPHandlerImpl::CDPHandlerImpl(
     std::unique_ptr<RuntimeAdapter> adapter,
-    const std::string &title,
     bool waitForDebugger)
     : runtimeAdapter_(std::move(adapter)),
       runtime_(runtimeAdapter_->getRuntime()),
-      title_(title),
       awaitingDebuggerOnStart_(waitForDebugger) {
   // Install __tickleJs. Do this activity before the call to setEventObserver,
   // so we don't get any didPause callback firings for these.
@@ -454,13 +446,6 @@ CDPHandlerImpl::~CDPHandlerImpl() {
 
   // TODO(T161620474): Properly clean up all the other variables being protected
   // by other mutex
-}
-
-std::string CDPHandlerImpl::getTitle() const {
-  // This is a public function, but the mutex is not required
-  // as we're just returning member that is unchanged for the
-  // lifetime of this instance.
-  return title_;
 }
 
 bool CDPHandlerImpl::registerCallbacks(
@@ -1641,20 +1626,26 @@ bool CDPHandlerImpl::validateExecutionContext(
  */
 std::shared_ptr<CDPHandler> CDPHandler::create(
     std::unique_ptr<RuntimeAdapter> adapter,
+    bool waitForDebugger) {
+  // Can't use make_shared here since the constructor is private.
+  return std::shared_ptr<CDPHandler>(
+      new CDPHandler(std::move(adapter), waitForDebugger));
+}
+
+std::shared_ptr<CDPHandler> CDPHandler::create(
+    std::unique_ptr<RuntimeAdapter> adapter,
     const std::string &title,
     bool waitForDebugger) {
   // Can't use make_shared here since the constructor is private.
   return std::shared_ptr<CDPHandler>(
-      new CDPHandler(std::move(adapter), title, waitForDebugger));
+      new CDPHandler(std::move(adapter), waitForDebugger));
 }
 
 CDPHandler::CDPHandler(
     std::unique_ptr<RuntimeAdapter> adapter,
-    const std::string &title,
     bool waitForDebugger)
     : impl_(std::make_shared<CDPHandlerImpl>(
           std::move(adapter),
-          title,
           waitForDebugger)) {
   impl_->installLogHandler();
 }
@@ -1662,7 +1653,7 @@ CDPHandler::CDPHandler(
 CDPHandler::~CDPHandler() = default;
 
 std::string CDPHandler::getTitle() const {
-  return impl_->getTitle();
+  return "";
 }
 
 bool CDPHandler::registerCallbacks(

--- a/API/hermes/inspector/chrome/CDPHandler.h
+++ b/API/hermes/inspector/chrome/CDPHandler.h
@@ -45,7 +45,6 @@ class INSPECTOR_EXPORT CDPHandler {
   /// methods.
   CDPHandler(
       std::unique_ptr<RuntimeAdapter> adapter,
-      const std::string &title,
       bool waitForDebugger = false);
 
  public:
@@ -53,6 +52,10 @@ class INSPECTOR_EXPORT CDPHandler {
   /// should generally called before you start running any JS in the runtime.
   /// This should also be called on the runtime thread, as methods are invoked
   /// on the given \p adapter.
+  static std::shared_ptr<CDPHandler> create(
+      std::unique_ptr<RuntimeAdapter> adapter,
+      bool waitForDebugger = false);
+  /// Temporarily kept to allow React Native build to still work
   static std::shared_ptr<CDPHandler> create(
       std::unique_ptr<RuntimeAdapter> adapter,
       const std::string &title,

--- a/API/hermes/inspector/chrome/tests/SyncConnection.cpp
+++ b/API/hermes/inspector/chrome/tests/SyncConnection.cpp
@@ -35,7 +35,6 @@ SyncConnection::SyncConnection(
     bool waitForDebugger)
     : cdpHandler_(CDPHandler::create(
           std::make_unique<ExecutorRuntimeAdapter>(runtime),
-          "testConn",
           waitForDebugger)) {
   registerCallbacks();
 }


### PR DESCRIPTION
Summary:
`ConnectionDemux` was using `CDPHandler` as storage for page title.
`CDPHandler` does nothing with the title string other than to hand it
back to `ConnectionDemux` via the `getTitle()` function. It doesn't
make sense to have title in `CDPHandler`.

Differential Revision: D50845247


