### PR TITLE
Fix AsyncDebuggerAPI::processInterruptWhilePaused() getting stuck

### DIFF
--- a/API/hermes/AsyncDebuggerAPI.cpp
+++ b/API/hermes/AsyncDebuggerAPI.cpp
@@ -172,12 +172,13 @@ debugger::Command AsyncDebuggerAPI::didPause(debugger::Debugger &debugger) {
 
 void AsyncDebuggerAPI::processInterruptWhilePaused() {
   std::unique_lock<std::mutex> lock(mutex_);
-  // We check whether `debuggerEventCallbacks_` has callbacks in all the
-  // while-loops below. This is because that callback could be cleared by users
-  // of AsyncDebuggerAPI at any time. We don't impose requirement on callers of
+  // We check whether `eventCallbacks_` has callbacks in all the while-loops
+  // below. This is because that callback could be cleared by users of
+  // AsyncDebuggerAPI at any time. We don't impose requirement on callers of
   // AsyncDebuggerAPI when they must be constructed and destructed.
   while (isWaitingForCommand_ && !eventCallbacks_.empty()) {
-    while (interruptCallbacks_.empty() && !eventCallbacks_.empty()) {
+    while (isWaitingForCommand_ && !eventCallbacks_.empty() &&
+           interruptCallbacks_.empty()) {
       signal_.wait(lock);
     }
     if (!eventCallbacks_.empty()) {

--- a/API/hermes/CMakeLists.txt
+++ b/API/hermes/CMakeLists.txt
@@ -37,6 +37,7 @@ if(HERMES_ENABLE_DEBUGGER)
     inspector/chrome/RemoteObjectsTable.cpp
     inspector/RuntimeAdapter.cpp
     cdp/CDPAgent.cpp
+    cdp/DebuggerDomainAgent.cpp
     ${INSPECTOR_NO_EH_RTTI_SOURCES}
   )
 

--- a/API/hermes/CMakeLists.txt
+++ b/API/hermes/CMakeLists.txt
@@ -30,14 +30,18 @@ if(HERMES_ENABLE_DEBUGGER)
     endif ()
   endif ()
 
+  set(CDP_API_SOURCES
+    cdp/CDPAgent.cpp
+    cdp/DebuggerDomainAgent.cpp
+  )
+
   set(INSPECTOR_API_SOURCES
     inspector/chrome/CallbackOStream.cpp
     inspector/chrome/CDPHandler.cpp
     inspector/chrome/RemoteObjectConverters.cpp
     inspector/chrome/RemoteObjectsTable.cpp
     inspector/RuntimeAdapter.cpp
-    cdp/CDPAgent.cpp
-    cdp/DebuggerDomainAgent.cpp
+    ${CDP_API_SOURCES}
     ${INSPECTOR_NO_EH_RTTI_SOURCES}
   )
 
@@ -64,8 +68,12 @@ file(GLOB api_headers ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
 file(GLOB api_public_headers ${PROJECT_SOURCE_DIR}/public/hermes/Public/*.h)
 
 if(HERMES_THREAD_SAFETY_ANALYSIS)
+  set(TSA_SOURCES
+    AsyncDebuggerAPI.cpp
+    ${CDP_API_SOURCES}
+  )
   if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-    set_property(SOURCE AsyncDebuggerAPI.cpp APPEND_STRING PROPERTY
+    set_property(SOURCE ${TSA_SOURCES} APPEND_STRING PROPERTY
       COMPILE_FLAGS "-Wthread-safety -Werror=thread-safety-analysis -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS")
   endif()
 endif()

--- a/API/hermes/DebuggerAPI.h
+++ b/API/hermes/DebuggerAPI.h
@@ -206,6 +206,8 @@ class HERMES_EXPORT Debugger {
   /// \return the source map URL for the \p fileId.
   String getSourceMappingUrl(uint32_t fileId) const;
 
+  /// Gets the list of loaded scripts. The order of the scripts in the vector
+  /// will be the same across calls.
   /// \return list of loaded scripts
   std::vector<SourceLocation> getLoadedScripts() const;
 

--- a/API/hermes/cdp/DebuggerDomainAgent.cpp
+++ b/API/hermes/cdp/DebuggerDomainAgent.cpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "DebuggerDomainAgent.h"
+
+#include <hermes/inspector/chrome/RemoteObjectConverters.h>
+
+namespace facebook {
+namespace hermes {
+namespace cdp {
+
+using namespace facebook::hermes::debugger;
+
+DebuggerDomainAgent::DebuggerDomainAgent(
+    HermesRuntime &runtime,
+    AsyncDebuggerAPI &asyncDebugger,
+    OutboundMessageFunc messageCallback)
+    : DomainAgent(messageCallback),
+      runtime_(runtime),
+      asyncDebugger_(asyncDebugger),
+      debuggerEventCallbackId_(kInvalidDebuggerEventCallbackID),
+      enabled_(false) {}
+
+DebuggerDomainAgent::~DebuggerDomainAgent() {
+  // Also remove DebuggerEventCallback here in case we don't receive a
+  // Debugger.disable command prior to destruction.
+  asyncDebugger_.removeDebuggerEventCallback_TS(debuggerEventCallbackId_);
+}
+
+void DebuggerDomainAgent::handleDebuggerEvent(
+    HermesRuntime &runtime,
+    AsyncDebuggerAPI &asyncDebugger,
+    DebuggerEventType event) {
+  assert(enabled_ && "Should only be receiving debugger events while enabled");
+
+  switch (event) {
+    case DebuggerEventType::ScriptLoaded:
+      processNewLoadedScript();
+      asyncDebugger_.setNextCommand(debugger::Command::continueExecution());
+      break;
+    case DebuggerEventType::Exception:
+      break;
+    case DebuggerEventType::EvalComplete:
+      break;
+    case DebuggerEventType::Resumed:
+      break;
+    case DebuggerEventType::DebuggerStatement:
+      break;
+    case DebuggerEventType::Breakpoint:
+      break;
+    case DebuggerEventType::StepFinish:
+      break;
+    case DebuggerEventType::ExplicitPause:
+      break;
+  }
+}
+
+void DebuggerDomainAgent::enable(const m::debugger::EnableRequest &req) {
+  if (enabled_) {
+    sendResponseToClient(m::makeErrorResponse(
+        req.id,
+        m::ErrorCode::InvalidRequest,
+        "Debugger domain already enabled"));
+    return;
+  }
+  enabled_ = true;
+  sendResponseToClient(m::makeOkResponse(req.id));
+
+  // The debugger just got enabled; inform the client about all scripts.
+  for (auto &srcLoc : runtime_.getDebugger().getLoadedScripts()) {
+    sendScriptParsedNotificationToClient(srcLoc);
+  }
+
+  runtime_.getDebugger().setShouldPauseOnScriptLoad(true);
+  asyncDebugger_.addDebuggerEventCallback_TS(
+      [this](
+          HermesRuntime &runtime,
+          AsyncDebuggerAPI &asyncDebugger,
+          DebuggerEventType event) {
+        handleDebuggerEvent(runtime, asyncDebugger, event);
+      });
+
+  // Check to see if debugger is currently paused. There could be multiple debug
+  // clients and the program could have already been paused.
+  if (asyncDebugger_.isWaitingForCommand()) {
+    sendPausedNotificationToClient();
+  }
+}
+
+void DebuggerDomainAgent::disable(const m::debugger::DisableRequest &req) {
+  if (!enabled_) {
+    sendResponseToClient(m::makeErrorResponse(
+        req.id, m::ErrorCode::InvalidRequest, "Debugger domain not enabled"));
+    return;
+  }
+
+  // This doesn't support other debug clients also setting breakpoints. If we
+  // need that functionality, then we might need to track breakpoints set by
+  // this client and only remove those.
+  runtime_.getDebugger().deleteAllBreakpoints();
+
+  asyncDebugger_.removeDebuggerEventCallback_TS(debuggerEventCallbackId_);
+  // This doesn't work well if there are other debug clients that also toggle
+  // this flag. If we need that functionality, then DebuggerAPI needs to be
+  // changed.
+  runtime_.getDebugger().setShouldPauseOnScriptLoad(false);
+
+  enabled_ = false;
+
+  sendResponseToClient(m::makeOkResponse(req.id));
+}
+
+void DebuggerDomainAgent::sendPausedNotificationToClient() {
+  m::debugger::PausedNotification note;
+  note.reason = "other";
+  note.callFrames = m::debugger::makeCallFrames(
+      runtime_.getDebugger().getProgramState(), objTable_, runtime_);
+  sendNotificationToClient(note);
+}
+
+void DebuggerDomainAgent::sendScriptParsedNotificationToClient(
+    const debugger::SourceLocation srcLoc) {
+  m::debugger::ScriptParsedNotification note;
+  note.scriptId = std::to_string(srcLoc.fileId);
+  note.url = srcLoc.fileName;
+  note.executionContextId = kHermesExecutionContextId;
+  std::string sourceMappingUrl =
+      runtime_.getDebugger().getSourceMappingUrl(srcLoc.fileId);
+  if (!sourceMappingUrl.empty()) {
+    note.sourceMapURL = sourceMappingUrl;
+  }
+  sendNotificationToClient(note);
+}
+
+void DebuggerDomainAgent::processNewLoadedScript() {
+  assert(
+      asyncDebugger_.isWaitingForCommand() &&
+      "Can only be called while paused");
+
+  auto stackTrace = runtime_.getDebugger().getProgramState().getStackTrace();
+
+  if (stackTrace.callFrameCount() > 0) {
+    debugger::SourceLocation loc = stackTrace.callFrameForIndex(0).location;
+
+    // Invalid fileId indicates debug info isn't included when compilation took
+    // place. E.g. compiling to bytecode without -g.
+    if (loc.fileId == debugger::kInvalidLocation) {
+      return;
+    }
+
+    sendScriptParsedNotificationToClient(loc);
+  }
+}
+
+} // namespace cdp
+} // namespace hermes
+} // namespace facebook

--- a/API/hermes/cdp/DebuggerDomainAgent.cpp
+++ b/API/hermes/cdp/DebuggerDomainAgent.cpp
@@ -18,8 +18,8 @@ using namespace facebook::hermes::debugger;
 DebuggerDomainAgent::DebuggerDomainAgent(
     HermesRuntime &runtime,
     AsyncDebuggerAPI &asyncDebugger,
-    OutboundMessageFunc messageCallback)
-    : DomainAgent(messageCallback),
+    SynchronizedOutboundCallback messageCallback)
+    : DomainAgent(std::move(messageCallback)),
       runtime_(runtime),
       asyncDebugger_(asyncDebugger),
       debuggerEventCallbackId_(kInvalidDebuggerEventCallbackID),

--- a/API/hermes/cdp/DebuggerDomainAgent.h
+++ b/API/hermes/cdp/DebuggerDomainAgent.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef HERMES_CDP_DEBUGGERDOMAINAGENT_H
+#define HERMES_CDP_DEBUGGERDOMAINAGENT_H
+
+#include <functional>
+#include <string>
+
+#include <hermes/AsyncDebuggerAPI.h>
+#include <hermes/hermes.h>
+#include <hermes/inspector/chrome/MessageConverters.h>
+#include <hermes/inspector/chrome/RemoteObjectsTable.h>
+
+#include "DomainAgent.h"
+
+namespace facebook {
+namespace hermes {
+namespace cdp {
+
+namespace m = ::facebook::hermes::inspector_modern::chrome::message;
+namespace old_cdp = ::facebook::hermes::inspector_modern::chrome;
+
+/// Handler for the "Debugger" domain of CDP. Accepts events from the runtime,
+/// and CDP requests from the debug client belonging to the "Debugger" domain.
+/// Produces CDP responses and events belonging to the "Debugger" domain. All
+/// methods expect to be invoked with exclusive access to the runtime.
+class DebuggerDomainAgent : public DomainAgent {
+ public:
+  DebuggerDomainAgent(
+      HermesRuntime &runtime,
+      debugger::AsyncDebuggerAPI &asyncDebugger,
+      OutboundMessageFunc messageCallback);
+  ~DebuggerDomainAgent();
+
+  /// Handles Debugger.enable request
+  void enable(const m::debugger::EnableRequest &req);
+  /// Handles Debugger.disable request
+  void disable(const m::debugger::DisableRequest &req);
+
+ private:
+  /// Fixed execution context ID because Hermes doesn't currently support realms
+  /// or Web Workers.
+  static constexpr int32_t kHermesExecutionContextId = 1;
+
+  /// Handle an event originating from the runtime.
+  void handleDebuggerEvent(
+      HermesRuntime &runtime,
+      debugger::AsyncDebuggerAPI &asyncDebugger,
+      debugger::DebuggerEventType event);
+
+  /// Send a notification to the debug client
+  void sendPausedNotificationToClient();
+  /// Send a Debugger.scriptParsed notification to the debug client
+  void sendScriptParsedNotificationToClient(
+      const debugger::SourceLocation srcLoc);
+
+  /// Obtain the newly loaded script and send a ScriptParsed notification to the
+  /// debug client
+  void processNewLoadedScript();
+
+  HermesRuntime &runtime_;
+  debugger::AsyncDebuggerAPI &asyncDebugger_;
+
+  /// ID for the registered DebuggerEventCallback
+  debugger::DebuggerEventCallbackID debuggerEventCallbackId_;
+
+  old_cdp::RemoteObjectsTable objTable_{};
+
+  /// Whether Debugger.enable was received and wasn't disabled by receiving
+  /// Debugger.disable
+  bool enabled_;
+};
+
+} // namespace cdp
+} // namespace hermes
+} // namespace facebook
+
+#endif // HERMES_CDP_DEBUGGERDOMAINAGENT_H

--- a/API/hermes/cdp/DebuggerDomainAgent.h
+++ b/API/hermes/cdp/DebuggerDomainAgent.h
@@ -34,7 +34,7 @@ class DebuggerDomainAgent : public DomainAgent {
   DebuggerDomainAgent(
       HermesRuntime &runtime,
       debugger::AsyncDebuggerAPI &asyncDebugger,
-      OutboundMessageFunc messageCallback);
+      SynchronizedOutboundCallback messageCallback);
   ~DebuggerDomainAgent();
 
   /// Handles Debugger.enable request

--- a/API/hermes/inspector/chrome/tests/ConnectionTests.cpp
+++ b/API/hermes/inspector/chrome/tests/ConnectionTests.cpp
@@ -555,6 +555,7 @@ TEST_F(ConnectionTests, testUnregisteringCallback) {
   EXPECT_TRUE(conn.registerCallbacks());
 }
 
+// Also implemented as CDPAgentTest::TestScriptsOnEnable
 TEST_F(ConnectionTests, testScriptsOnEnable) {
   int msgId = 1;
 
@@ -574,6 +575,7 @@ TEST_F(ConnectionTests, testScriptsOnEnable) {
   expectNotification<m::debugger::ScriptParsedNotification>(conn);
 }
 
+// Also implemented as CDPAgentTest::TestScriptsOrdering
 TEST_F(ConnectionTests, testScriptsOrdering) {
   int msgId = 1;
   std::vector<m::debugger::ScriptParsedNotification> notifications;
@@ -611,6 +613,7 @@ TEST_F(ConnectionTests, testScriptsOrdering) {
   }
 }
 
+// Also implemented as CDPAgentTest::TestBytecodeScript
 TEST_F(ConnectionTests, testBytecodeScript) {
   int msgId = 1;
   send<m::debugger::EnableRequest>(conn, msgId++);

--- a/unittests/API/AsyncDebuggerAPITest.cpp
+++ b/unittests/API/AsyncDebuggerAPITest.cpp
@@ -268,6 +268,45 @@ TEST_F(AsyncDebuggerAPITest, SetNextCommandTest) {
   EXPECT_EQ(finalEvent, DebuggerEventType::Resumed);
 }
 
+TEST_F(AsyncDebuggerAPITest, NotifyDueToEventCallbacksTest) {
+  scheduleScript("true");
+
+  // Multiple callbacks are registered to make sure AsyncDebuggerAPI doesn't
+  // break out of processInterruptWhilePaused() due to having no callbacks.
+  DebuggerEventCallbackID callbackID =
+      asyncDebuggerAPI_->addDebuggerEventCallback_TS(
+          [](HermesRuntime &runtime,
+             AsyncDebuggerAPI &asyncDebugger,
+             DebuggerEventType event) {});
+
+  EXPECT_TRUE(waitFor<bool>([this](auto promise) {
+    eventCallbackID_ = asyncDebuggerAPI_->addDebuggerEventCallback_TS(
+        [promise](
+            HermesRuntime &runtime,
+            AsyncDebuggerAPI &asyncDebugger,
+            DebuggerEventType event) { promise->set_value(true); });
+    runtime_->getDebugger().triggerAsyncPause(AsyncPauseKind::Explicit);
+  }));
+
+  // At this point, the runtime thread is paused due to Explicit AsyncBreak
+
+  // We're not on the runtime thread, but because we know for sure the runtime
+  // thread is paused at this point it's safe to call
+  // setNextCommand().
+  asyncDebuggerAPI_->setNextCommand(Command::continueExecution());
+
+  EXPECT_TRUE(waitFor<bool>([this](auto promise) {
+    // Schedule something on the runtime thread to confirm that we broke out of
+    // processInterruptWhilePaused() after removing a DebuggerEventCallback
+    runtimeThread_->add([promise]() { promise->set_value(true); });
+    // Removing a DebuggerEventCallback will signal and cause another iteration
+    // of processInterruptWhilePaused()
+    asyncDebuggerAPI_->removeDebuggerEventCallback_TS(eventCallbackID_);
+  }));
+
+  asyncDebuggerAPI_->removeDebuggerEventCallback_TS(callbackID);
+}
+
 TEST_F(AsyncDebuggerAPITest, NoDebuggerEventCallbackTest) {
   scheduleScript("debugger;");
   scheduleScript("debugger;");

--- a/unittests/API/CDPJSONHelpers.cpp
+++ b/unittests/API/CDPJSONHelpers.cpp
@@ -7,17 +7,71 @@
 
 #include <hermes/inspector/chrome/tests/TestHelpers.h>
 
-using namespace hermes::parser;
-using namespace facebook::hermes::inspector_modern::chrome;
+#include <hermes/inspector/chrome/MessageTypesInlines.h>
 
+using namespace facebook::hermes::inspector_modern::chrome::message;
+using namespace facebook::hermes::inspector_modern::chrome;
+using namespace hermes::parser;
+
+namespace facebook {
 namespace hermes {
 
-void ensureErrorResponse(int id, const std::string &json) {
+void ensureErrorResponse(const std::string &message, int id) {
   JSLexer::Allocator allocator;
   JSONFactory factory(allocator);
   auto response =
-      mustMake<message::ErrorResponse>(mustParseStrAsJsonObj(json, factory));
+      mustMake<message::ErrorResponse>(mustParseStrAsJsonObj(message, factory));
   EXPECT_EQ(response.id, id);
 }
 
+void ensureOkResponse(const std::string &message, int id) {
+  JSLexer::Allocator allocator;
+  JSONFactory factory(allocator);
+  auto response =
+      mustMake<message::OkResponse>(mustParseStrAsJsonObj(message, factory));
+  EXPECT_EQ(response.id, id);
+}
+
+template <typename T>
+std::unique_ptr<T> getValue(JSONValue *value, std::vector<std::string> paths) {
+  int numPaths = paths.size();
+  for (int i = 0; i < numPaths; i++) {
+    EXPECT_TRUE(JSONObject::classof(value));
+    value = static_cast<JSONObject *>(value)->get(paths[i]);
+
+    if (i != numPaths - 1) {
+      EXPECT_TRUE(value != nullptr);
+    } else {
+      std::unique_ptr<T> target = valueFromJson<T>(value);
+      return std::move(target);
+    }
+  }
+  // Should never reach here
+  EXPECT_TRUE(false);
+  return nullptr;
+}
+
+void ensureResponse(
+    const std::string &message,
+    const std::string &expectedMethod,
+    int expectedID) {
+  JSLexer::Allocator allocator;
+  JSONFactory factory(allocator);
+  JSONObject *obj = mustParseStrAsJsonObj(message, factory);
+
+  EXPECT_EQ(*getValue<std::string>(obj, {"method"}), expectedMethod);
+  EXPECT_EQ(*getValue<double>(obj, {"id"}), expectedID);
+}
+
+void ensureNotification(
+    const std::string &message,
+    const std::string &expectedMethod) {
+  JSLexer::Allocator allocator;
+  JSONFactory factory(allocator);
+  JSONObject *obj = mustParseStrAsJsonObj(message, factory);
+
+  EXPECT_EQ(*getValue<std::string>(obj, {"method"}), expectedMethod);
+}
+
 } // namespace hermes
+} // namespace facebook

--- a/unittests/API/CDPJSONHelpers.h
+++ b/unittests/API/CDPJSONHelpers.h
@@ -8,10 +8,19 @@
 #ifndef HERMES_UNITTESTS_API_CDPJSONHELPERS_H
 #define HERMES_UNITTESTS_API_CDPJSONHELPERS_H
 
+namespace facebook {
 namespace hermes {
 
-void ensureErrorResponse(int id, const std::string &json);
+void ensureErrorResponse(const std::string &message, int id);
+void ensureOkResponse(const std::string &message, int id);
+
+void ensureResponse(
+    const std::string &message,
+    const std::string &method,
+    int id);
+void ensureNotification(const std::string &message, const std::string &method);
 
 } // namespace hermes
+} // namespace facebook
 
 #endif // HERMES_UNITTESTS_API_CDPJSONHELPERS_H

--- a/unittests/API/CMakeLists.txt
+++ b/unittests/API/CMakeLists.txt
@@ -14,6 +14,7 @@ set(APITestsSources
   ${HERMES_JSI_DIR}/jsi/test/testlib.cpp
   AsyncDebuggerAPITest.cpp
   CDPAgentTest.cpp
+  SynchronizedCallbackTest.cpp
   ../../API/hermes/inspector/chrome/tests/SerialExecutor.cpp
   DebuggerTest.cpp
   SegmentTest.cpp

--- a/unittests/API/SynchronizedCallbackTest.cpp
+++ b/unittests/API/SynchronizedCallbackTest.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <hermes/cdp/DomainAgent.h>
+
+using namespace facebook::hermes::cdp;
+
+// In this test file, we're not verifying the thread safety. That is already
+// verified at compile time using Thread Safety Analysis.
+
+TEST(SynchronizedCallbackTest, ZeroArgsTest) {
+  bool wasCalled = false;
+  SynchronizedCallback<> callback([&wasCalled]() { wasCalled = true; });
+  // Verify it can be called successfully
+  callback();
+  EXPECT_TRUE(wasCalled);
+}
+
+TEST(SynchronizedCallbackTest, OneArgsTest) {
+  std::string result;
+  SynchronizedCallback<const std::string &> callback(
+      [&result](const std::string &message) {
+        result = "message: " + message;
+      });
+  // Verify it can be called successfully
+  callback("test");
+  EXPECT_EQ(result, "message: test");
+}
+
+TEST(SynchronizedCallbackTest, TwoArgsTest) {
+  int sum = -1;
+  SynchronizedCallback<int, int> callback(
+      [&sum](int a, int b) { sum = a + b; });
+  // Verify it can be called successfully
+  callback(1, 2);
+  EXPECT_EQ(sum, 3);
+}
+
+TEST(SynchronizedCallbackTest, UseAfterInvalidate) {
+  int sum = -1;
+  SynchronizedCallback<int, int> callback(
+      [&sum](int a, int b) { sum = a + b; });
+  callback.invalidate();
+  callback(1, 2);
+  // Should be a no-op and doesn't change sum
+  EXPECT_EQ(sum, -1);
+}


### PR DESCRIPTION
Summary:
Due to the inner while-loop not checking for `isWaitingForCommand_`, if 
there is a next command AND if the reason `signal_` gets notified is 
due to changes to `eventCallbacks_`, then 
`processInterruptWhilePaused()` doesn't properly exit even though there 
is a next command.

Reviewed By: mattbfb

Differential Revision: D53073819


