### PR TITLE
Fixes for ES6 class support

### DIFF
--- a/lib/InternalBytecode/03-ES6Class.js
+++ b/lib/InternalBytecode/03-ES6Class.js
@@ -2,6 +2,7 @@
   var objCreate = Object.create;
   var objDefineProperty = Object.defineProperty;
   var objectSetPrototypeOf = Object.setPrototypeOf;
+  var objectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
 
   function defineClass(ctor, superClass) {
     ctor.prototype = objCreate(superClass && superClass.prototype, {
@@ -21,20 +22,38 @@
     }
   }
 
-  function defineClassProperty(cls, methodName, getter, setter) {
-    objDefineProperty(cls.prototype, methodName, {
-      enumerable: false,
-      get: getter,
-      set: setter,
-    });
+  function definePropertyGetterOrSetter(obj, name, getter, setter) {
+    var existingDescriptor = objectGetOwnPropertyDescriptor(obj, name);
+    if (!existingDescriptor) {
+      existingDescriptor = {
+        configurable: true,
+        enumerable: false,
+      }
+    }
+
+    if (getter) {
+      existingDescriptor.get = getter;
+    } else if (setter) {
+      existingDescriptor.set = setter;
+    }
+
+    objDefineProperty(obj, name, existingDescriptor);
   }
 
-  function defineStaticClassProperty(cls, methodName, getter, setter) {
-    objDefineProperty(cls, methodName, {
-      enumerable: false,
-      get: getter,
-      set: setter,
-    });
+  function defineClassPropertyGetter(cls, methodName, getter) {
+    definePropertyGetterOrSetter(cls.prototype, methodName, getter, undefined);
+  }
+
+  function defineClassPropertySetter(cls, methodName, setter) {
+    definePropertyGetterOrSetter(cls.prototype, methodName, undefined, setter);
+  }
+
+  function defineStaticClassPropertyGetter(cls, methodName, getter) {
+    definePropertyGetterOrSetter(cls, methodName, getter, undefined);
+  }
+
+  function defineStaticClassPropertySetter(cls, methodName, setter) {
+    definePropertyGetterOrSetter(cls, methodName, undefined, setter);
   }
 
   function defineClassMethod(cls, methodName, fn) {
@@ -53,8 +72,10 @@
 
   var hermesES6InternalObj = {
     defineClass,
-    defineClassProperty,
-    defineStaticClassProperty,
+    defineClassPropertyGetter,
+    defineClassPropertySetter,
+    defineStaticClassPropertyGetter,
+    defineStaticClassPropertySetter,
     defineClassMethod,
     defineStaticClassMethod,
   };

--- a/lib/InternalBytecode/03-ES6Class.js
+++ b/lib/InternalBytecode/03-ES6Class.js
@@ -59,6 +59,8 @@
   function defineClassMethod(cls, methodName, fn) {
     objDefineProperty(cls.prototype, methodName, {
       enumerable: false,
+      configurable: true,
+      writable: true,
       value: fn,
     });
   }
@@ -66,6 +68,8 @@
   function defineStaticClassMethod(cls, methodName, fn) {
     objDefineProperty(cls, methodName, {
       enumerable: false,
+      configurable: true,
+      writable: true,
       value: fn,
     });
   }

--- a/test/hermes/es6-class-expr.js
+++ b/test/hermes/es6-class-expr.js
@@ -17,3 +17,19 @@ const parentInstance = new Parent(42);
 
 print(parentInstance.id);
 //CHECK: 42
+
+const childInstance = [0, new (class extends Parent {
+  constructor() {
+    super(1);
+  }
+
+  getDebugInfo() {
+    return `MyID: ${this.id}`;
+  }
+})][1];
+
+print(childInstance.id);
+//CHECK: 1
+
+print(childInstance.getDebugInfo());
+//CHECK: MyID: 1

--- a/test/hermes/es6-class-method-from-var.js
+++ b/test/hermes/es6-class-method-from-var.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -Xes6-class %s | %FileCheck --match-full-lines %s
+
+const keys = {
+  private: Symbol(),
+  public: 'myPublicMethod'
+}
+
+class Test {
+  [keys.private]() {
+    console.log('Hello from public method!');
+  }
+
+  [keys.public]() {
+    console.log('Hello from private method!');
+  }
+}
+
+const object = new Test();
+
+object.myPublicMethod();
+// CHECK: Hello from public method!
+
+object[keys.private]();
+// CHECK: Hello from private method!

--- a/test/hermes/es6-class-method-from-var.js
+++ b/test/hermes/es6-class-method-from-var.js
@@ -14,11 +14,11 @@ const keys = {
 
 class Test {
   [keys.private]() {
-    console.log('Hello from public method!');
+    print('Hello from private method!');
   }
 
   [keys.public]() {
-    console.log('Hello from private method!');
+    print('Hello from public method!');
   }
 }
 

--- a/test/hermes/es6-class-method-override-from-prop.js
+++ b/test/hermes/es6-class-method-override-from-prop.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -Xes6-class %s | %FileCheck --match-full-lines %s
+
+class Test {
+  constructor(getter) {
+    if (getter) {
+      this.getMyNumber = getter;
+    }
+  }
+
+  getMyNumber() {
+    return 42;
+  }
+}
+
+const instance1 = new Test();
+print(instance1.getMyNumber());
+//CHECK: 42
+
+const instance2 = new Test(() => 1);
+
+print(instance2.getMyNumber());
+//CHECK: 1

--- a/test/hermes/es6-class-method.js
+++ b/test/hermes/es6-class-method.js
@@ -44,3 +44,6 @@ print(Object.keys(parentInstance).length);
 
 print(Object.keys(childInstance).length);
 // CHECK: 0
+
+print(Parent.prototype.nonOverridenMethod.name);
+// CHECK: nonOverridenMethod

--- a/test/hermes/es6-class-property-from-var.js
+++ b/test/hermes/es6-class-property-from-var.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -Xes6-class %s | %FileCheck --match-full-lines %s
+
+const keys = {
+  private: Symbol(),
+  public: 'myPublicProperty'
+}
+
+class Test {
+  get [keys.private]() {
+    return `Private: ${this._private}`;
+  }
+
+  set [keys.private](v) {
+    this._private = v;
+  }
+
+  get [keys.public]() {
+    return `Public: ${this._public}`;
+  }
+
+  set [keys.public](v) {
+    this._public = v;
+  }
+}
+
+const object = new Test();
+
+print(object.myPublicProperty);
+// CHECK: Public: undefined
+
+object.myPublicProperty = '42';
+
+print(object.myPublicProperty);
+// CHECK: Public: 42
+
+print(object[keys.private]);
+// CHECK: Private: undefined
+
+object[keys.private] = '1';
+
+print(object[keys.private]);
+// CHECK: Private: 1


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `main`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/HEAD/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.
-->

## Summary

This change provides a few fixes to the ES6 class support which was added in this PR: https://github.com/facebook/hermes/pull/1176 

- Added support for class methods and properties being declared using the element expression syntax:
```js
const propKey = Symbol();
class Test {
  [propKey]() {    
  }
}
```
This change required that properties are no longer indexed at compile time into a map, as the property keys themselves might be provided from external values.
- Fixed class expressions not being processed in array literal expressions:
```js
const entries = [0, 1, 2, new (class extends Parent {})]
```
- Methods can now be overwritten as regular properties:
```js
class Test {
  constructor(getter) {
    if (getter) {
      this.getMyNumber = getter;
    }
  }

  getMyNumber() {
    return 42;
  }
}
```
- Method names are now preserved at runtime and can be read through `object.method.name()`
- Added more tests

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
-->

## Test Plan

All tests run
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes the user interface.
-->
