### PR TITLE
InstSimplify: fix handling of undefined in relational comparisons

### DIFF
--- a/lib/Optimizer/Scalar/InstSimplify.cpp
+++ b/lib/Optimizer/Scalar/InstSimplify.cpp
@@ -27,16 +27,21 @@ namespace {
 constexpr Type kNullOrUndef =
     Type::unionTy(Type::createUndefined(), Type::createNull());
 
-bool canBeNaN(Value *value) {
+/// \return true if the value is known to not be NaN. Note that it may still
+///    be convertible to NaN.
+bool notNaN(Value *value) {
+  // Only numbers can be NaN.
   if (!value->getType().canBeNumber()) {
-    return false;
+    return true;
   }
 
+  // If it is a literal, we can simply check.
   if (auto *literalNumber = llvh::dyn_cast<LiteralNumber>(value)) {
-    return std::isnan(literalNumber->getValue());
+    return !std::isnan(literalNumber->getValue());
   }
 
-  return true;
+  // The value could be a number, so it could be NaN.
+  return false;
 }
 
 template <typename T>
@@ -174,18 +179,33 @@ Value *simplifyBinOp(BinaryOperatorInst *binary) {
   // or type information can be used to simplify some non-constant expressions.
   Type leftTy = lhs->getType();
   Type rightTy = rhs->getType();
-  bool safeTypes = isSideEffectFree(leftTy) && isSideEffectFree(rightTy);
+  const bool primitiveTypes = leftTy.isPrimitive() && rightTy.isPrimitive();
 
-  // Verify that the operands are identical and can be replaced. NaN is never
-  // identical to itself, and comparisons with side effects can't be replaced.
-  bool identicalOperands = safeTypes && lhs == rhs && !canBeNaN(lhs);
+  // This flag helps to simplify equality comparisons (==, ===, !=, !===).
+  // Indicate that the operands are the same value which has a primitive type
+  // and always compares equal to itself when the comparison does NOT perform
+  // any conversions.
+  // NaN is never equal to itself, and comparisons between non-primitive types
+  // have side effects and can't be predicted.
+  const bool identicalForEquality = primitiveTypes && lhs == rhs && notNaN(lhs);
+
+  // This flag helps to simplify relational comparisons (<, <=, >, >=).
+  // In additional to the equality checks, it also checks that the operands
+  // will not be converted to NaN when the relational comparison invokes
+  // toNumeric().
+  // We know the identical operand is a primitive, and the only primitive types
+  // that can be converted to NaN by toNumeric() are string and undefined.
+  // However if the operands are strings, the comparison is performed before
+  // toNumeric(). So the only case that for NaN that remains is "undefined".
+  bool identicalForRelational =
+      identicalForEquality && !leftTy.canBeUndefined();
 
   using OpKind = BinaryOperatorInst::OpKind;
 
   switch (kind) {
     case OpKind::EqualKind: // ==
       // Identical operands must be equal.
-      if (identicalOperands) {
+      if (identicalForEquality) {
         return builder.getLiteralBool(true);
       }
 
@@ -200,7 +220,7 @@ Value *simplifyBinOp(BinaryOperatorInst *binary) {
 
     case OpKind::NotEqualKind: // !=
       // Identical operands can't be non-equal.
-      if (identicalOperands) {
+      if (identicalForEquality) {
         return builder.getLiteralBool(false);
       }
 
@@ -215,7 +235,7 @@ Value *simplifyBinOp(BinaryOperatorInst *binary) {
 
     case OpKind::StrictlyEqualKind: // ===
       // Identical operand must be strictly equal.
-      if (identicalOperands) {
+      if (identicalForEquality) {
         return builder.getLiteralBool(true);
       }
 
@@ -229,35 +249,35 @@ Value *simplifyBinOp(BinaryOperatorInst *binary) {
 
     case OpKind::StrictlyNotEqualKind: // !===
       // Identical operands can't be non-equal.
-      if (identicalOperands) {
+      if (identicalForEquality) {
         return builder.getLiteralBool(false);
       }
       break;
 
     case OpKind::LessThanKind: // <
       // Handle comparison to self:
-      if (identicalOperands && !leftTy.isUndefinedType()) {
+      if (identicalForRelational) {
         return builder.getLiteralBool(false);
       }
       break;
 
     case OpKind::LessThanOrEqualKind: // <=
       // Handle comparison to self:
-      if (identicalOperands && !leftTy.isUndefinedType()) {
+      if (identicalForRelational) {
         return builder.getLiteralBool(true);
       }
       break;
 
     case OpKind::GreaterThanKind: // >
       // Handle comparison to self:
-      if (identicalOperands && !leftTy.isUndefinedType()) {
+      if (identicalForRelational) {
         return builder.getLiteralBool(false);
       }
       break;
 
     case OpKind::GreaterThanOrEqualKind: // >=
       // Handle comparison to self:
-      if (identicalOperands && !leftTy.isUndefinedType()) {
+      if (identicalForRelational) {
         return builder.getLiteralBool(true);
       }
       break;

--- a/test/hermes/regress-relational-simplify.js
+++ b/test/hermes/regress-relational-simplify.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -exec -O0 %s | %FileCheck --match-full-lines %s
+// RUN: %hermes -exec -O %s | %FileCheck --match-full-lines %s
+
+// Verify that relational comparisons between an identical value that could
+// be converted to NaN are not optimized away.
+
+// The try/catch is needed to force the optimizer to introduce a Phi between
+// the initializing "undefined" and another value. Without it, "v" is just
+// replaced with a literal.
+
+// A function to convince the compiler that the try/catch is necessary.
+function maybeThrow() {
+    if (globalThis.XXX)
+        throw new Error();
+}
+
+function le() {
+    try { maybeThrow(); } catch { var v = ""; }
+    return v <= v;
+}
+function ge() {
+    try { maybeThrow(); } catch { var v = ""; }
+    return v <= v;
+}
+// These two weren't broken, but including for completeness.
+function lt() {
+    try { maybeThrow(); } catch { var v = ""; }
+    return v < v;
+}
+function gt() {
+    try { maybeThrow(); } catch { var v = ""; }
+    return v > v;
+}
+
+print(le(), ge(), lt(), gt());
+// CHECK: false false false false


### PR DESCRIPTION
Summary:
Relational comparisons (<= and >=) are simplified to a true/false when
it is known that the operands are the same value with a primitive type.
If the value is "undefined", it is converted to NaN, which never equals
itself.
The optimization was not correctly handling the case where the operand
could be "undefined" or another type - it was only checking for
"undefined".

Example:

    try {} catch {
      var v0 = "m";
    }
    return v0 <= v0;

The try/catch is necessary to make the optimizer believe `v0` is not a
constant.

Reported in https://github.com/facebook/hermes/issues/1200.

Differential Revision: D51555324


