### PR TITLE
Fix `error: signed shift result`

### DIFF
--- a/include/hermes/Support/StringTableEntry.h
+++ b/include/hermes/Support/StringTableEntry.h
@@ -16,7 +16,7 @@ namespace hermes {
 
 /// An entry in the string table inside the ConsecutiveStringStorage.
 class StringTableEntry {
-  static constexpr uint32_t UTF16_MASK = 1 << 31;
+  static constexpr uint32_t UTF16_MASK = static_cast<uint32_t>(1) << 31;
 
   /// The offset of this string in the string storage.
   uint32_t offset_;


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `main`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/HEAD/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.
-->

## Summary

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
-->
Fixes
```
hermes/Support/StringTableEntry.h:19:44: error: signed shift result (0x80000000) sets the sign bit of the shift expression's type ('int') and becomes negative [-Werror,-Wshift-sign-overflow]
```
which allows the `-Wshift-sign-overflow` flag to be set.


## Test Plan

Standard CI

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes the user interface.
-->
