### PR TITLE
EASY: silence memory leak with GCC ASAN

### DIFF
--- a/external/llvh/lib/Support/Unix/Signals.inc
+++ b/external/llvh/lib/Support/Unix/Signals.inc
@@ -236,7 +236,7 @@ static struct {
 // stack if we remove our signal handlers; that can't be done reliably if
 // someone else is also trying to do the same thing.
 static stack_t OldAltStack;
-static void* NewAltStackPointer;
+LLVM_ATTRIBUTE_USED static void* NewAltStackPointer;
 
 static void CreateSigAltStack() {
   const size_t AltStackSize = MINSIGSTKSZ + 64 * 1024;

--- a/external/llvh/patches/NewAltStackPointer.patch
+++ b/external/llvh/patches/NewAltStackPointer.patch
@@ -1,0 +1,12 @@
+diff --git a/lib/Support/Unix/Signals.inc b/lib/Support/Unix/Signals.inc
+--- a/lib/Support/Unix/Signals.inc
++++ b/lib/Support/Unix/Signals.inc
+@@ -236,7 +236,7 @@ static struct {
+ // stack if we remove our signal handlers; that can't be done reliably if
+ // someone else is also trying to do the same thing.
+ static stack_t OldAltStack;
+-static void* NewAltStackPointer;
++LLVM_ATTRIBUTE_USED static void* NewAltStackPointer;
+ 
+ static void CreateSigAltStack() {
+   const size_t AltStackSize = MINSIGSTKSZ + 64 * 1024;


### PR DESCRIPTION
Summary:
The leak was caused by the allocation of the alt signal stack. To
prevent leak reporting, it is stored into a global symbol. However, that
symbol is unused and can be optimized out. Force it to be considered
"used".

Closes https://github.com/facebook/hermes/issues/1225

Differential Revision: D52356667


