### PR TITLE
Fix bigint side effects for >>>, /, %

### DIFF
--- a/lib/IR/Instrs.cpp
+++ b/lib/IR/Instrs.cpp
@@ -25,6 +25,7 @@ unsigned TerminatorInst::getNumSuccessors() const {
   if (auto I = llvh::dyn_cast<CLASS>(this)) \
     return I->getNumSuccessors();
 #include "hermes/IR/Instrs.def"
+
   llvm_unreachable("not a terminator?!");
 }
 
@@ -34,6 +35,7 @@ BasicBlock *TerminatorInst::getSuccessor(unsigned idx) const {
   if (auto I = llvh::dyn_cast<CLASS>(this)) \
     return I->getSuccessor(idx);
 #include "hermes/IR/Instrs.def"
+
   llvm_unreachable("not a terminator?!");
 }
 
@@ -43,6 +45,7 @@ void TerminatorInst::setSuccessor(unsigned idx, BasicBlock *B) {
   if (auto I = llvh::dyn_cast<CLASS>(this)) \
     return I->setSuccessor(idx, B);
 #include "hermes/IR/Instrs.def"
+
   llvm_unreachable("not a terminator?!");
 }
 
@@ -175,6 +178,21 @@ BinaryOperatorInst::getBinarySideEffect(Type leftTy, Type rightTy, OpKind op) {
         return SideEffectKind::None;
       break;
 
+    case OpKind::UnsignedRightShiftKind:
+    case OpKind::DivideKind:
+    case OpKind::ModuloKind:
+      // We can only reason about primitive types.
+      if (!leftTy.isPrimitive() || !rightTy.isPrimitive())
+        break;
+      // if either of the operands can be a BigInt, this instruction may throw
+      // for one of the following reasons:
+      // - BigInt doesn't have unsigned right shift.
+      // - BigInt division by zero.
+      if (leftTy.canBeBigInt() || rightTy.canBeBigInt())
+        return SideEffectKind::Unknown;
+      // We have primitive operands that are not BigInt.
+      return SideEffectKind::None;
+
     case OpKind::AddKind:
       // We can only reason about primitive types.
       if (!leftTy.isPrimitive() || !rightTy.isPrimitive())
@@ -186,11 +204,8 @@ BinaryOperatorInst::getBinarySideEffect(Type leftTy, Type rightTy, OpKind op) {
 
     case OpKind::LeftShiftKind:
     case OpKind::RightShiftKind:
-    case OpKind::UnsignedRightShiftKind:
     case OpKind::SubtractKind:
     case OpKind::MultiplyKind:
-    case OpKind::DivideKind:
-    case OpKind::ModuloKind:
     case OpKind::OrKind:
     case OpKind::XorKind:
     case OpKind::AndKind:

--- a/test/hermes/regress-bigint-dce.js
+++ b/test/hermes/regress-bigint-dce.js
@@ -8,11 +8,12 @@
 // RUN: %hermes -O0 %s | %FileCheck --match-full-lines %s
 // RUN: %hermes -O %s | %FileCheck --match-full-lines %s
 
+(function() {
+
 // Verify that arithmetic operations with a BigInt operand and non-BigInt
 // operand (except adds) are not DCE-d, because that would throw a runtime
 // exception.
 
-(function() {
 try {
     1n + 1;
 } catch (e) {
@@ -25,5 +26,29 @@ try {
 } catch (e) {
     print(e);
 }
-})();
 //CHECK-NEXT: TypeError: Cannot convert BigInt to number
+
+// Verify that BigInt operations that may throw are not eliminated:
+// unsigned right shift, division, modulo.
+try {
+    1n >>> 1n;
+} catch (e) {
+    print(e);
+}
+//CHECK-NEXT: TypeError: BigInts have no unsigned shift
+
+try {
+    1n / 0n;
+} catch (e) {
+    print(e);
+}
+//CHECK-NEXT: RangeError: Division by zero
+
+try {
+    1n % 0n;
+} catch (e) {
+    print(e);
+}
+//CHECK-NEXT: RangeError: Division by zero
+
+})();


### PR DESCRIPTION
Summary:
BigInt differs from numbers - several bigint operations can throw an
exception, specifically:
- >>> is not allowed at all and throws
- / and % can result in division by zero

Improve the side effect model and add a test.

This diff was ported from SH.

Closes https://github.com/facebook/hermes/issues/1212

Differential Revision: D52013223


