### PR TITLE
Fix build when HERMES_ENABLE_DEBUGGER=0

### DIFF
--- a/API/hermes/AsyncDebuggerAPI.cpp
+++ b/API/hermes/AsyncDebuggerAPI.cpp
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#ifdef HERMES_ENABLE_DEBUGGER
+
 #include "AsyncDebuggerAPI.h"
 
 #include <llvh/ADT/ScopeExit.h>
@@ -243,3 +245,5 @@ std::unique_ptr<AsyncDebuggerAPI> AsyncDebuggerAPI::create(
 } // namespace debugger
 } // namespace hermes
 } // namespace facebook
+
+#endif // HERMES_ENABLE_DEBUGGER

--- a/API/hermes/AsyncDebuggerAPI.h
+++ b/API/hermes/AsyncDebuggerAPI.h
@@ -8,6 +8,8 @@
 #ifndef HERMES_ASYNCDEBUGGERAPI_H
 #define HERMES_ASYNCDEBUGGERAPI_H
 
+#ifdef HERMES_ENABLE_DEBUGGER
+
 #include <condition_variable>
 #include <mutex>
 #include <optional>
@@ -162,5 +164,69 @@ class HERMES_EXPORT AsyncDebuggerAPI : private debugger::EventObserver {
 } // namespace debugger
 } // namespace hermes
 } // namespace facebook
+
+#else // !HERMES_ENABLE_DEBUGGER
+
+#include <hermes/DebuggerAPI.h>
+#include <hermes/Public/HermesExport.h>
+#include <hermes/hermes.h>
+
+namespace facebook {
+namespace hermes {
+namespace debugger {
+
+class AsyncDebuggerAPI;
+
+enum class DebuggerEventType {
+  // Informational Events
+  ScriptLoaded, /// A script file was loaded, and the debugger has requested
+  /// pausing after script load.
+  Exception, /// An Exception was thrown.
+  EvalComplete, /// An eval() function finished.
+  Resumed, /// Script execution has resumed.
+
+  // Events Requiring Next Command
+  DebuggerStatement, /// A debugger; statement was hit.
+  Breakpoint, /// A breakpoint was hit.
+  StepFinish, /// A Step operation completed.
+};
+
+using DebuggerEventCallback = std::function<void(
+    HermesRuntime &runtime,
+    AsyncDebuggerAPI &asyncDebugger,
+    DebuggerEventType event)>;
+using DebuggerEventCallbackID = uint32_t;
+constexpr const uint32_t kInvalidDebuggerEventCallbackID = 0;
+using InterruptCallback = std::function<void(HermesRuntime &runtime)>;
+
+class HERMES_EXPORT AsyncDebuggerAPI {
+ public:
+  static std::unique_ptr<AsyncDebuggerAPI> create(HermesRuntime &runtime) {
+    return nullptr;
+  }
+
+  ~AsyncDebuggerAPI() {}
+
+  DebuggerEventCallbackID addDebuggerEventCallback_TS(
+      DebuggerEventCallback callback) {
+    return kInvalidDebuggerEventCallbackID;
+  }
+
+  void removeDebuggerEventCallback_TS(DebuggerEventCallbackID id) {}
+
+  bool isWaitingForCommand() {
+    return false;
+  }
+
+  void setNextCommand(debugger::Command command) {}
+
+  void triggerInterrupt_TS(InterruptCallback callback) {}
+};
+
+} // namespace debugger
+} // namespace hermes
+} // namespace facebook
+
+#endif // !HERMES_ENABLE_DEBUGGER
 
 #endif // HERMES_ASYNCDEBUGGERAPI_H

--- a/unittests/API/AsyncDebuggerAPITest.cpp
+++ b/unittests/API/AsyncDebuggerAPITest.cpp
@@ -280,4 +280,20 @@ TEST_F(AsyncDebuggerAPITest, NoDebuggerEventCallbackTest) {
   }));
 }
 
-#endif // HERMES_ENABLE_DEBUGGER
+#else // !HERMES_ENABLE_DEBUGGER
+
+#include <gtest/gtest.h>
+
+#include <hermes/AsyncDebuggerAPI.h>
+
+TEST(AsyncDebuggerAPITest, StubImplementationTest) {
+  auto builder = ::hermes::vm::RuntimeConfig::Builder();
+  std::unique_ptr<facebook::hermes::HermesRuntime> runtime =
+      facebook::hermes::makeHermesRuntime(builder.build());
+  std::unique_ptr<facebook::hermes::debugger::AsyncDebuggerAPI>
+      asyncDebuggerAPI =
+          facebook::hermes::debugger::AsyncDebuggerAPI::create(*runtime);
+  EXPECT_TRUE(asyncDebuggerAPI == nullptr);
+}
+
+#endif // !HERMES_ENABLE_DEBUGGER


### PR DESCRIPTION
Summary: Taking the same strategy as DebuggerAPI by stubbing out all functionality in AsyncDebuggerAPI when `HERMES_ENABLE_DEBUGGER=0`.

Differential Revision: D52812969


