### PR TITLE
Remove TracingRuntime configs

### DIFF
--- a/API/hermes/hermes_tracing.cpp
+++ b/API/hermes/hermes_tracing.cpp
@@ -15,16 +15,19 @@ namespace hermes {
 
 std::unique_ptr<jsi::Runtime> makeTracingHermesRuntime(
     std::unique_ptr<HermesRuntime> hermesRuntime,
-    const ::hermes::vm::RuntimeConfig &runtimeConfig) {
+    const ::hermes::vm::RuntimeConfig &runtimeConfig,
+    const std::string &traceScratchPath,
+    const std::string &traceResultPath,
+    std::function<bool()> traceCompletionCallback) {
   auto mode = runtimeConfig.getSynthTraceMode();
   if (mode == ::hermes::vm::SynthTraceMode::Tracing ||
       mode == ::hermes::vm::SynthTraceMode::TracingAndReplaying) {
     return tracing::makeTracingHermesRuntime(
         std::move(hermesRuntime),
         runtimeConfig,
-        runtimeConfig.getTraceScratchPath(),
-        runtimeConfig.getTraceResultPath(),
-        runtimeConfig.getTraceRegisterCallback());
+        traceScratchPath,
+        traceResultPath,
+        std::move(traceCompletionCallback));
   }
   return hermesRuntime;
 }

--- a/API/hermes/hermes_tracing.h
+++ b/API/hermes/hermes_tracing.h
@@ -17,13 +17,32 @@ class raw_ostream;
 namespace facebook {
 namespace hermes {
 
-/// Like the method above, except takes a file descriptor instead of
-/// a stream.  If the \p traceFileDescriptor argument is -1, do not write
-/// the trace to a file.
+/// Creates and returns a tracing runtime if \p runtimeConfig.SynthTraceMode is
+/// either SynthTraceMode::Tracing or SynthTraceMode::TracingAndReplaying.
+/// Otherwise, returns the passed \n hermesRuntime as is.
+/// The trace will be written to \p traceScratchPath incrementally.
+/// On completion, the file will be renamed to \p traceResultPath, and
+/// \p traceCompletionCallback (for post-processing) will be invoked.
+/// Completion can be triggered implicitly by crash (if crash manager is
+/// provided) or explicitly by invocation of flush.
+/// If the runtime is destructed without triggering trace completion,
+/// the file at \p traceScratchPath will be deleted.
+/// The return value of \p traceCompletionCallback indicates whether the
+/// invocation completed successfully. If \p traceCompletionCallback is null, it
+/// also assumes as if the callback is successful.
 std::unique_ptr<jsi::Runtime> makeTracingHermesRuntime(
     std::unique_ptr<HermesRuntime> hermesRuntime,
-    const ::hermes::vm::RuntimeConfig &runtimeConfig);
+    const ::hermes::vm::RuntimeConfig &runtimeConfig,
+    const std::string &traceScratchPath,
+    const std::string &traceResultPath,
+    std::function<bool()> traceCompletionCallback);
 
+/// Creates and returns a tracing runtime that wrapps the passed
+/// \p hermesRuntime. This API is mainly for Synth Trace replay (and tracing),
+/// and for testing.
+/// \p traceStream  the stream to write trace to.
+/// \p forReplay indicates whether the runtime is being used in trace replay and
+/// tracing.
 std::unique_ptr<jsi::Runtime> makeTracingHermesRuntime(
     std::unique_ptr<HermesRuntime> hermesRuntime,
     const ::hermes::vm::RuntimeConfig &runtimeConfig,

--- a/public/hermes/Public/RuntimeConfig.h
+++ b/public/hermes/Public/RuntimeConfig.h
@@ -81,19 +81,6 @@ class PinnedHermesValue;
   /* Runtime set up for synth trace. */                                \
   F(constexpr, SynthTraceMode, SynthTraceMode, SynthTraceMode::None)   \
                                                                        \
-  /* Scratch path for synth trace. */                                  \
-  F(HERMES_NON_CONSTEXPR, std::string, TraceScratchPath, "")           \
-                                                                       \
-  /* Result path for synth trace. */                                   \
-  F(HERMES_NON_CONSTEXPR, std::string, TraceResultPath, "")            \
-                                                                       \
-  /* Callout to register an interesting (e.g. lead to crash) */        \
-  /* and completed trace. */                                           \
-  F(HERMES_NON_CONSTEXPR,                                              \
-    std::function<bool()>,                                             \
-    TraceRegisterCallback,                                             \
-    nullptr)                                                           \
-                                                                       \
   /* Enable sampling certain statistics. */                            \
   F(constexpr, bool, EnableSampledStats, false)                        \
                                                                        \


### PR DESCRIPTION
Summary:
Attempt to remove unnecessary configs for TraceRuntime from
RuntimeConfig.

Naively moved up three params to `makeTracingHermesRuntime` and
`HermesExecutorFactory`.

Reviewed By: neildhar

Differential Revision: D51904121


