### PR TITLE
Add edges to WeakMap values

### DIFF
--- a/lib/VM/JSWeakMapImpl.cpp
+++ b/lib/VM/JSWeakMapImpl.cpp
@@ -145,7 +145,7 @@ void JSWeakMapImplBase::_snapshotAddEdgesImpl(
         HeapSnapshot::EdgeType::Internal, "map", self->getMapID(gc));
   }
 
-  // Add edges to objects pointed by WeakRef keys.
+  // Add edges to objects pointed by WeakRef keys and its mapped values.
   uint32_t edge_index = 0;
   for (const auto &key : self->set_) {
     // Skip if the ref is not valid.
@@ -157,6 +157,23 @@ void JSWeakMapImplBase::_snapshotAddEdgesImpl(
         HeapSnapshot::EdgeType::Weak,
         indexName,
         gc.getObjectID(key.ref.getKeyNoBarrierUnsafe(gc.getPointerBase())));
+
+    auto mappedValue = key.ref.getMappedValue(gc);
+    // TODO(T175014649): nodes for numbers may not exist since they are not seen
+    // by PrimitiveNodeAcceptor. We can't simply add them in
+    // _snapshotAddNodesImpl() either, because PrimitiveNodeAcceptor may see the
+    // same number in a heap object and the assertion of not writing duplicate
+    // node will fail.
+    if (mappedValue.isNumber()) {
+      continue;
+    }
+    if (auto id = gc.getSnapshotID(mappedValue)) {
+      snap.addNamedEdge(
+          HeapSnapshot::EdgeType::Internal,
+          // Add a suffix to distinguish key and value.
+          indexName + "[value]",
+          id.getValue());
+    }
   }
 }
 

--- a/unittests/VMRuntime/HeapSnapshotTest.cpp
+++ b/unittests/VMRuntime/HeapSnapshotTest.cpp
@@ -882,8 +882,8 @@ TEST_F(HeapSnapshotRuntimeTest, WeakMapTest) {
           "JSWeakMap",
           mapID,
           map->getAllocatedSize(),
-          firstNamed + 2));
-  EXPECT_EQ(nodesAndEdges.second.size(), firstNamed + 2);
+          firstNamed + 3));
+  EXPECT_EQ(nodesAndEdges.second.size(), firstNamed + 3);
 
   // Test the native edge.
   const auto nativeMapID = map->getMapID(runtime.getHeap());


### PR DESCRIPTION
Summary:
In new WeakMap implementation, we removed the value storage for 
values, instead, they are stored in a native set. So the edges to
them aren't  added automatically. This diff adds them back in 
`_snapshotAddEdgesImpl()`.

Differential Revision: D52740140


