### PR TITLE
Split PauseReason::AsyncTrigger into Implicit vs Explicit

### DIFF
--- a/API/hermes/AsyncDebuggerAPI.cpp
+++ b/API/hermes/AsyncDebuggerAPI.cpp
@@ -107,7 +107,7 @@ debugger::Command AsyncDebuggerAPI::didPause(debugger::Debugger &debugger) {
   debugger::PauseReason pauseReason =
       debugger.getProgramState().getPauseReason();
 
-  if (pauseReason == debugger::PauseReason::AsyncTrigger) {
+  if (pauseReason == debugger::PauseReason::AsyncTriggerImplicit) {
     runInterrupts();
     return debugger::Command::continueExecution();
   }
@@ -140,7 +140,10 @@ debugger::Command AsyncDebuggerAPI::didPause(debugger::Debugger &debugger) {
     case debugger::PauseReason::StepFinish:
       event = DebuggerEventType::StepFinish;
       break;
-    case debugger::PauseReason::AsyncTrigger:
+    case debugger::PauseReason::AsyncTriggerExplicit:
+      event = DebuggerEventType::ExplicitPause;
+      break;
+    case debugger::PauseReason::AsyncTriggerImplicit:
       assert(false && "Should have executed interrupts and returned already");
       break;
   }

--- a/API/hermes/AsyncDebuggerAPI.h
+++ b/API/hermes/AsyncDebuggerAPI.h
@@ -39,6 +39,7 @@ enum class DebuggerEventType {
   DebuggerStatement, /// A debugger; statement was hit.
   Breakpoint, /// A breakpoint was hit.
   StepFinish, /// A Step operation completed.
+  ExplicitPause, /// A pause requested using Explicit AsyncBreak
 };
 
 using DebuggerEventCallback = std::function<void(
@@ -189,6 +190,7 @@ enum class DebuggerEventType {
   DebuggerStatement, /// A debugger; statement was hit.
   Breakpoint, /// A breakpoint was hit.
   StepFinish, /// A Step operation completed.
+  ExplicitPause, /// A pause requested using Explicit AsyncBreak
 };
 
 using DebuggerEventCallback = std::function<void(

--- a/API/hermes/inspector/chrome/CDPHandler.cpp
+++ b/API/hermes/inspector/chrome/CDPHandler.cpp
@@ -1984,6 +1984,16 @@ debugger::Command CDPHandlerImpl::didPause(debugger::Debugger &debugger) {
     }
   }
 
+  // When we handle a `Debugger.pause` request, we simply call
+  // triggerAsyncPause(). This means that CDPHandler uses
+  // `debugger::AsyncPauseKind::Implicit` for both:
+  // 1) when user wants to pause, and
+  // 2) when CDPHandler wants to temporarily pause and run some code.
+  // The pause reason of didPause() will always be AsyncTriggerImplicit. The
+  // fact there are 2 cases is handled by having
+  // processPendingDesiredExecutions() deal with #1 and set `currentExecution_`
+  // to paused. For case #2, that will be taken care of by the following
+  // if-statement because nothing would have changed `currentExecution_`.
   if (Execution::Running == currentExecution_) {
     return debugger::Command::continueExecution();
   }

--- a/lib/VM/Debugger/Debugger.cpp
+++ b/lib/VM/Debugger/Debugger.cpp
@@ -227,7 +227,7 @@ ExecutionStatus Debugger::runDebugger(
       isDebugging_ = false;
       return ExecutionStatus::RETURNED;
     }
-    pauseReason = PauseReason::AsyncTrigger;
+    pauseReason = PauseReason::AsyncTriggerImplicit;
   } else if (runReason == RunReason::AsyncBreakExplicit) {
     // The user requested an async break, so we can clear stepping state
     // with the knowledge that the inspector isn't sending an immediate
@@ -236,7 +236,7 @@ ExecutionStatus Debugger::runDebugger(
       clearTempBreakpoints();
       curStepMode_ = llvh::None;
     }
-    pauseReason = PauseReason::AsyncTrigger;
+    pauseReason = PauseReason::AsyncTriggerExplicit;
   } else {
     assert(runReason == RunReason::Opcode && "Unknown run reason");
     // First, check if we have to finish a step that's in progress.

--- a/public/hermes/Public/DebuggerTypes.h
+++ b/public/hermes/Public/DebuggerTypes.h
@@ -120,7 +120,10 @@ enum class PauseReason {
   Breakpoint, /// A breakpoint was hit.
   StepFinish, /// A Step operation completed.
   Exception, /// An Exception was thrown.
-  AsyncTrigger, /// The Pause is the result of triggerAsyncPause().
+  AsyncTriggerImplicit, /// The Pause is the result of
+                        /// triggerAsyncPause(Implicit).
+  AsyncTriggerExplicit, /// The Pause is the result of
+                        /// triggerAsyncPause(Explicit).
   EvalComplete, /// An eval() function finished.
 };
 

--- a/tools/hdb/hdb.cpp
+++ b/tools/hdb/hdb.cpp
@@ -646,7 +646,10 @@ struct HDBDebugger : public debugger::EventObserver {
       case PauseReason::Exception:
         std::cout << "Break on exception in ";
         break;
-      case PauseReason::AsyncTrigger:
+      case PauseReason::AsyncTriggerImplicit:
+        assert(false && "hdb doesn't ever triggerAsyncPause with Implicit");
+        break;
+      case PauseReason::AsyncTriggerExplicit:
         std::cout << "Interrupted in ";
         break;
       case PauseReason::StepFinish:

--- a/unittests/API/DebuggerTest.cpp
+++ b/unittests/API/DebuggerTest.cpp
@@ -150,4 +150,34 @@ TEST_F(DebuggerAPITest, GetLoadedScriptsTest) {
   EXPECT_TRUE(foundTestJs);
 }
 
+TEST_F(DebuggerAPITest, ImplicitAsyncPauseTest) {
+  rt->getDebugger().triggerAsyncPause(AsyncPauseKind::Implicit);
+  eval("var x = 5;");
+  EXPECT_EQ(
+      std::vector<PauseReason>({PauseReason::AsyncTriggerImplicit}),
+      observer.pauseReasons);
+}
+
+TEST_F(DebuggerAPITest, ExplicitAsyncPauseTest) {
+  rt->getDebugger().triggerAsyncPause(AsyncPauseKind::Explicit);
+  eval("var x = 5;");
+  EXPECT_EQ(
+      std::vector<PauseReason>({PauseReason::AsyncTriggerExplicit}),
+      observer.pauseReasons);
+}
+
+TEST_F(DebuggerAPITest, ImplicitAndExplicitAsyncPauseTest) {
+  rt->getDebugger().triggerAsyncPause(AsyncPauseKind::Explicit);
+  rt->getDebugger().triggerAsyncPause(AsyncPauseKind::Implicit);
+  eval("var x = 5;");
+  // Current implementation uses flags to track if Implicit or Explicit has been
+  // requested, so there is no ordering information. This test just demonstrates
+  // that the order the PauseReason gets process could be in different order.
+  EXPECT_EQ(
+      std::vector<PauseReason>(
+          {PauseReason::AsyncTriggerImplicit,
+           PauseReason::AsyncTriggerExplicit}),
+      observer.pauseReasons);
+}
+
 #endif


### PR DESCRIPTION
Summary:
`PauseReason::AsyncTrigger` was used to represent both Implicit and 
Explicit cases of `triggerAsyncPause()`. However, using a single value 
to represent multiple cases makes it harder for `didPause()` to figure 
out what to do. Furthermore, the old code doesn't trigger one 
`didPause()` for each `triggerAsyncPause()`. If both Implicit and 
Explicit where requested, the old code only triggers one `didPause()`.

Implementors of `didPause()` could try to keep track of what was 
requested. However, there's no good reason to not just tell 
`didPause()` exactly what happened inside the Interpreter that led to 
the pause.

This diff does two things:
1) Split `AsyncTrigger` into `AsyncTriggerImplicit` and 
`AsyncTriggerExplicit`
2) When both Implicit and Explicit are requested, `didPause()` will 
trigger twice. One time for each reason.

Reviewed By: mattbfb

Differential Revision: D51779538


