### PR TITLE
Add optional length param to _sh_asciiz_to_string()

### DIFF
--- a/include/hermes/Support/UTF8.h
+++ b/include/hermes/Support/UTF8.h
@@ -52,21 +52,21 @@ bool isASCII(Char c) {
 }
 
 /// \return true if this is a pure ASCII char sequence.
-template <typename Iter>
-inline bool isAllASCII(Iter begin, Iter end) {
-  while (begin < end) {
-    if (!isASCII(*begin))
-      return false;
-    ++begin;
-  }
-  return true;
-}
-
 /// Overload for char* and uint8_t*.
 bool isAllASCII(const uint8_t *start, const uint8_t *end);
 
 inline bool isAllASCII(const char *start, const char *end) {
   return isAllASCII((const uint8_t *)start, (const uint8_t *)end);
+}
+
+/// \return true if this is a pure ASCII char sequence.
+/// Overload for char16_t.
+bool isAllASCII(const char16_t *start, const char16_t *end);
+
+/// \return true if this is a pure ASCII char sequence.
+template <typename T>
+inline bool isAllASCII(const T &str) {
+  return isAllASCII(str.data(), str.data() + str.size());
 }
 
 /// Decode a sequence of UTF8 encoded bytes when it is known that the first byte

--- a/include/hermes/VM/static_h.h
+++ b/include/hermes/VM/static_h.h
@@ -15,6 +15,7 @@
 #include <math.h>
 #include <setjmp.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -1031,8 +1032,10 @@ static inline SHLegacyValue _sh_ljs_native_pointer_or_throw(
 SHERMES_EXPORT int _sh_errno(void);
 
 /// Convert a C string to a JS string.
+/// \param str the C string to convert.
+/// \param len the length of the string, or -1 if the length is unknown.
 SHERMES_EXPORT SHLegacyValue
-_sh_asciiz_to_string(SHRuntime *shr, const char *str);
+_sh_asciiz_to_string(SHRuntime *shr, const char *str, ptrdiff_t len);
 
 static inline void _sh_ptr_write_char(char *ptr, int offset, char c) {
   ptr[offset] = c;

--- a/lib/BCGen/SH/SH.cpp
+++ b/lib/BCGen/SH/SH.cpp
@@ -107,7 +107,7 @@ class SHStringTable {
 
     for (const auto &str : strings_) {
       StringEntry entry;
-      if (isAllASCII(str.begin(), str.end())) {
+      if (isAllASCII(str)) {
         asciiStr += "  ";
         // The given string is entirely ASCII. Emit the sequence of ASCII
         // characters to asciiStr.

--- a/lib/Support/SourceErrorManager.cpp
+++ b/lib/Support/SourceErrorManager.cpp
@@ -612,7 +612,7 @@ static void printDiagnosticHelper(
   // If we find them, don't try to show the caret line
   // TODO: bravely teach buildSourceAndCaretLine to use wcwidth(), lifting this
   // restriction
-  bool showCaret = isAllASCII(sourceLine.begin(), sourceLine.end());
+  bool showCaret = isAllASCII(sourceLine);
 
   S << sourceLine << '\n';
   if (showCaret) {

--- a/lib/Support/UTF8.cpp
+++ b/lib/Support/UTF8.cpp
@@ -169,4 +169,12 @@ bool isAllASCII(const uint8_t *start, const uint8_t *end) {
   return true;
 }
 
+bool isAllASCII(const char16_t *start, const char16_t *end) {
+  for (; start != end; ++start) {
+    if (*start > 0x7F)
+      return false;
+  }
+  return true;
+}
+
 } // namespace hermes

--- a/lib/Support/UTF8.cpp
+++ b/lib/Support/UTF8.cpp
@@ -131,6 +131,54 @@ void convertUTF16ToUTF8WithSingleSurrogates(
   }
 }
 
+#if LLVM_PTR_SIZE == 8 && (defined(__clang__) || defined(__GNUC__))
+/// Unaligned data types.
+typedef uint32_t __attribute__((aligned(1))) u32;
+typedef uint64_t __attribute__((aligned(1))) u64;
+
+/// Check for non-ASCII characters in unaligned 8-byte chunks. The key idea is
+/// that unaligned loads are fast on modern hardware, and it is better to load
+/// the same data twice than to perform a conditional branch.
+/// This is about 2x faster than isAllASCII_32 on an M1 MacBook Pro.
+/// Idea from https://github.com/nadavrot/memset_benchmark.
+bool isAllASCII(const uint8_t *start, const uint8_t *end) {
+  static constexpr uint64_t kMask = 0x8080808080808080ull;
+  size_t len = end - start;
+  if (len <= 4) {
+    if (len == 0)
+      return true;
+    // len >= 1
+    uint8_t tmp = *start | *(end - 1);
+    if (len <= 2)
+      return (tmp & 0x80) == 0;
+    // len == 3 || len == 4
+    tmp |= start[1] | start[2];
+    return (tmp & 0x80) == 0;
+  }
+
+  if (len <= 16) {
+    if (len >= 8) {
+      // 8 <= len <= 16
+      // This could be handled by the loop below, but this is faster.
+      return ((*((const u64 *)start) | *((const u64 *)(end - 8))) & kMask) == 0;
+    }
+    // 4 <= len < 8
+    return ((*((const u32 *)start) | *((const u32 *)(end - 4))) & kMask) == 0;
+  }
+
+  // len > 16
+  const uint8_t *lastLL = end - 8;
+  do {
+    if (*(const u64 *)start & kMask)
+      return false;
+    start += 8;
+  } while (start < lastLL);
+  return (*((const u64 *)lastLL) & kMask) == 0;
+}
+
+#else
+
+/// Check for non-ASCII characters in 4-byte aligned chunks.
 bool isAllASCII(const uint8_t *start, const uint8_t *end) {
   const uint8_t *cursor = start;
   size_t len = end - start;
@@ -168,6 +216,8 @@ bool isAllASCII(const uint8_t *start, const uint8_t *end) {
     return false;
   return true;
 }
+
+#endif
 
 bool isAllASCII(const char16_t *start, const char16_t *end) {
   for (; start != end; ++start) {

--- a/lib/VM/StaticH.cpp
+++ b/lib/VM/StaticH.cpp
@@ -1952,6 +1952,7 @@ extern "C" int _sh_errno(void) {
 
 extern "C" SHLegacyValue _sh_asciiz_to_string(SHRuntime *shr, const char *str) {
   Runtime &runtime = getRuntime(shr);
+  NoHandleScope noHandle{runtime};
 
   auto res = StringPrimitive::createEfficient(
       runtime, UTF8Ref((const uint8_t *)str, strlen(str)), false);

--- a/lib/VM/StaticH.cpp
+++ b/lib/VM/StaticH.cpp
@@ -1950,12 +1950,15 @@ extern "C" int _sh_errno(void) {
   return errno;
 }
 
-extern "C" SHLegacyValue _sh_asciiz_to_string(SHRuntime *shr, const char *str) {
+extern "C" SHLegacyValue
+_sh_asciiz_to_string(SHRuntime *shr, const char *str, ptrdiff_t len) {
   Runtime &runtime = getRuntime(shr);
   NoHandleScope noHandle{runtime};
 
   auto res = StringPrimitive::createEfficient(
-      runtime, UTF8Ref((const uint8_t *)str, strlen(str)), false);
+      runtime,
+      UTF8Ref((const uint8_t *)str, len < 0 ? strlen(str) : len),
+      false);
   if (LLVM_UNLIKELY(res == ExecutionStatus::EXCEPTION))
     _sh_throw_current(shr);
   return *res;

--- a/lib/VM/StringPrimitive.cpp
+++ b/lib/VM/StringPrimitive.cpp
@@ -91,18 +91,19 @@ CallResult<HermesValue> StringPrimitive::createEfficientImpl(
     if (LLVM_UNLIKELY(result == ExecutionStatus::EXCEPTION)) {
       return ExecutionStatus::EXCEPTION;
     }
-    auto output = runtime.makeHandle<StringPrimitive>(*result);
     // Copy directly into the StringPrimitive storage.
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4244)
 #endif
-
-    std::copy(str.begin(), str.end(), output->castToASCIIPointerForWrite());
+    std::copy(
+        str.begin(),
+        str.end(),
+        vmcast<StringPrimitive>(*result)->castToASCIIPointerForWrite());
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
-    return output.getHermesValue();
+    return *result;
   }
 
   return StringPrimitive::create(runtime, str);

--- a/lib/VM/StringPrimitive.cpp
+++ b/lib/VM/StringPrimitive.cpp
@@ -198,8 +198,7 @@ CallResult<HermesValue> StringPrimitive::createEfficient(
 CallResult<HermesValue> StringPrimitive::createDynamic(
     Runtime &runtime,
     UTF16Ref str) {
-  return createDynamicWithKnownEncoding(
-      runtime, str, isAllASCII(str.begin(), str.end()));
+  return createDynamicWithKnownEncoding(runtime, str, isAllASCII(str));
 }
 
 CallResult<HermesValue> StringPrimitive::createDynamicWithKnownEncoding(

--- a/unittests/Support/UnicodeTest.cpp
+++ b/unittests/Support/UnicodeTest.cpp
@@ -10,7 +10,6 @@
 
 #include "gtest/gtest.h"
 
-#include <deque>
 #include <vector>
 
 using namespace hermes;
@@ -115,10 +114,10 @@ TEST(StringTest, UTF16ToUTF8StringWithReplacements) {
 }
 
 TEST(StringTest, IsAllASCIITest) {
-  std::deque<uint8_t> ascii = {32, 23, 18};
-  std::deque<uint8_t> notAscii = {234, 1, 0};
-  EXPECT_TRUE(isAllASCII(std::begin(ascii), std::end(ascii)));
-  EXPECT_FALSE(isAllASCII(std::begin(notAscii), std::end(notAscii)));
+  std::vector<uint8_t> ascii = {32, 23, 18};
+  std::vector<uint8_t> notAscii = {234, 1, 0};
+  EXPECT_TRUE(isAllASCII(ascii));
+  EXPECT_FALSE(isAllASCII(notAscii));
   // Check overloads.
   uint8_t asciiArr[] = {1, 3, 14, 54, 19, 124, 13, 43, 127, 19, 0};
   uint8_t partialAsciiArr[] = {1, 3, 14, 54, 219, 124, 13, 43, 127, 19};


### PR DESCRIPTION
Summary: If the length is non-negative, we don't need to call strlen().

Differential Revision: D52649632


