### PR TITLE
Fix NumberFormat SetNumberFormatDigitOptions logic

### DIFF
--- a/android/intltest/java/com/facebook/hermes/test/HermesIntlAndroidTest.java
+++ b/android/intltest/java/com/facebook/hermes/test/HermesIntlAndroidTest.java
@@ -31,6 +31,17 @@ public class HermesIntlAndroidTest extends InstrumentationTestCase {
   }
 
   @Test
+  public void testNumberFormatFractionDigitsFromAsset() throws IOException {
+    AssetManager assets = getInstrumentation().getContext().getAssets();
+    InputStream is = assets.open("number-format-fraction-digits.js");
+    String script =
+        new BufferedReader(new InputStreamReader(is)).lines().collect(Collectors.joining("\n"));
+    try (JSRuntime rt = JSRuntime.makeHermesRuntime()) {
+      rt.evaluateJavaScript(script);
+    }
+  }
+
+  @Test
   public void testDateTimeFormat() {
     try (JSRuntime rt = JSRuntime.makeHermesRuntime()) {
       rt.evaluateJavaScript(

--- a/doc/CrossCompilation.md
+++ b/doc/CrossCompilation.md
@@ -23,11 +23,11 @@ workspace where the `hermes` git checkout directory is a subdirectory.
 ```
 cd "$HERMES_WS_DIR"
 
-# Generate the build system at $HERMES_WS_DIR/build_host_hermesc
-cmake -S hermes -B ./build_host_hermesc
+# Generate the build system at $HERMES_WS_DIR/build
+cmake -S hermes -B ./build
 
 # Build the Hermes compiler
-cmake --build ./build_host_hermesc --target hermesc
+cmake --build ./build --target hermesc
 ```
 
 ### 2nd Stage: Building the target Hermes

--- a/lib/Platform/Intl/java/com/facebook/hermes/intl/OptionHelpers.java
+++ b/lib/Platform/Intl/java/com/facebook/hermes/intl/OptionHelpers.java
@@ -17,16 +17,18 @@ public class OptionHelpers {
   }
 
   public static Object DefaultNumberOption(
-      Object value, Object minimum, Object maximum, Object fallback) throws JSRangeErrorException {
+      String property, Object value, Object minimum, Object maximum, Object fallback)
+      throws JSRangeErrorException {
     if (JSObjects.isUndefined(value)) return fallback;
 
-    if (!JSObjects.isNumber(value)) throw new JSRangeErrorException("Invalid number value !");
+    if (!JSObjects.isNumber(value))
+      throw new JSRangeErrorException(property + " value is invalid.");
 
     double d = JSObjects.getJavaDouble(value);
     if (Double.isNaN(d)
         || d > JSObjects.getJavaDouble(maximum)
         || d < JSObjects.getJavaDouble(minimum))
-      throw new JSRangeErrorException("Invalid number value !");
+      throw new JSRangeErrorException(property + " value is invalid.");
 
     return value;
   }
@@ -35,7 +37,7 @@ public class OptionHelpers {
       Object options, String property, Object minimum, Object maximum, Object fallback)
       throws JSRangeErrorException {
     Object value = JSObjects.Get(options, property);
-    return DefaultNumberOption(value, minimum, maximum, fallback);
+    return DefaultNumberOption(property, value, minimum, maximum, fallback);
   }
 
   // https://tc39.es/ecma402/#sec-getoption

--- a/test/hermes/intl/number-format-fraction-digits.js
+++ b/test/hermes/intl/number-format-fraction-digits.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes %s
+// REQUIRES: intl
+
+function assert(pred, str) {
+  if (!pred) {
+    throw new Error('assertion failed' + (str === undefined ? '' : (': ' + str)));
+  }
+}
+
+let resolvedOptions;
+
+resolvedOptions = new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD' }).resolvedOptions();
+assert(resolvedOptions.minimumFractionDigits === 2);
+assert(resolvedOptions.maximumFractionDigits === 2);
+
+//
+// Validate minimumFractionDigits logic
+//
+try { new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD', minimumFractionDigits: -1 }) }
+catch (e) { assert(e.message.includes('minimumFractionDigits value is invalid.')) }
+
+try { new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD', minimumFractionDigits: 21 }) }
+catch (e) { assert(e.message.includes('minimumFractionDigits value is invalid.')) }
+
+resolvedOptions = new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD', minimumFractionDigits: 0 }).resolvedOptions();
+assert(resolvedOptions.minimumFractionDigits === 0);
+assert(resolvedOptions.maximumFractionDigits === 2);
+
+resolvedOptions = new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD', minimumFractionDigits: 20 }).resolvedOptions();
+assert(resolvedOptions.minimumFractionDigits === 20);
+assert(resolvedOptions.maximumFractionDigits === 20);
+
+//
+// Validate maximumFractionDigits logic
+//
+try { new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD', maximumFractionDigits: -1 }) }
+catch (e) { assert(e.message.includes('maximumFractionDigits value is invalid.')) }
+
+try { new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD', maximumFractionDigits: 21 }) }
+catch (e) { assert(e.message.includes('maximumFractionDigits value is invalid.')) }
+
+resolvedOptions = new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).resolvedOptions();
+assert(resolvedOptions.minimumFractionDigits === 0);
+assert(resolvedOptions.maximumFractionDigits === 0);
+
+resolvedOptions = new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD', maximumFractionDigits: 20 }).resolvedOptions();
+assert(resolvedOptions.minimumFractionDigits === 2);
+assert(resolvedOptions.maximumFractionDigits === 20);
+
+//
+// Validate when both are set
+//
+try { new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD', minimumFractionDigits: 5, maximumFractionDigits: 2 }) }
+catch (e) { assert(e.message.includes('minimumFractionDigits is greater than maximumFractionDigits')) }
+
+resolvedOptions = new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD', minimumFractionDigits: 3, maximumFractionDigits: 5 }).resolvedOptions();
+assert(resolvedOptions.minimumFractionDigits === 3);
+assert(resolvedOptions.maximumFractionDigits === 5);


### PR DESCRIPTION
Summary:
The old Android logic was the 2020 version of the [spec](https://402.ecma-international.org/7.0/index.html#sec-setnfdigitoptions).

The old logic passes `mnfdDefault` as the fallback to 
`DefaultNumberOption()` at step 12b. This causes the `mnfd` passed to 
step 12d to be whatever the default for 'currency' style is. And since 
`maximumFractionDigits` is set to 0 and 0 is less than `mnfd = 2`, a 
RangeError was thrown.

This problem was already fixed by the 2021 version of the spec.

`PlatformIntlApple.mm` already implements the newer spec, so that's why 
it's an Android-only issue.

Since the future plan is to move Intl to use ICU4C on Android, that 
means much of the Java code becomes obsolete. Still, it's relatively 
easy to just update the logic to match Apple platform [spec](https://402.ecma-international.org/8.0/index.html#sec-setnfdigitoptions), so I did.

In the process, I added tests to catch this bug. The tests are probably 
the more valuable part as we implement on top of ICU4C.

Reviewed By: neildhar

Differential Revision: D52641902


