### PR TITLE
TDZDedup: support full functionality of ThrowIf

### DIFF
--- a/API/hermes/SynthTrace.h
+++ b/API/hermes/SynthTrace.h
@@ -8,10 +8,10 @@
 #ifndef HERMES_SYNTHTRACE_H
 #define HERMES_SYNTHTRACE_H
 
+#include "hermes/ADT/StringSetVector.h"
 #include "hermes/Public/RuntimeConfig.h"
 #include "hermes/Support/JSONEmitter.h"
 #include "hermes/Support/SHA1.h"
-#include "hermes/Support/StringSetVector.h"
 #include "hermes/VM/GCExecTrace.h"
 #include "hermes/VM/MockedEnvironment.h"
 

--- a/include/hermes/ADT/StringSetVector.h
+++ b/include/hermes/ADT/StringSetVector.h
@@ -39,10 +39,17 @@ struct StringSetVector final {
   /// \return the index of the string in the vector.
   inline size_type insert(llvh::StringRef str);
 
+  /// Insert a sequence into the container.
+  template <class InputIt>
+  void insert(InputIt first, InputIt last);
+
   /// Return an iterator \c it such that *it == str if such an iterator exists
   /// or end() otherwise.
   inline iterator find(llvh::StringRef str);
   inline const_iterator find(llvh::StringRef str) const;
+
+  /// \return 0 or 1 depending on whether \p str is in the set.
+  inline unsigned count(llvh::StringRef str) const;
 
   /// Return a reference to the \p i'th string inserted into this set vector.
   /// Assumes \pre i < size().
@@ -92,6 +99,13 @@ inline StringSetVector::size_type StringSetVector::insert(llvh::StringRef str) {
   return storageSize;
 }
 
+template <class InputIt>
+void StringSetVector::insert(InputIt first, InputIt last) {
+  for (; first != last; ++first) {
+    insert(*first);
+  }
+}
+
 inline StringSetVector::iterator StringSetVector::find(llvh::StringRef str) {
   auto it = stringsToIndex_.find(str);
   if (it == stringsToIndex_.end()) {
@@ -104,6 +118,10 @@ inline StringSetVector::iterator StringSetVector::find(llvh::StringRef str) {
 inline StringSetVector::const_iterator StringSetVector::find(
     llvh::StringRef str) const {
   return const_cast<StringSetVector *>(this)->find(str);
+}
+
+inline unsigned StringSetVector::count(llvh::StringRef str) const {
+  return find(str) != end();
 }
 
 inline const std::string &StringSetVector::operator[](size_t i) const {

--- a/include/hermes/ADT/StringSetVector.h
+++ b/include/hermes/ADT/StringSetVector.h
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#ifndef HERMES_SUPPORT_STRINGSETVECTOR_H
-#define HERMES_SUPPORT_STRINGSETVECTOR_H
+#ifndef HERMES_ADT_STRINGSETVECTOR_H
+#define HERMES_ADT_STRINGSETVECTOR_H
 
 #include "llvh/ADT/DenseMap.h"
 #include "llvh/ADT/StringRef.h"
@@ -136,4 +136,4 @@ inline StringSetVector::const_iterator StringSetVector::end() const {
 
 } // namespace hermes
 
-#endif // HERMES_SUPPORT_STRINGSETVECTOR_H
+#endif

--- a/include/hermes/AST/Context.h
+++ b/include/hermes/AST/Context.h
@@ -8,6 +8,7 @@
 #ifndef HERMES_AST_CONTEXT_H
 #define HERMES_AST_CONTEXT_H
 
+#include "hermes/ADT/StringSetVector.h"
 #include "hermes/Parser/PreParser.h"
 #include "hermes/Regex/RegexSerialization.h"
 #include "hermes/Support/Allocator.h"
@@ -43,6 +44,10 @@ struct CodeGenerationSettings {
   bool verifyIRBetweenPasses{false};
   /// Use colors in IR dumps.
   bool colors{false};
+  /// If not empty, restricts IR dumps only the given functions.
+  StringSetVector dumpFunctions;
+  /// Functions to exclude from IR dumps.
+  StringSetVector noDumpFunctions;
 };
 
 struct OptimizationSettings {
@@ -247,14 +252,14 @@ class Context {
  public:
   explicit Context(
       SourceErrorManager &sm,
-      CodeGenerationSettings codeGenOpts = CodeGenerationSettings(),
+      CodeGenerationSettings &&codeGenOpts = CodeGenerationSettings(),
       OptimizationSettings optimizationOpts = OptimizationSettings(),
       const NativeSettings *nativeSettings = nullptr,
       std::unique_ptr<ResolutionTable> resolutionTable = nullptr,
       std::vector<uint32_t> segments = {});
 
   explicit Context(
-      CodeGenerationSettings codeGenOpts = CodeGenerationSettings(),
+      CodeGenerationSettings &&codeGenOpts = CodeGenerationSettings(),
       OptimizationSettings optimizationOpts = OptimizationSettings(),
       const NativeSettings *nativeSettings = nullptr,
       std::unique_ptr<ResolutionTable> resolutionTable = nullptr,

--- a/include/hermes/BCGen/HBC/ConsecutiveStringStorage.h
+++ b/include/hermes/BCGen/HBC/ConsecutiveStringStorage.h
@@ -8,8 +8,8 @@
 #ifndef HERMES_SUPPORT_STRINGSTORAGE_H
 #define HERMES_SUPPORT_STRINGSTORAGE_H
 
+#include "hermes/ADT/StringSetVector.h"
 #include "hermes/Support/OptValue.h"
-#include "hermes/Support/StringSetVector.h"
 #include "hermes/Support/StringTableEntry.h"
 
 #include "llvh/ADT/ArrayRef.h"

--- a/include/hermes/BCGen/HBC/UniquingFilenameTable.h
+++ b/include/hermes/BCGen/HBC/UniquingFilenameTable.h
@@ -8,8 +8,8 @@
 #ifndef HERMES_BCGEN_HBC_UNIQUINGFILENAMETABLE_H
 #define HERMES_BCGEN_HBC_UNIQUINGFILENAMETABLE_H
 
+#include "hermes/ADT/StringSetVector.h"
 #include "hermes/BCGen/HBC/ConsecutiveStringStorage.h"
-#include "hermes/Support/StringSetVector.h"
 
 #include "llvh/ADT/StringRef.h"
 

--- a/include/hermes/IR/IRBuilder.h
+++ b/include/hermes/IR/IRBuilder.h
@@ -464,7 +464,10 @@ class IRBuilder {
 
   CreateRegExpInst *createRegExpInst(Identifier pattern, Identifier flags);
 
-  UnaryOperatorInst *createUnaryOperatorInst(Value *value, ValueKind kind);
+  UnaryOperatorInst *createUnaryOperatorInst(
+      Value *value,
+      ValueKind kind,
+      Type type = Type::createAnyType());
 
   DirectEvalInst *createDirectEvalInst(Value *evalText, bool strictCaller);
 

--- a/include/hermes/IR/IRBuilder.h
+++ b/include/hermes/IR/IRBuilder.h
@@ -172,6 +172,11 @@ class IRBuilder {
   /// Create a new literal 'empty'.
   LiteralEmpty *getLiteralEmpty();
 
+  /// Return the "Uninit" literal singletone.
+  LiteralUninit *getLiteralUninit() {
+    return M->getLiteralUninit();
+  }
+
   /// Create a new literal 'undefined'.
   LiteralUndefined *getLiteralUndefined();
 

--- a/include/hermes/IR/Instrs.h
+++ b/include/hermes/IR/Instrs.h
@@ -2922,8 +2922,9 @@ class ThrowIfInst : public Instruction {
         savedResultType_(Type::createAnyType()) {
     assert(
         !invalidTypes->getData().isNoType() &&
-        invalidTypes->getData().isSubsetOf(Type::createEmpty()) &&
-        "invalidTypes set can only contain Empty");
+        invalidTypes->getData().isSubsetOf(
+            Type::unionTy(Type::createEmpty(), Type::createUninit())) &&
+        "invalidTypes set can only contain Empty or Uninit");
     pushOperand(checkedValue);
     pushOperand(invalidTypes);
 
@@ -2960,8 +2961,9 @@ class ThrowIfInst : public Instruction {
   void setInvalidTypes(LiteralIRType *invalidTypes) {
     assert(
         !invalidTypes->getData().isNoType() &&
-        invalidTypes->getData().isSubsetOf(Type::createEmpty()) &&
-        "invalidTypes set can only contain Empty");
+        invalidTypes->getData().isSubsetOf(
+            Type::unionTy(Type::createEmpty(), Type::createUninit())) &&
+        "invalidTypes set can only contain Empty or Uninit");
     setOperand(invalidTypes, InvalidTypesIdx);
   }
 

--- a/include/hermes/IR/Instrs.h
+++ b/include/hermes/IR/Instrs.h
@@ -2169,9 +2169,10 @@ class UnaryOperatorInst : public SingleOperandInst {
     return opStringRepr[HERMES_IR_KIND_TO_OFFSET(UnaryOperatorInst, getKind())];
   }
 
-  explicit UnaryOperatorInst(ValueKind kind, Value *value)
+  explicit UnaryOperatorInst(ValueKind kind, Value *value, Type type)
       : SingleOperandInst(kind, value) {
     assert(HERMES_IR_KIND_IN_CLASS(kind, UnaryOperatorInst));
+    setType(type);
   }
   explicit UnaryOperatorInst(
       const UnaryOperatorInst *src,

--- a/include/hermes/IR/ValueKinds.def
+++ b/include/hermes/IR/ValueKinds.def
@@ -26,6 +26,7 @@ MARK_LAST(Instruction)
 
 MARK_FIRST(Literal, Value)
 DEF_VALUE(LiteralEmpty, Literal)
+DEF_VALUE(LiteralUninit, Literal)
 DEF_VALUE(LiteralUndefined, Literal)
 DEF_VALUE(LiteralNull, Literal)
 DEF_VALUE(LiteralNumber, Literal)

--- a/include/hermes/SourceMap/SourceMapGenerator.h
+++ b/include/hermes/SourceMap/SourceMapGenerator.h
@@ -8,9 +8,9 @@
 #ifndef HERMES_SUPPORT_SOURCEMAPGENERATOR_H
 #define HERMES_SUPPORT_SOURCEMAPGENERATOR_H
 
+#include "hermes/ADT/StringSetVector.h"
 #include "hermes/SourceMap/SourceMap.h"
 #include "hermes/Support/OSCompat.h"
-#include "hermes/Support/StringSetVector.h"
 #include "llvh/ADT/ArrayRef.h"
 
 #include <llvh/ADT/DenseMap.h>

--- a/include/hermes/Support/SourceErrorManager.h
+++ b/include/hermes/Support/SourceErrorManager.h
@@ -8,8 +8,8 @@
 #ifndef HERMES_SUPPORT_SOURCEERRORMANAGER_H
 #define HERMES_SUPPORT_SOURCEERRORMANAGER_H
 
+#include "hermes/ADT/StringSetVector.h"
 #include "hermes/Support/OptValue.h"
-#include "hermes/Support/StringSetVector.h"
 #include "hermes/Support/Warning.h"
 
 #include "llvh/ADT/DenseMap.h"

--- a/include/hermes/Utils/Dumper.h
+++ b/include/hermes/Utils/Dumper.h
@@ -177,6 +177,7 @@ class IRPrinter : public IRVisitor<IRPrinter, void> {
   /// Indentation level.
   unsigned indent_;
 
+  Context &ctx_;
   SourceErrorManager &sm_;
   /// Output stream.
   llvh::raw_ostream &os_;

--- a/include/hermes/VM/HeapSnapshot.h
+++ b/include/hermes/VM/HeapSnapshot.h
@@ -8,10 +8,10 @@
 #ifndef HERMES_VM_HEAPSNAPSHOT_H
 #define HERMES_VM_HEAPSNAPSHOT_H
 
+#include "hermes/ADT/StringSetVector.h"
 #include "hermes/Public/DebuggerTypes.h"
 #include "hermes/Public/GCConfig.h"
 #include "hermes/Support/JSONEmitter.h"
-#include "hermes/Support/StringSetVector.h"
 #include "hermes/VM/CellKind.h"
 #include "hermes/VM/HermesValue.h"
 #include "hermes/VM/StackTracesTree-NoRuntime.h"

--- a/include/hermes/VM/StackTracesTree-NoRuntime.h
+++ b/include/hermes/VM/StackTracesTree-NoRuntime.h
@@ -13,9 +13,9 @@
 #ifndef HERMES_STACK_TRACES_TREE_NO_RUNTIME_H
 #define HERMES_STACK_TRACES_TREE_NO_RUNTIME_H
 
+#include "hermes/ADT/StringSetVector.h"
 #include "hermes/Public/DebuggerTypes.h"
 #include "hermes/Support/OptValue.h"
-#include "hermes/Support/StringSetVector.h"
 
 #include "llvh/ADT/DenseMap.h"
 

--- a/lib/AST/Context.cpp
+++ b/lib/AST/Context.cpp
@@ -14,7 +14,7 @@ namespace hermes {
 
 Context::Context(
     SourceErrorManager &sm,
-    CodeGenerationSettings codeGenOpts,
+    CodeGenerationSettings &&codeGenOpts,
     OptimizationSettings optimizationOpts,
     const NativeSettings *nativeSettings,
     std::unique_ptr<ResolutionTable> resolutionTable,
@@ -28,7 +28,7 @@ Context::Context(
           nativeSettings ? *nativeSettings : NativeSettings())) {}
 
 Context::Context(
-    CodeGenerationSettings codeGenOpts,
+    CodeGenerationSettings &&codeGenOpts,
     OptimizationSettings optimizationOpts,
     const NativeSettings *nativeSettings,
     std::unique_ptr<ResolutionTable> resolutionTable,

--- a/lib/BCGen/HBC/BytecodeProviderFromSrc.cpp
+++ b/lib/BCGen/HBC/BytecodeProviderFromSrc.cpp
@@ -137,7 +137,7 @@ BCProviderFromSrc::createBCProviderFromSrcImpl(
       ? compileFlags.staticBuiltins.getValue()
       : false;
 
-  auto context = std::make_shared<Context>(codeGenOpts, optSettings);
+  auto context = std::make_shared<Context>(std::move(codeGenOpts), optSettings);
   std::unique_ptr<SimpleDiagHandlerRAII> outputManager;
   if (diagHandler) {
     context->getSourceErrorManager().setDiagHandler(diagHandler, diagContext);

--- a/lib/BCGen/RegAlloc.cpp
+++ b/lib/BCGen/RegAlloc.cpp
@@ -838,7 +838,7 @@ struct LivenessRegAllocIRPrinter : irdumper::IRPrinter {
       : IRPrinter(RA.getContext(), ost, escape), allocator(RA) {}
 
   bool printInstructionDestination(Instruction *I) override {
-    auto codeGenOpts = I->getContext().getCodeGenerationSettings();
+    const auto &codeGenOpts = I->getContext().getCodeGenerationSettings();
 
     if (!allocator.isAllocated(I)) {
       os_ << "$???";

--- a/lib/BCGen/SH/SHRegAlloc.cpp
+++ b/lib/BCGen/SH/SHRegAlloc.cpp
@@ -828,7 +828,7 @@ struct LivenessRegAllocIRPrinter : irdumper::IRPrinter {
       : IRPrinter(RA.getContext(), ost, escape), allocator(RA) {}
 
   bool printInstructionDestination(Instruction *I) override {
-    auto codeGenOpts = I->getContext().getCodeGenerationSettings();
+    const auto &codeGenOpts = I->getContext().getCodeGenerationSettings();
 
     auto optReg = allocator.getOptionalRegister(I);
 
@@ -877,7 +877,7 @@ struct LivenessRegAllocIRPrinter : irdumper::IRPrinter {
   }
 
   void printValueLabel(Instruction *I, Value *V, unsigned opIndex) override {
-    auto codeGenOpts = I->getContext().getCodeGenerationSettings();
+    const auto &codeGenOpts = I->getContext().getCodeGenerationSettings();
     if (codeGenOpts.dumpRegisterInterval) {
       if (auto *opInst = llvh::dyn_cast<Instruction>(V)) {
         setColor(Color::Name);

--- a/lib/CompilerDriver/CompilerDriver.cpp
+++ b/lib/CompilerDriver/CompilerDriver.cpp
@@ -222,6 +222,19 @@ static opt<OutputFormatKind> DumpTarget(
         clEnumValN(EmitBundle, "emit-binary", "Emit compiled binary")),
     cat(CompilerCategory));
 
+static list<std::string> DumpFunctions(
+    "Xdump-functions",
+    desc("Only dump the IR for the given functions"),
+    Hidden,
+    llvh::cl::CommaSeparated,
+    cat(CompilerCategory));
+static list<std::string> NoDumpFunctions(
+    "Xno-dump-functions",
+    desc("Exclude the given functions from IR dumps"),
+    Hidden,
+    llvh::cl::CommaSeparated,
+    cat(CompilerCategory));
+
 static opt<bool> Pretty(
     "pretty",
     init(true),
@@ -1038,6 +1051,10 @@ std::shared_ptr<Context> createContext(
       cl::DumpSourceLocation != LocationDumpMode::None;
   codeGenOpts.dumpIRBetweenPasses = cl::DumpBetweenPasses;
   codeGenOpts.verifyIRBetweenPasses = cl::VerifyIR;
+  codeGenOpts.dumpFunctions.insert(
+      cl::DumpFunctions.begin(), cl::DumpFunctions.end());
+  codeGenOpts.noDumpFunctions.insert(
+      cl::NoDumpFunctions.begin(), cl::NoDumpFunctions.end());
 
   OptimizationSettings optimizationOpts;
 
@@ -1053,7 +1070,7 @@ std::shared_ptr<Context> createContext(
   optimizationOpts.staticRequire = cl::StaticRequire;
 
   auto context = std::make_shared<Context>(
-      codeGenOpts,
+      std::move(codeGenOpts),
       optimizationOpts,
       nullptr,
       std::move(resolutionTable),

--- a/lib/IR/IR.cpp
+++ b/lib/IR/IR.cpp
@@ -791,12 +791,12 @@ void Type::print(llvh::raw_ostream &OS) const {
     OS << "notype";
     return;
   }
-  if (isAnyOrEmptyType()) {
-    OS << "any|empty";
-    return;
-  }
-  if (isAnyType()) {
+  if (canBeAny()) {
     OS << "any";
+    if (canBeEmpty())
+      OS << "|empty";
+    if (canBeUninit())
+      OS << "|uninit";
     return;
   }
   for (unsigned i = 0; i < (unsigned)Type::TypeKind::LAST_TYPE; i++) {

--- a/lib/IR/IRBuilder.cpp
+++ b/lib/IR/IRBuilder.cpp
@@ -692,10 +692,9 @@ CreateRegExpInst *IRBuilder::createRegExpInst(
   return res;
 }
 
-UnaryOperatorInst *IRBuilder::createUnaryOperatorInst(
-    Value *value,
-    ValueKind kind) {
-  auto UOI = new UnaryOperatorInst(kind, value);
+UnaryOperatorInst *
+IRBuilder::createUnaryOperatorInst(Value *value, ValueKind kind, Type type) {
+  auto UOI = new UnaryOperatorInst(kind, value, type);
   insert(UOI);
   return UOI;
 }

--- a/lib/IRGen/ESTreeIRGen-expr.cpp
+++ b/lib/IRGen/ESTreeIRGen-expr.cpp
@@ -15,7 +15,35 @@
 namespace hermes {
 namespace irgen {
 
+Value *ESTreeIRGen::enforceExprType(hermes::Value *value, ESTree::Node *expr) {
+  flow::Type *exprFlowType = flowContext_.findNodeType(expr);
+  if (!exprFlowType)
+    return value;
+
+  Type exprIRType = flowTypeToIRType(exprFlowType);
+  Type valueType = value->getType();
+  if (exprIRType == valueType || valueType.isSubsetOf(exprIRType))
+    return value;
+
+  if (!exprIRType.isSubsetOf(valueType)) {
+    Mod->getContext().getSourceErrorManager().error(
+        expr->getSourceRange(),
+        "Internal error: Flow expr type is not a subset of value type");
+    return value;
+  }
+
+  Instruction *cast = Builder.createCheckedTypeCastInst(value, exprIRType);
+  cast->setLocation(expr->getDebugLoc());
+  return cast;
+}
+
 Value *ESTreeIRGen::genExpression(ESTree::Node *expr, Identifier nameHint) {
+  return enforceExprType(_genExpressionImpl(expr, nameHint), expr);
+}
+
+Value *ESTreeIRGen::_genExpressionImpl(
+    ESTree::Node *expr,
+    Identifier nameHint) {
   LLVM_DEBUG(
       llvh::dbgs() << "IRGen expression of type " << expr->getNodeName()
                    << "\n");
@@ -1889,13 +1917,23 @@ Value *ESTreeIRGen::genUpdateExpr(ESTree::UpdateExpressionNode *updateExpr) {
 
   LReference lref = createLRef(updateExpr->_argument, false);
 
-  // Load the original value. Postfix updates need to convert it toNumeric
-  // before Inc/Dec to ensure the updateExpr has the proper result value.
-  Value *original =
-      isPrefix ? lref.emitLoad() : Builder.createAsNumericInst(lref.emitLoad());
+  // Load the original value.
+  Value *original = enforceExprType(lref.emitLoad(), updateExpr->_argument);
+
+  // Postfix updates need to convert the original value to numeric before
+  // Inc/Dec to ensure the updateExpr has the proper result value.
+  if (!isPrefix && !original->getType().isSubsetOf(Type::createNumeric()))
+    original = Builder.createAsNumericInst(original);
 
   // Create the inc or dec.
   Value *result = Builder.createUnaryOperatorInst(original, opKind);
+  // Number and BigInt types are preserved, otherwise the result is numeric.
+  result->setType(
+      original->getType().isNumberType() || original->getType().isBigIntType()
+          ? original->getType()
+          : Type::createNumeric());
+
+  result = enforceExprType(result, updateExpr);
 
   // Store the result.
   lref.emitStore(result);
@@ -1951,8 +1989,9 @@ Value *ESTreeIRGen::genAssignmentExpr(ESTree::AssignmentExpressionNode *AE) {
   // expression should be implicitly casted, so skip it when computing the lref.
   auto *optImplicitCast =
       llvh::dyn_cast<ESTree::ImplicitCheckedCastNode>(AE->_left);
-  LReference lref = createLRef(
-      optImplicitCast ? optImplicitCast->_argument : AE->_left, false);
+  ESTree::Node *left = optImplicitCast ? optImplicitCast->_argument : AE->_left;
+
+  LReference lref = createLRef(left, false);
   Identifier nameHint = extractNameHint(lref);
 
   auto logicalAssign =
@@ -1971,8 +2010,10 @@ Value *ESTreeIRGen::genAssignmentExpr(ESTree::AssignmentExpressionNode *AE) {
   // LHS before materializing the RHS. Unlike in C, this
   // code is well defined: "x+= x++".
   // https://es5.github.io/#x11.13.1
-  auto V = lref.emitLoad();
-  auto *RHS = genExpression(AE->_right, nameHint);
+  Value *V = lref.emitLoad();
+  V = enforceExprType(V, left);
+
+  Value *RHS = genExpression(AE->_right, nameHint);
   Value *result;
   result = Builder.createBinaryOperatorInst(V, RHS, AssignmentKind);
 
@@ -1983,6 +2024,7 @@ Value *ESTreeIRGen::genAssignmentExpr(ESTree::AssignmentExpressionNode *AE) {
         flowTypeToIRType(flowContext_.getNodeTypeOrAny(optImplicitCast)));
   }
 
+  result = enforceExprType(result, AE);
   lref.emitStore(result);
 
   // Return the value that we stored as the result of the expression.

--- a/lib/IRGen/ESTreeIRGen-func.cpp
+++ b/lib/IRGen/ESTreeIRGen-func.cpp
@@ -530,7 +530,8 @@ void ESTreeIRGen::emitScopeDeclarations(sema::LexicalScope *scope) {
           var = Builder.createVariable(
               func->getFunctionScope(),
               decl->name,
-              tdz ? Type::createAnyOrEmpty() : Type::createAnyType());
+              tdz ? Type::unionTy(Type::createAnyType(), Type::createEmpty())
+                  : Type::createAnyType());
           var->setObeysTDZ(tdz);
           var->setIsConst(decl->kind == sema::Decl::Kind::Const);
           setDeclData(decl, var);
@@ -639,7 +640,8 @@ void ESTreeIRGen::emitParameters(ESTree::FunctionLikeNode *funcNode) {
     Variable *var = Builder.createVariable(
         newFunc->getFunctionScope(),
         decl->name,
-        tdz ? Type::createAnyOrEmpty() : Type::createAnyType());
+        tdz ? Type::unionTy(Type::createAnyType(), Type::createEmpty())
+            : Type::createAnyType());
     setDeclData(decl, var);
 
     // If not simple parameter list, enable TDZ and init every param.

--- a/lib/IRGen/ESTreeIRGen.h
+++ b/lib/IRGen/ESTreeIRGen.h
@@ -566,12 +566,22 @@ class ESTreeIRGen {
   /// @name expressions
   /// @{
 
-  /// Generate IR for the expression \p Expr.
+  /// Optionally emit a checked cast if the IR value type does not match the
+  /// Flow type of the specified expression.
+  /// This is called automatically by genExpression() but may need to be used
+  /// manually in some rare cases.
+  Value *enforceExprType(Value *value, ESTree::Node *expr);
+
+  /// Generate IR for the expression \p Expr. Emit a checked cast if the Flow
+  /// type of the expression doesn't match the compiled IR type.
   /// \p nameHint is used to provide names for anonymous functions.
   /// We currently provide names for functions that are assigned to a variable,
   /// or functions that are assigned to an object key. These are a subset of
   /// ES6, but not all of it.
   Value *genExpression(ESTree::Node *expr, Identifier nameHint = Identifier{});
+
+  /// A helper called only from \c genExpression. It performs the actual work.
+  Value *_genExpressionImpl(ESTree::Node *expr, Identifier nameHint);
 
   /// Generate an expression and perform a conditional branch depending on
   /// whether it evaluates to true or false (or optionally, nullish).

--- a/lib/Optimizer/Scalar/Auditor.cpp
+++ b/lib/Optimizer/Scalar/Auditor.cpp
@@ -117,7 +117,7 @@ static void auditInferredTypes(Function *F) {
         TypeNumber++;
       } else if (t.isObjectType()) {
         TypeObject++;
-      } else if (t.isAnyOrEmptyType() || t.isAnyType()) {
+      } else if (t.canBeAny()) {
         TypeAny++;
       } else {
         // Other cases not counted above, e.g. union types.

--- a/lib/Optimizer/Scalar/TDZDedup.cpp
+++ b/lib/Optimizer/Scalar/TDZDedup.cpp
@@ -24,8 +24,26 @@ namespace {
 
 class TDZDedupContext;
 
-using ScopedHTType = hermes::ScopedHashTable<Value *, bool>;
-using ScopeType = hermes::ScopedHashTableScope<Value *, bool>;
+/// States in order from less initialized to more initialized. The order matters
+/// and is used for comparisons. The initial state "Missing" means that we have
+/// not seen any stores to the value yet.
+/// The valid transitions can only increase the ValueState into a "better"
+/// state:
+/// - Missing -> Empty -> Uninit -> Initialized
+/// - Missing -> Empty -> Initialized
+/// - Missing -> Uninit -> Initialized
+/// - Missing -> Initialized
+enum class ValueState {
+  /// We have not seen any stores to the value. This is always the starting
+  /// state.
+  Missing,
+  /// The value could be empty or better.
+  Empty,
+  /// The value could be uninit or better.
+  Uninit,
+  /// The value has been initialized.
+  Initialized,
+};
 
 // StackNode - contains all the needed information to create a stack for doing
 // a depth first traversal of the tree. This includes scopes for values and
@@ -38,12 +56,33 @@ class StackNode : public DomTreeDFS::StackNode {
  private:
   /// RAII to create and pop a scope when the stack node is created and
   /// destroyed.
-  ScopeType scope_;
+  ScopedHashTableScope<Value *, ValueState> scope_;
 };
 
 /// TDZDedupContext - This pass does a simple depth-first walk of the dominator
-/// tree, eliminating trivially redundant instructions.
+/// tree, eliminating trivially redundant ThrowIf instructions.
 class TDZDedupContext : public DomTreeDFS::Visitor<TDZDedupContext, StackNode> {
+  friend StackNode;
+
+  Function *const F_;
+  IRBuilder builder_;
+
+  /// All TDZ variables are collected here.
+  llvh::DenseSet<Value *> tdzStorage_{};
+
+  /// AvailableValues - This scoped hash table conceptually contains the
+  /// TDZ-obeying values and their state. It maps from instances of Variable,
+  /// AllocStackInst, or theoretically an Instruction * (if the value has been
+  /// SSA-ed), to \c ValueState.
+  ///
+  /// Values can transition between these states as we walk the dominator tree.
+  /// Due to the recursive nature of the dominator walk, we must be careful
+  /// how we update them. If the value is in the current scope, we update its
+  /// value in-place. Otherwise, we insert a new key/value in the current scope.
+  ///
+  /// We eliminate checks to values whose state makes the check redundant.
+  ScopedHashTable<Value *, ValueState> availableValues_{};
+
  public:
   TDZDedupContext(Function *F, DominanceInfo &DT)
       : DomTreeDFS::Visitor<TDZDedupContext, StackNode>(DT),
@@ -51,38 +90,28 @@ class TDZDedupContext : public DomTreeDFS::Visitor<TDZDedupContext, StackNode> {
         builder_(F) {}
 
   bool run();
-
   bool processNode(StackNode *SN);
 
  private:
-  friend StackNode;
+  /// Handle stores to frame or stack. If the target is not a TDZ variable, do
+  /// nothing.
+  void processStore(Value *tdzStorage, Value *storedValue);
 
-  Function *const F_;
-  IRBuilder builder_;
-
-  /// All TDZ state variables are collected here.
-  llvh::DenseSet<Value *> tdzState_{};
-
-  /// AvailableValues - This scoped hash table conceptually contains the
-  /// TDZ-obeying values and whether they are known to be non-empty. It maps
-  /// from instances of Variable, AllocStackInst, or theoretically an
-  /// Instruction * if the value has been SSA-ed, to a boolean. True means the
-  /// value is known to be non-empty, false means it could be empty.
-  ///
-  /// Values can transition between these states as we walk the dominator tree.
-  /// Due to the recursive nature of the dominator walk, we must be careful
-  /// how we update them. If he value is in the current scope, we update its
-  /// value in-place. Otherwise, we insert a new key/value in the current scope.
-  ///
-  /// We eliminate checks to values that are known to be non-empty at the time.
-  ScopedHTType availableValues_{};
+  /// Handle ThrowIf instructions.
+  bool processThrowIf(
+      ThrowIfInst *TI,
+      IRBuilder::InstructionDestroyer &destroyer);
+  /// Remove a ThrowIf instruction that has been deemed unnecessary.
+  bool eliminateThrowIf(
+      ThrowIfInst *TI,
+      IRBuilder::InstructionDestroyer &destroyer);
 };
 
 inline StackNode::StackNode(TDZDedupContext *ctx, const DominanceInfoNode *n)
     : DomTreeDFS::StackNode(n), scope_{ctx->availableValues_} {}
 
 bool TDZDedupContext::run() {
-  // First, collect all TDZ state variables.
+  // First, collect all TDZ variables.
   for (auto &BB : *F_) {
     for (auto &I : BB) {
       auto *TIU = llvh::dyn_cast<ThrowIfInst>(&I);
@@ -100,7 +129,7 @@ bool TDZDedupContext::run() {
         continue;
       }
 
-      tdzState_.insert(tdzStorage);
+      tdzStorage_.insert(tdzStorage);
     }
   }
 
@@ -115,82 +144,136 @@ bool TDZDedupContext::processNode(StackNode *SN) {
   // is processed.
   IRBuilder::InstructionDestroyer destroyer;
 
-  // See if any instructions in the block can be eliminated.  If so, do it.  If
-  // not, add them to AvailableValues.
+  // Check for instructions that affect TDZ value states: ThrowIf and
+  // StoreFrame/StoreStack.
   for (auto &inst : *BB) {
-    // The storage containing the value that can potentially be empty.
-    Value *tdzStorage = nullptr;
-    ThrowIfInst *TIE = nullptr;
-    if ((TIE = llvh::dyn_cast<ThrowIfInst>(&inst)) != nullptr) {
-      auto *checkedValue = TIE->getCheckedValue();
-
-      if (auto *LFI = llvh::dyn_cast<LoadFrameInst>(checkedValue)) {
-        tdzStorage = LFI->getLoadVariable();
-      } else if (auto *LSI = llvh::dyn_cast<LoadStackInst>(checkedValue)) {
-        tdzStorage = LSI->getSingleOperand();
-      } else {
-        tdzStorage = checkedValue;
-      }
-    } else if (auto *SF = llvh::dyn_cast<StoreFrameInst>(&inst)) {
-      tdzStorage = SF->getVariable();
-      // Is the target a TDZ state variable?
-      if (!tdzState_.count(tdzStorage))
-        continue;
-      // Check whether it is setting the target to empty, in which case we
-      // mark it is "unavailable".
-      if (SF->getValue()->getType().canBeEmpty()) {
-        availableValues_.setInCurrentScope(tdzStorage, false);
-        continue;
-      }
-    } else if (auto *SS = llvh::dyn_cast<StoreStackInst>(&inst)) {
-      tdzStorage = SS->getPtr();
-      // Is the target a TDZ state variable?
-      if (!tdzState_.count(tdzStorage))
-        continue;
-      // Check whether it is setting the target to non-empty.
-      if (SS->getValue()->getType().canBeEmpty()) {
-        availableValues_.setInCurrentScope(tdzStorage, false);
-        continue;
-      }
-    } else {
-      continue;
-    }
-
-    // If the tdz state is not already known to be set to true, add it to
-    // the map.
-    if (!availableValues_.lookup(tdzStorage)) {
-      availableValues_.setInCurrentScope(tdzStorage, true);
-      continue;
-    }
-
-    // Handle only ThrowIf from here on.
-    if (!TIE)
-      continue;
-
-    // The TDZ state is known to be true, so we can eliminate the check
-    // instruction.
-    destroyer.add(TIE);
-    changed = true;
-    ++NumTDZDedup;
-
-    // If ThrowIf has no users, we will attempt to destroy the load too, to
-    // save work in other passes.
-    if (!TIE->hasUsers()) {
-      if (TIE->getCheckedValue()->hasOneUser() &&
-          (llvh::isa<LoadFrameInst>(TIE->getCheckedValue()) ||
-           llvh::isa<LoadStackInst>(TIE->getCheckedValue()))) {
-        destroyer.add(llvh::cast<Instruction>(TIE->getCheckedValue()));
-      }
-    } else {
-      builder_.setInsertionPoint(TIE);
-      builder_.setLocation(TIE->getLocation());
-      auto *cast = builder_.createUnionNarrowTrustedInst(
-          TIE->getCheckedValue(), TIE->getType());
-      TIE->replaceAllUsesWith(cast);
-    }
+    if (auto *TI = llvh::dyn_cast<ThrowIfInst>(&inst))
+      changed |= processThrowIf(TI, destroyer);
+    else if (auto *SF = llvh::dyn_cast<StoreFrameInst>(&inst))
+      processStore(SF->getVariable(), SF->getValue());
+    else if (auto *SS = llvh::dyn_cast<StoreStackInst>(&inst))
+      processStore(SS->getPtr(), SS->getValue());
   }
 
   return changed;
+}
+
+void TDZDedupContext::processStore(Value *tdzStorage, Value *storedValue) {
+  // Is the target a TDZ state variable?
+  if (!tdzStorage_.count(tdzStorage))
+    return;
+
+#ifndef NDEBUG
+  ValueState oldState = availableValues_.lookup(tdzStorage);
+#endif
+
+  // Check whether it is setting the target to Empty or Uninit, and record the
+  // state accordingly.
+  ValueState newState;
+  if (storedValue->getType().canBeEmpty()) {
+    assert(
+        oldState < ValueState::Empty &&
+        "TDZ variable can't be set to Empty twice");
+    newState = ValueState::Empty;
+  } else if (storedValue->getType().canBeUninit()) {
+    assert(
+        oldState < ValueState::Uninit &&
+        "TDZ variable can't be set to Uninit twice");
+    newState = ValueState::Uninit;
+  } else if (availableValues_.lookup(tdzStorage) != ValueState::Initialized) {
+    newState = ValueState::Initialized;
+  } else {
+    return;
+  }
+
+  availableValues_.setInCurrentScope(tdzStorage, newState);
+}
+
+bool TDZDedupContext::processThrowIf(
+    ThrowIfInst *TI,
+    IRBuilder::InstructionDestroyer &destroyer) {
+  // A ThrowIfInst always discards a type, and a value can never transition back
+  // from Uninit to Empty.
+  ValueState newState = TI->getType().canBeUninit() ? ValueState::Uninit
+                                                    : ValueState::Initialized;
+
+  // The storage containing the value that can potentially be empty.
+  Value *tdzStorage;
+  auto *checkedValue = TI->getCheckedValue();
+  if (auto *LFI = llvh::dyn_cast<LoadFrameInst>(checkedValue)) {
+    tdzStorage = LFI->getLoadVariable();
+  } else if (auto *LSI = llvh::dyn_cast<LoadStackInst>(checkedValue)) {
+    tdzStorage = LSI->getSingleOperand();
+  } else {
+    tdzStorage = checkedValue;
+  }
+
+  ValueState oldState = availableValues_.lookup(tdzStorage);
+  // If the check doesn't reveal any additional information (doesn't move the
+  // value into a more initialized state), we can delete it.
+  if (newState <= oldState)
+    return eliminateThrowIf(TI, destroyer);
+
+  availableValues_.setInCurrentScope(tdzStorage, newState);
+
+  // This check moves the value into a more initialized state, so it can't be
+  // deleted. But depending on the previous state, the check could possibly be
+  // simplified. The only case is when moving from Uninit to Initialized, while
+  // unnecessarily checking for Empty.
+  if (oldState == ValueState::Uninit &&
+      TI->getInvalidTypes()->getData().canBeEmpty()) {
+    assert(
+        newState == ValueState::Initialized &&
+        "impossible: newState is known be > oldState");
+    assert(
+        TI->getInvalidTypes()->getData().canBeUninit() &&
+        "impossible: the only possible transition from Uninit state involves removing Uninit type");
+
+    // If the checked value still has Empty in its type, we must strip it away.
+    // This can happen when loading from a variable - it's type includes Empty,
+    // which needs to be discarded.
+    if (checkedValue->getType().canBeEmpty()) {
+      builder_.setInsertionPoint(TI);
+      builder_.setLocation(TI->getLocation());
+      auto *cast = builder_.createUnionNarrowTrustedInst(
+          checkedValue,
+          Type::subtractTy(checkedValue->getType(), Type::createEmpty()));
+      TI->setCheckedValue(cast);
+    }
+    TI->setInvalidTypes(builder_.getLiteralIRType(Type::createUninit()));
+    return true;
+  }
+
+  return false;
+}
+
+bool TDZDedupContext::eliminateThrowIf(
+    ThrowIfInst *TI,
+    IRBuilder::InstructionDestroyer &destroyer) {
+  // The TDZ state is known to be true, so we can eliminate the check
+  // instruction.
+  destroyer.add(TI);
+  ++NumTDZDedup;
+
+  // If ThrowIf has no users, we will attempt to destroy the load too, to
+  // save work in other passes.
+  if (!TI->hasUsers()) {
+    if (TI->getCheckedValue()->hasOneUser() &&
+        (llvh::isa<LoadFrameInst>(TI->getCheckedValue()) ||
+         llvh::isa<LoadStackInst>(TI->getCheckedValue()))) {
+      destroyer.add(llvh::cast<Instruction>(TI->getCheckedValue()));
+    }
+  } else {
+    builder_.setInsertionPoint(TI);
+    builder_.setLocation(TI->getLocation());
+    auto *cast = builder_.createUnionNarrowTrustedInst(
+        TI->getCheckedValue(), TI->getType());
+    TI->replaceAllUsesWith(cast);
+  }
+
+  // Return constant true to enable tail-recursion elimination in the caller,
+  // which also returns a bool.
+  return true;
 }
 
 } // end anonymous namespace

--- a/lib/Utils/Dumper.cpp
+++ b/lib/Utils/Dumper.cpp
@@ -185,6 +185,8 @@ void IRPrinter::printValueLabel(Instruction *I, Value *V, unsigned opIndex) {
     }
   } else if (isa<LiteralEmpty>(V)) {
     os_ << "empty";
+  } else if (isa<LiteralUninit>(V)) {
+    os_ << "uninit";
   } else if (isa<LiteralNull>(V)) {
     os_ << "null";
   } else if (isa<LiteralUndefined>(V)) {

--- a/lib/Utils/Dumper.cpp
+++ b/lib/Utils/Dumper.cpp
@@ -35,6 +35,7 @@ IRPrinter::IRPrinter(
     llvh::raw_ostream &ost,
     bool escape)
     : indent_(0),
+      ctx_(ctx),
       sm_(ctx.getSourceErrorManager()),
       os_(ost),
       colors_(ctx.getCodeGenerationSettings().colors && os_.has_colors()),
@@ -330,7 +331,7 @@ void IRPrinter::printInstruction(Instruction *I) {
     first = false;
   }
 
-  auto codeGenOpts = I->getContext().getCodeGenerationSettings();
+  const auto &codeGenOpts = I->getContext().getCodeGenerationSettings();
   // Print the use list if there is any user for the instruction.
   if (!codeGenOpts.dumpUseList || I->getUsers().empty())
     return;
@@ -384,6 +385,16 @@ void IRPrinter::visitFunction(const Function &F) {
 void IRPrinter::visitFunction(
     const Function &F,
     llvh::ArrayRef<BasicBlock *> order) {
+  if (!ctx_.getCodeGenerationSettings().dumpFunctions.empty()) {
+    if (!ctx_.getCodeGenerationSettings().dumpFunctions.count(
+            F.getInternalNameStr()))
+      return;
+  }
+  if (ctx_.getCodeGenerationSettings().noDumpFunctions.count(
+          F.getInternalNameStr())) {
+    return;
+  }
+
   auto *UF = const_cast<Function *>(&F);
   os_.indent(indent_);
   namer_.newFunction(&F);
@@ -397,7 +408,7 @@ void IRPrinter::visitFunction(
   printFunctionVariables(UF);
   os_ << "\n";
 
-  auto codeGenOpts = F.getContext().getCodeGenerationSettings();
+  const auto &codeGenOpts = F.getContext().getCodeGenerationSettings();
   if (codeGenOpts.dumpSourceLocation) {
     os_ << "source location: ";
     printSourceLocation(F.getSourceRange());
@@ -432,7 +443,7 @@ void IRPrinter::visitBasicBlock(const BasicBlock &BB) {
 
 void IRPrinter::visitInstruction(const Instruction &I) {
   auto *UII = const_cast<Instruction *>(&I);
-  auto codeGenOpts = I.getContext().getCodeGenerationSettings();
+  const auto &codeGenOpts = I.getContext().getCodeGenerationSettings();
   if (codeGenOpts.dumpSourceLocation) {
     os_ << "; ";
     printSourceLocation(UII->getLocation());

--- a/test/BCGen/HBC/arguments-decrement.js
+++ b/test/BCGen/HBC/arguments-decrement.js
@@ -48,8 +48,8 @@ function decrementArguments() {
 // CHKIR-NEXT:       StoreFrameInst undefined: undefined, [var3]: any
 // CHKIR-NEXT:       StoreFrameInst 0: number, [i]: any
 // CHKIR-NEXT:  %10 = LoadFrameInst (:any) [i]: any
-// CHKIR-NEXT:  %11 = BinaryLessThanInst (:any) %10: any, 2: number
-// CHKIR-NEXT:        CondBranchInst %11: any, %BB1, %BB2
+// CHKIR-NEXT:  %11 = BinaryLessThanInst (:boolean) %10: any, 2: number
+// CHKIR-NEXT:        CondBranchInst %11: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB1:
 // CHKIR-NEXT:  %13 = CreateFunctionInst (:object) %var1(): any
 // CHKIR-NEXT:        StoreFrameInst %13: object, [var1]: any
@@ -61,8 +61,8 @@ function decrementArguments() {
 // CHKIR-NEXT:        ReturnInst %18: any
 // CHKIR-NEXT:%BB4:
 // CHKIR-NEXT:  %20 = LoadFrameInst (:any) [i]: any
-// CHKIR-NEXT:  %21 = BinaryLessThanInst (:any) %20: any, 2: number
-// CHKIR-NEXT:        CondBranchInst %21: any, %BB1, %BB2
+// CHKIR-NEXT:  %21 = BinaryLessThanInst (:boolean) %20: any, 2: number
+// CHKIR-NEXT:        CondBranchInst %21: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB3:
 // CHKIR-NEXT:  %23 = LoadFrameInst (:any) [i]: any
 // CHKIR-NEXT:  %24 = AsNumericInst (:number|bigint) %23: any
@@ -106,8 +106,8 @@ function decrementArguments() {
 // CHKIR-NEXT:       StoreFrameInst undefined: undefined, [var3]: any
 // CHKIR-NEXT:       StoreFrameInst 0: number, [i]: any
 // CHKIR-NEXT:  %10 = LoadFrameInst (:any) [i]: any
-// CHKIR-NEXT:  %11 = BinaryLessThanInst (:any) %10: any, 2: number
-// CHKIR-NEXT:        CondBranchInst %11: any, %BB1, %BB2
+// CHKIR-NEXT:  %11 = BinaryLessThanInst (:boolean) %10: any, 2: number
+// CHKIR-NEXT:        CondBranchInst %11: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB1:
 // CHKIR-NEXT:  %13 = CreateFunctionInst (:object) %var1(): any
 // CHKIR-NEXT:        StoreFrameInst %13: object, [var1]: any
@@ -119,8 +119,8 @@ function decrementArguments() {
 // CHKIR-NEXT:        ReturnInst %18: any
 // CHKIR-NEXT:%BB4:
 // CHKIR-NEXT:  %20 = LoadFrameInst (:any) [i]: any
-// CHKIR-NEXT:  %21 = BinaryLessThanInst (:any) %20: any, 2: number
-// CHKIR-NEXT:        CondBranchInst %21: any, %BB1, %BB2
+// CHKIR-NEXT:  %21 = BinaryLessThanInst (:boolean) %20: any, 2: number
+// CHKIR-NEXT:        CondBranchInst %21: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB3:
 // CHKIR-NEXT:  %23 = LoadFrameInst (:any) [i]: any
 // CHKIR-NEXT:  %24 = UnaryIncInst (:any) %23: any
@@ -163,8 +163,8 @@ function decrementArguments() {
 // CHKIR-NEXT:       StoreFrameInst undefined: undefined, [var3]: any
 // CHKIR-NEXT:       StoreFrameInst 0: number, [i]: any
 // CHKIR-NEXT:  %10 = LoadFrameInst (:any) [i]: any
-// CHKIR-NEXT:  %11 = BinaryLessThanInst (:any) %10: any, 2: number
-// CHKIR-NEXT:        CondBranchInst %11: any, %BB1, %BB2
+// CHKIR-NEXT:  %11 = BinaryLessThanInst (:boolean) %10: any, 2: number
+// CHKIR-NEXT:        CondBranchInst %11: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB1:
 // CHKIR-NEXT:  %13 = CreateFunctionInst (:object) %var1(): any
 // CHKIR-NEXT:        StoreFrameInst %13: object, [var1]: any
@@ -176,8 +176,8 @@ function decrementArguments() {
 // CHKIR-NEXT:        ReturnInst %18: any
 // CHKIR-NEXT:%BB4:
 // CHKIR-NEXT:  %20 = LoadFrameInst (:any) [i]: any
-// CHKIR-NEXT:  %21 = BinaryLessThanInst (:any) %20: any, 2: number
-// CHKIR-NEXT:        CondBranchInst %21: any, %BB1, %BB2
+// CHKIR-NEXT:  %21 = BinaryLessThanInst (:boolean) %20: any, 2: number
+// CHKIR-NEXT:        CondBranchInst %21: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB3:
 // CHKIR-NEXT:  %23 = LoadFrameInst (:any) [i]: any
 // CHKIR-NEXT:  %24 = UnaryIncInst (:any) %23: any
@@ -220,8 +220,8 @@ function decrementArguments() {
 // CHKIR-NEXT:       StoreFrameInst undefined: undefined, [var3]: any
 // CHKIR-NEXT:       StoreFrameInst 0: number, [i]: any
 // CHKIR-NEXT:  %10 = LoadFrameInst (:any) [i]: any
-// CHKIR-NEXT:  %11 = BinaryLessThanInst (:any) %10: any, 2: number
-// CHKIR-NEXT:        CondBranchInst %11: any, %BB1, %BB2
+// CHKIR-NEXT:  %11 = BinaryLessThanInst (:boolean) %10: any, 2: number
+// CHKIR-NEXT:        CondBranchInst %11: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB1:
 // CHKIR-NEXT:  %13 = CreateFunctionInst (:object) %var1(): any
 // CHKIR-NEXT:        StoreFrameInst %13: object, [var1]: any
@@ -233,8 +233,8 @@ function decrementArguments() {
 // CHKIR-NEXT:        ReturnInst %18: any
 // CHKIR-NEXT:%BB4:
 // CHKIR-NEXT:  %20 = LoadFrameInst (:any) [i]: any
-// CHKIR-NEXT:  %21 = BinaryLessThanInst (:any) %20: any, 2: number
-// CHKIR-NEXT:        CondBranchInst %21: any, %BB1, %BB2
+// CHKIR-NEXT:  %21 = BinaryLessThanInst (:boolean) %20: any, 2: number
+// CHKIR-NEXT:        CondBranchInst %21: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB3:
 // CHKIR-NEXT:  %23 = LoadFrameInst (:any) [i]: any
 // CHKIR-NEXT:  %24 = UnaryIncInst (:any) %23: any
@@ -277,8 +277,8 @@ function decrementArguments() {
 // CHKIR-NEXT:       StoreFrameInst undefined: undefined, [var3]: any
 // CHKIR-NEXT:       StoreFrameInst 0: number, [i]: any
 // CHKIR-NEXT:  %10 = LoadFrameInst (:any) [i]: any
-// CHKIR-NEXT:  %11 = BinaryLessThanInst (:any) %10: any, 2: number
-// CHKIR-NEXT:        CondBranchInst %11: any, %BB1, %BB2
+// CHKIR-NEXT:  %11 = BinaryLessThanInst (:boolean) %10: any, 2: number
+// CHKIR-NEXT:        CondBranchInst %11: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB1:
 // CHKIR-NEXT:  %13 = CreateFunctionInst (:object) %var1(): any
 // CHKIR-NEXT:        StoreFrameInst %13: object, [var1]: any
@@ -287,8 +287,8 @@ function decrementArguments() {
 // CHKIR-NEXT:  %17 = UnaryIncInst (:any) %16: any
 // CHKIR-NEXT:        StoreFrameInst %17: any, [i]: any
 // CHKIR-NEXT:  %19 = LoadFrameInst (:any) [i]: any
-// CHKIR-NEXT:  %20 = BinaryLessThanInst (:any) %19: any, 2: number
-// CHKIR-NEXT:        CondBranchInst %20: any, %BB1, %BB2
+// CHKIR-NEXT:  %20 = BinaryLessThanInst (:boolean) %19: any, 2: number
+// CHKIR-NEXT:        CondBranchInst %20: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB2:
 // CHKIR-NEXT:  %22 = LoadFrameInst (:any) [var3]: any
 // CHKIR-NEXT:  %23 = BinarySubtractInst (:any) %22: any, 1: number
@@ -328,8 +328,8 @@ function decrementArguments() {
 // CHKIR-NEXT:       StoreFrameInst undefined: undefined, [var3]: any
 // CHKIR-NEXT:       StoreStackInst 0: number, %0: any
 // CHKIR-NEXT:  %8 = LoadStackInst (:any) %0: any
-// CHKIR-NEXT:  %9 = BinaryLessThanInst (:any) %8: any, 2: number
-// CHKIR-NEXT:        CondBranchInst %9: any, %BB1, %BB2
+// CHKIR-NEXT:  %9 = BinaryLessThanInst (:boolean) %8: any, 2: number
+// CHKIR-NEXT:        CondBranchInst %9: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB1:
 // CHKIR-NEXT:  %11 = CreateFunctionInst (:object) %var1(): any
 // CHKIR-NEXT:        StoreFrameInst %1: object, [var3]: any
@@ -337,8 +337,8 @@ function decrementArguments() {
 // CHKIR-NEXT:  %14 = UnaryIncInst (:any) %13: any
 // CHKIR-NEXT:        StoreStackInst %14: any, %0: any
 // CHKIR-NEXT:  %16 = LoadStackInst (:any) %0: any
-// CHKIR-NEXT:  %17 = BinaryLessThanInst (:any) %16: any, 2: number
-// CHKIR-NEXT:        CondBranchInst %17: any, %BB1, %BB2
+// CHKIR-NEXT:  %17 = BinaryLessThanInst (:boolean) %16: any, 2: number
+// CHKIR-NEXT:        CondBranchInst %17: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB2:
 // CHKIR-NEXT:  %19 = LoadFrameInst (:any) [var3]: any
 // CHKIR-NEXT:  %20 = BinarySubtractInst (:any) %19: any, 1: number
@@ -378,8 +378,8 @@ function decrementArguments() {
 // CHKIR-NEXT:       StoreFrameInst undefined: undefined, [var3]: any
 // CHKIR-NEXT:       StoreStackInst 0: number, %0: any
 // CHKIR-NEXT:  %8 = LoadStackInst (:any) %0: any
-// CHKIR-NEXT:  %9 = BinaryLessThanInst (:any) %8: any, 2: number
-// CHKIR-NEXT:        CondBranchInst %9: any, %BB1, %BB2
+// CHKIR-NEXT:  %9 = BinaryLessThanInst (:boolean) %8: any, 2: number
+// CHKIR-NEXT:        CondBranchInst %9: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB1:
 // CHKIR-NEXT:  %11 = CreateFunctionInst (:object) %var1(): any
 // CHKIR-NEXT:        StoreFrameInst %1: object, [var3]: any
@@ -387,8 +387,8 @@ function decrementArguments() {
 // CHKIR-NEXT:  %14 = UnaryIncInst (:any) %13: any
 // CHKIR-NEXT:        StoreStackInst %14: any, %0: any
 // CHKIR-NEXT:  %16 = LoadStackInst (:any) %0: any
-// CHKIR-NEXT:  %17 = BinaryLessThanInst (:any) %16: any, 2: number
-// CHKIR-NEXT:        CondBranchInst %17: any, %BB1, %BB2
+// CHKIR-NEXT:  %17 = BinaryLessThanInst (:boolean) %16: any, 2: number
+// CHKIR-NEXT:        CondBranchInst %17: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB2:
 // CHKIR-NEXT:  %19 = LoadFrameInst (:any) [var3]: any
 // CHKIR-NEXT:  %20 = BinarySubtractInst (:any) %19: any, 1: number
@@ -422,15 +422,15 @@ function decrementArguments() {
 // CHKIR-NEXT:  %3 = CoerceThisNSInst (:object) %2: any
 // CHKIR-NEXT:  %4 = GetNewTargetInst (:undefined|object) %new.target: undefined|object
 // CHKIR-NEXT:       StoreFrameInst undefined: undefined, [var3]: any
-// CHKIR-NEXT:  %6 = BinaryLessThanInst (:any) 0: number, 2: number
-// CHKIR-NEXT:       CondBranchInst %6: any, %BB1, %BB2
+// CHKIR-NEXT:  %6 = BinaryLessThanInst (:boolean) 0: number, 2: number
+// CHKIR-NEXT:       CondBranchInst %6: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB1:
 // CHKIR-NEXT:  %8 = PhiInst (:any) 0: number, %BB0, %11: any, %BB1
 // CHKIR-NEXT:  %9 = CreateFunctionInst (:object) %var1(): any
 // CHKIR-NEXT:        StoreFrameInst %1: object, [var3]: any
 // CHKIR-NEXT:  %11 = UnaryIncInst (:any) %8: any
-// CHKIR-NEXT:  %12 = BinaryLessThanInst (:any) %11: any, 2: number
-// CHKIR-NEXT:        CondBranchInst %12: any, %BB1, %BB2
+// CHKIR-NEXT:  %12 = BinaryLessThanInst (:boolean) %11: any, 2: number
+// CHKIR-NEXT:        CondBranchInst %12: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB2:
 // CHKIR-NEXT:  %14 = PhiInst (:any) 0: number, %BB0, %11: any, %BB1
 // CHKIR-NEXT:  %15 = LoadFrameInst (:any) [var3]: any
@@ -465,15 +465,15 @@ function decrementArguments() {
 // CHKIR-NEXT:  %3 = CoerceThisNSInst (:object) %2: any
 // CHKIR-NEXT:  %4 = GetNewTargetInst (:undefined|object) %new.target: undefined|object
 // CHKIR-NEXT:       StoreFrameInst undefined: undefined, [var3]: any
-// CHKIR-NEXT:  %6 = BinaryLessThanInst (:any) 0: number, 2: number
-// CHKIR-NEXT:       CondBranchInst %6: any, %BB1, %BB2
+// CHKIR-NEXT:  %6 = BinaryLessThanInst (:boolean) 0: number, 2: number
+// CHKIR-NEXT:       CondBranchInst %6: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB1:
 // CHKIR-NEXT:  %8 = PhiInst (:any) 0: number, %BB0, %11: any, %BB1
 // CHKIR-NEXT:  %9 = CreateFunctionInst (:object) %var1(): any
 // CHKIR-NEXT:        StoreFrameInst %1: object, [var3]: any
 // CHKIR-NEXT:  %11 = UnaryIncInst (:any) %8: any
-// CHKIR-NEXT:  %12 = BinaryLessThanInst (:any) %11: any, 2: number
-// CHKIR-NEXT:        CondBranchInst %12: any, %BB1, %BB2
+// CHKIR-NEXT:  %12 = BinaryLessThanInst (:boolean) %11: any, 2: number
+// CHKIR-NEXT:        CondBranchInst %12: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB2:
 // CHKIR-NEXT:  %14 = PhiInst (:any) 0: number, %BB0, %11: any, %BB1
 // CHKIR-NEXT:  %15 = LoadFrameInst (:any) [var3]: any
@@ -508,15 +508,15 @@ function decrementArguments() {
 // CHKIR-NEXT:  %3 = CoerceThisNSInst (:object) %2: any
 // CHKIR-NEXT:  %4 = GetNewTargetInst (:undefined|object) %new.target: undefined|object
 // CHKIR-NEXT:       StoreFrameInst undefined: undefined, [var3]: any
-// CHKIR-NEXT:  %6 = BinaryLessThanInst (:any) 0: number, 2: number
-// CHKIR-NEXT:       CondBranchInst %6: any, %BB1, %BB2
+// CHKIR-NEXT:  %6 = BinaryLessThanInst (:boolean) 0: number, 2: number
+// CHKIR-NEXT:       CondBranchInst %6: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB1:
 // CHKIR-NEXT:  %8 = PhiInst (:any) 0: number, %BB0, %11: any, %BB1
 // CHKIR-NEXT:  %9 = CreateFunctionInst (:object) %var1(): any
 // CHKIR-NEXT:        StoreFrameInst %1: object, [var3]: any
 // CHKIR-NEXT:  %11 = UnaryIncInst (:any) %8: any
-// CHKIR-NEXT:  %12 = BinaryLessThanInst (:any) %11: any, 2: number
-// CHKIR-NEXT:        CondBranchInst %12: any, %BB1, %BB2
+// CHKIR-NEXT:  %12 = BinaryLessThanInst (:boolean) %11: any, 2: number
+// CHKIR-NEXT:        CondBranchInst %12: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB2:
 // CHKIR-NEXT:  %14 = PhiInst (:any) 0: number, %BB0, %11: any, %BB1
 // CHKIR-NEXT:  %15 = LoadFrameInst (:any) [var3]: any
@@ -551,15 +551,15 @@ function decrementArguments() {
 // CHKIR-NEXT:  %3 = CoerceThisNSInst (:object) %2: any
 // CHKIR-NEXT:  %4 = GetNewTargetInst (:undefined|object) %new.target: undefined|object
 // CHKIR-NEXT:       StoreFrameInst undefined: undefined, [var3]: any
-// CHKIR-NEXT:  %6 = BinaryLessThanInst (:any) 0: number, 2: number
-// CHKIR-NEXT:       CondBranchInst %6: any, %BB1, %BB2
+// CHKIR-NEXT:  %6 = BinaryLessThanInst (:boolean) 0: number, 2: number
+// CHKIR-NEXT:       CondBranchInst %6: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB1:
 // CHKIR-NEXT:  %8 = PhiInst (:any) 0: number, %BB0, %11: any, %BB1
 // CHKIR-NEXT:  %9 = CreateFunctionInst (:object) %var1(): any
 // CHKIR-NEXT:        StoreFrameInst %1: object, [var3]: any
 // CHKIR-NEXT:  %11 = UnaryIncInst (:any) %8: any
-// CHKIR-NEXT:  %12 = BinaryLessThanInst (:any) %11: any, 2: number
-// CHKIR-NEXT:        CondBranchInst %12: any, %BB1, %BB2
+// CHKIR-NEXT:  %12 = BinaryLessThanInst (:boolean) %11: any, 2: number
+// CHKIR-NEXT:        CondBranchInst %12: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB2:
 // CHKIR-NEXT:  %14 = PhiInst (:any) 0: number, %BB0, %11: any, %BB1
 // CHKIR-NEXT:  %15 = LoadFrameInst (:any) [var3]: any
@@ -594,15 +594,15 @@ function decrementArguments() {
 // CHKIR-NEXT:  %3 = CoerceThisNSInst (:object) %2: any
 // CHKIR-NEXT:  %4 = GetNewTargetInst (:undefined|object) %new.target: undefined|object
 // CHKIR-NEXT:       StoreFrameInst undefined: undefined, [var3]: any
-// CHKIR-NEXT:  %6 = BinaryLessThanInst (:any) 0: number, 2: number
-// CHKIR-NEXT:       CondBranchInst %6: any, %BB1, %BB2
+// CHKIR-NEXT:  %6 = BinaryLessThanInst (:boolean) 0: number, 2: number
+// CHKIR-NEXT:       CondBranchInst %6: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB1:
 // CHKIR-NEXT:  %8 = PhiInst (:any) 0: number, %BB0, %11: any, %BB1
 // CHKIR-NEXT:  %9 = CreateFunctionInst (:object) %var1(): any
 // CHKIR-NEXT:        StoreFrameInst %1: object, [var3]: any
 // CHKIR-NEXT:  %11 = UnaryIncInst (:any) %8: any
-// CHKIR-NEXT:  %12 = BinaryLessThanInst (:any) %11: any, 2: number
-// CHKIR-NEXT:        CondBranchInst %12: any, %BB1, %BB2
+// CHKIR-NEXT:  %12 = BinaryLessThanInst (:boolean) %11: any, 2: number
+// CHKIR-NEXT:        CondBranchInst %12: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB2:
 // CHKIR-NEXT:  %14 = PhiInst (:any) 0: number, %BB0, %11: any, %BB1
 // CHKIR-NEXT:  %15 = LoadFrameInst (:any) [var3]: any
@@ -637,15 +637,15 @@ function decrementArguments() {
 // CHKIR-NEXT:  %3 = CoerceThisNSInst (:object) %2: any
 // CHKIR-NEXT:  %4 = GetNewTargetInst (:undefined|object) %new.target: undefined|object
 // CHKIR-NEXT:       StoreFrameInst undefined: undefined, [var3]: any
-// CHKIR-NEXT:  %6 = BinaryLessThanInst (:any) 0: number, 2: number
-// CHKIR-NEXT:       CondBranchInst %6: any, %BB1, %BB2
+// CHKIR-NEXT:  %6 = BinaryLessThanInst (:boolean) 0: number, 2: number
+// CHKIR-NEXT:       CondBranchInst %6: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB1:
 // CHKIR-NEXT:  %8 = PhiInst (:any) 0: number, %BB0, %11: any, %BB1
 // CHKIR-NEXT:  %9 = CreateFunctionInst (:object) %var1(): any
 // CHKIR-NEXT:        StoreFrameInst %1: object, [var3]: any
 // CHKIR-NEXT:  %11 = UnaryIncInst (:any) %8: any
-// CHKIR-NEXT:  %12 = BinaryLessThanInst (:any) %11: any, 2: number
-// CHKIR-NEXT:        CondBranchInst %12: any, %BB1, %BB2
+// CHKIR-NEXT:  %12 = BinaryLessThanInst (:boolean) %11: any, 2: number
+// CHKIR-NEXT:        CondBranchInst %12: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB2:
 // CHKIR-NEXT:  %14 = PhiInst (:any) 0: number, %BB0, %11: any, %BB1
 // CHKIR-NEXT:  %15 = LoadFrameInst (:any) [var3]: any
@@ -676,14 +676,14 @@ function decrementArguments() {
 // CHKIR-NEXT:%BB0:
 // CHKIR-NEXT:  %0 = CreateArgumentsLooseInst (:object)
 // CHKIR-NEXT:       StoreFrameInst undefined: undefined, [var3]: any
-// CHKIR-NEXT:  %2 = BinaryLessThanInst (:any) 0: number, 2: number
-// CHKIR-NEXT:       CondBranchInst %2: any, %BB1, %BB2
+// CHKIR-NEXT:  %2 = BinaryLessThanInst (:boolean) 0: number, 2: number
+// CHKIR-NEXT:       CondBranchInst %2: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB1:
 // CHKIR-NEXT:  %4 = PhiInst (:any) 0: number, %BB0, %6: any, %BB1
 // CHKIR-NEXT:       StoreFrameInst %0: object, [var3]: any
 // CHKIR-NEXT:  %6 = UnaryIncInst (:any) %4: any
-// CHKIR-NEXT:  %7 = BinaryLessThanInst (:any) %6: any, 2: number
-// CHKIR-NEXT:       CondBranchInst %7: any, %BB1, %BB2
+// CHKIR-NEXT:  %7 = BinaryLessThanInst (:boolean) %6: any, 2: number
+// CHKIR-NEXT:       CondBranchInst %7: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB2:
 // CHKIR-NEXT:  %9 = LoadFrameInst (:any) [var3]: any
 // CHKIR-NEXT:  %10 = BinarySubtractInst (:any) %9: any, 1: number
@@ -706,14 +706,14 @@ function decrementArguments() {
 // CHKIR-NEXT:%BB0:
 // CHKIR-NEXT:  %0 = CreateArgumentsLooseInst (:object)
 // CHKIR-NEXT:       StoreFrameInst undefined: undefined, [var3]: any
-// CHKIR-NEXT:  %2 = BinaryLessThanInst (:any) 0: number, 2: number
-// CHKIR-NEXT:       CondBranchInst %2: any, %BB1, %BB2
+// CHKIR-NEXT:  %2 = BinaryLessThanInst (:boolean) 0: number, 2: number
+// CHKIR-NEXT:       CondBranchInst %2: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB1:
 // CHKIR-NEXT:  %4 = PhiInst (:any) 0: number, %BB0, %6: any, %BB1
 // CHKIR-NEXT:       StoreFrameInst %0: object, [var3]: any
 // CHKIR-NEXT:  %6 = UnaryIncInst (:any) %4: any
-// CHKIR-NEXT:  %7 = BinaryLessThanInst (:any) %6: any, 2: number
-// CHKIR-NEXT:       CondBranchInst %7: any, %BB1, %BB2
+// CHKIR-NEXT:  %7 = BinaryLessThanInst (:boolean) %6: any, 2: number
+// CHKIR-NEXT:       CondBranchInst %7: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB2:
 // CHKIR-NEXT:  %9 = LoadFrameInst (:any) [var3]: any
 // CHKIR-NEXT:  %10 = BinarySubtractInst (:any) %9: any, 1: number

--- a/test/BCGen/HBC/arguments-decrement.js
+++ b/test/BCGen/HBC/arguments-decrement.js
@@ -66,8 +66,8 @@ function decrementArguments() {
 // CHKIR-NEXT:%BB3:
 // CHKIR-NEXT:  %23 = LoadFrameInst (:any) [i]: any
 // CHKIR-NEXT:  %24 = AsNumericInst (:number|bigint) %23: any
-// CHKIR-NEXT:  %25 = UnaryIncInst (:any) %24: number|bigint
-// CHKIR-NEXT:        StoreFrameInst %25: any, [i]: any
+// CHKIR-NEXT:  %25 = UnaryIncInst (:number|bigint) %24: number|bigint
+// CHKIR-NEXT:        StoreFrameInst %25: number|bigint, [i]: any
 // CHKIR-NEXT:        BranchInst %BB4
 // CHKIR-NEXT:function_end
 
@@ -123,8 +123,8 @@ function decrementArguments() {
 // CHKIR-NEXT:        CondBranchInst %21: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB3:
 // CHKIR-NEXT:  %23 = LoadFrameInst (:any) [i]: any
-// CHKIR-NEXT:  %24 = UnaryIncInst (:any) %23: any
-// CHKIR-NEXT:        StoreFrameInst %24: any, [i]: any
+// CHKIR-NEXT:  %24 = UnaryIncInst (:number|bigint) %23: any
+// CHKIR-NEXT:        StoreFrameInst %24: number|bigint, [i]: any
 // CHKIR-NEXT:        BranchInst %BB4
 // CHKIR-NEXT:function_end
 
@@ -180,8 +180,8 @@ function decrementArguments() {
 // CHKIR-NEXT:        CondBranchInst %21: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB3:
 // CHKIR-NEXT:  %23 = LoadFrameInst (:any) [i]: any
-// CHKIR-NEXT:  %24 = UnaryIncInst (:any) %23: any
-// CHKIR-NEXT:        StoreFrameInst %24: any, [i]: any
+// CHKIR-NEXT:  %24 = UnaryIncInst (:number|bigint) %23: any
+// CHKIR-NEXT:        StoreFrameInst %24: number|bigint, [i]: any
 // CHKIR-NEXT:        BranchInst %BB4
 // CHKIR-NEXT:function_end
 
@@ -237,8 +237,8 @@ function decrementArguments() {
 // CHKIR-NEXT:        CondBranchInst %21: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB3:
 // CHKIR-NEXT:  %23 = LoadFrameInst (:any) [i]: any
-// CHKIR-NEXT:  %24 = UnaryIncInst (:any) %23: any
-// CHKIR-NEXT:        StoreFrameInst %24: any, [i]: any
+// CHKIR-NEXT:  %24 = UnaryIncInst (:number|bigint) %23: any
+// CHKIR-NEXT:        StoreFrameInst %24: number|bigint, [i]: any
 // CHKIR-NEXT:        BranchInst %BB4
 // CHKIR-NEXT:function_end
 
@@ -284,8 +284,8 @@ function decrementArguments() {
 // CHKIR-NEXT:        StoreFrameInst %13: object, [var1]: any
 // CHKIR-NEXT:        StoreFrameInst %0: object, [var3]: any
 // CHKIR-NEXT:  %16 = LoadFrameInst (:any) [i]: any
-// CHKIR-NEXT:  %17 = UnaryIncInst (:any) %16: any
-// CHKIR-NEXT:        StoreFrameInst %17: any, [i]: any
+// CHKIR-NEXT:  %17 = UnaryIncInst (:number|bigint) %16: any
+// CHKIR-NEXT:        StoreFrameInst %17: number|bigint, [i]: any
 // CHKIR-NEXT:  %19 = LoadFrameInst (:any) [i]: any
 // CHKIR-NEXT:  %20 = BinaryLessThanInst (:boolean) %19: any, 2: number
 // CHKIR-NEXT:        CondBranchInst %20: boolean, %BB1, %BB2
@@ -334,8 +334,8 @@ function decrementArguments() {
 // CHKIR-NEXT:  %11 = CreateFunctionInst (:object) %var1(): any
 // CHKIR-NEXT:        StoreFrameInst %1: object, [var3]: any
 // CHKIR-NEXT:  %13 = LoadStackInst (:any) %0: any
-// CHKIR-NEXT:  %14 = UnaryIncInst (:any) %13: any
-// CHKIR-NEXT:        StoreStackInst %14: any, %0: any
+// CHKIR-NEXT:  %14 = UnaryIncInst (:number|bigint) %13: any
+// CHKIR-NEXT:        StoreStackInst %14: number|bigint, %0: any
 // CHKIR-NEXT:  %16 = LoadStackInst (:any) %0: any
 // CHKIR-NEXT:  %17 = BinaryLessThanInst (:boolean) %16: any, 2: number
 // CHKIR-NEXT:        CondBranchInst %17: boolean, %BB1, %BB2
@@ -384,8 +384,8 @@ function decrementArguments() {
 // CHKIR-NEXT:  %11 = CreateFunctionInst (:object) %var1(): any
 // CHKIR-NEXT:        StoreFrameInst %1: object, [var3]: any
 // CHKIR-NEXT:  %13 = LoadStackInst (:any) %0: any
-// CHKIR-NEXT:  %14 = UnaryIncInst (:any) %13: any
-// CHKIR-NEXT:        StoreStackInst %14: any, %0: any
+// CHKIR-NEXT:  %14 = UnaryIncInst (:number|bigint) %13: any
+// CHKIR-NEXT:        StoreStackInst %14: number|bigint, %0: any
 // CHKIR-NEXT:  %16 = LoadStackInst (:any) %0: any
 // CHKIR-NEXT:  %17 = BinaryLessThanInst (:boolean) %16: any, 2: number
 // CHKIR-NEXT:        CondBranchInst %17: boolean, %BB1, %BB2
@@ -425,14 +425,14 @@ function decrementArguments() {
 // CHKIR-NEXT:  %6 = BinaryLessThanInst (:boolean) 0: number, 2: number
 // CHKIR-NEXT:       CondBranchInst %6: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB1:
-// CHKIR-NEXT:  %8 = PhiInst (:any) 0: number, %BB0, %11: any, %BB1
+// CHKIR-NEXT:  %8 = PhiInst (:any) 0: number, %BB0, %11: number|bigint, %BB1
 // CHKIR-NEXT:  %9 = CreateFunctionInst (:object) %var1(): any
 // CHKIR-NEXT:        StoreFrameInst %1: object, [var3]: any
-// CHKIR-NEXT:  %11 = UnaryIncInst (:any) %8: any
-// CHKIR-NEXT:  %12 = BinaryLessThanInst (:boolean) %11: any, 2: number
+// CHKIR-NEXT:  %11 = UnaryIncInst (:number|bigint) %8: any
+// CHKIR-NEXT:  %12 = BinaryLessThanInst (:boolean) %11: number|bigint, 2: number
 // CHKIR-NEXT:        CondBranchInst %12: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB2:
-// CHKIR-NEXT:  %14 = PhiInst (:any) 0: number, %BB0, %11: any, %BB1
+// CHKIR-NEXT:  %14 = PhiInst (:any) 0: number, %BB0, %11: number|bigint, %BB1
 // CHKIR-NEXT:  %15 = LoadFrameInst (:any) [var3]: any
 // CHKIR-NEXT:  %16 = BinarySubtractInst (:any) %15: any, 1: number
 // CHKIR-NEXT:        ReturnInst %16: any
@@ -468,14 +468,14 @@ function decrementArguments() {
 // CHKIR-NEXT:  %6 = BinaryLessThanInst (:boolean) 0: number, 2: number
 // CHKIR-NEXT:       CondBranchInst %6: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB1:
-// CHKIR-NEXT:  %8 = PhiInst (:any) 0: number, %BB0, %11: any, %BB1
+// CHKIR-NEXT:  %8 = PhiInst (:any) 0: number, %BB0, %11: number|bigint, %BB1
 // CHKIR-NEXT:  %9 = CreateFunctionInst (:object) %var1(): any
 // CHKIR-NEXT:        StoreFrameInst %1: object, [var3]: any
-// CHKIR-NEXT:  %11 = UnaryIncInst (:any) %8: any
-// CHKIR-NEXT:  %12 = BinaryLessThanInst (:boolean) %11: any, 2: number
+// CHKIR-NEXT:  %11 = UnaryIncInst (:number|bigint) %8: any
+// CHKIR-NEXT:  %12 = BinaryLessThanInst (:boolean) %11: number|bigint, 2: number
 // CHKIR-NEXT:        CondBranchInst %12: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB2:
-// CHKIR-NEXT:  %14 = PhiInst (:any) 0: number, %BB0, %11: any, %BB1
+// CHKIR-NEXT:  %14 = PhiInst (:any) 0: number, %BB0, %11: number|bigint, %BB1
 // CHKIR-NEXT:  %15 = LoadFrameInst (:any) [var3]: any
 // CHKIR-NEXT:  %16 = BinarySubtractInst (:any) %15: any, 1: number
 // CHKIR-NEXT:        ReturnInst %16: any
@@ -511,14 +511,14 @@ function decrementArguments() {
 // CHKIR-NEXT:  %6 = BinaryLessThanInst (:boolean) 0: number, 2: number
 // CHKIR-NEXT:       CondBranchInst %6: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB1:
-// CHKIR-NEXT:  %8 = PhiInst (:any) 0: number, %BB0, %11: any, %BB1
+// CHKIR-NEXT:  %8 = PhiInst (:any) 0: number, %BB0, %11: number|bigint, %BB1
 // CHKIR-NEXT:  %9 = CreateFunctionInst (:object) %var1(): any
 // CHKIR-NEXT:        StoreFrameInst %1: object, [var3]: any
-// CHKIR-NEXT:  %11 = UnaryIncInst (:any) %8: any
-// CHKIR-NEXT:  %12 = BinaryLessThanInst (:boolean) %11: any, 2: number
+// CHKIR-NEXT:  %11 = UnaryIncInst (:number|bigint) %8: any
+// CHKIR-NEXT:  %12 = BinaryLessThanInst (:boolean) %11: number|bigint, 2: number
 // CHKIR-NEXT:        CondBranchInst %12: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB2:
-// CHKIR-NEXT:  %14 = PhiInst (:any) 0: number, %BB0, %11: any, %BB1
+// CHKIR-NEXT:  %14 = PhiInst (:any) 0: number, %BB0, %11: number|bigint, %BB1
 // CHKIR-NEXT:  %15 = LoadFrameInst (:any) [var3]: any
 // CHKIR-NEXT:  %16 = BinarySubtractInst (:any) %15: any, 1: number
 // CHKIR-NEXT:        ReturnInst %16: any
@@ -554,14 +554,14 @@ function decrementArguments() {
 // CHKIR-NEXT:  %6 = BinaryLessThanInst (:boolean) 0: number, 2: number
 // CHKIR-NEXT:       CondBranchInst %6: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB1:
-// CHKIR-NEXT:  %8 = PhiInst (:any) 0: number, %BB0, %11: any, %BB1
+// CHKIR-NEXT:  %8 = PhiInst (:any) 0: number, %BB0, %11: number|bigint, %BB1
 // CHKIR-NEXT:  %9 = CreateFunctionInst (:object) %var1(): any
 // CHKIR-NEXT:        StoreFrameInst %1: object, [var3]: any
-// CHKIR-NEXT:  %11 = UnaryIncInst (:any) %8: any
-// CHKIR-NEXT:  %12 = BinaryLessThanInst (:boolean) %11: any, 2: number
+// CHKIR-NEXT:  %11 = UnaryIncInst (:number|bigint) %8: any
+// CHKIR-NEXT:  %12 = BinaryLessThanInst (:boolean) %11: number|bigint, 2: number
 // CHKIR-NEXT:        CondBranchInst %12: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB2:
-// CHKIR-NEXT:  %14 = PhiInst (:any) 0: number, %BB0, %11: any, %BB1
+// CHKIR-NEXT:  %14 = PhiInst (:any) 0: number, %BB0, %11: number|bigint, %BB1
 // CHKIR-NEXT:  %15 = LoadFrameInst (:any) [var3]: any
 // CHKIR-NEXT:  %16 = BinarySubtractInst (:any) %15: any, 1: number
 // CHKIR-NEXT:        ReturnInst %16: any
@@ -597,14 +597,14 @@ function decrementArguments() {
 // CHKIR-NEXT:  %6 = BinaryLessThanInst (:boolean) 0: number, 2: number
 // CHKIR-NEXT:       CondBranchInst %6: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB1:
-// CHKIR-NEXT:  %8 = PhiInst (:any) 0: number, %BB0, %11: any, %BB1
+// CHKIR-NEXT:  %8 = PhiInst (:any) 0: number, %BB0, %11: number|bigint, %BB1
 // CHKIR-NEXT:  %9 = CreateFunctionInst (:object) %var1(): any
 // CHKIR-NEXT:        StoreFrameInst %1: object, [var3]: any
-// CHKIR-NEXT:  %11 = UnaryIncInst (:any) %8: any
-// CHKIR-NEXT:  %12 = BinaryLessThanInst (:boolean) %11: any, 2: number
+// CHKIR-NEXT:  %11 = UnaryIncInst (:number|bigint) %8: any
+// CHKIR-NEXT:  %12 = BinaryLessThanInst (:boolean) %11: number|bigint, 2: number
 // CHKIR-NEXT:        CondBranchInst %12: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB2:
-// CHKIR-NEXT:  %14 = PhiInst (:any) 0: number, %BB0, %11: any, %BB1
+// CHKIR-NEXT:  %14 = PhiInst (:any) 0: number, %BB0, %11: number|bigint, %BB1
 // CHKIR-NEXT:  %15 = LoadFrameInst (:any) [var3]: any
 // CHKIR-NEXT:  %16 = BinarySubtractInst (:any) %15: any, 1: number
 // CHKIR-NEXT:        ReturnInst %16: any
@@ -640,14 +640,14 @@ function decrementArguments() {
 // CHKIR-NEXT:  %6 = BinaryLessThanInst (:boolean) 0: number, 2: number
 // CHKIR-NEXT:       CondBranchInst %6: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB1:
-// CHKIR-NEXT:  %8 = PhiInst (:any) 0: number, %BB0, %11: any, %BB1
+// CHKIR-NEXT:  %8 = PhiInst (:any) 0: number, %BB0, %11: number|bigint, %BB1
 // CHKIR-NEXT:  %9 = CreateFunctionInst (:object) %var1(): any
 // CHKIR-NEXT:        StoreFrameInst %1: object, [var3]: any
-// CHKIR-NEXT:  %11 = UnaryIncInst (:any) %8: any
-// CHKIR-NEXT:  %12 = BinaryLessThanInst (:boolean) %11: any, 2: number
+// CHKIR-NEXT:  %11 = UnaryIncInst (:number|bigint) %8: any
+// CHKIR-NEXT:  %12 = BinaryLessThanInst (:boolean) %11: number|bigint, 2: number
 // CHKIR-NEXT:        CondBranchInst %12: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB2:
-// CHKIR-NEXT:  %14 = PhiInst (:any) 0: number, %BB0, %11: any, %BB1
+// CHKIR-NEXT:  %14 = PhiInst (:any) 0: number, %BB0, %11: number|bigint, %BB1
 // CHKIR-NEXT:  %15 = LoadFrameInst (:any) [var3]: any
 // CHKIR-NEXT:  %16 = BinarySubtractInst (:any) %15: any, 1: number
 // CHKIR-NEXT:        ReturnInst %16: any
@@ -679,10 +679,10 @@ function decrementArguments() {
 // CHKIR-NEXT:  %2 = BinaryLessThanInst (:boolean) 0: number, 2: number
 // CHKIR-NEXT:       CondBranchInst %2: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB1:
-// CHKIR-NEXT:  %4 = PhiInst (:any) 0: number, %BB0, %6: any, %BB1
+// CHKIR-NEXT:  %4 = PhiInst (:any) 0: number, %BB0, %6: number|bigint, %BB1
 // CHKIR-NEXT:       StoreFrameInst %0: object, [var3]: any
-// CHKIR-NEXT:  %6 = UnaryIncInst (:any) %4: any
-// CHKIR-NEXT:  %7 = BinaryLessThanInst (:boolean) %6: any, 2: number
+// CHKIR-NEXT:  %6 = UnaryIncInst (:number|bigint) %4: any
+// CHKIR-NEXT:  %7 = BinaryLessThanInst (:boolean) %6: number|bigint, 2: number
 // CHKIR-NEXT:       CondBranchInst %7: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB2:
 // CHKIR-NEXT:  %9 = LoadFrameInst (:any) [var3]: any
@@ -709,10 +709,10 @@ function decrementArguments() {
 // CHKIR-NEXT:  %2 = BinaryLessThanInst (:boolean) 0: number, 2: number
 // CHKIR-NEXT:       CondBranchInst %2: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB1:
-// CHKIR-NEXT:  %4 = PhiInst (:any) 0: number, %BB0, %6: any, %BB1
+// CHKIR-NEXT:  %4 = PhiInst (:any) 0: number, %BB0, %6: number|bigint, %BB1
 // CHKIR-NEXT:       StoreFrameInst %0: object, [var3]: any
-// CHKIR-NEXT:  %6 = UnaryIncInst (:any) %4: any
-// CHKIR-NEXT:  %7 = BinaryLessThanInst (:boolean) %6: any, 2: number
+// CHKIR-NEXT:  %6 = UnaryIncInst (:number|bigint) %4: any
+// CHKIR-NEXT:  %7 = BinaryLessThanInst (:boolean) %6: number|bigint, 2: number
 // CHKIR-NEXT:       CondBranchInst %7: boolean, %BB1, %BB2
 // CHKIR-NEXT:%BB2:
 // CHKIR-NEXT:  %9 = LoadFrameInst (:any) [var3]: any

--- a/test/BCGen/SH/tdz-unionnarrow.js
+++ b/test/BCGen/SH/tdz-unionnarrow.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// RUN: %shermes -Xcustom-opt=tdzdedup -dump-ir --test262 %s | %FileCheckOrRegen --check-prefix=CHKIR --match-full-lines %s
-// RUN: %shermes -Xcustom-opt=tdzdedup -dump-lir --test262 %s | %FileCheckOrRegen --check-prefix=CHKLIR --match-full-lines %s
+// RUN: %shermes -Xdump-functions=f1,f2,inner -Xcustom-opt=tdzdedup -dump-ir --test262 %s | %FileCheckOrRegen --check-prefix=CHKIR --match-full-lines %s
+// RUN: %shermes -Xdump-functions=f1,f2,inner -Xcustom-opt=tdzdedup -dump-lir --test262 %s | %FileCheckOrRegen --check-prefix=CHKLIR --match-full-lines %s
 
 // Verify that LIRDeadValueInst is emitted after TDZDedup has eliminated a ThrowIfEmpty
 function f1() {
@@ -25,21 +25,6 @@ function f2() {
 }
 
 // Auto-generated content below. Please do not modify manually.
-
-// CHKIR:function global(): any
-// CHKIR-NEXT:frame = []
-// CHKIR-NEXT:%BB0:
-// CHKIR-NEXT:       DeclareGlobalVarInst "f1": string
-// CHKIR-NEXT:       DeclareGlobalVarInst "f2": string
-// CHKIR-NEXT:  %2 = CreateFunctionInst (:object) %f1(): any
-// CHKIR-NEXT:       StorePropertyLooseInst %2: object, globalObject: object, "f1": string
-// CHKIR-NEXT:  %4 = CreateFunctionInst (:object) %f2(): any
-// CHKIR-NEXT:       StorePropertyLooseInst %4: object, globalObject: object, "f2": string
-// CHKIR-NEXT:  %6 = AllocStackInst (:any) $?anon_0_ret: any
-// CHKIR-NEXT:       StoreStackInst undefined: undefined, %6: any
-// CHKIR-NEXT:  %8 = LoadStackInst (:any) %6: any
-// CHKIR-NEXT:       ReturnInst %8: any
-// CHKIR-NEXT:function_end
 
 // CHKIR:function f1(): any
 // CHKIR-NEXT:frame = [x: any|empty]
@@ -72,24 +57,6 @@ function f2() {
 // CHKIR-NEXT:  %4 = UnionNarrowTrustedInst (:any) %3: any|empty
 // CHKIR-NEXT:       ReturnInst %4: any
 // CHKIR-NEXT:function_end
-
-// CHKLIR:function global(): undefined
-// CHKLIR-NEXT:frame = []
-// CHKLIR-NEXT:%BB0:
-// CHKLIR-NEXT:  %0 = HBCCreateEnvironmentInst (:environment)
-// CHKLIR-NEXT:       DeclareGlobalVarInst "f1": string
-// CHKLIR-NEXT:       DeclareGlobalVarInst "f2": string
-// CHKLIR-NEXT:  %3 = HBCCreateFunctionInst (:object) %f1(): string|number, %0: environment
-// CHKLIR-NEXT:  %4 = HBCGetGlobalObjectInst (:object)
-// CHKLIR-NEXT:       StorePropertyLooseInst %3: object, %4: object, "f1": string
-// CHKLIR-NEXT:  %6 = HBCCreateFunctionInst (:object) %f2(): undefined, %0: environment
-// CHKLIR-NEXT:       StorePropertyLooseInst %6: object, %4: object, "f2": string
-// CHKLIR-NEXT:  %8 = AllocStackInst (:undefined) $?anon_0_ret: any
-// CHKLIR-NEXT:  %9 = HBCLoadConstInst (:undefined) undefined: undefined
-// CHKLIR-NEXT:        StoreStackInst %9: undefined, %8: undefined
-// CHKLIR-NEXT:  %11 = LoadStackInst (:undefined) %8: undefined
-// CHKLIR-NEXT:        ReturnInst %11: undefined
-// CHKLIR-NEXT:function_end
 
 // CHKLIR:function f1(): string|number
 // CHKLIR-NEXT:frame = [x: empty]

--- a/test/IRGen/binary_operator.js
+++ b/test/IRGen/binary_operator.js
@@ -209,8 +209,8 @@
 // CHECK-NEXT:         StorePropertyLooseInst %106: any, %103: any, "t": string
 // CHECK-NEXT:  %108 = LoadFrameInst (:any) [x]: any
 // CHECK-NEXT:  %109 = LoadFrameInst (:any) [y]: any
-// CHECK-NEXT:  %110 = BinaryEqualInst (:any) %108: any, %109: any
-// CHECK-NEXT:         ReturnInst %110: any
+// CHECK-NEXT:  %110 = BinaryEqualInst (:boolean) %108: any, %109: any
+// CHECK-NEXT:         ReturnInst %110: boolean
 // CHECK-NEXT:function_end
 
 // CHECK:function assignment_test(x: any, y: any): any

--- a/test/IRGen/do_while.js
+++ b/test/IRGen/do_while.js
@@ -109,8 +109,8 @@ function for_while_do_mixed_test(cond) {
 // CHECK-NEXT:       StoreFrameInst undefined: undefined, [i]: any
 // CHECK-NEXT:       StoreFrameInst 0: number, [i]: any
 // CHECK-NEXT:  %4 = LoadFrameInst (:any) [i]: any
-// CHECK-NEXT:  %5 = BinaryLessThanInst (:any) %4: any, 10: number
-// CHECK-NEXT:       CondBranchInst %5: any, %BB1, %BB2
+// CHECK-NEXT:  %5 = BinaryLessThanInst (:boolean) %4: any, 10: number
+// CHECK-NEXT:       CondBranchInst %5: boolean, %BB1, %BB2
 // CHECK-NEXT:%BB1:
 // CHECK-NEXT:  %7 = LoadFrameInst (:any) [cond]: any
 // CHECK-NEXT:       CondBranchInst %7: any, %BB3, %BB4
@@ -118,8 +118,8 @@ function for_while_do_mixed_test(cond) {
 // CHECK-NEXT:       ReturnInst undefined: undefined
 // CHECK-NEXT:%BB5:
 // CHECK-NEXT:  %10 = LoadFrameInst (:any) [i]: any
-// CHECK-NEXT:  %11 = BinaryLessThanInst (:any) %10: any, 10: number
-// CHECK-NEXT:        CondBranchInst %11: any, %BB1, %BB2
+// CHECK-NEXT:  %11 = BinaryLessThanInst (:boolean) %10: any, 10: number
+// CHECK-NEXT:        CondBranchInst %11: boolean, %BB1, %BB2
 // CHECK-NEXT:%BB6:
 // CHECK-NEXT:  %13 = LoadFrameInst (:any) [i]: any
 // CHECK-NEXT:  %14 = AsNumericInst (:number|bigint) %13: any

--- a/test/IRGen/do_while.js
+++ b/test/IRGen/do_while.js
@@ -123,8 +123,8 @@ function for_while_do_mixed_test(cond) {
 // CHECK-NEXT:%BB6:
 // CHECK-NEXT:  %13 = LoadFrameInst (:any) [i]: any
 // CHECK-NEXT:  %14 = AsNumericInst (:number|bigint) %13: any
-// CHECK-NEXT:  %15 = UnaryIncInst (:any) %14: number|bigint
-// CHECK-NEXT:        StoreFrameInst %15: any, [i]: any
+// CHECK-NEXT:  %15 = UnaryIncInst (:number|bigint) %14: number|bigint
+// CHECK-NEXT:        StoreFrameInst %15: number|bigint, [i]: any
 // CHECK-NEXT:        BranchInst %BB5
 // CHECK-NEXT:%BB3:
 // CHECK-NEXT:        BranchInst %BB7

--- a/test/IRGen/es6/disable-tdz.js
+++ b/test/IRGen/es6/disable-tdz.js
@@ -52,10 +52,10 @@ function check1() {
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = LoadFrameInst (:any|empty) [x@check1]: any|empty
 // CHECK-NEXT:  %1 = ThrowIfInst (:any) %0: any|empty, type(empty)
-// CHECK-NEXT:  %2 = UnaryIncInst (:any) %1: any
+// CHECK-NEXT:  %2 = UnaryIncInst (:number|bigint) %1: any
 // CHECK-NEXT:  %3 = LoadFrameInst (:any|empty) [x@check1]: any|empty
 // CHECK-NEXT:  %4 = ThrowIfInst (:any) %3: any|empty, type(empty)
-// CHECK-NEXT:       StoreFrameInst %2: any, [x@check1]: any|empty
+// CHECK-NEXT:       StoreFrameInst %2: number|bigint, [x@check1]: any|empty
 // CHECK-NEXT:  %6 = LoadFrameInst (:any|empty) [y@check1]: any|empty
 // CHECK-NEXT:  %7 = ThrowIfInst (:any) %6: any|empty, type(empty)
 // CHECK-NEXT:       ReturnInst %7: any
@@ -91,8 +91,8 @@ function check1() {
 // CHKDIS-NEXT:frame = []
 // CHKDIS-NEXT:%BB0:
 // CHKDIS-NEXT:  %0 = LoadFrameInst (:any) [x@check1]: any
-// CHKDIS-NEXT:  %1 = UnaryIncInst (:any) %0: any
-// CHKDIS-NEXT:       StoreFrameInst %1: any, [x@check1]: any
+// CHKDIS-NEXT:  %1 = UnaryIncInst (:number|bigint) %0: any
+// CHKDIS-NEXT:       StoreFrameInst %1: number|bigint, [x@check1]: any
 // CHKDIS-NEXT:  %3 = LoadFrameInst (:any) [y@check1]: any
 // CHKDIS-NEXT:       ReturnInst %3: any
 // CHKDIS-NEXT:function_end

--- a/test/IRGen/es6/for-let-tdz.js
+++ b/test/IRGen/es6/for-let-tdz.js
@@ -118,8 +118,8 @@ function foo_var() {
 // CHECK-NEXT:  %19 = LoadFrameInst (:any) [i#1]: any
 // CHECK-NEXT:  %20 = UnaryIncInst (:any) %19: any
 // CHECK-NEXT:        StoreFrameInst %20: any, [i#1]: any
-// CHECK-NEXT:  %22 = BinaryLessThanInst (:any) %20: any, 10: number
-// CHECK-NEXT:        CondBranchInst %22: any, %BB4, %BB5
+// CHECK-NEXT:  %22 = BinaryLessThanInst (:boolean) %20: any, 10: number
+// CHECK-NEXT:        CondBranchInst %22: boolean, %BB4, %BB5
 // CHECK-NEXT:%BB3:
 // CHECK-NEXT:  %24 = LoadPropertyInst (:any) globalObject: object, "arr": string
 // CHECK-NEXT:  %25 = LoadPropertyInst (:any) %24: any, "push": string
@@ -170,8 +170,8 @@ function foo_var() {
 // CHECK-NEXT:  %15 = LoadFrameInst (:any) [i#1]: any
 // CHECK-NEXT:  %16 = UnaryIncInst (:any) %15: any
 // CHECK-NEXT:        StoreFrameInst %16: any, [i#1]: any
-// CHECK-NEXT:  %18 = BinaryLessThanInst (:any) %16: any, 10: number
-// CHECK-NEXT:        CondBranchInst %18: any, %BB4, %BB5
+// CHECK-NEXT:  %18 = BinaryLessThanInst (:boolean) %16: any, 10: number
+// CHECK-NEXT:        CondBranchInst %18: boolean, %BB4, %BB5
 // CHECK-NEXT:%BB3:
 // CHECK-NEXT:  %20 = LoadPropertyInst (:any) globalObject: object, "arr": string
 // CHECK-NEXT:  %21 = LoadPropertyInst (:any) %20: any, "push": string
@@ -221,8 +221,8 @@ function foo_var() {
 // CHECK-NEXT:  %15 = LoadFrameInst (:any) [i#1]: any
 // CHECK-NEXT:  %16 = UnaryIncInst (:any) %15: any
 // CHECK-NEXT:        StoreFrameInst %16: any, [i#1]: any
-// CHECK-NEXT:  %18 = BinaryLessThanInst (:any) %16: any, 10: number
-// CHECK-NEXT:        CondBranchInst %18: any, %BB2, %BB3
+// CHECK-NEXT:  %18 = BinaryLessThanInst (:boolean) %16: any, 10: number
+// CHECK-NEXT:        CondBranchInst %18: boolean, %BB2, %BB3
 // CHECK-NEXT:%BB2:
 // CHECK-NEXT:  %20 = LoadPropertyInst (:any) globalObject: object, "arr": string
 // CHECK-NEXT:  %21 = LoadPropertyInst (:any) %20: any, "push": string
@@ -258,8 +258,8 @@ function foo_var() {
 // CHECK-NEXT:  %8 = UnionNarrowTrustedInst (:any) %7: any|empty
 // CHECK-NEXT:  %9 = UnaryIncInst (:any) %8: any
 // CHECK-NEXT:        StoreFrameInst %9: any, [i]: any|empty
-// CHECK-NEXT:  %11 = BinaryLessThanInst (:any) %9: any, 10: number
-// CHECK-NEXT:        CondBranchInst %11: any, %BB1, %BB2
+// CHECK-NEXT:  %11 = BinaryLessThanInst (:boolean) %9: any, 10: number
+// CHECK-NEXT:        CondBranchInst %11: boolean, %BB1, %BB2
 // CHECK-NEXT:%BB1:
 // CHECK-NEXT:        BranchInst %BB3
 // CHECK-NEXT:%BB3:
@@ -287,8 +287,8 @@ function foo_var() {
 // CHECK-NEXT:  %33 = UnionNarrowTrustedInst (:any) %32: any|empty
 // CHECK-NEXT:  %34 = UnaryIncInst (:any) %33: any
 // CHECK-NEXT:        StoreFrameInst %34: any, [i]: any|empty
-// CHECK-NEXT:  %36 = BinaryLessThanInst (:any) %34: any, 10: number
-// CHECK-NEXT:        CondBranchInst %36: any, %BB3, %BB2
+// CHECK-NEXT:  %36 = BinaryLessThanInst (:boolean) %34: any, 10: number
+// CHECK-NEXT:        CondBranchInst %36: boolean, %BB3, %BB2
 // CHECK-NEXT:%BB2:
 // CHECK-NEXT:        ReturnInst undefined: undefined
 // CHECK-NEXT:function_end
@@ -302,8 +302,8 @@ function foo_var() {
 // CHECK-NEXT:  %3 = UnionNarrowTrustedInst (:any) %2: any|empty
 // CHECK-NEXT:  %4 = UnaryIncInst (:any) %3: any
 // CHECK-NEXT:       StoreFrameInst %4: any, [i]: any|empty
-// CHECK-NEXT:  %6 = BinaryLessThanInst (:any) %4: any, 10: number
-// CHECK-NEXT:       CondBranchInst %6: any, %BB1, %BB2
+// CHECK-NEXT:  %6 = BinaryLessThanInst (:boolean) %4: any, 10: number
+// CHECK-NEXT:       CondBranchInst %6: boolean, %BB1, %BB2
 // CHECK-NEXT:%BB1:
 // CHECK-NEXT:  %8 = TryLoadGlobalPropertyInst (:any) globalObject: object, "print": string
 // CHECK-NEXT:  %9 = LoadFrameInst (:any|empty) [i]: any|empty
@@ -317,8 +317,8 @@ function foo_var() {
 // CHECK-NEXT:  %15 = UnionNarrowTrustedInst (:any) %14: any|empty
 // CHECK-NEXT:  %16 = UnaryIncInst (:any) %15: any
 // CHECK-NEXT:        StoreFrameInst %16: any, [i]: any|empty
-// CHECK-NEXT:  %18 = BinaryLessThanInst (:any) %16: any, 10: number
-// CHECK-NEXT:        CondBranchInst %18: any, %BB1, %BB2
+// CHECK-NEXT:  %18 = BinaryLessThanInst (:boolean) %16: any, 10: number
+// CHECK-NEXT:        CondBranchInst %18: boolean, %BB1, %BB2
 // CHECK-NEXT:%BB3:
 // CHECK-NEXT:  %20 = LoadFrameInst (:any|empty) [i]: any|empty
 // CHECK-NEXT:  %21 = UnionNarrowTrustedInst (:any) %20: any|empty
@@ -335,8 +335,8 @@ function foo_var() {
 // CHECK-NEXT:  %2 = LoadFrameInst (:any) [i]: any
 // CHECK-NEXT:  %3 = UnaryIncInst (:any) %2: any
 // CHECK-NEXT:       StoreFrameInst %3: any, [i]: any
-// CHECK-NEXT:  %5 = BinaryLessThanInst (:any) %3: any, 10: number
-// CHECK-NEXT:       CondBranchInst %5: any, %BB1, %BB2
+// CHECK-NEXT:  %5 = BinaryLessThanInst (:boolean) %3: any, 10: number
+// CHECK-NEXT:       CondBranchInst %5: boolean, %BB1, %BB2
 // CHECK-NEXT:%BB1:
 // CHECK-NEXT:  %7 = TryLoadGlobalPropertyInst (:any) globalObject: object, "print": string
 // CHECK-NEXT:  %8 = LoadFrameInst (:any) [i]: any
@@ -348,8 +348,8 @@ function foo_var() {
 // CHECK-NEXT:  %12 = LoadFrameInst (:any) [i]: any
 // CHECK-NEXT:  %13 = UnaryIncInst (:any) %12: any
 // CHECK-NEXT:        StoreFrameInst %13: any, [i]: any
-// CHECK-NEXT:  %15 = BinaryLessThanInst (:any) %13: any, 10: number
-// CHECK-NEXT:        CondBranchInst %15: any, %BB1, %BB2
+// CHECK-NEXT:  %15 = BinaryLessThanInst (:boolean) %13: any, 10: number
+// CHECK-NEXT:        CondBranchInst %15: boolean, %BB1, %BB2
 // CHECK-NEXT:%BB3:
 // CHECK-NEXT:  %17 = LoadFrameInst (:any) [i]: any
 // CHECK-NEXT:  %18 = BinaryAddInst (:any) %17: any, 2: number

--- a/test/IRGen/es6/for-let-tdz.js
+++ b/test/IRGen/es6/for-let-tdz.js
@@ -116,9 +116,9 @@ function foo_var() {
 // CHECK-NEXT:  %17 = CreateFunctionInst (:object) %" 1#"(): any
 // CHECK-NEXT:  %18 = CallInst (:any) %16: any, empty: any, empty: any, undefined: undefined, %15: any, %17: object
 // CHECK-NEXT:  %19 = LoadFrameInst (:any) [i#1]: any
-// CHECK-NEXT:  %20 = UnaryIncInst (:any) %19: any
-// CHECK-NEXT:        StoreFrameInst %20: any, [i#1]: any
-// CHECK-NEXT:  %22 = BinaryLessThanInst (:boolean) %20: any, 10: number
+// CHECK-NEXT:  %20 = UnaryIncInst (:number|bigint) %19: any
+// CHECK-NEXT:        StoreFrameInst %20: number|bigint, [i#1]: any
+// CHECK-NEXT:  %22 = BinaryLessThanInst (:boolean) %20: number|bigint, 10: number
 // CHECK-NEXT:        CondBranchInst %22: boolean, %BB4, %BB5
 // CHECK-NEXT:%BB3:
 // CHECK-NEXT:  %24 = LoadPropertyInst (:any) globalObject: object, "arr": string
@@ -168,9 +168,9 @@ function foo_var() {
 // CHECK-NEXT:        CondBranchInst %13: boolean, %BB2, %BB3
 // CHECK-NEXT:%BB2:
 // CHECK-NEXT:  %15 = LoadFrameInst (:any) [i#1]: any
-// CHECK-NEXT:  %16 = UnaryIncInst (:any) %15: any
-// CHECK-NEXT:        StoreFrameInst %16: any, [i#1]: any
-// CHECK-NEXT:  %18 = BinaryLessThanInst (:boolean) %16: any, 10: number
+// CHECK-NEXT:  %16 = UnaryIncInst (:number|bigint) %15: any
+// CHECK-NEXT:        StoreFrameInst %16: number|bigint, [i#1]: any
+// CHECK-NEXT:  %18 = BinaryLessThanInst (:boolean) %16: number|bigint, 10: number
 // CHECK-NEXT:        CondBranchInst %18: boolean, %BB4, %BB5
 // CHECK-NEXT:%BB3:
 // CHECK-NEXT:  %20 = LoadPropertyInst (:any) globalObject: object, "arr": string
@@ -219,9 +219,9 @@ function foo_var() {
 // CHECK-NEXT:  %13 = CreateFunctionInst (:object) %" 5#"(): any
 // CHECK-NEXT:  %14 = CallInst (:any) %12: any, empty: any, empty: any, undefined: undefined, %11: any, %13: object
 // CHECK-NEXT:  %15 = LoadFrameInst (:any) [i#1]: any
-// CHECK-NEXT:  %16 = UnaryIncInst (:any) %15: any
-// CHECK-NEXT:        StoreFrameInst %16: any, [i#1]: any
-// CHECK-NEXT:  %18 = BinaryLessThanInst (:boolean) %16: any, 10: number
+// CHECK-NEXT:  %16 = UnaryIncInst (:number|bigint) %15: any
+// CHECK-NEXT:        StoreFrameInst %16: number|bigint, [i#1]: any
+// CHECK-NEXT:  %18 = BinaryLessThanInst (:boolean) %16: number|bigint, 10: number
 // CHECK-NEXT:        CondBranchInst %18: boolean, %BB2, %BB3
 // CHECK-NEXT:%BB2:
 // CHECK-NEXT:  %20 = LoadPropertyInst (:any) globalObject: object, "arr": string
@@ -256,9 +256,9 @@ function foo_var() {
 // CHECK-NEXT:       StoreFrameInst 0: number, [i]: any|empty
 // CHECK-NEXT:  %7 = LoadFrameInst (:any|empty) [i]: any|empty
 // CHECK-NEXT:  %8 = UnionNarrowTrustedInst (:any) %7: any|empty
-// CHECK-NEXT:  %9 = UnaryIncInst (:any) %8: any
-// CHECK-NEXT:        StoreFrameInst %9: any, [i]: any|empty
-// CHECK-NEXT:  %11 = BinaryLessThanInst (:boolean) %9: any, 10: number
+// CHECK-NEXT:  %9 = UnaryIncInst (:number|bigint) %8: any
+// CHECK-NEXT:        StoreFrameInst %9: number|bigint, [i]: any|empty
+// CHECK-NEXT:  %11 = BinaryLessThanInst (:boolean) %9: number|bigint, 10: number
 // CHECK-NEXT:        CondBranchInst %11: boolean, %BB1, %BB2
 // CHECK-NEXT:%BB1:
 // CHECK-NEXT:        BranchInst %BB3
@@ -285,9 +285,9 @@ function foo_var() {
 // CHECK-NEXT:        StoreFrameInst %30: any, [i]: any|empty
 // CHECK-NEXT:  %32 = LoadFrameInst (:any|empty) [i]: any|empty
 // CHECK-NEXT:  %33 = UnionNarrowTrustedInst (:any) %32: any|empty
-// CHECK-NEXT:  %34 = UnaryIncInst (:any) %33: any
-// CHECK-NEXT:        StoreFrameInst %34: any, [i]: any|empty
-// CHECK-NEXT:  %36 = BinaryLessThanInst (:boolean) %34: any, 10: number
+// CHECK-NEXT:  %34 = UnaryIncInst (:number|bigint) %33: any
+// CHECK-NEXT:        StoreFrameInst %34: number|bigint, [i]: any|empty
+// CHECK-NEXT:  %36 = BinaryLessThanInst (:boolean) %34: number|bigint, 10: number
 // CHECK-NEXT:        CondBranchInst %36: boolean, %BB3, %BB2
 // CHECK-NEXT:%BB2:
 // CHECK-NEXT:        ReturnInst undefined: undefined
@@ -300,9 +300,9 @@ function foo_var() {
 // CHECK-NEXT:       StoreFrameInst 0: number, [i]: any|empty
 // CHECK-NEXT:  %2 = LoadFrameInst (:any|empty) [i]: any|empty
 // CHECK-NEXT:  %3 = UnionNarrowTrustedInst (:any) %2: any|empty
-// CHECK-NEXT:  %4 = UnaryIncInst (:any) %3: any
-// CHECK-NEXT:       StoreFrameInst %4: any, [i]: any|empty
-// CHECK-NEXT:  %6 = BinaryLessThanInst (:boolean) %4: any, 10: number
+// CHECK-NEXT:  %4 = UnaryIncInst (:number|bigint) %3: any
+// CHECK-NEXT:       StoreFrameInst %4: number|bigint, [i]: any|empty
+// CHECK-NEXT:  %6 = BinaryLessThanInst (:boolean) %4: number|bigint, 10: number
 // CHECK-NEXT:       CondBranchInst %6: boolean, %BB1, %BB2
 // CHECK-NEXT:%BB1:
 // CHECK-NEXT:  %8 = TryLoadGlobalPropertyInst (:any) globalObject: object, "print": string
@@ -315,9 +315,9 @@ function foo_var() {
 // CHECK-NEXT:%BB4:
 // CHECK-NEXT:  %14 = LoadFrameInst (:any|empty) [i]: any|empty
 // CHECK-NEXT:  %15 = UnionNarrowTrustedInst (:any) %14: any|empty
-// CHECK-NEXT:  %16 = UnaryIncInst (:any) %15: any
-// CHECK-NEXT:        StoreFrameInst %16: any, [i]: any|empty
-// CHECK-NEXT:  %18 = BinaryLessThanInst (:boolean) %16: any, 10: number
+// CHECK-NEXT:  %16 = UnaryIncInst (:number|bigint) %15: any
+// CHECK-NEXT:        StoreFrameInst %16: number|bigint, [i]: any|empty
+// CHECK-NEXT:  %18 = BinaryLessThanInst (:boolean) %16: number|bigint, 10: number
 // CHECK-NEXT:        CondBranchInst %18: boolean, %BB1, %BB2
 // CHECK-NEXT:%BB3:
 // CHECK-NEXT:  %20 = LoadFrameInst (:any|empty) [i]: any|empty
@@ -333,9 +333,9 @@ function foo_var() {
 // CHECK-NEXT:       StoreFrameInst undefined: undefined, [i]: any
 // CHECK-NEXT:       StoreFrameInst 0: number, [i]: any
 // CHECK-NEXT:  %2 = LoadFrameInst (:any) [i]: any
-// CHECK-NEXT:  %3 = UnaryIncInst (:any) %2: any
-// CHECK-NEXT:       StoreFrameInst %3: any, [i]: any
-// CHECK-NEXT:  %5 = BinaryLessThanInst (:boolean) %3: any, 10: number
+// CHECK-NEXT:  %3 = UnaryIncInst (:number|bigint) %2: any
+// CHECK-NEXT:       StoreFrameInst %3: number|bigint, [i]: any
+// CHECK-NEXT:  %5 = BinaryLessThanInst (:boolean) %3: number|bigint, 10: number
 // CHECK-NEXT:       CondBranchInst %5: boolean, %BB1, %BB2
 // CHECK-NEXT:%BB1:
 // CHECK-NEXT:  %7 = TryLoadGlobalPropertyInst (:any) globalObject: object, "print": string
@@ -346,9 +346,9 @@ function foo_var() {
 // CHECK-NEXT:        ReturnInst undefined: undefined
 // CHECK-NEXT:%BB4:
 // CHECK-NEXT:  %12 = LoadFrameInst (:any) [i]: any
-// CHECK-NEXT:  %13 = UnaryIncInst (:any) %12: any
-// CHECK-NEXT:        StoreFrameInst %13: any, [i]: any
-// CHECK-NEXT:  %15 = BinaryLessThanInst (:boolean) %13: any, 10: number
+// CHECK-NEXT:  %13 = UnaryIncInst (:number|bigint) %12: any
+// CHECK-NEXT:        StoreFrameInst %13: number|bigint, [i]: any
+// CHECK-NEXT:  %15 = BinaryLessThanInst (:boolean) %13: number|bigint, 10: number
 // CHECK-NEXT:        CondBranchInst %15: boolean, %BB1, %BB2
 // CHECK-NEXT:%BB3:
 // CHECK-NEXT:  %17 = LoadFrameInst (:any) [i]: any

--- a/test/IRGen/es6/for-of.js
+++ b/test/IRGen/es6/for-of.js
@@ -182,8 +182,8 @@ function forof_continue(seq) {
 // CHECK-NEXT:%BB5:
 // CHECK-NEXT:        StoreFrameInst %13: any, [i]: any
 // CHECK-NEXT:  %25 = LoadFrameInst (:any) [i]: any
-// CHECK-NEXT:  %26 = BinaryLessThanInst (:any) %25: any, 0: number
-// CHECK-NEXT:        CondBranchInst %26: any, %BB6, %BB7
+// CHECK-NEXT:  %26 = BinaryLessThanInst (:boolean) %25: any, 0: number
+// CHECK-NEXT:        CondBranchInst %26: boolean, %BB6, %BB7
 // CHECK-NEXT:%BB6:
 // CHECK-NEXT:        BranchInst %BB8
 // CHECK-NEXT:%BB7:
@@ -238,8 +238,8 @@ function forof_continue(seq) {
 // CHECK-NEXT:%BB5:
 // CHECK-NEXT:        StoreFrameInst %13: any, [i]: any
 // CHECK-NEXT:  %25 = LoadFrameInst (:any) [i]: any
-// CHECK-NEXT:  %26 = BinaryLessThanInst (:any) %25: any, 0: number
-// CHECK-NEXT:        CondBranchInst %26: any, %BB6, %BB7
+// CHECK-NEXT:  %26 = BinaryLessThanInst (:boolean) %25: any, 0: number
+// CHECK-NEXT:        CondBranchInst %26: boolean, %BB6, %BB7
 // CHECK-NEXT:%BB6:
 // CHECK-NEXT:        BranchInst %BB8
 // CHECK-NEXT:%BB7:

--- a/test/IRGen/es6/for-of.js
+++ b/test/IRGen/es6/for-of.js
@@ -139,8 +139,8 @@ function forof_continue(seq) {
 // CHECK-NEXT:  %26 = LoadFrameInst (:any) [ar]: any
 // CHECK-NEXT:  %27 = LoadFrameInst (:any) [i]: any
 // CHECK-NEXT:  %28 = AsNumericInst (:number|bigint) %27: any
-// CHECK-NEXT:  %29 = UnaryIncInst (:any) %28: number|bigint
-// CHECK-NEXT:        StoreFrameInst %29: any, [i]: any
+// CHECK-NEXT:  %29 = UnaryIncInst (:number|bigint) %28: number|bigint
+// CHECK-NEXT:        StoreFrameInst %29: number|bigint, [i]: any
 // CHECK-NEXT:        StorePropertyLooseInst %15: any, %26: any, %28: number|bigint
 // CHECK-NEXT:        BranchInst %BB6
 // CHECK-NEXT:%BB6:

--- a/test/IRGen/es6/generator.js
+++ b/test/IRGen/es6/generator.js
@@ -192,8 +192,8 @@ var initializer = function*(x = foo()) {
 // CHECK-NEXT:  %11 = LoadFrameInst (:any) [x]: any
 // CHECK-NEXT:  %12 = LoadFrameInst (:any) [i]: any
 // CHECK-NEXT:  %13 = AsNumericInst (:number|bigint) %12: any
-// CHECK-NEXT:  %14 = UnaryIncInst (:any) %13: number|bigint
-// CHECK-NEXT:        StoreFrameInst %14: any, [i]: any
+// CHECK-NEXT:  %14 = UnaryIncInst (:number|bigint) %13: number|bigint
+// CHECK-NEXT:        StoreFrameInst %14: number|bigint, [i]: any
 // CHECK-NEXT:  %16 = LoadPropertyInst (:any) %11: any, %13: number|bigint
 // CHECK-NEXT:  %17 = AllocStackInst (:boolean) $?anon_1_isReturn: any
 // CHECK-NEXT:        SaveAndYieldInst %16: any, %BB5

--- a/test/IRGen/es6/new-target.js
+++ b/test/IRGen/es6/new-target.js
@@ -80,8 +80,8 @@ function func4() {
 // CHECK-NEXT:%BB3:
 // CHECK-NEXT:  %7 = TryLoadGlobalPropertyInst (:any) globalObject: object, "print": string
 // CHECK-NEXT:  %8 = GetNewTargetInst (:undefined|object) %new.target: undefined|object
-// CHECK-NEXT:  %9 = BinaryStrictlyNotEqualInst (:any) %8: undefined|object, undefined: undefined
-// CHECK-NEXT:  %10 = CallInst (:any) %7: any, empty: any, empty: any, undefined: undefined, undefined: undefined, %9: any
+// CHECK-NEXT:  %9 = BinaryStrictlyNotEqualInst (:boolean) %8: undefined|object, undefined: undefined
+// CHECK-NEXT:  %10 = CallInst (:any) %7: any, empty: any, empty: any, undefined: undefined, undefined: undefined, %9: boolean
 // CHECK-NEXT:        ReturnInst undefined: undefined
 // CHECK-NEXT:function_end
 
@@ -99,8 +99,8 @@ function func4() {
 // CHECK-NEXT:       StoreFrameInst %7: object, [innerFunction]: any
 // CHECK-NEXT:  %9 = TryLoadGlobalPropertyInst (:any) globalObject: object, "print": string
 // CHECK-NEXT:  %10 = GetNewTargetInst (:undefined|object) %new.target: undefined|object
-// CHECK-NEXT:  %11 = BinaryStrictlyNotEqualInst (:any) %10: undefined|object, undefined: undefined
-// CHECK-NEXT:  %12 = CallInst (:any) %9: any, empty: any, empty: any, undefined: undefined, undefined: undefined, %11: any
+// CHECK-NEXT:  %11 = BinaryStrictlyNotEqualInst (:boolean) %10: undefined|object, undefined: undefined
+// CHECK-NEXT:  %12 = CallInst (:any) %9: any, empty: any, empty: any, undefined: undefined, undefined: undefined, %11: boolean
 // CHECK-NEXT:  %13 = CreateFunctionInst (:object) %innerArrow1(): any
 // CHECK-NEXT:        StoreFrameInst %13: object, [innerArrow1]: any
 // CHECK-NEXT:  %15 = LoadFrameInst (:any) [innerFunction]: any
@@ -132,8 +132,8 @@ function func4() {
 // CHECK-NEXT:       StoreFrameInst undefined: undefined, [innerArrow2]: any
 // CHECK-NEXT:  %1 = TryLoadGlobalPropertyInst (:any) globalObject: object, "print": string
 // CHECK-NEXT:  %2 = LoadFrameInst (:undefined|object) [?anon_1_new.target@func3]: undefined|object
-// CHECK-NEXT:  %3 = BinaryStrictlyNotEqualInst (:any) %2: undefined|object, undefined: undefined
-// CHECK-NEXT:  %4 = CallInst (:any) %1: any, empty: any, empty: any, undefined: undefined, undefined: undefined, %3: any
+// CHECK-NEXT:  %3 = BinaryStrictlyNotEqualInst (:boolean) %2: undefined|object, undefined: undefined
+// CHECK-NEXT:  %4 = CallInst (:any) %1: any, empty: any, empty: any, undefined: undefined, undefined: undefined, %3: boolean
 // CHECK-NEXT:  %5 = CreateFunctionInst (:object) %innerArrow2(): any
 // CHECK-NEXT:       StoreFrameInst %5: object, [innerArrow2]: any
 // CHECK-NEXT:  %7 = LoadFrameInst (:any) [innerArrow2]: any

--- a/test/IRGen/flow/array-for-of.js
+++ b/test/IRGen/flow/array-for-of.js
@@ -57,8 +57,8 @@ return function main(x: number[]) {
 // CHECK-NEXT:  %10 = FastArrayLoadInst (:number) %3: any, %9: number
 // CHECK-NEXT:        StoreFrameInst %10: number, [i]: any
 // CHECK-NEXT:  %12 = LoadFrameInst (:any) [i]: any
-// CHECK-NEXT:  %13 = BinaryStrictlyEqualInst (:any) %12: any, 0: number
-// CHECK-NEXT:        CondBranchInst %13: any, %BB3, %BB4
+// CHECK-NEXT:  %13 = BinaryStrictlyEqualInst (:boolean) %12: any, 0: number
+// CHECK-NEXT:        CondBranchInst %13: boolean, %BB3, %BB4
 // CHECK-NEXT:%BB2:
 // CHECK-NEXT:        ReturnInst undefined: undefined
 // CHECK-NEXT:%BB5:
@@ -76,8 +76,8 @@ return function main(x: number[]) {
 // CHECK-NEXT:        BranchInst %BB7
 // CHECK-NEXT:%BB7:
 // CHECK-NEXT:  %25 = LoadFrameInst (:any) [i]: any
-// CHECK-NEXT:  %26 = BinaryStrictlyEqualInst (:any) %25: any, 1: number
-// CHECK-NEXT:        CondBranchInst %26: any, %BB8, %BB9
+// CHECK-NEXT:  %26 = BinaryStrictlyEqualInst (:boolean) %25: any, 1: number
+// CHECK-NEXT:        CondBranchInst %26: boolean, %BB8, %BB9
 // CHECK-NEXT:%BB8:
 // CHECK-NEXT:        BranchInst %BB6
 // CHECK-NEXT:%BB9:

--- a/test/IRGen/flow/array-for-of.js
+++ b/test/IRGen/flow/array-for-of.js
@@ -47,44 +47,45 @@ return function main(x: number[]) {
 // CHECK-NEXT:       StoreFrameInst %0: object, [x]: any
 // CHECK-NEXT:       StoreFrameInst undefined: undefined, [i]: any
 // CHECK-NEXT:  %3 = LoadFrameInst (:any) [x]: any
-// CHECK-NEXT:  %4 = AllocStackInst (:number) $?anon_0_forOfIndex: any
-// CHECK-NEXT:       StoreStackInst 0: number, %4: number
-// CHECK-NEXT:  %6 = LoadStackInst (:number) %4: number
-// CHECK-NEXT:  %7 = FastArrayLengthInst (:number) %3: any
-// CHECK-NEXT:       CmpBrLessThanInst %6: number, %7: number, %BB1, %BB2
+// CHECK-NEXT:  %4 = CheckedTypeCastInst (:object) %3: any, type(object)
+// CHECK-NEXT:  %5 = AllocStackInst (:number) $?anon_0_forOfIndex: any
+// CHECK-NEXT:       StoreStackInst 0: number, %5: number
+// CHECK-NEXT:  %7 = LoadStackInst (:number) %5: number
+// CHECK-NEXT:  %8 = FastArrayLengthInst (:number) %4: object
+// CHECK-NEXT:       CmpBrLessThanInst %7: number, %8: number, %BB1, %BB2
 // CHECK-NEXT:%BB1:
-// CHECK-NEXT:  %9 = LoadStackInst (:number) %4: number
-// CHECK-NEXT:  %10 = FastArrayLoadInst (:number) %3: any, %9: number
-// CHECK-NEXT:        StoreFrameInst %10: number, [i]: any
-// CHECK-NEXT:  %12 = LoadFrameInst (:any) [i]: any
-// CHECK-NEXT:  %13 = BinaryStrictlyEqualInst (:boolean) %12: any, 0: number
-// CHECK-NEXT:        CondBranchInst %13: boolean, %BB3, %BB4
+// CHECK-NEXT:  %10 = LoadStackInst (:number) %5: number
+// CHECK-NEXT:  %11 = FastArrayLoadInst (:number) %4: object, %10: number
+// CHECK-NEXT:        StoreFrameInst %11: number, [i]: any
+// CHECK-NEXT:  %13 = LoadFrameInst (:any) [i]: any
+// CHECK-NEXT:  %14 = BinaryStrictlyEqualInst (:boolean) %13: any, 0: number
+// CHECK-NEXT:        CondBranchInst %14: boolean, %BB3, %BB4
 // CHECK-NEXT:%BB2:
 // CHECK-NEXT:        ReturnInst undefined: undefined
 // CHECK-NEXT:%BB5:
-// CHECK-NEXT:  %16 = LoadStackInst (:number) %4: number
-// CHECK-NEXT:  %17 = FastArrayLengthInst (:number) %3: any
-// CHECK-NEXT:        CmpBrLessThanInst %16: number, %17: number, %BB1, %BB2
+// CHECK-NEXT:  %17 = LoadStackInst (:number) %5: number
+// CHECK-NEXT:  %18 = FastArrayLengthInst (:number) %4: object
+// CHECK-NEXT:        CmpBrLessThanInst %17: number, %18: number, %BB1, %BB2
 // CHECK-NEXT:%BB6:
-// CHECK-NEXT:  %19 = LoadStackInst (:number) %4: number
-// CHECK-NEXT:  %20 = FAddInst (:number) %19: number, 1: number
-// CHECK-NEXT:        StoreStackInst %20: number, %4: number
+// CHECK-NEXT:  %20 = LoadStackInst (:number) %5: number
+// CHECK-NEXT:  %21 = FAddInst (:number) %20: number, 1: number
+// CHECK-NEXT:        StoreStackInst %21: number, %5: number
 // CHECK-NEXT:        BranchInst %BB5
 // CHECK-NEXT:%BB3:
 // CHECK-NEXT:        BranchInst %BB2
 // CHECK-NEXT:%BB4:
 // CHECK-NEXT:        BranchInst %BB7
 // CHECK-NEXT:%BB7:
-// CHECK-NEXT:  %25 = LoadFrameInst (:any) [i]: any
-// CHECK-NEXT:  %26 = BinaryStrictlyEqualInst (:boolean) %25: any, 1: number
-// CHECK-NEXT:        CondBranchInst %26: boolean, %BB8, %BB9
+// CHECK-NEXT:  %26 = LoadFrameInst (:any) [i]: any
+// CHECK-NEXT:  %27 = BinaryStrictlyEqualInst (:boolean) %26: any, 1: number
+// CHECK-NEXT:        CondBranchInst %27: boolean, %BB8, %BB9
 // CHECK-NEXT:%BB8:
 // CHECK-NEXT:        BranchInst %BB6
 // CHECK-NEXT:%BB9:
 // CHECK-NEXT:        BranchInst %BB10
 // CHECK-NEXT:%BB10:
-// CHECK-NEXT:  %30 = TryLoadGlobalPropertyInst (:any) globalObject: object, "print": string
-// CHECK-NEXT:  %31 = LoadFrameInst (:any) [i]: any
-// CHECK-NEXT:  %32 = CallInst (:any) %30: any, empty: any, empty: any, undefined: undefined, undefined: undefined, %31: any
+// CHECK-NEXT:  %31 = TryLoadGlobalPropertyInst (:any) globalObject: object, "print": string
+// CHECK-NEXT:  %32 = LoadFrameInst (:any) [i]: any
+// CHECK-NEXT:  %33 = CallInst (:any) %31: any, empty: any, empty: any, undefined: undefined, undefined: undefined, %32: any
 // CHECK-NEXT:        BranchInst %BB6
 // CHECK-NEXT:function_end

--- a/test/IRGen/flow/as-numeric.js
+++ b/test/IRGen/flow/as-numeric.js
@@ -5,46 +5,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// RUN: %shermes -Werror -typed -O0 -dump-ir %s | %FileCheckOrRegen --match-full-lines %s
+// RUN: %shermes -Xdump-functions=baz -Werror -typed -O0 -dump-ir %s | %FileCheckOrRegen --match-full-lines %s
 
-function main() {
-  function baz(x: number): void {
-    x++;
-  }
+// NOTE: this test doesn't test anything yet, since its goal is to demonstrate that
+// AsNumericInst narrows its result type based on the type of the input.
+
+function baz(x: number): void {
+  x++;
 }
 
 // Auto-generated content below. Please do not modify manually.
-
-// CHECK:function global(): any
-// CHECK-NEXT:frame = []
-// CHECK-NEXT:%BB0:
-// CHECK-NEXT:  %0 = AllocStackInst (:any) $?anon_0_ret: any
-// CHECK-NEXT:       StoreStackInst undefined: undefined, %0: any
-// CHECK-NEXT:  %2 = CreateFunctionInst (:object) %""(): any
-// CHECK-NEXT:  %3 = AllocObjectInst (:object) 0: number, empty: any
-// CHECK-NEXT:  %4 = CallInst [njsf] (:any) %2: object, empty: any, empty: any, undefined: undefined, undefined: undefined, %3: object
-// CHECK-NEXT:       StoreStackInst %4: any, %0: any
-// CHECK-NEXT:  %6 = LoadStackInst (:any) %0: any
-// CHECK-NEXT:       ReturnInst %6: any
-// CHECK-NEXT:function_end
-
-// CHECK:function ""(exports: any): any
-// CHECK-NEXT:frame = [exports: any, main: any]
-// CHECK-NEXT:%BB0:
-// CHECK-NEXT:  %0 = LoadParamInst (:any) %exports: any
-// CHECK-NEXT:       StoreFrameInst %0: any, [exports]: any
-// CHECK-NEXT:  %2 = CreateFunctionInst (:object) %main(): any
-// CHECK-NEXT:       StoreFrameInst %2: object, [main]: any
-// CHECK-NEXT:       ReturnInst undefined: undefined
-// CHECK-NEXT:function_end
-
-// CHECK:function main(): any
-// CHECK-NEXT:frame = [baz: any]
-// CHECK-NEXT:%BB0:
-// CHECK-NEXT:  %0 = CreateFunctionInst (:object) %baz(): any
-// CHECK-NEXT:       StoreFrameInst %0: object, [baz]: any
-// CHECK-NEXT:       ReturnInst undefined: undefined
-// CHECK-NEXT:function_end
 
 // CHECK:function baz(x: number): any [typed]
 // CHECK-NEXT:frame = [x: any]
@@ -52,8 +22,8 @@ function main() {
 // CHECK-NEXT:  %0 = LoadParamInst (:number) %x: number
 // CHECK-NEXT:       StoreFrameInst %0: number, [x]: any
 // CHECK-NEXT:  %2 = LoadFrameInst (:any) [x]: any
-// CHECK-NEXT:  %3 = AsNumericInst (:number|bigint) %2: any
-// CHECK-NEXT:  %4 = UnaryIncInst (:any) %3: number|bigint
-// CHECK-NEXT:       StoreFrameInst %4: any, [x]: any
+// CHECK-NEXT:  %3 = CheckedTypeCastInst (:number) %2: any, type(number)
+// CHECK-NEXT:  %4 = UnaryIncInst (:number) %3: number
+// CHECK-NEXT:       StoreFrameInst %4: number, [x]: any
 // CHECK-NEXT:       ReturnInst undefined: undefined
 // CHECK-NEXT:function_end

--- a/test/IRGen/flow/as.js
+++ b/test/IRGen/flow/as.js
@@ -5,43 +5,21 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// RUN: %shermes -Werror -typed -dump-ir -O0 %s | %FileCheckOrRegen %s --match-full-lines
+// RUN: %shermes -Xdump-functions=test_as -Werror -typed -dump-ir -O0 %s | %FileCheckOrRegen %s --match-full-lines
 
-(function(){
-  return (Math.PI as number) * 3.0;
-})();
+function test_as(): number {
+   return (Math.PI as number) * 3.0;
+}
 
 // Auto-generated content below. Please do not modify manually.
 
-// CHECK:function global(): any
-// CHECK-NEXT:frame = []
-// CHECK-NEXT:%BB0:
-// CHECK-NEXT:  %0 = AllocStackInst (:any) $?anon_0_ret: any
-// CHECK-NEXT:       StoreStackInst undefined: undefined, %0: any
-// CHECK-NEXT:  %2 = CreateFunctionInst (:object) %""(): any
-// CHECK-NEXT:  %3 = AllocObjectInst (:object) 0: number, empty: any
-// CHECK-NEXT:  %4 = CallInst [njsf] (:any) %2: object, empty: any, empty: any, undefined: undefined, undefined: undefined, %3: object
-// CHECK-NEXT:       StoreStackInst %4: any, %0: any
-// CHECK-NEXT:  %6 = LoadStackInst (:any) %0: any
-// CHECK-NEXT:       ReturnInst %6: any
-// CHECK-NEXT:function_end
-
-// CHECK:function ""(exports: any): any
-// CHECK-NEXT:frame = [exports: any]
-// CHECK-NEXT:%BB0:
-// CHECK-NEXT:  %0 = LoadParamInst (:any) %exports: any
-// CHECK-NEXT:       StoreFrameInst %0: any, [exports]: any
-// CHECK-NEXT:  %2 = CreateFunctionInst (:object) %" 1#"(): any
-// CHECK-NEXT:  %3 = CallInst [njsf] (:any) %2: object, empty: any, empty: any, undefined: undefined, undefined: undefined
-// CHECK-NEXT:       ReturnInst undefined: undefined
-// CHECK-NEXT:function_end
-
-// CHECK:function " 1#"(): any
+// CHECK:function test_as(): any [typed]
 // CHECK-NEXT:frame = []
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = TryLoadGlobalPropertyInst (:any) globalObject: object, "Math": string
 // CHECK-NEXT:  %1 = LoadPropertyInst (:any) %0: any, "PI": string
 // CHECK-NEXT:  %2 = CheckedTypeCastInst (:number) %1: any, type(number)
 // CHECK-NEXT:  %3 = BinaryMultiplyInst (:any) %2: number, 3: number
-// CHECK-NEXT:       ReturnInst %3: any
+// CHECK-NEXT:  %4 = CheckedTypeCastInst (:number) %3: any, type(number)
+// CHECK-NEXT:       ReturnInst %4: number
 // CHECK-NEXT:function_end

--- a/test/IRGen/flow/assign-ops.js
+++ b/test/IRGen/flow/assign-ops.js
@@ -57,14 +57,16 @@ return function f(x: any, n: number) {
 // CHECK-NEXT:  %2 = LoadParamInst (:number) %n: number
 // CHECK-NEXT:       StoreFrameInst %2: number, [n]: any
 // CHECK-NEXT:  %4 = LoadFrameInst (:any) [n]: any
-// CHECK-NEXT:  %5 = LoadFrameInst (:any) [x]: any
-// CHECK-NEXT:  %6 = BinaryAddInst (:any) %4: any, %5: any
-// CHECK-NEXT:  %7 = CheckedTypeCastInst (:number) %6: any, type(number)
-// CHECK-NEXT:       StoreFrameInst %7: number, [n]: any
-// CHECK-NEXT:  %9 = LoadFrameInst (:any) [n]: any
-// CHECK-NEXT:  %10 = LoadFrameInst (:any) [x]: any
-// CHECK-NEXT:  %11 = BinarySubtractInst (:any) %9: any, %10: any
-// CHECK-NEXT:  %12 = CheckedTypeCastInst (:number) %11: any, type(number)
-// CHECK-NEXT:        StoreFrameInst %12: number, [n]: any
+// CHECK-NEXT:  %5 = CheckedTypeCastInst (:number) %4: any, type(number)
+// CHECK-NEXT:  %6 = LoadFrameInst (:any) [x]: any
+// CHECK-NEXT:  %7 = BinaryAddInst (:any) %5: number, %6: any
+// CHECK-NEXT:  %8 = CheckedTypeCastInst (:number) %7: any, type(number)
+// CHECK-NEXT:       StoreFrameInst %8: number, [n]: any
+// CHECK-NEXT:  %10 = LoadFrameInst (:any) [n]: any
+// CHECK-NEXT:  %11 = CheckedTypeCastInst (:number) %10: any, type(number)
+// CHECK-NEXT:  %12 = LoadFrameInst (:any) [x]: any
+// CHECK-NEXT:  %13 = BinarySubtractInst (:any) %11: number, %12: any
+// CHECK-NEXT:  %14 = CheckedTypeCastInst (:number) %13: any, type(number)
+// CHECK-NEXT:        StoreFrameInst %14: number, [n]: any
 // CHECK-NEXT:        ReturnInst undefined: undefined
 // CHECK-NEXT:function_end

--- a/test/IRGen/flow/class-construct-order.js
+++ b/test/IRGen/flow/class-construct-order.js
@@ -5,11 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// RUN: %shermes -Werror -typed -dump-ir -fno-inline -O0 %s | %FileCheckOrRegen --match-full-lines %s
-
-'use strict';
-
-(function main() {
+// RUN: %shermes -Xdump-functions=foo -Werror -typed -dump-ir -O0 %s | %FileCheckOrRegen --match-full-lines %s
 
 function foo(x: number): C {
   // Ensure the target operand of new C() is populated at IRGen.
@@ -23,74 +19,21 @@ class C {
   }
 }
 
-return foo;
-
-})();
-
 // Auto-generated content below. Please do not modify manually.
-
-// CHECK:function global(): any
-// CHECK-NEXT:frame = []
-// CHECK-NEXT:%BB0:
-// CHECK-NEXT:  %0 = AllocStackInst (:any) $?anon_0_ret: any
-// CHECK-NEXT:       StoreStackInst undefined: undefined, %0: any
-// CHECK-NEXT:  %2 = CreateFunctionInst (:object) %""(): any
-// CHECK-NEXT:  %3 = AllocObjectInst (:object) 0: number, empty: any
-// CHECK-NEXT:  %4 = CallInst [njsf] (:any) %2: object, empty: any, empty: any, undefined: undefined, undefined: undefined, %3: object
-// CHECK-NEXT:       StoreStackInst %4: any, %0: any
-// CHECK-NEXT:  %6 = LoadStackInst (:any) %0: any
-// CHECK-NEXT:       ReturnInst %6: any
-// CHECK-NEXT:function_end
-
-// CHECK:function ""(exports: any): any
-// CHECK-NEXT:frame = [exports: any, main: any]
-// CHECK-NEXT:%BB0:
-// CHECK-NEXT:  %0 = LoadParamInst (:any) %exports: any
-// CHECK-NEXT:       StoreFrameInst %0: any, [exports]: any
-// CHECK-NEXT:  %2 = CreateFunctionInst (:object) %main(): any
-// CHECK-NEXT:       StoreFrameInst %2: object, [main]: any
-// CHECK-NEXT:  %4 = CallInst [njsf] (:any) %2: object, empty: any, empty: any, undefined: undefined, undefined: undefined
-// CHECK-NEXT:       ReturnInst undefined: undefined
-// CHECK-NEXT:function_end
-
-// CHECK:function main(): any
-// CHECK-NEXT:frame = [foo: any, C: any, ?C.prototype: object]
-// CHECK-NEXT:%BB0:
-// CHECK-NEXT:       StoreFrameInst undefined: undefined, [C]: any
-// CHECK-NEXT:  %1 = CreateFunctionInst (:object) %foo(): any
-// CHECK-NEXT:       StoreFrameInst %1: object, [foo]: any
-// CHECK-NEXT:  %3 = CreateFunctionInst (:object) %C(): any
-// CHECK-NEXT:       StoreFrameInst %3: object, [C]: any
-// CHECK-NEXT:  %5 = AllocObjectInst (:object) 0: number, empty: any
-// CHECK-NEXT:       StoreFrameInst %5: object, [?C.prototype]: object
-// CHECK-NEXT:       StorePropertyStrictInst %5: object, %3: object, "prototype": string
-// CHECK-NEXT:  %8 = LoadFrameInst (:any) [foo]: any
-// CHECK-NEXT:       ReturnInst %8: any
-// CHECK-NEXT:function_end
 
 // CHECK:function foo(x: number): any [typed]
 // CHECK-NEXT:frame = [x: any]
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = LoadParamInst (:number) %x: number
 // CHECK-NEXT:       StoreFrameInst %0: number, [x]: any
-// CHECK-NEXT:  %2 = LoadFrameInst (:any) [C@main]: any
-// CHECK-NEXT:  %3 = LoadFrameInst (:object) [?C.prototype@main]: object
-// CHECK-NEXT:  %4 = UnionNarrowTrustedInst (:object) %3: object
-// CHECK-NEXT:  %5 = AllocObjectLiteralInst (:object) "x": string, 0: number
-// CHECK-NEXT:       StoreParentInst %4: object, %5: object
-// CHECK-NEXT:  %7 = LoadFrameInst (:any) [x]: any
-// CHECK-NEXT:  %8 = CallInst (:any) %2: any, %C(): any, empty: any, %2: any, %5: object, %7: any
-// CHECK-NEXT:       ReturnInst %5: object
-// CHECK-NEXT:function_end
-
-// CHECK:function C(x: any): any [typed]
-// CHECK-NEXT:frame = [x: any]
-// CHECK-NEXT:%BB0:
-// CHECK-NEXT:  %0 = LoadParamInst (:object) %<this>: object
-// CHECK-NEXT:  %1 = LoadParamInst (:any) %x: any
-// CHECK-NEXT:       StoreFrameInst %1: any, [x]: any
-// CHECK-NEXT:  %3 = LoadFrameInst (:any) [x]: any
-// CHECK-NEXT:  %4 = CheckedTypeCastInst (:number) %3: any, type(number)
-// CHECK-NEXT:       PrStoreInst %4: number, %0: object, 0: number, "x": string, true: boolean
-// CHECK-NEXT:       ReturnInst undefined: undefined
+// CHECK-NEXT:  %2 = LoadFrameInst (:any) [C@""]: any
+// CHECK-NEXT:  %3 = CheckedTypeCastInst (:object) %2: any, type(object)
+// CHECK-NEXT:  %4 = LoadFrameInst (:object) [?C.prototype@""]: object
+// CHECK-NEXT:  %5 = UnionNarrowTrustedInst (:object) %4: object
+// CHECK-NEXT:  %6 = AllocObjectLiteralInst (:object) "x": string, 0: number
+// CHECK-NEXT:       StoreParentInst %5: object, %6: object
+// CHECK-NEXT:  %8 = LoadFrameInst (:any) [x]: any
+// CHECK-NEXT:  %9 = CheckedTypeCastInst (:number) %8: any, type(number)
+// CHECK-NEXT:  %10 = CallInst (:any) %3: object, %C(): any, empty: any, %3: object, %6: object, %9: number
+// CHECK-NEXT:        ReturnInst %6: object
 // CHECK-NEXT:function_end

--- a/test/IRGen/flow/class-constructor-super.js
+++ b/test/IRGen/flow/class-constructor-super.js
@@ -50,17 +50,19 @@ new D();
 // CHECK-NEXT:       StoreFrameInst %6: object, [?C.prototype]: object
 // CHECK-NEXT:       StorePropertyStrictInst %6: object, %4: object, "prototype": string
 // CHECK-NEXT:  %9 = LoadFrameInst (:any) [C]: any
-// CHECK-NEXT:  %10 = CreateFunctionInst (:object) %D(): any
-// CHECK-NEXT:        StoreFrameInst %10: object, [D]: any
-// CHECK-NEXT:  %12 = LoadFrameInst (:object) [?C.prototype]: object
-// CHECK-NEXT:  %13 = AllocObjectInst (:object) 0: number, %12: object
-// CHECK-NEXT:        StoreFrameInst %13: object, [?D.prototype]: object
-// CHECK-NEXT:        StorePropertyStrictInst %13: object, %10: object, "prototype": string
-// CHECK-NEXT:  %16 = LoadFrameInst (:any) [D]: any
-// CHECK-NEXT:  %17 = LoadFrameInst (:object) [?D.prototype]: object
-// CHECK-NEXT:  %18 = UnionNarrowTrustedInst (:object) %17: object
-// CHECK-NEXT:  %19 = AllocObjectInst (:object) 0: number, %18: object
-// CHECK-NEXT:  %20 = CallInst (:any) %16: any, %D(): any, empty: any, %16: any, %19: object
+// CHECK-NEXT:  %10 = CheckedTypeCastInst (:object) %9: any, type(object)
+// CHECK-NEXT:  %11 = CreateFunctionInst (:object) %D(): any
+// CHECK-NEXT:        StoreFrameInst %11: object, [D]: any
+// CHECK-NEXT:  %13 = LoadFrameInst (:object) [?C.prototype]: object
+// CHECK-NEXT:  %14 = AllocObjectInst (:object) 0: number, %13: object
+// CHECK-NEXT:        StoreFrameInst %14: object, [?D.prototype]: object
+// CHECK-NEXT:        StorePropertyStrictInst %14: object, %11: object, "prototype": string
+// CHECK-NEXT:  %17 = LoadFrameInst (:any) [D]: any
+// CHECK-NEXT:  %18 = CheckedTypeCastInst (:object) %17: any, type(object)
+// CHECK-NEXT:  %19 = LoadFrameInst (:object) [?D.prototype]: object
+// CHECK-NEXT:  %20 = UnionNarrowTrustedInst (:object) %19: object
+// CHECK-NEXT:  %21 = AllocObjectInst (:object) 0: number, %20: object
+// CHECK-NEXT:  %22 = CallInst (:any) %18: object, %D(): any, empty: any, %18: object, %21: object
 // CHECK-NEXT:        ReturnInst undefined: undefined
 // CHECK-NEXT:function_end
 
@@ -75,7 +77,9 @@ new D();
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = LoadParamInst (:object) %<this>: object
 // CHECK-NEXT:  %1 = LoadFrameInst (:any) [C@""]: any
-// CHECK-NEXT:  %2 = GetNewTargetInst (:undefined|object) %new.target: undefined|object
-// CHECK-NEXT:  %3 = CallInst [njsf] (:any) %1: any, empty: any, empty: any, %2: undefined|object, %0: object
+// CHECK-NEXT:  %2 = CheckedTypeCastInst (:object) %1: any, type(object)
+// CHECK-NEXT:  %3 = GetNewTargetInst (:undefined|object) %new.target: undefined|object
+// CHECK-NEXT:  %4 = CallInst [njsf] (:any) %2: object, empty: any, empty: any, %3: undefined|object, %0: object
+// CHECK-NEXT:  %5 = CheckedTypeCastInst (:undefined) %4: any, type(undefined)
 // CHECK-NEXT:       ReturnInst undefined: undefined
 // CHECK-NEXT:function_end

--- a/test/IRGen/flow/class-method-inherited.js
+++ b/test/IRGen/flow/class-method-inherited.js
@@ -52,22 +52,25 @@ new D().inherited();
 // CHECK-NEXT:       StoreFrameInst %7: object, [?C.prototype]: object
 // CHECK-NEXT:       StorePropertyStrictInst %7: object, %4: object, "prototype": string
 // CHECK-NEXT:  %10 = LoadFrameInst (:any) [C]: any
-// CHECK-NEXT:  %11 = CreateFunctionInst (:object) %D(): any
-// CHECK-NEXT:        StoreFrameInst %11: object, [D]: any
-// CHECK-NEXT:  %13 = LoadFrameInst (:object) [?C.prototype]: object
-// CHECK-NEXT:  %14 = PrLoadInst (:object) %13: object, 0: number, "inherited": string
-// CHECK-NEXT:  %15 = AllocObjectLiteralInst (:object) "inherited": string, %14: object
-// CHECK-NEXT:        StoreParentInst %13: object, %15: object
-// CHECK-NEXT:        StoreFrameInst %15: object, [?D.prototype]: object
-// CHECK-NEXT:        StorePropertyStrictInst %15: object, %11: object, "prototype": string
-// CHECK-NEXT:  %19 = LoadFrameInst (:any) [D]: any
-// CHECK-NEXT:  %20 = LoadFrameInst (:object) [?D.prototype]: object
-// CHECK-NEXT:  %21 = UnionNarrowTrustedInst (:object) %20: object
-// CHECK-NEXT:  %22 = AllocObjectInst (:object) 0: number, %21: object
-// CHECK-NEXT:  %23 = CallInst (:any) %19: any, %D(): any, empty: any, %19: any, %22: object
-// CHECK-NEXT:  %24 = LoadParentInst (:object) %22: object
-// CHECK-NEXT:  %25 = PrLoadInst (:object) %24: object, 0: number, "inherited": string
-// CHECK-NEXT:  %26 = CallInst [njsf] (:any) %25: object, empty: any, empty: any, undefined: undefined, %22: object
+// CHECK-NEXT:  %11 = CheckedTypeCastInst (:object) %10: any, type(object)
+// CHECK-NEXT:  %12 = CreateFunctionInst (:object) %D(): any
+// CHECK-NEXT:        StoreFrameInst %12: object, [D]: any
+// CHECK-NEXT:  %14 = LoadFrameInst (:object) [?C.prototype]: object
+// CHECK-NEXT:  %15 = PrLoadInst (:object) %14: object, 0: number, "inherited": string
+// CHECK-NEXT:  %16 = AllocObjectLiteralInst (:object) "inherited": string, %15: object
+// CHECK-NEXT:        StoreParentInst %14: object, %16: object
+// CHECK-NEXT:        StoreFrameInst %16: object, [?D.prototype]: object
+// CHECK-NEXT:        StorePropertyStrictInst %16: object, %12: object, "prototype": string
+// CHECK-NEXT:  %20 = LoadFrameInst (:any) [D]: any
+// CHECK-NEXT:  %21 = CheckedTypeCastInst (:object) %20: any, type(object)
+// CHECK-NEXT:  %22 = LoadFrameInst (:object) [?D.prototype]: object
+// CHECK-NEXT:  %23 = UnionNarrowTrustedInst (:object) %22: object
+// CHECK-NEXT:  %24 = AllocObjectInst (:object) 0: number, %23: object
+// CHECK-NEXT:  %25 = CallInst (:any) %21: object, %D(): any, empty: any, %21: object, %24: object
+// CHECK-NEXT:  %26 = LoadParentInst (:object) %24: object
+// CHECK-NEXT:  %27 = PrLoadInst (:object) %26: object, 0: number, "inherited": string
+// CHECK-NEXT:  %28 = CallInst [njsf] (:any) %27: object, empty: any, empty: any, undefined: undefined, %24: object
+// CHECK-NEXT:  %29 = CheckedTypeCastInst (:number) %28: any, type(number)
 // CHECK-NEXT:        ReturnInst undefined: undefined
 // CHECK-NEXT:function_end
 
@@ -88,7 +91,8 @@ new D().inherited();
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = LoadParamInst (:object) %<this>: object
 // CHECK-NEXT:  %1 = LoadFrameInst (:any) [C@""]: any
-// CHECK-NEXT:  %2 = GetNewTargetInst (:undefined|object) %new.target: undefined|object
-// CHECK-NEXT:  %3 = CallInst (:any) %1: any, empty: any, empty: any, %2: undefined|object, %0: object
+// CHECK-NEXT:  %2 = CheckedTypeCastInst (:object) %1: any, type(object)
+// CHECK-NEXT:  %3 = GetNewTargetInst (:undefined|object) %new.target: undefined|object
+// CHECK-NEXT:  %4 = CallInst (:any) %2: object, empty: any, empty: any, %3: undefined|object, %0: object
 // CHECK-NEXT:       ReturnInst undefined: undefined
 // CHECK-NEXT:function_end

--- a/test/IRGen/flow/class-method-override.js
+++ b/test/IRGen/flow/class-method-override.js
@@ -63,23 +63,26 @@ new D().override();
 // CHECK-NEXT:       StoreFrameInst %8: object, [?C.prototype]: object
 // CHECK-NEXT:        StorePropertyStrictInst %8: object, %4: object, "prototype": string
 // CHECK-NEXT:  %11 = LoadFrameInst (:any) [C]: any
-// CHECK-NEXT:  %12 = CreateFunctionInst (:object) %D(): any
-// CHECK-NEXT:        StoreFrameInst %12: object, [D]: any
-// CHECK-NEXT:  %14 = LoadFrameInst (:object) [?C.prototype]: object
-// CHECK-NEXT:  %15 = CreateFunctionInst (:object) %"override 1#"(): any
-// CHECK-NEXT:  %16 = CreateFunctionInst (:object) %"override2 1#"(): any
-// CHECK-NEXT:  %17 = AllocObjectLiteralInst (:object) "override": string, %15: object, "override2": string, %16: object
-// CHECK-NEXT:        StoreParentInst %14: object, %17: object
-// CHECK-NEXT:        StoreFrameInst %17: object, [?D.prototype]: object
-// CHECK-NEXT:        StorePropertyStrictInst %17: object, %12: object, "prototype": string
-// CHECK-NEXT:  %21 = LoadFrameInst (:any) [D]: any
-// CHECK-NEXT:  %22 = LoadFrameInst (:object) [?D.prototype]: object
-// CHECK-NEXT:  %23 = UnionNarrowTrustedInst (:object) %22: object
-// CHECK-NEXT:  %24 = AllocObjectInst (:object) 0: number, %23: object
-// CHECK-NEXT:  %25 = CallInst (:any) %21: any, %D(): any, empty: any, %21: any, %24: object
-// CHECK-NEXT:  %26 = LoadParentInst (:object) %24: object
-// CHECK-NEXT:  %27 = PrLoadInst (:object) %26: object, 0: number, "override": string
-// CHECK-NEXT:  %28 = CallInst [njsf] (:any) %27: object, empty: any, empty: any, undefined: undefined, %24: object
+// CHECK-NEXT:  %12 = CheckedTypeCastInst (:object) %11: any, type(object)
+// CHECK-NEXT:  %13 = CreateFunctionInst (:object) %D(): any
+// CHECK-NEXT:        StoreFrameInst %13: object, [D]: any
+// CHECK-NEXT:  %15 = LoadFrameInst (:object) [?C.prototype]: object
+// CHECK-NEXT:  %16 = CreateFunctionInst (:object) %"override 1#"(): any
+// CHECK-NEXT:  %17 = CreateFunctionInst (:object) %"override2 1#"(): any
+// CHECK-NEXT:  %18 = AllocObjectLiteralInst (:object) "override": string, %16: object, "override2": string, %17: object
+// CHECK-NEXT:        StoreParentInst %15: object, %18: object
+// CHECK-NEXT:        StoreFrameInst %18: object, [?D.prototype]: object
+// CHECK-NEXT:        StorePropertyStrictInst %18: object, %13: object, "prototype": string
+// CHECK-NEXT:  %22 = LoadFrameInst (:any) [D]: any
+// CHECK-NEXT:  %23 = CheckedTypeCastInst (:object) %22: any, type(object)
+// CHECK-NEXT:  %24 = LoadFrameInst (:object) [?D.prototype]: object
+// CHECK-NEXT:  %25 = UnionNarrowTrustedInst (:object) %24: object
+// CHECK-NEXT:  %26 = AllocObjectInst (:object) 0: number, %25: object
+// CHECK-NEXT:  %27 = CallInst (:any) %23: object, %D(): any, empty: any, %23: object, %26: object
+// CHECK-NEXT:  %28 = LoadParentInst (:object) %26: object
+// CHECK-NEXT:  %29 = PrLoadInst (:object) %28: object, 0: number, "override": string
+// CHECK-NEXT:  %30 = CallInst [njsf] (:any) %29: object, empty: any, empty: any, undefined: undefined, %26: object
+// CHECK-NEXT:  %31 = CheckedTypeCastInst (:number) %30: any, type(number)
 // CHECK-NEXT:        ReturnInst undefined: undefined
 // CHECK-NEXT:function_end
 
@@ -108,8 +111,9 @@ new D().override();
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = LoadParamInst (:object) %<this>: object
 // CHECK-NEXT:  %1 = LoadFrameInst (:any) [C@""]: any
-// CHECK-NEXT:  %2 = GetNewTargetInst (:undefined|object) %new.target: undefined|object
-// CHECK-NEXT:  %3 = CallInst (:any) %1: any, empty: any, empty: any, %2: undefined|object, %0: object
+// CHECK-NEXT:  %2 = CheckedTypeCastInst (:object) %1: any, type(object)
+// CHECK-NEXT:  %3 = GetNewTargetInst (:undefined|object) %new.target: undefined|object
+// CHECK-NEXT:  %4 = CallInst (:any) %2: object, empty: any, empty: any, %3: undefined|object, %0: object
 // CHECK-NEXT:       ReturnInst undefined: undefined
 // CHECK-NEXT:function_end
 

--- a/test/IRGen/flow/class-method.js
+++ b/test/IRGen/flow/class-method.js
@@ -46,13 +46,15 @@ print(new C().method());
 // CHECK-NEXT:       StorePropertyStrictInst %6: object, %3: object, "prototype": string
 // CHECK-NEXT:  %9 = TryLoadGlobalPropertyInst (:any) globalObject: object, "print": string
 // CHECK-NEXT:  %10 = LoadFrameInst (:any) [C]: any
-// CHECK-NEXT:  %11 = LoadFrameInst (:object) [?C.prototype]: object
-// CHECK-NEXT:  %12 = UnionNarrowTrustedInst (:object) %11: object
-// CHECK-NEXT:  %13 = AllocObjectInst (:object) 0: number, %12: object
-// CHECK-NEXT:  %14 = LoadParentInst (:object) %13: object
-// CHECK-NEXT:  %15 = PrLoadInst (:object) %14: object, 0: number, "method": string
-// CHECK-NEXT:  %16 = CallInst [njsf] (:any) %15: object, empty: any, empty: any, undefined: undefined, %13: object
-// CHECK-NEXT:  %17 = CallInst (:any) %9: any, empty: any, empty: any, undefined: undefined, undefined: undefined, %16: any
+// CHECK-NEXT:  %11 = CheckedTypeCastInst (:object) %10: any, type(object)
+// CHECK-NEXT:  %12 = LoadFrameInst (:object) [?C.prototype]: object
+// CHECK-NEXT:  %13 = UnionNarrowTrustedInst (:object) %12: object
+// CHECK-NEXT:  %14 = AllocObjectInst (:object) 0: number, %13: object
+// CHECK-NEXT:  %15 = LoadParentInst (:object) %14: object
+// CHECK-NEXT:  %16 = PrLoadInst (:object) %15: object, 0: number, "method": string
+// CHECK-NEXT:  %17 = CallInst [njsf] (:any) %16: object, empty: any, empty: any, undefined: undefined, %14: object
+// CHECK-NEXT:  %18 = CheckedTypeCastInst (:number) %17: any, type(number)
+// CHECK-NEXT:  %19 = CallInst (:any) %9: any, empty: any, empty: any, undefined: undefined, undefined: undefined, %18: number
 // CHECK-NEXT:        ReturnInst undefined: undefined
 // CHECK-NEXT:function_end
 

--- a/test/IRGen/flow/class-super-method.js
+++ b/test/IRGen/flow/class-super-method.js
@@ -60,14 +60,15 @@ class B extends A {
 // CHECK-NEXT:       StoreFrameInst %7: object, [?A.prototype]: object
 // CHECK-NEXT:       StorePropertyStrictInst %7: object, %4: object, "prototype": string
 // CHECK-NEXT:  %10 = LoadFrameInst (:any) [A]: any
-// CHECK-NEXT:  %11 = CreateFunctionInst (:object) %B(): any
-// CHECK-NEXT:        StoreFrameInst %11: object, [B]: any
-// CHECK-NEXT:  %13 = LoadFrameInst (:object) [?A.prototype]: object
-// CHECK-NEXT:  %14 = CreateFunctionInst (:object) %"f 1#"(): any
-// CHECK-NEXT:  %15 = AllocObjectLiteralInst (:object) "f": string, %14: object
-// CHECK-NEXT:        StoreParentInst %13: object, %15: object
-// CHECK-NEXT:        StoreFrameInst %15: object, [?B.prototype]: object
-// CHECK-NEXT:        StorePropertyStrictInst %15: object, %11: object, "prototype": string
+// CHECK-NEXT:  %11 = CheckedTypeCastInst (:object) %10: any, type(object)
+// CHECK-NEXT:  %12 = CreateFunctionInst (:object) %B(): any
+// CHECK-NEXT:        StoreFrameInst %12: object, [B]: any
+// CHECK-NEXT:  %14 = LoadFrameInst (:object) [?A.prototype]: object
+// CHECK-NEXT:  %15 = CreateFunctionInst (:object) %"f 1#"(): any
+// CHECK-NEXT:  %16 = AllocObjectLiteralInst (:object) "f": string, %15: object
+// CHECK-NEXT:        StoreParentInst %14: object, %16: object
+// CHECK-NEXT:        StoreFrameInst %16: object, [?B.prototype]: object
+// CHECK-NEXT:        StorePropertyStrictInst %16: object, %12: object, "prototype": string
 // CHECK-NEXT:        ReturnInst undefined: undefined
 // CHECK-NEXT:function_end
 
@@ -78,7 +79,8 @@ class B extends A {
 // CHECK-NEXT:  %1 = LoadParamInst (:number) %x: number
 // CHECK-NEXT:       StoreFrameInst %1: number, [x]: any
 // CHECK-NEXT:  %3 = LoadFrameInst (:any) [x]: any
-// CHECK-NEXT:       PrStoreInst %3: any, %0: object, 0: number, "x": string, true: boolean
+// CHECK-NEXT:  %4 = CheckedTypeCastInst (:number) %3: any, type(number)
+// CHECK-NEXT:       PrStoreInst %4: number, %0: object, 0: number, "x": string, true: boolean
 // CHECK-NEXT:       ReturnInst undefined: undefined
 // CHECK-NEXT:function_end
 
@@ -88,7 +90,8 @@ class B extends A {
 // CHECK-NEXT:  %0 = LoadParamInst (:object) %<this>: object
 // CHECK-NEXT:  %1 = PrLoadInst (:number) %0: object, 0: number, "x": string
 // CHECK-NEXT:  %2 = BinaryMultiplyInst (:any) %1: number, 10: number
-// CHECK-NEXT:       ReturnInst %2: any
+// CHECK-NEXT:  %3 = CheckedTypeCastInst (:number) %2: any, type(number)
+// CHECK-NEXT:       ReturnInst %3: number
 // CHECK-NEXT:function_end
 
 // CHECK:function B(x: number): any [typed]
@@ -98,10 +101,13 @@ class B extends A {
 // CHECK-NEXT:  %1 = LoadParamInst (:number) %x: number
 // CHECK-NEXT:       StoreFrameInst %1: number, [x]: any
 // CHECK-NEXT:  %3 = LoadFrameInst (:any) [A@""]: any
-// CHECK-NEXT:  %4 = GetNewTargetInst (:undefined|object) %new.target: undefined|object
-// CHECK-NEXT:  %5 = LoadFrameInst (:any) [x]: any
-// CHECK-NEXT:  %6 = CallInst [njsf] (:any) %3: any, empty: any, empty: any, %4: undefined|object, %0: object, %5: any
-// CHECK-NEXT:       ReturnInst undefined: undefined
+// CHECK-NEXT:  %4 = CheckedTypeCastInst (:object) %3: any, type(object)
+// CHECK-NEXT:  %5 = GetNewTargetInst (:undefined|object) %new.target: undefined|object
+// CHECK-NEXT:  %6 = LoadFrameInst (:any) [x]: any
+// CHECK-NEXT:  %7 = CheckedTypeCastInst (:number) %6: any, type(number)
+// CHECK-NEXT:  %8 = CallInst [njsf] (:any) %4: object, empty: any, empty: any, %5: undefined|object, %0: object, %7: number
+// CHECK-NEXT:  %9 = CheckedTypeCastInst (:undefined) %8: any, type(undefined)
+// CHECK-NEXT:        ReturnInst undefined: undefined
 // CHECK-NEXT:function_end
 
 // CHECK:function "f 1#"(): any [typed]
@@ -111,6 +117,8 @@ class B extends A {
 // CHECK-NEXT:  %1 = LoadFrameInst (:object) [?A.prototype@""]: object
 // CHECK-NEXT:  %2 = PrLoadInst (:object) %1: object, 0: number, "f": string
 // CHECK-NEXT:  %3 = CallInst [njsf] (:any) %2: object, empty: any, empty: any, undefined: undefined, %0: object
-// CHECK-NEXT:  %4 = BinaryAddInst (:any) %3: any, 23: number
-// CHECK-NEXT:       ReturnInst %4: any
+// CHECK-NEXT:  %4 = CheckedTypeCastInst (:number) %3: any, type(number)
+// CHECK-NEXT:  %5 = BinaryAddInst (:any) %4: number, 23: number
+// CHECK-NEXT:  %6 = CheckedTypeCastInst (:number) %5: any, type(number)
+// CHECK-NEXT:       ReturnInst %6: number
 // CHECK-NEXT:function_end

--- a/test/IRGen/flow/class-super-prop.js
+++ b/test/IRGen/flow/class-super-prop.js
@@ -55,14 +55,15 @@ class B extends A {
 // CHECK-NEXT:       StoreFrameInst %6: object, [?A.prototype]: object
 // CHECK-NEXT:       StorePropertyStrictInst %6: object, %4: object, "prototype": string
 // CHECK-NEXT:  %9 = LoadFrameInst (:any) [A]: any
-// CHECK-NEXT:  %10 = CreateFunctionInst (:object) %B(): any
-// CHECK-NEXT:        StoreFrameInst %10: object, [B]: any
-// CHECK-NEXT:  %12 = LoadFrameInst (:object) [?A.prototype]: object
-// CHECK-NEXT:  %13 = CreateFunctionInst (:object) %f(): any
-// CHECK-NEXT:  %14 = AllocObjectLiteralInst (:object) "f": string, %13: object
-// CHECK-NEXT:        StoreParentInst %12: object, %14: object
-// CHECK-NEXT:        StoreFrameInst %14: object, [?B.prototype]: object
-// CHECK-NEXT:        StorePropertyStrictInst %14: object, %10: object, "prototype": string
+// CHECK-NEXT:  %10 = CheckedTypeCastInst (:object) %9: any, type(object)
+// CHECK-NEXT:  %11 = CreateFunctionInst (:object) %B(): any
+// CHECK-NEXT:        StoreFrameInst %11: object, [B]: any
+// CHECK-NEXT:  %13 = LoadFrameInst (:object) [?A.prototype]: object
+// CHECK-NEXT:  %14 = CreateFunctionInst (:object) %f(): any
+// CHECK-NEXT:  %15 = AllocObjectLiteralInst (:object) "f": string, %14: object
+// CHECK-NEXT:        StoreParentInst %13: object, %15: object
+// CHECK-NEXT:        StoreFrameInst %15: object, [?B.prototype]: object
+// CHECK-NEXT:        StorePropertyStrictInst %15: object, %11: object, "prototype": string
 // CHECK-NEXT:        ReturnInst undefined: undefined
 // CHECK-NEXT:function_end
 
@@ -73,7 +74,8 @@ class B extends A {
 // CHECK-NEXT:  %1 = LoadParamInst (:number) %x: number
 // CHECK-NEXT:       StoreFrameInst %1: number, [x]: any
 // CHECK-NEXT:  %3 = LoadFrameInst (:any) [x]: any
-// CHECK-NEXT:       PrStoreInst %3: any, %0: object, 0: number, "x": string, true: boolean
+// CHECK-NEXT:  %4 = CheckedTypeCastInst (:number) %3: any, type(number)
+// CHECK-NEXT:       PrStoreInst %4: number, %0: object, 0: number, "x": string, true: boolean
 // CHECK-NEXT:       ReturnInst undefined: undefined
 // CHECK-NEXT:function_end
 
@@ -84,10 +86,13 @@ class B extends A {
 // CHECK-NEXT:  %1 = LoadParamInst (:number) %x: number
 // CHECK-NEXT:       StoreFrameInst %1: number, [x]: any
 // CHECK-NEXT:  %3 = LoadFrameInst (:any) [A@""]: any
-// CHECK-NEXT:  %4 = GetNewTargetInst (:undefined|object) %new.target: undefined|object
-// CHECK-NEXT:  %5 = LoadFrameInst (:any) [x]: any
-// CHECK-NEXT:  %6 = CallInst [njsf] (:any) %3: any, empty: any, empty: any, %4: undefined|object, %0: object, %5: any
-// CHECK-NEXT:       ReturnInst undefined: undefined
+// CHECK-NEXT:  %4 = CheckedTypeCastInst (:object) %3: any, type(object)
+// CHECK-NEXT:  %5 = GetNewTargetInst (:undefined|object) %new.target: undefined|object
+// CHECK-NEXT:  %6 = LoadFrameInst (:any) [x]: any
+// CHECK-NEXT:  %7 = CheckedTypeCastInst (:number) %6: any, type(number)
+// CHECK-NEXT:  %8 = CallInst [njsf] (:any) %4: object, empty: any, empty: any, %5: undefined|object, %0: object, %7: number
+// CHECK-NEXT:  %9 = CheckedTypeCastInst (:undefined) %8: any, type(undefined)
+// CHECK-NEXT:        ReturnInst undefined: undefined
 // CHECK-NEXT:function_end
 
 // CHECK:function f(): any [typed]

--- a/test/IRGen/flow/template-literal.js
+++ b/test/IRGen/flow/template-literal.js
@@ -45,6 +45,7 @@ return function main() {
 // CHECK-NEXT:       StoreFrameInst "X": string, [x]: any
 // CHECK-NEXT:  %2 = LoadFrameInst (:any) [x]: any
 // CHECK-NEXT:  %3 = CheckedTypeCastInst (:string) %2: any, type(string)
-// CHECK-NEXT:  %4 = StringConcatInst (:string) "hello": string, %3: string, "world": string
-// CHECK-NEXT:       ReturnInst %4: string
+// CHECK-NEXT:  %4 = CheckedTypeCastInst (:string) %3: string, type(string)
+// CHECK-NEXT:  %5 = StringConcatInst (:string) "hello": string, %4: string, "world": string
+// CHECK-NEXT:       ReturnInst %5: string
 // CHECK-NEXT:function_end

--- a/test/IRGen/flow/tuple-access.js
+++ b/test/IRGen/flow/tuple-access.js
@@ -41,14 +41,18 @@ x[1] = false;
 // CHECK-NEXT:  %5 = AllocObjectLiteralInst (:object) "0": string, 1: number, "1": string, true: boolean
 // CHECK-NEXT:       StoreFrameInst %5: object, [x]: any
 // CHECK-NEXT:  %7 = LoadFrameInst (:any) [x]: any
-// CHECK-NEXT:  %8 = PrLoadInst (:number) %7: any, 0: number, "0": string
-// CHECK-NEXT:       StoreFrameInst %8: number, [y]: any
-// CHECK-NEXT:  %10 = LoadFrameInst (:any) [x]: any
-// CHECK-NEXT:  %11 = PrLoadInst (:boolean) %10: any, 1: number, "1": string
-// CHECK-NEXT:        StoreFrameInst %11: boolean, [z]: any
-// CHECK-NEXT:  %13 = LoadFrameInst (:any) [x]: any
-// CHECK-NEXT:        PrStoreInst 2: number, %13: any, 0: number, "0": string, true: boolean
+// CHECK-NEXT:  %8 = CheckedTypeCastInst (:object) %7: any, type(object)
+// CHECK-NEXT:  %9 = PrLoadInst (:number) %8: object, 0: number, "0": string
+// CHECK-NEXT:        StoreFrameInst %9: number, [y]: any
+// CHECK-NEXT:  %11 = LoadFrameInst (:any) [x]: any
+// CHECK-NEXT:  %12 = CheckedTypeCastInst (:object) %11: any, type(object)
+// CHECK-NEXT:  %13 = PrLoadInst (:boolean) %12: object, 1: number, "1": string
+// CHECK-NEXT:        StoreFrameInst %13: boolean, [z]: any
 // CHECK-NEXT:  %15 = LoadFrameInst (:any) [x]: any
-// CHECK-NEXT:        PrStoreInst false: boolean, %15: any, 1: number, "1": string, true: boolean
+// CHECK-NEXT:  %16 = CheckedTypeCastInst (:object) %15: any, type(object)
+// CHECK-NEXT:        PrStoreInst 2: number, %16: object, 0: number, "0": string, true: boolean
+// CHECK-NEXT:  %18 = LoadFrameInst (:any) [x]: any
+// CHECK-NEXT:  %19 = CheckedTypeCastInst (:object) %18: any, type(object)
+// CHECK-NEXT:        PrStoreInst false: boolean, %19: object, 1: number, "1": string, true: boolean
 // CHECK-NEXT:        ReturnInst undefined: undefined
 // CHECK-NEXT:function_end

--- a/test/IRGen/flow/tuple-destr.js
+++ b/test/IRGen/flow/tuple-destr.js
@@ -47,24 +47,27 @@ let j: string;
 // CHECK-NEXT:  %10 = AllocObjectLiteralInst (:object) "0": string, 2: number, "1": string, "asdf": string
 // CHECK-NEXT:        StoreFrameInst %10: object, [inner]: any
 // CHECK-NEXT:  %12 = LoadFrameInst (:any) [inner]: any
-// CHECK-NEXT:  %13 = AllocObjectLiteralInst (:object) "0": string, 1: number, "1": string, true: boolean, "2": string, %12: any
-// CHECK-NEXT:        StoreFrameInst %13: object, [outer]: any
-// CHECK-NEXT:  %15 = LoadFrameInst (:any) [outer]: any
-// CHECK-NEXT:  %16 = PrLoadInst (:number) %15: any, 0: number, "0": string
-// CHECK-NEXT:        StoreFrameInst %16: number, [x]: any
-// CHECK-NEXT:  %18 = PrLoadInst (:boolean) %15: any, 1: number, "1": string
-// CHECK-NEXT:        StoreFrameInst %18: boolean, [y]: any
-// CHECK-NEXT:  %20 = PrLoadInst (:object) %15: any, 2: number, "2": string
-// CHECK-NEXT:  %21 = PrLoadInst (:number) %20: object, 0: number, "0": string
-// CHECK-NEXT:        StoreFrameInst %21: number, [a]: any
-// CHECK-NEXT:  %23 = PrLoadInst (:string) %20: object, 1: number, "1": string
-// CHECK-NEXT:        StoreFrameInst %23: string, [b]: any
+// CHECK-NEXT:  %13 = CheckedTypeCastInst (:object) %12: any, type(object)
+// CHECK-NEXT:  %14 = AllocObjectLiteralInst (:object) "0": string, 1: number, "1": string, true: boolean, "2": string, %13: object
+// CHECK-NEXT:        StoreFrameInst %14: object, [outer]: any
+// CHECK-NEXT:  %16 = LoadFrameInst (:any) [outer]: any
+// CHECK-NEXT:  %17 = CheckedTypeCastInst (:object) %16: any, type(object)
+// CHECK-NEXT:  %18 = PrLoadInst (:number) %17: object, 0: number, "0": string
+// CHECK-NEXT:        StoreFrameInst %18: number, [x]: any
+// CHECK-NEXT:  %20 = PrLoadInst (:boolean) %17: object, 1: number, "1": string
+// CHECK-NEXT:        StoreFrameInst %20: boolean, [y]: any
+// CHECK-NEXT:  %22 = PrLoadInst (:object) %17: object, 2: number, "2": string
+// CHECK-NEXT:  %23 = PrLoadInst (:number) %22: object, 0: number, "0": string
+// CHECK-NEXT:        StoreFrameInst %23: number, [a]: any
+// CHECK-NEXT:  %25 = PrLoadInst (:string) %22: object, 1: number, "1": string
+// CHECK-NEXT:        StoreFrameInst %25: string, [b]: any
 // CHECK-NEXT:        StoreFrameInst undefined: undefined, [i]: any
 // CHECK-NEXT:        StoreFrameInst undefined: undefined, [j]: any
-// CHECK-NEXT:  %27 = LoadFrameInst (:any) [inner]: any
-// CHECK-NEXT:  %28 = PrLoadInst (:number) %27: any, 0: number, "0": string
-// CHECK-NEXT:        StoreFrameInst %28: number, [i]: any
-// CHECK-NEXT:  %30 = PrLoadInst (:string) %27: any, 1: number, "1": string
-// CHECK-NEXT:        StoreFrameInst %30: string, [j]: any
+// CHECK-NEXT:  %29 = LoadFrameInst (:any) [inner]: any
+// CHECK-NEXT:  %30 = CheckedTypeCastInst (:object) %29: any, type(object)
+// CHECK-NEXT:  %31 = PrLoadInst (:number) %30: object, 0: number, "0": string
+// CHECK-NEXT:        StoreFrameInst %31: number, [i]: any
+// CHECK-NEXT:  %33 = PrLoadInst (:string) %30: object, 1: number, "1": string
+// CHECK-NEXT:        StoreFrameInst %33: string, [j]: any
 // CHECK-NEXT:        ReturnInst undefined: undefined
 // CHECK-NEXT:function_end

--- a/test/IRGen/flow/typecast.js
+++ b/test/IRGen/flow/typecast.js
@@ -43,5 +43,6 @@
 // CHECK-NEXT:  %1 = LoadPropertyInst (:any) %0: any, "PI": string
 // CHECK-NEXT:  %2 = CheckedTypeCastInst (:number) %1: any, type(number)
 // CHECK-NEXT:  %3 = BinaryMultiplyInst (:any) %2: number, 3: number
-// CHECK-NEXT:       ReturnInst %3: any
+// CHECK-NEXT:  %4 = CheckedTypeCastInst (:number) %3: any, type(number)
+// CHECK-NEXT:       ReturnInst %4: number
 // CHECK-NEXT:function_end

--- a/test/IRGen/flow/update-expr-types.js
+++ b/test/IRGen/flow/update-expr-types.js
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %shermes -Xdump-functions=f1,f2,f3,f4,f5,f6 -Werror -typed -dump-ir -O0 %s | %FileCheckOrRegen %s --match-full-lines
+
+// Ensure that the type of the lvalue load is correct and the type of the whole
+// expression is correct.
+
+function f1(n: number): number {
+    return ++n;
+}
+function f2(n: number): number {
+    return n++;
+}
+function f3(n: any): any {
+    return ++n;
+}
+function f4(n: any): any {
+    return n++;
+}
+function f5(n: number): number {
+    return n += 10;
+}
+function f6(n: number, a: any): number {
+    return n += a;
+}
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:function f1(n: number): any [typed]
+// CHECK-NEXT:frame = [n: any]
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = LoadParamInst (:number) %n: number
+// CHECK-NEXT:       StoreFrameInst %0: number, [n]: any
+// CHECK-NEXT:  %2 = LoadFrameInst (:any) [n]: any
+// CHECK-NEXT:  %3 = CheckedTypeCastInst (:number) %2: any, type(number)
+// CHECK-NEXT:  %4 = UnaryIncInst (:number) %3: number
+// CHECK-NEXT:       StoreFrameInst %4: number, [n]: any
+// CHECK-NEXT:       ReturnInst %4: number
+// CHECK-NEXT:function_end
+
+// CHECK:function f2(n: number): any [typed]
+// CHECK-NEXT:frame = [n: any]
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = LoadParamInst (:number) %n: number
+// CHECK-NEXT:       StoreFrameInst %0: number, [n]: any
+// CHECK-NEXT:  %2 = LoadFrameInst (:any) [n]: any
+// CHECK-NEXT:  %3 = CheckedTypeCastInst (:number) %2: any, type(number)
+// CHECK-NEXT:  %4 = UnaryIncInst (:number) %3: number
+// CHECK-NEXT:       StoreFrameInst %4: number, [n]: any
+// CHECK-NEXT:       ReturnInst %3: number
+// CHECK-NEXT:function_end
+
+// CHECK:function f3(n: any): any [typed]
+// CHECK-NEXT:frame = [n: any]
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = LoadParamInst (:any) %n: any
+// CHECK-NEXT:       StoreFrameInst %0: any, [n]: any
+// CHECK-NEXT:  %2 = LoadFrameInst (:any) [n]: any
+// CHECK-NEXT:  %3 = UnaryIncInst (:number|bigint) %2: any
+// CHECK-NEXT:       StoreFrameInst %3: number|bigint, [n]: any
+// CHECK-NEXT:       ReturnInst %3: number|bigint
+// CHECK-NEXT:function_end
+
+// CHECK:function f4(n: any): any [typed]
+// CHECK-NEXT:frame = [n: any]
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = LoadParamInst (:any) %n: any
+// CHECK-NEXT:       StoreFrameInst %0: any, [n]: any
+// CHECK-NEXT:  %2 = LoadFrameInst (:any) [n]: any
+// CHECK-NEXT:  %3 = AsNumericInst (:number|bigint) %2: any
+// CHECK-NEXT:  %4 = UnaryIncInst (:number|bigint) %3: number|bigint
+// CHECK-NEXT:       StoreFrameInst %4: number|bigint, [n]: any
+// CHECK-NEXT:       ReturnInst %3: number|bigint
+// CHECK-NEXT:function_end
+
+// CHECK:function f5(n: number): any [typed]
+// CHECK-NEXT:frame = [n: any]
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = LoadParamInst (:number) %n: number
+// CHECK-NEXT:       StoreFrameInst %0: number, [n]: any
+// CHECK-NEXT:  %2 = LoadFrameInst (:any) [n]: any
+// CHECK-NEXT:  %3 = CheckedTypeCastInst (:number) %2: any, type(number)
+// CHECK-NEXT:  %4 = BinaryAddInst (:any) %3: number, 10: number
+// CHECK-NEXT:  %5 = CheckedTypeCastInst (:number) %4: any, type(number)
+// CHECK-NEXT:       StoreFrameInst %5: number, [n]: any
+// CHECK-NEXT:       ReturnInst %5: number
+// CHECK-NEXT:function_end
+
+// CHECK:function f6(n: number, a: any): any [typed]
+// CHECK-NEXT:frame = [n: any, a: any]
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = LoadParamInst (:number) %n: number
+// CHECK-NEXT:       StoreFrameInst %0: number, [n]: any
+// CHECK-NEXT:  %2 = LoadParamInst (:any) %a: any
+// CHECK-NEXT:       StoreFrameInst %2: any, [a]: any
+// CHECK-NEXT:  %4 = LoadFrameInst (:any) [n]: any
+// CHECK-NEXT:  %5 = CheckedTypeCastInst (:number) %4: any, type(number)
+// CHECK-NEXT:  %6 = LoadFrameInst (:any) [a]: any
+// CHECK-NEXT:  %7 = BinaryAddInst (:any) %5: number, %6: any
+// CHECK-NEXT:  %8 = CheckedTypeCastInst (:number) %7: any, type(number)
+// CHECK-NEXT:       StoreFrameInst %8: number, [n]: any
+// CHECK-NEXT:        ReturnInst %8: number
+// CHECK-NEXT:function_end

--- a/test/IRGen/for_in_prop_access.js
+++ b/test/IRGen/for_in_prop_access.js
@@ -256,8 +256,8 @@ function expression_prop(obj) {
 // CHECK-NEXT:  %19 = LoadFrameInst (:any) [x]: any
 // CHECK-NEXT:  %20 = LoadPropertyInst (:any) %18: any, %19: any
 // CHECK-NEXT:  %21 = AsNumericInst (:number|bigint) %20: any
-// CHECK-NEXT:  %22 = UnaryIncInst (:any) %21: number|bigint
-// CHECK-NEXT:        StorePropertyLooseInst %22: any, %18: any, %19: any
+// CHECK-NEXT:  %22 = UnaryIncInst (:number|bigint) %21: number|bigint
+// CHECK-NEXT:        StorePropertyLooseInst %22: number|bigint, %18: any, %19: any
 // CHECK-NEXT:  %24 = LoadFrameInst (:any) [ret]: any
 // CHECK-NEXT:  %25 = LoadFrameInst (:any) [obj]: any
 // CHECK-NEXT:  %26 = LoadFrameInst (:any) [x]: any

--- a/test/IRGen/for_loops.js
+++ b/test/IRGen/for_loops.js
@@ -254,8 +254,8 @@ function test_init_update_exprs(param1) {
 // CHECK-NEXT:%BB3:
 // CHECK-NEXT:  %8 = LoadFrameInst (:any) [i]: any
 // CHECK-NEXT:  %9 = AsNumericInst (:number|bigint) %8: any
-// CHECK-NEXT:  %10 = UnaryIncInst (:any) %9: number|bigint
-// CHECK-NEXT:        StoreFrameInst %10: any, [i]: any
+// CHECK-NEXT:  %10 = UnaryIncInst (:number|bigint) %9: number|bigint
+// CHECK-NEXT:        StoreFrameInst %10: number|bigint, [i]: any
 // CHECK-NEXT:        BranchInst %BB6
 // CHECK-NEXT:%BB4:
 // CHECK-NEXT:        BranchInst %BB7
@@ -266,8 +266,8 @@ function test_init_update_exprs(param1) {
 // CHECK-NEXT:        CondBranchInst false: boolean, %BB4, %BB5
 // CHECK-NEXT:%BB7:
 // CHECK-NEXT:  %17 = LoadFrameInst (:any) [i]: any
-// CHECK-NEXT:  %18 = UnaryDecInst (:any) %17: any
-// CHECK-NEXT:        StoreFrameInst %18: any, [i]: any
+// CHECK-NEXT:  %18 = UnaryDecInst (:number|bigint) %17: any
+// CHECK-NEXT:        StoreFrameInst %18: number|bigint, [i]: any
 // CHECK-NEXT:        BranchInst %BB10
 // CHECK-NEXT:%BB8:
 // CHECK-NEXT:        BranchInst %BB11

--- a/test/IRGen/for_loops.js
+++ b/test/IRGen/for_loops.js
@@ -99,8 +99,8 @@ function test_init_update_exprs(param1) {
 // CHECK-NEXT:       StoreFrameInst undefined: undefined, [i]: any
 // CHECK-NEXT:       StoreFrameInst 0: number, [i]: any
 // CHECK-NEXT:  %2 = LoadFrameInst (:any) [i]: any
-// CHECK-NEXT:  %3 = BinaryLessThanInst (:any) %2: any, 10: number
-// CHECK-NEXT:       CondBranchInst %3: any, %BB1, %BB2
+// CHECK-NEXT:  %3 = BinaryLessThanInst (:boolean) %2: any, 10: number
+// CHECK-NEXT:       CondBranchInst %3: boolean, %BB1, %BB2
 // CHECK-NEXT:%BB1:
 // CHECK-NEXT:  %5 = LoadPropertyInst (:any) globalObject: object, "sink": string
 // CHECK-NEXT:  %6 = LoadFrameInst (:any) [i]: any
@@ -110,8 +110,8 @@ function test_init_update_exprs(param1) {
 // CHECK-NEXT:       ReturnInst undefined: undefined
 // CHECK-NEXT:%BB4:
 // CHECK-NEXT:  %10 = LoadFrameInst (:any) [i]: any
-// CHECK-NEXT:  %11 = BinaryLessThanInst (:any) %10: any, 10: number
-// CHECK-NEXT:        CondBranchInst %11: any, %BB1, %BB2
+// CHECK-NEXT:  %11 = BinaryLessThanInst (:boolean) %10: any, 10: number
+// CHECK-NEXT:        CondBranchInst %11: boolean, %BB1, %BB2
 // CHECK-NEXT:%BB3:
 // CHECK-NEXT:  %13 = LoadFrameInst (:any) [i]: any
 // CHECK-NEXT:  %14 = BinaryAddInst (:any) %13: any, 1: number
@@ -125,8 +125,8 @@ function test_init_update_exprs(param1) {
 // CHECK-NEXT:       StoreFrameInst undefined: undefined, [i]: any
 // CHECK-NEXT:       StoreFrameInst 0: number, [i]: any
 // CHECK-NEXT:  %2 = LoadFrameInst (:any) [i]: any
-// CHECK-NEXT:  %3 = BinaryLessThanInst (:any) %2: any, 10: number
-// CHECK-NEXT:       CondBranchInst %3: any, %BB1, %BB2
+// CHECK-NEXT:  %3 = BinaryLessThanInst (:boolean) %2: any, 10: number
+// CHECK-NEXT:       CondBranchInst %3: boolean, %BB1, %BB2
 // CHECK-NEXT:%BB1:
 // CHECK-NEXT:       BranchInst %BB2
 // CHECK-NEXT:%BB2:
@@ -139,8 +139,8 @@ function test_init_update_exprs(param1) {
 // CHECK-NEXT:       StoreFrameInst undefined: undefined, [i]: any
 // CHECK-NEXT:       StoreFrameInst 0: number, [i]: any
 // CHECK-NEXT:  %2 = LoadFrameInst (:any) [i]: any
-// CHECK-NEXT:  %3 = BinaryLessThanInst (:any) %2: any, 10: number
-// CHECK-NEXT:       CondBranchInst %3: any, %BB1, %BB2
+// CHECK-NEXT:  %3 = BinaryLessThanInst (:boolean) %2: any, 10: number
+// CHECK-NEXT:       CondBranchInst %3: boolean, %BB1, %BB2
 // CHECK-NEXT:%BB3:
 // CHECK-NEXT:       ReturnInst undefined: undefined
 // CHECK-NEXT:%BB1:
@@ -155,16 +155,16 @@ function test_init_update_exprs(param1) {
 // CHECK-NEXT:       StoreFrameInst undefined: undefined, [i]: any
 // CHECK-NEXT:       StoreFrameInst 0: number, [i]: any
 // CHECK-NEXT:  %2 = LoadFrameInst (:any) [i]: any
-// CHECK-NEXT:  %3 = BinaryLessThanInst (:any) %2: any, 10: number
-// CHECK-NEXT:       CondBranchInst %3: any, %BB1, %BB2
+// CHECK-NEXT:  %3 = BinaryLessThanInst (:boolean) %2: any, 10: number
+// CHECK-NEXT:       CondBranchInst %3: boolean, %BB1, %BB2
 // CHECK-NEXT:%BB1:
 // CHECK-NEXT:       BranchInst %BB3
 // CHECK-NEXT:%BB2:
 // CHECK-NEXT:       ReturnInst undefined: undefined
 // CHECK-NEXT:%BB4:
 // CHECK-NEXT:  %7 = LoadFrameInst (:any) [i]: any
-// CHECK-NEXT:  %8 = BinaryLessThanInst (:any) %7: any, 10: number
-// CHECK-NEXT:       CondBranchInst %8: any, %BB1, %BB2
+// CHECK-NEXT:  %8 = BinaryLessThanInst (:boolean) %7: any, 10: number
+// CHECK-NEXT:       CondBranchInst %8: boolean, %BB1, %BB2
 // CHECK-NEXT:%BB3:
 // CHECK-NEXT:  %10 = LoadFrameInst (:any) [i]: any
 // CHECK-NEXT:  %11 = BinaryAddInst (:any) %10: any, 1: number
@@ -178,8 +178,8 @@ function test_init_update_exprs(param1) {
 // CHECK-NEXT:       StoreFrameInst undefined: undefined, [i]: any
 // CHECK-NEXT:       StoreFrameInst 0: number, [i]: any
 // CHECK-NEXT:  %2 = LoadFrameInst (:any) [i]: any
-// CHECK-NEXT:  %3 = BinaryLessThanInst (:any) %2: any, 10: number
-// CHECK-NEXT:       CondBranchInst %3: any, %BB1, %BB2
+// CHECK-NEXT:  %3 = BinaryLessThanInst (:boolean) %2: any, 10: number
+// CHECK-NEXT:       CondBranchInst %3: boolean, %BB1, %BB2
 // CHECK-NEXT:%BB3:
 // CHECK-NEXT:       ReturnInst undefined: undefined
 // CHECK-NEXT:%BB1:
@@ -188,8 +188,8 @@ function test_init_update_exprs(param1) {
 // CHECK-NEXT:       BranchInst %BB3
 // CHECK-NEXT:%BB5:
 // CHECK-NEXT:  %8 = LoadFrameInst (:any) [i]: any
-// CHECK-NEXT:  %9 = BinaryLessThanInst (:any) %8: any, 10: number
-// CHECK-NEXT:        CondBranchInst %9: any, %BB1, %BB2
+// CHECK-NEXT:  %9 = BinaryLessThanInst (:boolean) %8: any, 10: number
+// CHECK-NEXT:        CondBranchInst %9: boolean, %BB1, %BB2
 // CHECK-NEXT:%BB4:
 // CHECK-NEXT:  %11 = LoadFrameInst (:any) [i]: any
 // CHECK-NEXT:  %12 = BinaryAddInst (:any) %11: any, 1: number

--- a/test/IRGen/instance_of.js
+++ b/test/IRGen/instance_of.js
@@ -35,6 +35,6 @@ function simple_test0(x, y) {
 // CHECK-NEXT:       StoreFrameInst %2: any, [y]: any
 // CHECK-NEXT:  %4 = LoadFrameInst (:any) [x]: any
 // CHECK-NEXT:  %5 = LoadFrameInst (:any) [y]: any
-// CHECK-NEXT:  %6 = BinaryInstanceOfInst (:any) %4: any, %5: any
-// CHECK-NEXT:       ReturnInst %6: any
+// CHECK-NEXT:  %6 = BinaryInstanceOfInst (:boolean) %4: any, %5: any
+// CHECK-NEXT:       ReturnInst %6: boolean
 // CHECK-NEXT:function_end

--- a/test/IRGen/shbuiltin-call.js
+++ b/test/IRGen/shbuiltin-call.js
@@ -5,58 +5,22 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// RUN: %shermes -typed -dump-ir -fno-inline -O0 %s | %FileCheckOrRegen --match-full-lines %s
-
-(function() {
-
-'use strict'
+// RUN: %shermes -Xdump-functions="" -typed -dump-ir -O0 %s | %FileCheckOrRegen --match-full-lines %s
 
 function foo(x, y) {}
 $SHBuiltin.call(foo, 11, 12, 13);
 
-})();
-
 // Auto-generated content below. Please do not modify manually.
 
-// CHECK:function global(): any
-// CHECK-NEXT:frame = []
-// CHECK-NEXT:%BB0:
-// CHECK-NEXT:  %0 = AllocStackInst (:any) $?anon_0_ret: any
-// CHECK-NEXT:       StoreStackInst undefined: undefined, %0: any
-// CHECK-NEXT:  %2 = CreateFunctionInst (:object) %""(): any
-// CHECK-NEXT:  %3 = AllocObjectInst (:object) 0: number, empty: any
-// CHECK-NEXT:  %4 = CallInst [njsf] (:any) %2: object, empty: any, empty: any, undefined: undefined, undefined: undefined, %3: object
-// CHECK-NEXT:       StoreStackInst %4: any, %0: any
-// CHECK-NEXT:  %6 = LoadStackInst (:any) %0: any
-// CHECK-NEXT:       ReturnInst %6: any
-// CHECK-NEXT:function_end
-
 // CHECK:function ""(exports: any): any
-// CHECK-NEXT:frame = [exports: any]
+// CHECK-NEXT:frame = [exports: any, foo: any]
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = LoadParamInst (:any) %exports: any
 // CHECK-NEXT:       StoreFrameInst %0: any, [exports]: any
-// CHECK-NEXT:  %2 = CreateFunctionInst (:object) %" 1#"(): any
-// CHECK-NEXT:  %3 = CallInst [njsf] (:any) %2: object, empty: any, empty: any, undefined: undefined, undefined: undefined
-// CHECK-NEXT:       ReturnInst undefined: undefined
-// CHECK-NEXT:function_end
-
-// CHECK:function " 1#"(): any
-// CHECK-NEXT:frame = [foo: any]
-// CHECK-NEXT:%BB0:
-// CHECK-NEXT:  %0 = CreateFunctionInst (:object) %foo(): any
-// CHECK-NEXT:       StoreFrameInst %0: object, [foo]: any
-// CHECK-NEXT:  %2 = LoadFrameInst (:any) [foo]: any
-// CHECK-NEXT:  %3 = CallInst (:any) %2: any, empty: any, empty: any, undefined: undefined, 11: number, 12: number, 13: number
-// CHECK-NEXT:       ReturnInst undefined: undefined
-// CHECK-NEXT:function_end
-
-// CHECK:function foo(x: any, y: any): any
-// CHECK-NEXT:frame = [x: any, y: any]
-// CHECK-NEXT:%BB0:
-// CHECK-NEXT:  %0 = LoadParamInst (:any) %x: any
-// CHECK-NEXT:       StoreFrameInst %0: any, [x]: any
-// CHECK-NEXT:  %2 = LoadParamInst (:any) %y: any
-// CHECK-NEXT:       StoreFrameInst %2: any, [y]: any
+// CHECK-NEXT:  %2 = CreateFunctionInst (:object) %foo(): any
+// CHECK-NEXT:       StoreFrameInst %2: object, [foo]: any
+// CHECK-NEXT:  %4 = LoadFrameInst (:any) [foo]: any
+// CHECK-NEXT:  %5 = CheckedTypeCastInst (:object) %4: any, type(object)
+// CHECK-NEXT:  %6 = CallInst (:any) %5: object, empty: any, empty: any, undefined: undefined, 11: number, 12: number, 13: number
 // CHECK-NEXT:       ReturnInst undefined: undefined
 // CHECK-NEXT:function_end

--- a/test/IRGen/source_loc.js
+++ b/test/IRGen/source_loc.js
@@ -56,9 +56,9 @@ function foo(a,b) {
 // CHECK-NEXT:; <stdin>:11:13
 // CHECK-NEXT:  %5 = LoadFrameInst (:any) [b]: any
 // CHECK-NEXT:; <stdin>:11:9
-// CHECK-NEXT:  %6 = BinaryGreaterThanInst (:any) %4: any, %5: any
+// CHECK-NEXT:  %6 = BinaryGreaterThanInst (:boolean) %4: any, %5: any
 // CHECK-NEXT:; <stdin>:11:5
-// CHECK-NEXT:       CondBranchInst %6: any, %BB1, %BB2
+// CHECK-NEXT:       CondBranchInst %6: boolean, %BB1, %BB2
 // CHECK-NEXT:%BB1:
 // CHECK-NEXT:; <stdin>:12:9
 // CHECK-NEXT:  %8 = LoadFrameInst (:any) [a]: any

--- a/test/IRGen/ternary.js
+++ b/test/IRGen/ternary.js
@@ -75,8 +75,8 @@ function test_three(x, one, two) {
 // CHECK-NEXT:       StoreFrameInst false: boolean, [stop]: any
 // CHECK-NEXT:       StoreFrameInst 16: number, [age]: any
 // CHECK-NEXT:  %4 = LoadFrameInst (:any) [age]: any
-// CHECK-NEXT:  %5 = BinaryGreaterThanInst (:any) %4: any, 18: number
-// CHECK-NEXT:       CondBranchInst %5: any, %BB1, %BB2
+// CHECK-NEXT:  %5 = BinaryGreaterThanInst (:boolean) %4: any, 18: number
+// CHECK-NEXT:       CondBranchInst %5: boolean, %BB1, %BB2
 // CHECK-NEXT:%BB2:
 // CHECK-NEXT:       StoreFrameInst true: boolean, [stop]: any
 // CHECK-NEXT:       BranchInst %BB3

--- a/test/IRGen/try_catch.js
+++ b/test/IRGen/try_catch.js
@@ -193,8 +193,8 @@ function finally_with_break_continue_test() {
 // CHECK-NEXT:       StoreFrameInst %2: any, [e]: any
 // CHECK-NEXT:  %4 = LoadFrameInst (:any) [e]: any
 // CHECK-NEXT:  %5 = AsNumericInst (:number|bigint) %4: any
-// CHECK-NEXT:  %6 = UnaryIncInst (:any) %5: number|bigint
-// CHECK-NEXT:       StoreFrameInst %6: any, [e]: any
+// CHECK-NEXT:  %6 = UnaryIncInst (:number|bigint) %5: number|bigint
+// CHECK-NEXT:       StoreFrameInst %6: number|bigint, [e]: any
 // CHECK-NEXT:  %8 = LoadFrameInst (:any) [i]: any
 // CHECK-NEXT:  %9 = BinarySubtractInst (:any) %8: any, 3: number
 // CHECK-NEXT:        StoreFrameInst %9: any, [i]: any
@@ -222,8 +222,8 @@ function finally_with_break_continue_test() {
 // CHECK-NEXT:%BB6:
 // CHECK-NEXT:  %27 = LoadFrameInst (:any) [i]: any
 // CHECK-NEXT:  %28 = AsNumericInst (:number|bigint) %27: any
-// CHECK-NEXT:  %29 = UnaryIncInst (:any) %28: number|bigint
-// CHECK-NEXT:        StoreFrameInst %29: any, [i]: any
+// CHECK-NEXT:  %29 = UnaryIncInst (:number|bigint) %28: number|bigint
+// CHECK-NEXT:        StoreFrameInst %29: number|bigint, [i]: any
 // CHECK-NEXT:        BranchInst %BB7
 // CHECK-NEXT:function_end
 
@@ -258,8 +258,8 @@ function finally_with_break_continue_test() {
 // CHECK-NEXT:%BB5:
 // CHECK-NEXT:  %20 = LoadFrameInst (:any) [i]: any
 // CHECK-NEXT:  %21 = AsNumericInst (:number|bigint) %20: any
-// CHECK-NEXT:  %22 = UnaryIncInst (:any) %21: number|bigint
-// CHECK-NEXT:        StoreFrameInst %22: any, [i]: any
+// CHECK-NEXT:  %22 = UnaryIncInst (:number|bigint) %21: number|bigint
+// CHECK-NEXT:        StoreFrameInst %22: number|bigint, [i]: any
 // CHECK-NEXT:        BranchInst %BB8
 // CHECK-NEXT:%BB8:
 // CHECK-NEXT:        TryEndInst
@@ -292,8 +292,8 @@ function finally_with_break_continue_test() {
 // CHECK-NEXT:%BB2:
 // CHECK-NEXT:  %12 = LoadFrameInst (:any) [i]: any
 // CHECK-NEXT:  %13 = AsNumericInst (:number|bigint) %12: any
-// CHECK-NEXT:  %14 = UnaryIncInst (:any) %13: number|bigint
-// CHECK-NEXT:        StoreFrameInst %14: any, [i]: any
+// CHECK-NEXT:  %14 = UnaryIncInst (:number|bigint) %13: number|bigint
+// CHECK-NEXT:        StoreFrameInst %14: number|bigint, [i]: any
 // CHECK-NEXT:        BranchInst %BB4
 // CHECK-NEXT:%BB4:
 // CHECK-NEXT:        TryEndInst
@@ -327,8 +327,8 @@ function finally_with_break_continue_test() {
 // CHECK-NEXT:%BB4:
 // CHECK-NEXT:  %15 = LoadFrameInst (:any) [i]: any
 // CHECK-NEXT:  %16 = AsNumericInst (:number|bigint) %15: any
-// CHECK-NEXT:  %17 = UnaryIncInst (:any) %16: number|bigint
-// CHECK-NEXT:        StoreFrameInst %17: any, [i]: any
+// CHECK-NEXT:  %17 = UnaryIncInst (:number|bigint) %16: number|bigint
+// CHECK-NEXT:        StoreFrameInst %17: number|bigint, [i]: any
 // CHECK-NEXT:        BranchInst %BB6
 // CHECK-NEXT:%BB6:
 // CHECK-NEXT:        TryEndInst
@@ -378,8 +378,8 @@ function finally_with_break_continue_test() {
 // CHECK-NEXT:%BB5:
 // CHECK-NEXT:  %20 = LoadFrameInst (:any) [i]: any
 // CHECK-NEXT:  %21 = AsNumericInst (:number|bigint) %20: any
-// CHECK-NEXT:  %22 = UnaryIncInst (:any) %21: number|bigint
-// CHECK-NEXT:        StoreFrameInst %22: any, [i]: any
+// CHECK-NEXT:  %22 = UnaryIncInst (:number|bigint) %21: number|bigint
+// CHECK-NEXT:        StoreFrameInst %22: number|bigint, [i]: any
 // CHECK-NEXT:        TryStartInst %BB8, %BB9
 // CHECK-NEXT:%BB8:
 // CHECK-NEXT:  %25 = CatchInst (:any)
@@ -513,8 +513,8 @@ function finally_with_break_continue_test() {
 // CHECK-NEXT:%BB5:
 // CHECK-NEXT:  %20 = LoadFrameInst (:any) [i]: any
 // CHECK-NEXT:  %21 = AsNumericInst (:number|bigint) %20: any
-// CHECK-NEXT:  %22 = UnaryIncInst (:any) %21: number|bigint
-// CHECK-NEXT:        StoreFrameInst %22: any, [i]: any
+// CHECK-NEXT:  %22 = UnaryIncInst (:number|bigint) %21: number|bigint
+// CHECK-NEXT:        StoreFrameInst %22: number|bigint, [i]: any
 // CHECK-NEXT:        BranchInst %BB10
 // CHECK-NEXT:%BB10:
 // CHECK-NEXT:        TryEndInst
@@ -648,8 +648,8 @@ function finally_with_break_continue_test() {
 // CHECK-NEXT:%BB6:
 // CHECK-NEXT:  %13 = LoadFrameInst (:any) [i]: any
 // CHECK-NEXT:  %14 = AsNumericInst (:number|bigint) %13: any
-// CHECK-NEXT:  %15 = UnaryIncInst (:any) %14: number|bigint
-// CHECK-NEXT:        StoreFrameInst %15: any, [i]: any
+// CHECK-NEXT:  %15 = UnaryIncInst (:number|bigint) %14: number|bigint
+// CHECK-NEXT:        StoreFrameInst %15: number|bigint, [i]: any
 // CHECK-NEXT:        BranchInst %BB5
 // CHECK-NEXT:%BB3:
 // CHECK-NEXT:  %18 = CatchInst (:any)
@@ -671,8 +671,8 @@ function finally_with_break_continue_test() {
 // CHECK-NEXT:%BB8:
 // CHECK-NEXT:  %32 = LoadFrameInst (:any) [i]: any
 // CHECK-NEXT:  %33 = AsNumericInst (:number|bigint) %32: any
-// CHECK-NEXT:  %34 = UnaryIncInst (:any) %33: number|bigint
-// CHECK-NEXT:        StoreFrameInst %34: any, [i]: any
+// CHECK-NEXT:  %34 = UnaryIncInst (:number|bigint) %33: number|bigint
+// CHECK-NEXT:        StoreFrameInst %34: number|bigint, [i]: any
 // CHECK-NEXT:        BranchInst %BB11
 // CHECK-NEXT:%BB11:
 // CHECK-NEXT:        TryEndInst

--- a/test/IRGen/try_catch.js
+++ b/test/IRGen/try_catch.js
@@ -205,8 +205,8 @@ function finally_with_break_continue_test() {
 // CHECK-NEXT:%BB2:
 // CHECK-NEXT:        StoreFrameInst 0: number, [i]: any
 // CHECK-NEXT:  %15 = LoadFrameInst (:any) [i]: any
-// CHECK-NEXT:  %16 = BinaryLessThanInst (:any) %15: any, 10: number
-// CHECK-NEXT:        CondBranchInst %16: any, %BB4, %BB5
+// CHECK-NEXT:  %16 = BinaryLessThanInst (:boolean) %15: any, 10: number
+// CHECK-NEXT:        CondBranchInst %16: boolean, %BB4, %BB5
 // CHECK-NEXT:%BB4:
 // CHECK-NEXT:  %18 = LoadFrameInst (:any) [i]: any
 // CHECK-NEXT:  %19 = BinaryAddInst (:any) %18: any, 2: number
@@ -217,8 +217,8 @@ function finally_with_break_continue_test() {
 // CHECK-NEXT:        ThrowInst %22: any
 // CHECK-NEXT:%BB7:
 // CHECK-NEXT:  %24 = LoadFrameInst (:any) [i]: any
-// CHECK-NEXT:  %25 = BinaryLessThanInst (:any) %24: any, 10: number
-// CHECK-NEXT:        CondBranchInst %25: any, %BB4, %BB5
+// CHECK-NEXT:  %25 = BinaryLessThanInst (:boolean) %24: any, 10: number
+// CHECK-NEXT:        CondBranchInst %25: boolean, %BB4, %BB5
 // CHECK-NEXT:%BB6:
 // CHECK-NEXT:  %27 = LoadFrameInst (:any) [i]: any
 // CHECK-NEXT:  %28 = AsNumericInst (:number|bigint) %27: any
@@ -632,8 +632,8 @@ function finally_with_break_continue_test() {
 // CHECK-NEXT:       StoreFrameInst undefined: undefined, [i]: any
 // CHECK-NEXT:       StoreFrameInst 0: number, [i]: any
 // CHECK-NEXT:  %2 = LoadFrameInst (:any) [i]: any
-// CHECK-NEXT:  %3 = BinaryLessThanInst (:any) %2: any, 10: number
-// CHECK-NEXT:       CondBranchInst %3: any, %BB1, %BB2
+// CHECK-NEXT:  %3 = BinaryLessThanInst (:boolean) %2: any, 10: number
+// CHECK-NEXT:       CondBranchInst %3: boolean, %BB1, %BB2
 // CHECK-NEXT:%BB1:
 // CHECK-NEXT:       TryStartInst %BB3, %BB4
 // CHECK-NEXT:%BB2:
@@ -643,8 +643,8 @@ function finally_with_break_continue_test() {
 // CHECK-NEXT:       ReturnInst undefined: undefined
 // CHECK-NEXT:%BB5:
 // CHECK-NEXT:  %10 = LoadFrameInst (:any) [i]: any
-// CHECK-NEXT:  %11 = BinaryLessThanInst (:any) %10: any, 10: number
-// CHECK-NEXT:        CondBranchInst %11: any, %BB1, %BB2
+// CHECK-NEXT:  %11 = BinaryLessThanInst (:boolean) %10: any, 10: number
+// CHECK-NEXT:        CondBranchInst %11: boolean, %BB1, %BB2
 // CHECK-NEXT:%BB6:
 // CHECK-NEXT:  %13 = LoadFrameInst (:any) [i]: any
 // CHECK-NEXT:  %14 = AsNumericInst (:number|bigint) %13: any
@@ -666,8 +666,8 @@ function finally_with_break_continue_test() {
 // CHECK-NEXT:  %27 = BinaryAddInst (:any) %26: any, 2: number
 // CHECK-NEXT:        StoreFrameInst %27: any, [i]: any
 // CHECK-NEXT:  %29 = LoadFrameInst (:any) [i]: any
-// CHECK-NEXT:  %30 = BinaryEqualInst (:any) %29: any, 3: number
-// CHECK-NEXT:        CondBranchInst %30: any, %BB9, %BB10
+// CHECK-NEXT:  %30 = BinaryEqualInst (:boolean) %29: any, 3: number
+// CHECK-NEXT:        CondBranchInst %30: boolean, %BB9, %BB10
 // CHECK-NEXT:%BB8:
 // CHECK-NEXT:  %32 = LoadFrameInst (:any) [i]: any
 // CHECK-NEXT:  %33 = AsNumericInst (:number|bigint) %32: any

--- a/test/IRGen/typeof_undefined.js
+++ b/test/IRGen/typeof_undefined.js
@@ -18,8 +18,8 @@ var x = typeof foo;
 // CHECK-NEXT:  %1 = AllocStackInst (:any) $?anon_0_ret: any
 // CHECK-NEXT:       StoreStackInst undefined: undefined, %1: any
 // CHECK-NEXT:  %3 = LoadPropertyInst (:any) globalObject: object, "foo": string
-// CHECK-NEXT:  %4 = UnaryTypeofInst (:any) %3: any
-// CHECK-NEXT:       StorePropertyStrictInst %4: any, globalObject: object, "x": string
+// CHECK-NEXT:  %4 = UnaryTypeofInst (:string) %3: any
+// CHECK-NEXT:       StorePropertyStrictInst %4: string, globalObject: object, "x": string
 // CHECK-NEXT:  %6 = LoadStackInst (:any) %1: any
 // CHECK-NEXT:       ReturnInst %6: any
 // CHECK-NEXT:function_end

--- a/test/IRGen/update_expr.js
+++ b/test/IRGen/update_expr.js
@@ -67,8 +67,8 @@ function update_variable_test3(x) { return --x; }
 // CHECK-NEXT:  %2 = LoadFrameInst (:any) [o]: any
 // CHECK-NEXT:  %3 = LoadPropertyInst (:any) %2: any, "f": string
 // CHECK-NEXT:  %4 = AsNumericInst (:number|bigint) %3: any
-// CHECK-NEXT:  %5 = UnaryIncInst (:any) %4: number|bigint
-// CHECK-NEXT:       StorePropertyLooseInst %5: any, %2: any, "f": string
+// CHECK-NEXT:  %5 = UnaryIncInst (:number|bigint) %4: number|bigint
+// CHECK-NEXT:       StorePropertyLooseInst %5: number|bigint, %2: any, "f": string
 // CHECK-NEXT:       ReturnInst %4: number|bigint
 // CHECK-NEXT:function_end
 
@@ -80,8 +80,8 @@ function update_variable_test3(x) { return --x; }
 // CHECK-NEXT:  %2 = LoadFrameInst (:any) [o]: any
 // CHECK-NEXT:  %3 = LoadPropertyInst (:any) %2: any, "f": string
 // CHECK-NEXT:  %4 = AsNumericInst (:number|bigint) %3: any
-// CHECK-NEXT:  %5 = UnaryDecInst (:any) %4: number|bigint
-// CHECK-NEXT:       StorePropertyLooseInst %5: any, %2: any, "f": string
+// CHECK-NEXT:  %5 = UnaryDecInst (:number|bigint) %4: number|bigint
+// CHECK-NEXT:       StorePropertyLooseInst %5: number|bigint, %2: any, "f": string
 // CHECK-NEXT:       ReturnInst %4: number|bigint
 // CHECK-NEXT:function_end
 
@@ -92,9 +92,9 @@ function update_variable_test3(x) { return --x; }
 // CHECK-NEXT:       StoreFrameInst %0: any, [o]: any
 // CHECK-NEXT:  %2 = LoadFrameInst (:any) [o]: any
 // CHECK-NEXT:  %3 = LoadPropertyInst (:any) %2: any, "f": string
-// CHECK-NEXT:  %4 = UnaryIncInst (:any) %3: any
-// CHECK-NEXT:       StorePropertyLooseInst %4: any, %2: any, "f": string
-// CHECK-NEXT:       ReturnInst %4: any
+// CHECK-NEXT:  %4 = UnaryIncInst (:number|bigint) %3: any
+// CHECK-NEXT:       StorePropertyLooseInst %4: number|bigint, %2: any, "f": string
+// CHECK-NEXT:       ReturnInst %4: number|bigint
 // CHECK-NEXT:function_end
 
 // CHECK:function update_field_test3(o: any): any
@@ -104,9 +104,9 @@ function update_variable_test3(x) { return --x; }
 // CHECK-NEXT:       StoreFrameInst %0: any, [o]: any
 // CHECK-NEXT:  %2 = LoadFrameInst (:any) [o]: any
 // CHECK-NEXT:  %3 = LoadPropertyInst (:any) %2: any, "f": string
-// CHECK-NEXT:  %4 = UnaryDecInst (:any) %3: any
-// CHECK-NEXT:       StorePropertyLooseInst %4: any, %2: any, "f": string
-// CHECK-NEXT:       ReturnInst %4: any
+// CHECK-NEXT:  %4 = UnaryDecInst (:number|bigint) %3: any
+// CHECK-NEXT:       StorePropertyLooseInst %4: number|bigint, %2: any, "f": string
+// CHECK-NEXT:       ReturnInst %4: number|bigint
 // CHECK-NEXT:function_end
 
 // CHECK:function update_variable_test0(x: any): any
@@ -116,8 +116,8 @@ function update_variable_test3(x) { return --x; }
 // CHECK-NEXT:       StoreFrameInst %0: any, [x]: any
 // CHECK-NEXT:  %2 = LoadFrameInst (:any) [x]: any
 // CHECK-NEXT:  %3 = AsNumericInst (:number|bigint) %2: any
-// CHECK-NEXT:  %4 = UnaryIncInst (:any) %3: number|bigint
-// CHECK-NEXT:       StoreFrameInst %4: any, [x]: any
+// CHECK-NEXT:  %4 = UnaryIncInst (:number|bigint) %3: number|bigint
+// CHECK-NEXT:       StoreFrameInst %4: number|bigint, [x]: any
 // CHECK-NEXT:       ReturnInst %3: number|bigint
 // CHECK-NEXT:function_end
 
@@ -128,8 +128,8 @@ function update_variable_test3(x) { return --x; }
 // CHECK-NEXT:       StoreFrameInst %0: any, [x]: any
 // CHECK-NEXT:  %2 = LoadFrameInst (:any) [x]: any
 // CHECK-NEXT:  %3 = AsNumericInst (:number|bigint) %2: any
-// CHECK-NEXT:  %4 = UnaryDecInst (:any) %3: number|bigint
-// CHECK-NEXT:       StoreFrameInst %4: any, [x]: any
+// CHECK-NEXT:  %4 = UnaryDecInst (:number|bigint) %3: number|bigint
+// CHECK-NEXT:       StoreFrameInst %4: number|bigint, [x]: any
 // CHECK-NEXT:       ReturnInst %3: number|bigint
 // CHECK-NEXT:function_end
 
@@ -139,9 +139,9 @@ function update_variable_test3(x) { return --x; }
 // CHECK-NEXT:  %0 = LoadParamInst (:any) %x: any
 // CHECK-NEXT:       StoreFrameInst %0: any, [x]: any
 // CHECK-NEXT:  %2 = LoadFrameInst (:any) [x]: any
-// CHECK-NEXT:  %3 = UnaryIncInst (:any) %2: any
-// CHECK-NEXT:       StoreFrameInst %3: any, [x]: any
-// CHECK-NEXT:       ReturnInst %3: any
+// CHECK-NEXT:  %3 = UnaryIncInst (:number|bigint) %2: any
+// CHECK-NEXT:       StoreFrameInst %3: number|bigint, [x]: any
+// CHECK-NEXT:       ReturnInst %3: number|bigint
 // CHECK-NEXT:function_end
 
 // CHECK:function update_variable_test3(x: any): any
@@ -150,7 +150,7 @@ function update_variable_test3(x) { return --x; }
 // CHECK-NEXT:  %0 = LoadParamInst (:any) %x: any
 // CHECK-NEXT:       StoreFrameInst %0: any, [x]: any
 // CHECK-NEXT:  %2 = LoadFrameInst (:any) [x]: any
-// CHECK-NEXT:  %3 = UnaryDecInst (:any) %2: any
-// CHECK-NEXT:       StoreFrameInst %3: any, [x]: any
-// CHECK-NEXT:       ReturnInst %3: any
+// CHECK-NEXT:  %3 = UnaryDecInst (:number|bigint) %2: any
+// CHECK-NEXT:       StoreFrameInst %3: number|bigint, [x]: any
+// CHECK-NEXT:       ReturnInst %3: number|bigint
 // CHECK-NEXT:function_end

--- a/test/Optimizer/es6/tdz-dedup.js
+++ b/test/Optimizer/es6/tdz-dedup.js
@@ -98,19 +98,19 @@ function check_after_check() {
 // CHECK-NEXT:       StoreFrameInst %0: any, [p]: any
 // CHECK-NEXT:  %2 = LoadFrameInst (:any|empty) [x@check_after_check]: any|empty
 // CHECK-NEXT:  %3 = ThrowIfInst (:any) %2: any|empty, type(empty)
-// CHECK-NEXT:  %4 = UnaryIncInst (:any) %3: any
+// CHECK-NEXT:  %4 = UnaryIncInst (:number|bigint) %3: any
 // CHECK-NEXT:  %5 = LoadFrameInst (:any|empty) [x@check_after_check]: any|empty
 // CHECK-NEXT:  %6 = ThrowIfInst (:any) %5: any|empty, type(empty)
-// CHECK-NEXT:       StoreFrameInst %4: any, [x@check_after_check]: any|empty
+// CHECK-NEXT:       StoreFrameInst %4: number|bigint, [x@check_after_check]: any|empty
 // CHECK-NEXT:  %8 = LoadFrameInst (:any) [p]: any
 // CHECK-NEXT:       CondBranchInst %8: any, %BB1, %BB2
 // CHECK-NEXT:%BB1:
 // CHECK-NEXT:  %10 = LoadFrameInst (:any|empty) [x@check_after_check]: any|empty
 // CHECK-NEXT:  %11 = ThrowIfInst (:any) %10: any|empty, type(empty)
-// CHECK-NEXT:  %12 = UnaryIncInst (:any) %11: any
+// CHECK-NEXT:  %12 = UnaryIncInst (:number|bigint) %11: any
 // CHECK-NEXT:  %13 = LoadFrameInst (:any|empty) [x@check_after_check]: any|empty
 // CHECK-NEXT:  %14 = ThrowIfInst (:any) %13: any|empty, type(empty)
-// CHECK-NEXT:        StoreFrameInst %12: any, [x@check_after_check]: any|empty
+// CHECK-NEXT:        StoreFrameInst %12: number|bigint, [x@check_after_check]: any|empty
 // CHECK-NEXT:        BranchInst %BB3
 // CHECK-NEXT:%BB2:
 // CHECK-NEXT:        BranchInst %BB3

--- a/test/Optimizer/flow/func-analysis-ccast.js
+++ b/test/Optimizer/flow/func-analysis-ccast.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %shermes -typed -dump-ir -Xdump-functions=bar -Xcustom-opt=frameloadstoreopts,functionanalysis %s | %FileCheckOrRegen %s --match-full-lines
+
+// Ensure that FunctionAnalysis needs to follow checked casts.
+// bar() below uses a checked cast before calling foo().
+// The IR output we are checking shows the cast and that CallInst instruction has the
+// correct target.
+
+var foo: any = function () {}
+
+function bar() {
+    return (foo as () => void)();
+}
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:function bar(): any [allCallsitesKnownInStrictMode]
+// CHECK-NEXT:frame = []
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = LoadFrameInst (:any) [foo@""]: any
+// CHECK-NEXT:  %1 = CheckedTypeCastInst (:object) %0: any, type(object)
+// CHECK-NEXT:  %2 = CallInst [njsf] (:any) %1: object, %foo(): any, empty: any, undefined: undefined, undefined: undefined
+// CHECK-NEXT:       ReturnInst %2: any
+// CHECK-NEXT:function_end

--- a/test/Optimizer/flow/func-analysis-ccast.js
+++ b/test/Optimizer/flow/func-analysis-ccast.js
@@ -26,5 +26,6 @@ function bar() {
 // CHECK-NEXT:  %0 = LoadFrameInst (:any) [foo@""]: any
 // CHECK-NEXT:  %1 = CheckedTypeCastInst (:object) %0: any, type(object)
 // CHECK-NEXT:  %2 = CallInst [njsf] (:any) %1: object, %foo(): any, empty: any, undefined: undefined, undefined: undefined
-// CHECK-NEXT:       ReturnInst %2: any
+// CHECK-NEXT:  %3 = CheckedTypeCastInst (:undefined) %2: any, type(undefined)
+// CHECK-NEXT:       ReturnInst %3: undefined
 // CHECK-NEXT:function_end

--- a/test/Sema/flow/assign-ops-2.js
+++ b/test/Sema/flow/assign-ops-2.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %shermes -Werror -fno-std-globals --typed --dump-sema %s | %FileCheckOrRegen %s --match-full-lines
+
+// Test that an assignment with a narrower RHS into a wider LHS takes the
+// narrower type.
+function f(a: any, u: number|string, n: number) {
+  n = u = 5;
+  let n1: number;
+  n1 = n = a;
+}
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:%untyped_function.1 = untyped_function()
+// CHECK-NEXT:%union.2 = union(string | number)
+// CHECK-NEXT:%function.3 = function(a: any, u: %union.2, n: number): any
+
+// CHECK:SemContext
+// CHECK-NEXT:Func strict
+// CHECK-NEXT:    Scope %s.1
+// CHECK-NEXT:    Func strict
+// CHECK-NEXT:        Scope %s.2
+// CHECK-NEXT:            Decl %d.1 'exports' Parameter : any
+// CHECK-NEXT:            Decl %d.2 'f' ScopedFunction : %function.3
+// CHECK-NEXT:            Decl %d.3 'arguments' Var Arguments
+// CHECK-NEXT:            hoistedFunction f
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.3
+// CHECK-NEXT:                Decl %d.4 'a' Parameter : any
+// CHECK-NEXT:                Decl %d.5 'u' Parameter : %union.2
+// CHECK-NEXT:                Decl %d.6 'n' Parameter : number
+// CHECK-NEXT:                Decl %d.7 'n1' Let : number
+// CHECK-NEXT:                Decl %d.8 'arguments' Var Arguments
+
+// CHECK:Program Scope %s.1
+// CHECK-NEXT:    ExpressionStatement
+// CHECK-NEXT:        CallExpression : any
+// CHECK-NEXT:            FunctionExpression : %untyped_function.1
+// CHECK-NEXT:                Id 'exports' [D:E:%d.1 'exports']
+// CHECK-NEXT:                BlockStatement
+// CHECK-NEXT:                    FunctionDeclaration : %function.3
+// CHECK-NEXT:                        Id 'f' [D:E:%d.2 'f']
+// CHECK-NEXT:                        Id 'a' [D:E:%d.4 'a']
+// CHECK-NEXT:                        Id 'u' [D:E:%d.5 'u']
+// CHECK-NEXT:                        Id 'n' [D:E:%d.6 'n']
+// CHECK-NEXT:                        BlockStatement
+// CHECK-NEXT:                            ExpressionStatement
+// CHECK-NEXT:                                AssignmentExpression : number
+// CHECK-NEXT:                                    Id 'n' [D:E:%d.6 'n'] : number
+// CHECK-NEXT:                                    AssignmentExpression : number
+// CHECK-NEXT:                                        Id 'u' [D:E:%d.5 'u'] : %union.2
+// CHECK-NEXT:                                        NumericLiteral : number
+// CHECK-NEXT:                            VariableDeclaration
+// CHECK-NEXT:                                VariableDeclarator
+// CHECK-NEXT:                                    Id 'n1' [D:E:%d.7 'n1']
+// CHECK-NEXT:                            ExpressionStatement
+// CHECK-NEXT:                                AssignmentExpression : number
+// CHECK-NEXT:                                    Id 'n1' [D:E:%d.7 'n1'] : number
+// CHECK-NEXT:                                    AssignmentExpression : number
+// CHECK-NEXT:                                        Id 'n' [D:E:%d.6 'n'] : number
+// CHECK-NEXT:                                        ImplicitCheckedCast : number
+// CHECK-NEXT:                                            Id 'a' [D:E:%d.4 'a'] : any
+// CHECK-NEXT:            ObjectExpression

--- a/test/Sema/flow/assign-ops.js
+++ b/test/Sema/flow/assign-ops.js
@@ -7,15 +7,11 @@
 
 // RUN: %shermes -Werror -fno-std-globals --typed --dump-sema %s | %FileCheckOrRegen %s --match-full-lines
 
-(function() {
-
 function f(x: any, n: number) {
   // These need ImplicitCheckedCast on the LHS.
   n += x;
   n -= x;
 }
-
-});
 
 // Auto-generated content below. Please do not modify manually.
 
@@ -28,17 +24,14 @@ function f(x: any, n: number) {
 // CHECK-NEXT:    Func strict
 // CHECK-NEXT:        Scope %s.2
 // CHECK-NEXT:            Decl %d.1 'exports' Parameter : any
-// CHECK-NEXT:            Decl %d.2 'arguments' Var Arguments
+// CHECK-NEXT:            Decl %d.2 'f' ScopedFunction : %function.2
+// CHECK-NEXT:            Decl %d.3 'arguments' Var Arguments
+// CHECK-NEXT:            hoistedFunction f
 // CHECK-NEXT:        Func strict
 // CHECK-NEXT:            Scope %s.3
-// CHECK-NEXT:                Decl %d.3 'f' ScopedFunction : %function.2
-// CHECK-NEXT:                Decl %d.4 'arguments' Var Arguments
-// CHECK-NEXT:                hoistedFunction f
-// CHECK-NEXT:            Func strict
-// CHECK-NEXT:                Scope %s.4
-// CHECK-NEXT:                    Decl %d.5 'x' Parameter : any
-// CHECK-NEXT:                    Decl %d.6 'n' Parameter : number
-// CHECK-NEXT:                    Decl %d.7 'arguments' Var Arguments
+// CHECK-NEXT:                Decl %d.4 'x' Parameter : any
+// CHECK-NEXT:                Decl %d.5 'n' Parameter : number
+// CHECK-NEXT:                Decl %d.6 'arguments' Var Arguments
 
 // CHECK:Program Scope %s.1
 // CHECK-NEXT:    ExpressionStatement
@@ -46,22 +39,19 @@ function f(x: any, n: number) {
 // CHECK-NEXT:            FunctionExpression : %untyped_function.1
 // CHECK-NEXT:                Id 'exports' [D:E:%d.1 'exports']
 // CHECK-NEXT:                BlockStatement
-// CHECK-NEXT:                    ExpressionStatement
-// CHECK-NEXT:                        FunctionExpression : %untyped_function.1
-// CHECK-NEXT:                            BlockStatement
-// CHECK-NEXT:                                FunctionDeclaration : %function.2
-// CHECK-NEXT:                                    Id 'f' [D:E:%d.3 'f']
-// CHECK-NEXT:                                    Id 'x' [D:E:%d.5 'x']
-// CHECK-NEXT:                                    Id 'n' [D:E:%d.6 'n']
-// CHECK-NEXT:                                    BlockStatement
-// CHECK-NEXT:                                        ExpressionStatement
-// CHECK-NEXT:                                            AssignmentExpression : any
-// CHECK-NEXT:                                                ImplicitCheckedCast : number
-// CHECK-NEXT:                                                    Id 'n' [D:E:%d.6 'n'] : number
-// CHECK-NEXT:                                                Id 'x' [D:E:%d.5 'x'] : any
-// CHECK-NEXT:                                        ExpressionStatement
-// CHECK-NEXT:                                            AssignmentExpression : any
-// CHECK-NEXT:                                                ImplicitCheckedCast : number
-// CHECK-NEXT:                                                    Id 'n' [D:E:%d.6 'n'] : number
-// CHECK-NEXT:                                                Id 'x' [D:E:%d.5 'x'] : any
+// CHECK-NEXT:                    FunctionDeclaration : %function.2
+// CHECK-NEXT:                        Id 'f' [D:E:%d.2 'f']
+// CHECK-NEXT:                        Id 'x' [D:E:%d.4 'x']
+// CHECK-NEXT:                        Id 'n' [D:E:%d.5 'n']
+// CHECK-NEXT:                        BlockStatement
+// CHECK-NEXT:                            ExpressionStatement
+// CHECK-NEXT:                                AssignmentExpression : number
+// CHECK-NEXT:                                    ImplicitCheckedCast : number
+// CHECK-NEXT:                                        Id 'n' [D:E:%d.5 'n'] : number
+// CHECK-NEXT:                                    Id 'x' [D:E:%d.4 'x'] : any
+// CHECK-NEXT:                            ExpressionStatement
+// CHECK-NEXT:                                AssignmentExpression : number
+// CHECK-NEXT:                                    ImplicitCheckedCast : number
+// CHECK-NEXT:                                        Id 'n' [D:E:%d.5 'n'] : number
+// CHECK-NEXT:                                    Id 'x' [D:E:%d.4 'x'] : any
 // CHECK-NEXT:            ObjectExpression

--- a/test/Sema/flow/infer-decl-outoforder.js
+++ b/test/Sema/flow/infer-decl-outoforder.js
@@ -63,7 +63,7 @@ let z;
 // CHECK-NEXT:                                        Id 'foo' [D:E:%d.3 'foo']
 // CHECK-NEXT:                                        BlockStatement
 // CHECK-NEXT:                                            ExpressionStatement
-// CHECK-NEXT:                                                AssignmentExpression : any
+// CHECK-NEXT:                                                AssignmentExpression : number
 // CHECK-NEXT:                                                    Id 'z' [D:E:%d.6 'z'] : any
 // CHECK-NEXT:                                                    NumericLiteral : number
 // CHECK-NEXT:                                    VariableDeclaration

--- a/tools/shermes/shermes.cpp
+++ b/tools/shermes/shermes.cpp
@@ -243,6 +243,19 @@ cl::opt<OutputLevelKind> OutputLevel(
             "Execute the compiled binary")),
     cl::cat(CompilerCategory));
 
+static cl::list<std::string> DumpFunctions(
+    "Xdump-functions",
+    cl::desc("Only dump the IR for the given functions"),
+    cl::Hidden,
+    cl::CommaSeparated,
+    cl::cat(CompilerCategory));
+static cl::list<std::string> NoDumpFunctions(
+    "Xno-dump-functions",
+    cl::desc("Exclude the given functions from IR dumps"),
+    cl::Hidden,
+    cl::CommaSeparated,
+    cl::cat(CompilerCategory));
+
 static cl::opt<std::string> ExportedUnit(
     "exported-unit",
     cl::desc("Produce an SHUnit with the given name to be used by other code. "
@@ -565,6 +578,10 @@ std::shared_ptr<Context> createContext() {
   codeGenOpts.dumpIRBetweenPasses = cli::DumpBetweenPasses;
   codeGenOpts.verifyIRBetweenPasses = cli::VerifyIR;
   codeGenOpts.colors = cli::Colors;
+  codeGenOpts.dumpFunctions.insert(
+      cli::DumpFunctions.begin(), cli::DumpFunctions.end());
+  codeGenOpts.noDumpFunctions.insert(
+      cli::NoDumpFunctions.begin(), cli::NoDumpFunctions.end());
 
   OptimizationSettings optimizationOpts;
 
@@ -590,8 +607,8 @@ std::shared_ptr<Context> createContext() {
   // TODO: error checking, etc.
   nativeSettings.targetTriple = llvh::Triple(cli::XNativeTarget);
 
-  auto context =
-      std::make_shared<Context>(codeGenOpts, optimizationOpts, &nativeSettings);
+  auto context = std::make_shared<Context>(
+      std::move(codeGenOpts), optimizationOpts, &nativeSettings);
 
   if (codeGenOpts.dumpIRBetweenPasses)
     context->createPersistentIRNamer();

--- a/unittests/IR/BuilderTest.cpp
+++ b/unittests/IR/BuilderTest.cpp
@@ -202,30 +202,30 @@ TEST(BuilderTest, TestValueTypes) {
 }
 
 TEST(BuilderTest, Types) {
-  Type T = Type::createAnyOrEmpty();
+  Type T = Type::createAnyEmptyUninit();
   EXPECT_FALSE(T.isNoType());
-  EXPECT_TRUE(T.isAnyOrEmptyType());
+  EXPECT_TRUE(T.isAnyEmptyUninitType());
 
   Type W = Type::unionTy(Type::createNumber(), Type::createBoolean());
-  EXPECT_FALSE(W.isAnyOrEmptyType());
+  EXPECT_FALSE(W.isAnyEmptyUninitType());
   EXPECT_TRUE(W.isPrimitive());
   EXPECT_FALSE(W.isStringType());
   EXPECT_FALSE(W.isObjectType());
 
   EXPECT_EQ(
-      Type::createAnyOrEmpty(),
-      Type::unionTy(Type::createAnyOrEmpty(), Type::createBoolean()));
+      Type::createAnyEmptyUninit(),
+      Type::unionTy(Type::createAnyEmptyUninit(), Type::createBoolean()));
 
   EXPECT_EQ(
-      Type::createAnyOrEmpty(),
-      Type::unionTy(Type::createAnyOrEmpty(), Type::createBoolean()));
+      Type::createAnyEmptyUninit(),
+      Type::unionTy(Type::createAnyEmptyUninit(), Type::createBoolean()));
 
   Type U = Type::unionTy(Type::createUndefined(), Type::createObject());
   EXPECT_FALSE(U.isObjectType());
   EXPECT_FALSE(U.isBooleanType());
 
   Type R = Type::unionTy(Type::createNumber(), Type::createObject());
-  EXPECT_FALSE(R.isAnyOrEmptyType());
+  EXPECT_FALSE(R.isAnyEmptyUninitType());
   EXPECT_FALSE(R.isPrimitive());
   EXPECT_FALSE(R.isNumberType());
   EXPECT_FALSE(R.isObjectType());

--- a/unittests/Support/StringSetVectorTest.cpp
+++ b/unittests/Support/StringSetVectorTest.cpp
@@ -7,7 +7,7 @@
 
 #include <gtest/gtest.h>
 
-#include "hermes/Support/StringSetVector.h"
+#include "hermes/ADT/StringSetVector.h"
 
 namespace {
 

--- a/unittests/VMRuntime/TestHelpers1.cpp
+++ b/unittests/VMRuntime/TestHelpers1.cpp
@@ -33,7 +33,8 @@ std::vector<uint8_t> hermes::bytecodeForSource(
   CodeGenerationSettings codeGenOpts;
   OptimizationSettings optSettings;
   optSettings.staticBuiltins = flags.staticBuiltins;
-  auto context = std::make_shared<Context>(sm, codeGenOpts, optSettings);
+  auto context =
+      std::make_shared<Context>(sm, std::move(codeGenOpts), optSettings);
   if (sourceMapGen) {
     context->setDebugInfoSetting(DebugInfoSetting::SOURCE_MAP);
     sourceMapGen->addSource("JavaScript");


### PR DESCRIPTION
Summary:
`ThrowIf` now distinguishes between more states. Update (and cleanup)
TDZDedup for it.

The full functionality will be tested in followup diff.

Differential Revision: D52477267

