### PR TITLE
Added support for providing bytecode generation option to BytecodeProviderFromSrc

### DIFF
--- a/include/hermes/BCGen/HBC/BytecodeProviderFromSrc.h
+++ b/include/hermes/BCGen/HBC/BytecodeProviderFromSrc.h
@@ -95,6 +95,9 @@ class BCProviderFromSrc final : public BCProviderBase {
   ///     and this is non-null, invoke this callback with the IR module to
   ///     perform optimizations. This allows us to defer the decision of
   ///     whether to link all optimizations to the caller.
+  /// \param bytecodeGenerationOptions if provided, will be used during the
+  ///     bytecode generation phase, otherwise a set of default options will
+  ///     be used.
   ///
   /// \return a BCProvider and an empty error, or a null BCProvider and an error
   ///     message (if diagHandler was provided, the error message is "error").
@@ -107,7 +110,8 @@ class BCProviderFromSrc final : public BCProviderBase {
       const ScopeChain &scopeChain,
       SourceErrorManager::DiagHandlerTy diagHandler,
       void *diagContext,
-      const std::function<void(Module &)> &runOptimizationPasses);
+      const std::function<void(Module &)> &runOptimizationPasses,
+      llvh::Optional<BytecodeGenerationOptions> bytecodeGenerationOptions);
 
  public:
   static std::unique_ptr<BCProviderFromSrc> createBCProviderFromSrc(
@@ -173,7 +177,8 @@ class BCProviderFromSrc final : public BCProviderBase {
       const ScopeChain &scopeChain,
       SourceErrorManager::DiagHandlerTy diagHandler = nullptr,
       void *diagContext = nullptr,
-      const std::function<void(Module &)> &runOptimizationPasses = {});
+      const std::function<void(Module &)> &runOptimizationPasses = {},
+      llvh::Optional<BytecodeGenerationOptions> bytecodeGenerationOptions = {});
 
   RuntimeFunctionHeader getFunctionHeader(uint32_t functionID) const override {
     return RuntimeFunctionHeader(&module_->getFunction(functionID).getHeader());

--- a/include/hermes/BCGen/HBC/BytecodeProviderFromSrc.h
+++ b/include/hermes/BCGen/HBC/BytecodeProviderFromSrc.h
@@ -178,7 +178,8 @@ class BCProviderFromSrc final : public BCProviderBase {
       SourceErrorManager::DiagHandlerTy diagHandler = nullptr,
       void *diagContext = nullptr,
       const std::function<void(Module &)> &runOptimizationPasses = {},
-      BytecodeGenerationOptions defaultBytecodeGenerationOptions = BytecodeGenerationOptions::defaults());
+      BytecodeGenerationOptions defaultBytecodeGenerationOptions =
+          BytecodeGenerationOptions::defaults());
 
   RuntimeFunctionHeader getFunctionHeader(uint32_t functionID) const override {
     return RuntimeFunctionHeader(&module_->getFunction(functionID).getHeader());

--- a/include/hermes/BCGen/HBC/BytecodeProviderFromSrc.h
+++ b/include/hermes/BCGen/HBC/BytecodeProviderFromSrc.h
@@ -95,9 +95,9 @@ class BCProviderFromSrc final : public BCProviderBase {
   ///     and this is non-null, invoke this callback with the IR module to
   ///     perform optimizations. This allows us to defer the decision of
   ///     whether to link all optimizations to the caller.
-  /// \param bytecodeGenerationOptions if provided, will be used during the
-  ///     bytecode generation phase, otherwise a set of default options will
-  ///     be used.
+  /// \param defaultBytecodeGenerationOptions the starting bytecode generation
+  ///     options that will be used during the bytecode generation phase.
+  ///     Some options will be overriden depending on other arguments passed in.
   ///
   /// \return a BCProvider and an empty error, or a null BCProvider and an error
   ///     message (if diagHandler was provided, the error message is "error").
@@ -111,7 +111,7 @@ class BCProviderFromSrc final : public BCProviderBase {
       SourceErrorManager::DiagHandlerTy diagHandler,
       void *diagContext,
       const std::function<void(Module &)> &runOptimizationPasses,
-      llvh::Optional<BytecodeGenerationOptions> bytecodeGenerationOptions);
+      BytecodeGenerationOptions defaultBytecodeGenerationOptions);
 
  public:
   static std::unique_ptr<BCProviderFromSrc> createBCProviderFromSrc(
@@ -178,7 +178,7 @@ class BCProviderFromSrc final : public BCProviderBase {
       SourceErrorManager::DiagHandlerTy diagHandler = nullptr,
       void *diagContext = nullptr,
       const std::function<void(Module &)> &runOptimizationPasses = {},
-      llvh::Optional<BytecodeGenerationOptions> bytecodeGenerationOptions = {});
+      BytecodeGenerationOptions defaultBytecodeGenerationOptions = BytecodeGenerationOptions::defaults());
 
   RuntimeFunctionHeader getFunctionHeader(uint32_t functionID) const override {
     return RuntimeFunctionHeader(&module_->getFunction(functionID).getHeader());


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `main`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/HEAD/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.
-->

## Summary

This change adds support for providing the bytecode generation options to the `BytecodeProviderFromSrc` API. This makes it possible to strip the function names and debug information when using the high level `BytecodeProviderFromSrc` API without having to re-write what `BytecodeProviderFromSrc` or `CompilerDriver` are already doing. For context, we currently statically embed Hermes into one of our own CLI binary that is able to do a lot of different compile related tasks for us, as such we are not using the Hermes CLI API. We still would like to be able to compile modules as byte code, and the only thing missing from `BytecodeProviderFromSrc` to be at parity with the `CompilerDriver` CLI option that does bytecode generation was the ability to configure the bytecode generation phase.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
-->

## Test Plan

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes the user interface.
-->

Tests pass