### PR TITLE
Implement vm_uncommit on Windows

### DIFF
--- a/lib/Support/OSCompatWindows.cpp
+++ b/lib/Support/OSCompatWindows.cpp
@@ -280,7 +280,9 @@ llvh::ErrorOr<void *> vm_commit(void *p, size_t sz) {
   return result;
 }
 
-void vm_uncommit(void *, size_t) {}
+void vm_uncommit(void *p, size_t sz) {
+  VirtualFree(p, sz, MEM_DECOMMIT);
+}
 
 void vm_hugepage(void *p, size_t sz) {
   assert(


### PR DESCRIPTION
Summary:
Pull in Microsoft's patch made in:
https://github.com/microsoft/hermes-windows/commit/94a8bd49e971b48a6ce353780433b3d307b7b5f9

which adds vm_uncommit in OSCompat. This ensures that when we are using
a contiguous heap, compacted segments are returned to the OS.

Differential Revision: D52919351


