### PR TITLE
Fix binop side effects with BigInt

### DIFF
--- a/lib/Optimizer/Scalar/InstSimplify.cpp
+++ b/lib/Optimizer/Scalar/InstSimplify.cpp
@@ -27,16 +27,21 @@ namespace {
 constexpr Type kNullOrUndef =
     Type::unionTy(Type::createUndefined(), Type::createNull());
 
-bool canBeNaN(Value *value) {
+/// \return true if the value is known to not be NaN. Note that it may still
+///    be convertible to NaN.
+bool notNaN(Value *value) {
+  // Only numbers can be NaN.
   if (!value->getType().canBeNumber()) {
-    return false;
+    return true;
   }
 
+  // If it is a literal, we can simply check.
   if (auto *literalNumber = llvh::dyn_cast<LiteralNumber>(value)) {
-    return std::isnan(literalNumber->getValue());
+    return !std::isnan(literalNumber->getValue());
   }
 
-  return true;
+  // The value could be a number, so it could be NaN.
+  return false;
 }
 
 template <typename T>
@@ -174,18 +179,33 @@ Value *simplifyBinOp(BinaryOperatorInst *binary) {
   // or type information can be used to simplify some non-constant expressions.
   Type leftTy = lhs->getType();
   Type rightTy = rhs->getType();
-  bool safeTypes = isSideEffectFree(leftTy) && isSideEffectFree(rightTy);
+  const bool primitiveTypes = leftTy.isPrimitive() && rightTy.isPrimitive();
 
-  // Verify that the operands are identical and can be replaced. NaN is never
-  // identical to itself, and comparisons with side effects can't be replaced.
-  bool identicalOperands = safeTypes && lhs == rhs && !canBeNaN(lhs);
+  // This flag helps to simplify equality comparisons (==, ===, !=, !===).
+  // Indicate that the operands are the same value which has a primitive type
+  // and always compares equal to itself when the comparison does NOT perform
+  // any conversions.
+  // NaN is never equal to itself, and comparisons between non-primitive types
+  // have side effects and can't be predicted.
+  const bool identicalForEquality = primitiveTypes && lhs == rhs && notNaN(lhs);
+
+  // This flag helps to simplify relational comparisons (<, <=, >, >=).
+  // In additional to the equality checks, it also checks that the operands
+  // will not be converted to NaN when the relational comparison invokes
+  // toNumeric().
+  // We know the identical operand is a primitive, and the only primitive types
+  // that can be converted to NaN by toNumeric() are string and undefined.
+  // However if the operands are strings, the comparison is performed before
+  // toNumeric(). So the only case that for NaN that remains is "undefined".
+  bool identicalForRelational =
+      identicalForEquality && !leftTy.canBeUndefined();
 
   using OpKind = BinaryOperatorInst::OpKind;
 
   switch (kind) {
     case OpKind::EqualKind: // ==
       // Identical operands must be equal.
-      if (identicalOperands) {
+      if (identicalForEquality) {
         return builder.getLiteralBool(true);
       }
 
@@ -200,7 +220,7 @@ Value *simplifyBinOp(BinaryOperatorInst *binary) {
 
     case OpKind::NotEqualKind: // !=
       // Identical operands can't be non-equal.
-      if (identicalOperands) {
+      if (identicalForEquality) {
         return builder.getLiteralBool(false);
       }
 
@@ -215,7 +235,7 @@ Value *simplifyBinOp(BinaryOperatorInst *binary) {
 
     case OpKind::StrictlyEqualKind: // ===
       // Identical operand must be strictly equal.
-      if (identicalOperands) {
+      if (identicalForEquality) {
         return builder.getLiteralBool(true);
       }
 
@@ -229,35 +249,35 @@ Value *simplifyBinOp(BinaryOperatorInst *binary) {
 
     case OpKind::StrictlyNotEqualKind: // !===
       // Identical operands can't be non-equal.
-      if (identicalOperands) {
+      if (identicalForEquality) {
         return builder.getLiteralBool(false);
       }
       break;
 
     case OpKind::LessThanKind: // <
       // Handle comparison to self:
-      if (identicalOperands && !leftTy.isUndefinedType()) {
+      if (identicalForRelational) {
         return builder.getLiteralBool(false);
       }
       break;
 
     case OpKind::LessThanOrEqualKind: // <=
       // Handle comparison to self:
-      if (identicalOperands && !leftTy.isUndefinedType()) {
+      if (identicalForRelational) {
         return builder.getLiteralBool(true);
       }
       break;
 
     case OpKind::GreaterThanKind: // >
       // Handle comparison to self:
-      if (identicalOperands && !leftTy.isUndefinedType()) {
+      if (identicalForRelational) {
         return builder.getLiteralBool(false);
       }
       break;
 
     case OpKind::GreaterThanOrEqualKind: // >=
       // Handle comparison to self:
-      if (identicalOperands && !leftTy.isUndefinedType()) {
+      if (identicalForRelational) {
         return builder.getLiteralBool(true);
       }
       break;

--- a/test/Optimizer/regress-bigint-dce.js
+++ b/test/Optimizer/regress-bigint-dce.js
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermesc -dump-ir %s -O | %FileCheckOrRegen %s --match-full-lines
+// XFAIL: *
+
+// This test fails in Hermes because IR dumping of bigints is broken.
+
+// Verify that arithmetic operations with a BigInt operand and non-BigInt
+// operand (except adds) are not DCE-d, because that would throw a runtime
+// exception.
+
+
+function f1_throws() { 1n << 1; }
+function f2_throws() { 1n + 1; }
+function f3_ok() { "a" + 1n; }
+function f4_ok() { 1n + "a"; }
+function f5_ok() { 1n < "a"; }
+function f6_ok() { "a" >= 1n; }
+function f7_ok() { 1 >= 1n; }
+function f8_ok() { 1 * "a"; }
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:function global#0()#1 : undefined
+// CHECK-NEXT:globals = [f1_throws, f2_throws, f3_ok, f4_ok, f5_ok, f6_ok, f7_ok, f8_ok]
+// CHECK-NEXT:S{global#0()#1} = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = CreateScopeInst %S{global#0()#1}
+// CHECK-NEXT:  %1 = CreateFunctionInst %f1_throws#0#1()#2 : undefined, %0
+// CHECK-NEXT:  %2 = StorePropertyInst %1 : closure, globalObject : object, "f1_throws" : string
+// CHECK-NEXT:  %3 = CreateFunctionInst %f2_throws#0#1()#3 : undefined, %0
+// CHECK-NEXT:  %4 = StorePropertyInst %3 : closure, globalObject : object, "f2_throws" : string
+// CHECK-NEXT:  %5 = CreateFunctionInst %f3_ok#0#1()#4 : undefined, %0
+// CHECK-NEXT:  %6 = StorePropertyInst %5 : closure, globalObject : object, "f3_ok" : string
+// CHECK-NEXT:  %7 = CreateFunctionInst %f4_ok#0#1()#5 : undefined, %0
+// CHECK-NEXT:  %8 = StorePropertyInst %7 : closure, globalObject : object, "f4_ok" : string
+// CHECK-NEXT:  %9 = CreateFunctionInst %f5_ok#0#1()#6 : undefined, %0
+// CHECK-NEXT:  %10 = StorePropertyInst %9 : closure, globalObject : object, "f5_ok" : string
+// CHECK-NEXT:  %11 = CreateFunctionInst %f6_ok#0#1()#7 : undefined, %0
+// CHECK-NEXT:  %12 = StorePropertyInst %11 : closure, globalObject : object, "f6_ok" : string
+// CHECK-NEXT:  %13 = CreateFunctionInst %f7_ok#0#1()#8 : undefined, %0
+// CHECK-NEXT:  %14 = StorePropertyInst %13 : closure, globalObject : object, "f7_ok" : string
+// CHECK-NEXT:  %15 = CreateFunctionInst %f8_ok#0#1()#9 : undefined, %0
+// CHECK-NEXT:  %16 = StorePropertyInst %15 : closure, globalObject : object, "f8_ok" : string
+// CHECK-NEXT:  %17 = ReturnInst undefined : undefined
+// CHECK-NEXT:function_end
+
+// CHECK:function f1_throws#0#1()#2 : undefined
+// CHECK-NEXT:S{f1_throws#0#1()#2} = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = CreateScopeInst %S{f1_throws#0#1()#2}
+// CHECK-NEXT:  %1 = BinaryOperatorInst '*', 0x1480d9830 : bigint, 1 : number
+// CHECK-NEXT:  %2 = ReturnInst undefined : undefined
+// CHECK-NEXT:function_end
+
+// CHECK:function f2_throws#0#1()#3 : undefined
+// CHECK-NEXT:S{f2_throws#0#1()#3} = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = CreateScopeInst %S{f2_throws#0#1()#3}
+// CHECK-NEXT:  %1 = BinaryOperatorInst '+', 0x1480d9830 : bigint, 1 : number
+// CHECK-NEXT:  %2 = ReturnInst undefined : undefined
+// CHECK-NEXT:function_end
+
+// CHECK:function f3_ok#0#1()#4 : undefined
+// CHECK-NEXT:S{f3_ok#0#1()#4} = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = CreateScopeInst %S{f3_ok#0#1()#4}
+// CHECK-NEXT:  %1 = ReturnInst undefined : undefined
+// CHECK-NEXT:function_end
+
+// CHECK:function f4_ok#0#1()#5 : undefined
+// CHECK-NEXT:S{f4_ok#0#1()#5} = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = CreateScopeInst %S{f4_ok#0#1()#5}
+// CHECK-NEXT:  %1 = ReturnInst undefined : undefined
+// CHECK-NEXT:function_end
+
+// CHECK:function f5_ok#0#1()#6 : undefined
+// CHECK-NEXT:S{f5_ok#0#1()#6} = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = CreateScopeInst %S{f5_ok#0#1()#6}
+// CHECK-NEXT:  %1 = ReturnInst undefined : undefined
+// CHECK-NEXT:function_end
+
+// CHECK:function f6_ok#0#1()#7 : undefined
+// CHECK-NEXT:S{f6_ok#0#1()#7} = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = CreateScopeInst %S{f6_ok#0#1()#7}
+// CHECK-NEXT:  %1 = ReturnInst undefined : undefined
+// CHECK-NEXT:function_end
+
+// CHECK:function f7_ok#0#1()#8 : undefined
+// CHECK-NEXT:S{f7_ok#0#1()#8} = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = CreateScopeInst %S{f7_ok#0#1()#8}
+// CHECK-NEXT:  %1 = ReturnInst undefined : undefined
+// CHECK-NEXT:function_end
+
+// CHECK:function f8_ok#0#1()#9 : undefined
+// CHECK-NEXT:S{f8_ok#0#1()#9} = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = CreateScopeInst %S{f8_ok#0#1()#9}
+// CHECK-NEXT:  %1 = ReturnInst undefined : undefined
+// CHECK-NEXT:function_end

--- a/test/Optimizer/variables.js
+++ b/test/Optimizer/variables.js
@@ -33,7 +33,8 @@ function foo(p1, p2, p3) {
 // OPT-CHECK-NEXT:  %0 = CreateScopeInst %S{foo#0#1()#2}
 // OPT-CHECK-NEXT:  %1 = BinaryOperatorInst '+', %p1, %p2
 // OPT-CHECK-NEXT:  %2 = BinaryOperatorInst '+', %p2, %p3
-// OPT-CHECK-NEXT:  %3 = ReturnInst undefined : undefined
+// OPT-CHECK-NEXT:  %3 = BinaryOperatorInst '+', %2 : string|number|bigint, %1 : string|number|bigint
+// OPT-CHECK-NEXT:  %4 = ReturnInst undefined : undefined
 // OPT-CHECK-NEXT:function_end
 
 // CHECK:function global#0()#1

--- a/test/hermes/regress-bigint-dce.js
+++ b/test/hermes/regress-bigint-dce.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -O0 %s | %FileCheck --match-full-lines %s
+// RUN: %hermes -O %s | %FileCheck --match-full-lines %s
+
+// Verify that arithmetic operations with a BigInt operand and non-BigInt
+// operand (except adds) are not DCE-d, because that would throw a runtime
+// exception.
+
+(function() {
+try {
+    1n + 1;
+} catch (e) {
+    print(e);
+}
+//CHECK: TypeError: Cannot convert 1 to BigInt
+
+try {
+    1 << 1n;
+} catch (e) {
+    print(e);
+}
+})();
+//CHECK-NEXT: TypeError: Cannot convert BigInt to number

--- a/test/hermes/regress-relational-simplify.js
+++ b/test/hermes/regress-relational-simplify.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -exec -O0 %s | %FileCheck --match-full-lines %s
+// RUN: %hermes -exec -O %s | %FileCheck --match-full-lines %s
+
+// Verify that relational comparisons between an identical value that could
+// be converted to NaN are not optimized away.
+
+// The try/catch is needed to force the optimizer to introduce a Phi between
+// the initializing "undefined" and another value. Without it, "v" is just
+// replaced with a literal.
+
+// A function to convince the compiler that the try/catch is necessary.
+function maybeThrow() {
+    if (globalThis.XXX)
+        throw new Error();
+}
+
+function le() {
+    try { maybeThrow(); } catch { var v = ""; }
+    return v <= v;
+}
+function ge() {
+    try { maybeThrow(); } catch { var v = ""; }
+    return v <= v;
+}
+// These two weren't broken, but including for completeness.
+function lt() {
+    try { maybeThrow(); } catch { var v = ""; }
+    return v < v;
+}
+function gt() {
+    try { maybeThrow(); } catch { var v = ""; }
+    return v > v;
+}
+
+print(le(), ge(), lt(), gt());
+// CHECK: false false false false


### PR DESCRIPTION
Summary:
`getBinarySideEffect()` wasn't considering that arithmetic operations
between BigInt and non-BigInt (except string addition) throw a
TypeError.

Refactor the code to be explicit about all operators. Add new tests.

Curiously, this change revealed a bug in an existing test:

        t5: string|number|bigint = t1:any + t2:any
        t6: string|number|bigint = t3:any + t4:any
        t7: string|number|bigint = t5 + t6
        t7 is unused

We were incorrectly removing the calculation of t7, because both
operands are primitive types. However it might happen, for example, that
t5 is biging and t6 is a number, which would throw an exception.

Reported in https://github.com/facebook/hermes/issues/1199.

This diff was ported from Static Hermes (since this is a bug).
Unfortunately one of the newly added tests fails in Hermes, since Hermes
does not correctly dump IR bigints.

Differential Revision: D51555323


