### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -16,11 +16,11 @@ jobs:
     steps:
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Get the target SHA
         id: targetSha
-        run: echo "::set-output name=targetSha::$(if [ -z "$TARGET_SHA" ]; then echo $GITHUB_SHA; else echo $TARGET_SHA; fi)"
+        run: echo "targetSha=$(if [ -z "$TARGET_SHA" ]; then echo $GITHUB_SHA; else echo $TARGET_SHA; fi)" >> $GITHUB_OUTPUT
         env:
           TARGET_SHA: ${{ github.event.inputs.targetSha }}
 


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter