### PR TITLE
Fix build for synth and tablegen targets on linux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,4 +66,5 @@ jobs:
           name: Run Hermes regression tests
           command: |
             cmake -S hermes -B build
+            cmake --build build -j 4
             cmake --build build --target check-hermes -j 4

--- a/API/hermes/CMakeLists.txt
+++ b/API/hermes/CMakeLists.txt
@@ -31,10 +31,10 @@ add_hermes_library(timerStats TimerStats.cpp LINK_LIBS jsi LINK_OBJLIBS hermesSu
 add_hermes_library(traceInterpreter TraceInterpreter.cpp
   LINK_OBJLIBS hermesapi hermesInstrumentation synthTrace synthTraceParser)
 
-add_hermes_library(synthTraceParser SynthTraceParser.cpp LINK_OBJLIBS hermesSupport hermesParser synthTrace)
-
 set(HERMES_ENABLE_RTTI OFF)
 set(HERMES_ENABLE_EH OFF)
+
+add_hermes_library(synthTraceParser SynthTraceParser.cpp LINK_OBJLIBS hermesSupport hermesParser synthTrace)
 
 # compileJS uses neither exceptions nor RTTI
 add_hermes_library(compileJS CompileJS.cpp LINK_OBJLIBS hermesPublic)

--- a/external/llvh/utils/TableGen/CMakeLists.txt
+++ b/external/llvh/utils/TableGen/CMakeLists.txt
@@ -2,5 +2,5 @@ add_hermes_executable(llvh-tblgen
   TableGen.cpp
   Example.cpp
 
-  LINK_LIBS LLVHSupport LLVHTableGen
+  LINK_LIBS LLVHSupport_obj LLVHTableGen_obj
   )

--- a/tools/synth/CMakeLists.txt
+++ b/tools/synth/CMakeLists.txt
@@ -10,7 +10,9 @@ add_hermes_tool(synth
 )
 
 target_link_libraries(synth
-  hermesConsoleHost
+  hermesConsoleHost_obj
   hermesvm_a
-  traceInterpreter
+  traceInterpreter_obj
+  synthTrace_obj
+  synthTraceParser_obj
 )


### PR DESCRIPTION
Summary:
Fix the synth and tablegen targets by directly using object libraries
as their dependencies, instead of taking static libraries. This avoids
needing to worry about dependency propagation and ordering for the
libraries, since everything that is needed by each target is listed
explicitly.

Also stop building `synthTraceParser` with exceptions and RTTI, since
it uses the Hermes JSON parser and produces complaints about missing
typeinfo under GCC.

Differential Revision: D52578160


