### PR TITLE
Enable Synth Trace unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,8 +286,11 @@ set(HERMES_BUILD_LEAN_LIBHERMES OFF CACHE BOOL "Exclude the Hermes compiler from
 
 set(HERMES_BUILD_SHARED_JSI OFF CACHE BOOL "Build JSI as a shared library.")
 
-set(IMPORT_SHERMES "" CACHE FILEPATH
-  "Import the shermes compiler from another build using the given CMake file.")
+set(IMPORT_HOST_COMPILERS "" CACHE FILEPATH
+  "Import the shermes and hermesc compiler from another build using the given CMake file.")
+
+set(HERMESVM_INTERNAL_JAVASCRIPT_NATIVE OFF CACHE BOOL
+  "Use natively compiled InternalJavaScript. Set OFF to use bytecode version")
 
 # This definition is used by source that must be kept identical between Hermes and
 # Static Hermes, but needs to behave differently in each case.

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -122,7 +122,7 @@ target_link_libraries(hermesvm_a PUBLIC
   hermesHBCBackend_obj
   hermesInst_obj
   hermesInstrumentation_obj
-  hermesInternalUnit_obj
+  hermesInternalJavaScript_obj
   hermesOptimizer_obj
   hermesParser_obj
   hermesPlatformUnicode_obj
@@ -148,6 +148,7 @@ target_link_libraries(hermesvmlean_a PUBLIC
   hermesInst_obj
   hermesInstrumentation_obj
   hermesInternalUnit_obj
+  hermesInternalJavaScript_obj
   hermesPlatformUnicode_obj
   hermesPlatform_obj
   hermesPublic_obj

--- a/lib/InternalJavaScript/CMakeLists.txt
+++ b/lib/InternalJavaScript/CMakeLists.txt
@@ -3,17 +3,15 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-if(IMPORT_SHERMES)
-  file(TO_CMAKE_PATH "${IMPORT_SHERMES}" IMPORT_SHERMES_CMAKE)
-  include(${IMPORT_SHERMES_CMAKE})
+if(IMPORT_HOST_COMPILERS)
+  file(TO_CMAKE_PATH "${IMPORT_HOST_COMPILERS}" IMPORT_HOST_COMPILERS_CMAKE)
+  include(${IMPORT_HOST_COMPILERS_CMAKE})
   set(shermes_EXE imported-shermes)
+  set(hermesc_EXE imported-hermesc)
 else()
   set(shermes_EXE shermes)
+  set(hermesc_EXE hermesc)
 endif()
-
-add_hermes_library(hermesInternalUnit internal_unit.c)
-target_compile_options(hermesInternalUnit_obj PRIVATE -w)
-target_include_directories(hermesInternalUnit_obj PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 # Concatenate all JS files into one source file for compilation.
 # This way there is only one RuntimeModule made for them.
@@ -42,7 +40,7 @@ add_custom_command(
   VERBATIM
 )
 
-# Compile the one source file to Hermes bytecode.
+# Compile the one source file to a C file.
 add_custom_command(
   OUTPUT internal_unit.c
   COMMAND ${shermes_EXE} -O -g0 -w -emit-c -exported-unit=internal_unit -o=${CMAKE_CURRENT_BINARY_DIR}/internal_unit.c ${CMAKE_CURRENT_BINARY_DIR}/InternalBytecode.js
@@ -50,3 +48,54 @@ add_custom_command(
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   VERBATIM
 )
+
+# Native compiled InternalJavaScript target
+add_hermes_library(hermesInternalUnit internal_unit.c)
+target_compile_options(hermesInternalUnit_obj PRIVATE -w)
+target_include_directories(hermesInternalUnit_obj PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+# Bytecode compiled InternalJavaScript target
+add_hermes_library(hermesInternalBytecode
+    InternalBytecode.cpp
+)
+
+set_source_files_properties(InternalBytecode.cpp
+  PROPERTIES
+  OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/InternalBytecode.inc
+)
+
+# Allow InternalBytecode to find its .inc file
+target_include_directories(hermesInternalBytecode_obj
+  PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+set(JS_COMPILER_FLAGS "-O" "-Wno-undefined-variable" "-g0")
+
+add_custom_command(
+  OUTPUT InternalBytecode.hbc
+  COMMAND ${hermesc_EXE} ${JS_COMPILER_FLAGS} -emit-binary -out=${CMAKE_CURRENT_BINARY_DIR}/InternalBytecode.hbc ${CMAKE_CURRENT_BINARY_DIR}/InternalBytecode.js
+  DEPENDS ${hermesc_EXE} InternalBytecode.js
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  VERBATIM
+)
+
+add_custom_target(InternalBytecode ALL DEPENDS InternalBytecode.hbc)
+
+# X.inc is the hex dump of the compiled bytecode artifact that can be included
+# in the InternalBytecode.cpp as C/C++ hex literal to initialize a byte array.
+add_custom_command(
+  OUTPUT InternalBytecode.inc
+  COMMAND ${Python_EXECUTABLE} xxd.py ${CMAKE_CURRENT_BINARY_DIR}/InternalBytecode.hbc > ${CMAKE_CURRENT_BINARY_DIR}/InternalBytecode.inc
+  DEPENDS xxd.py InternalBytecode.hbc
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  VERBATIM
+)
+
+add_custom_target(InternalBytecodeInclude ALL DEPENDS InternalBytecode.inc)
+
+# Switch native version and bytecode version
+if(HERMESVM_INTERNAL_JAVASCRIPT_NATIVE)
+add_library(hermesInternalJavaScript_obj ALIAS hermesInternalUnit_obj)
+else()
+add_library(hermesInternalJavaScript_obj ALIAS hermesInternalBytecode_obj)
+endif()

--- a/lib/InternalJavaScript/InternalBytecode.cpp
+++ b/lib/InternalJavaScript/InternalBytecode.cpp
@@ -15,11 +15,7 @@ llvh::ArrayRef<uint8_t> getInternalBytecode() {
   // Bytecode is required to be aligned, so ensure we don't fail to load it
   // at runtime.
   alignas(hbc::BYTECODE_ALIGNMENT) static const uint8_t InternalBytecode[] = {
-#ifdef HERMES_CMAKE_BUILD
 #include "InternalBytecode.inc"
-#else
-#include "hermes/InternalBytecode/InternalBytecode.inc"
-#endif
   };
 
   return llvh::makeArrayRef(InternalBytecode, sizeof(InternalBytecode));

--- a/lib/VM/JSLib/HermesInternal.cpp
+++ b/lib/VM/JSLib/HermesInternal.cpp
@@ -148,7 +148,7 @@ hermesInternalGetInstrumentedStats(void *, Runtime &runtime, NativeArgs args) {
   ADD_PROP("js_markStackOverflows", info.numMarkStackOverflows);
 #undef ADD_PROP
 
-  return ExecutionStatus::RETURNED;
+  return resultHandle.getHermesValue();
 }
 
 /// \return a static string summarising the presence and resolution type of

--- a/tools/hermesc/CMakeLists.txt
+++ b/tools/hermesc/CMakeLists.txt
@@ -10,10 +10,7 @@ add_hermes_tool(hermesc hermesc.cpp
 # The Hermes compiler is used as part of the build of the VM.
 # During cross-compilation, the compiler needs to be built for the host system,
 # then used to build the VM for the target system.
-if(NOT CMAKE_CROSSCOMPILING)
-  # Namespace added to avoid clashing the host binary with the target binary.
-  export(TARGETS hermesc FILE ${CMAKE_BINARY_DIR}/ImportHermesc.cmake NAMESPACE native-)
-endif()
+export(TARGETS hermesc APPEND FILE ${CMAKE_BINARY_DIR}/ImportHostCompilers.cmake NAMESPACE imported-)
 
 install(TARGETS hermesc
   RUNTIME DESTINATION bin

--- a/tools/shermes/CMakeLists.txt
+++ b/tools/shermes/CMakeLists.txt
@@ -28,7 +28,7 @@ add_hermes_tool(shermes
 # During cross-compilation, the compiler needs to be built for the host system,
 # then used to build the VM for the target system.
 # Namespace added to avoid clashing the imported binary with the target binary.
-export(TARGETS shermes FILE ${CMAKE_BINARY_DIR}/ImportShermes.cmake NAMESPACE imported-)
+export(TARGETS shermes APPEND FILE ${CMAKE_BINARY_DIR}/ImportHostCompilers.cmake NAMESPACE imported-)
 
 # A target building both the shermes compiler and the libraries potentially
 # needed for linking of a compiled binary.

--- a/unittests/API/CMakeLists.txt
+++ b/unittests/API/CMakeLists.txt
@@ -6,9 +6,9 @@
 set(APITestsSources
   APITest.cpp
   APITestFactory.cpp
-  ${HERMES_JSI_DIR}/jsi/test/testlib.cpp
+  # ${HERMES_JSI_DIR}/jsi/test/testlib.cpp # Should we remove jsi dir?
   DebuggerTest.cpp
-  SegmentTest.cpp
+  # SegmentTest.cpp
   HeapSnapshotAPITest.cpp
   SynthTraceTest.cpp
   SynthTraceParserTest.cpp
@@ -20,7 +20,8 @@ set(APISegmentTestCompileSources
   )
 
 # Build SegmentTestCompile without EH and RTTI
-add_hermes_library(SegmentTestCompile ${APISegmentTestCompileSources} LINK_OBJLIBS hermesHBCBackend)
+# TODO: Fix the compilation error in SH
+# add_hermes_library(SegmentTestCompile ${APISegmentTestCompileSources} LINK_OBJLIBS hermesHBCBackend)
 
 # Turn on EH and RTTI for APITests
 set(HERMES_ENABLE_EH ON)
@@ -31,7 +32,14 @@ set(LLVM_ENABLE_RTTI ON)
 
 add_hermes_unittest(APITests ${APITestsSources})
 
-target_link_libraries(APITests hermesapi compileJS SegmentTestCompile traceInterpreter timerStats)
+target_link_libraries(APITests
+  compileJS
+  traceInterpreter
+  timerStats
+  hermesvm_a
+  hermesSandboxRuntime
+  # SegmentTestCompile # Commenting out for now
+)
 
 add_hermes_unittest(APILeanTests APILeanTest.cpp)
-target_link_libraries(APILeanTests hermesapiLean)
+target_link_libraries(APILeanTests hermesvmlean_a)

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -35,6 +35,6 @@ add_subdirectory(dtoa)
 add_subdirectory(PlatformIntl)
 add_subdirectory(PlatformUnicode)
 # API tests rely on the interpreter.
-# add_subdirectory(API)
+add_subdirectory(API)
 add_subdirectory(ADT)
 add_subdirectory(Optimizer)


### PR DESCRIPTION
Summary:
Enabling Synth Trace related unit tests and some other tests that are
not difficult to make it compile.

Reviewed By: avp

Differential Revision: D52963410


