### PR TITLE
Fixed symbol conflicts when using identical function and method names in an ES6 class

### DIFF
--- a/lib/AST/ES6Class.cpp
+++ b/lib/AST/ES6Class.cpp
@@ -685,8 +685,9 @@ class ES6ClassesTransformations {
 
         auto *functionExpr =
             llvh::cast<ESTree::FunctionExpressionNode>(srcNode->_value);
-        // Preserve method name
-        functionExpr->_id = cloneNode(identifierNode);
+        // Remove method name to prevent symbol resolution conflicts.
+        // The function name will be re-added at runtime
+        functionExpr->_id = nullptr;
         parameters.append(functionExpr);
       } else {
         parameters.append(cloneNode(classMember.key));

--- a/lib/InternalBytecode/03-ES6Class.js
+++ b/lib/InternalBytecode/03-ES6Class.js
@@ -56,22 +56,26 @@
     definePropertyGetterOrSetter(cls, methodName, undefined, setter);
   }
 
-  function defineClassMethod(cls, methodName, fn) {
-    objDefineProperty(cls.prototype, methodName, {
+  function doDefineMethod(obj, methodName, fn) {
+    objDefineProperty(obj, methodName, {
       enumerable: false,
       configurable: true,
       writable: true,
       value: fn,
+    });
+
+    objDefineProperty(fn, 'name', {
+      configurable: true,
+      value: methodName,
     });
   }
 
+  function defineClassMethod(cls, methodName, fn) {
+    doDefineMethod(cls.prototype, methodName, fn);
+  }
+
   function defineStaticClassMethod(cls, methodName, fn) {
-    objDefineProperty(cls, methodName, {
-      enumerable: false,
-      configurable: true,
-      writable: true,
-      value: fn,
-    });
+    doDefineMethod(cls, methodName, fn);
   }
 
   var hermesES6InternalObj = {

--- a/lib/InternalBytecode/03-ES6Class.js
+++ b/lib/InternalBytecode/03-ES6Class.js
@@ -64,10 +64,12 @@
       value: fn,
     });
 
-    objDefineProperty(fn, 'name', {
-      configurable: true,
-      value: methodName,
-    });
+    if (typeof methodName === 'string') {
+      objDefineProperty(fn, 'name', {
+        configurable: true,
+        value: methodName,
+      });
+    }
   }
 
   function defineClassMethod(cls, methodName, fn) {

--- a/test/hermes/es6-class-method-conflict.js
+++ b/test/hermes/es6-class-method-conflict.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -Xes6-class %s | %FileCheck --match-full-lines %s
+
+function multiply(left, right) {
+  return left * right;
+}
+
+class Number {
+
+  constructor(value) {
+    this.value = value;
+  }
+
+  multiply(value) {
+    this.value = multiply(this.value, value);
+    return this;
+  }
+}
+
+const number = new Number(4);
+
+number.multiply(2);
+print(number.value);
+//CHECK: 8


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `main`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/HEAD/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.
-->

## Summary

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
-->

This change fixes an issue that could occur when calling a function from a method that has the same name. Consider this example:
```js
function myMethod() {
  console.log('Hello from function');
}

class MyClass {
  myMethod() {
    myMethod();
  }
}
```
In this scenario, `Hello from function` would not be printed when `instance.myMethod()` is called as the method would be called recursively instead of the function that is available in the outer scope.

## Changes
- Added test showcasing the issue
- Always create an anonymous function for methods (maybe there is a way to make the identifier private instead?), so that the method body cannot recursively refers to itself by its name.
- Insert `method.name` at the JS level when the method is about to be registered into the class. 

## Test Plan

All tests passes.
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes the user interface.
-->
