### PR TITLE
Fix ulimit on array-flat test

### DIFF
--- a/test/hermes/array-flat-recursion-native.js
+++ b/test/hermes/array-flat-recursion-native.js
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//RUN: ulimit -s 512 && %hermes -O %s -gc-sanitize-handles=0 | %FileCheck --match-full-lines %s
+//RUN: ulimit -s 1024 && %hermes -O %s -gc-sanitize-handles=0 | %FileCheck --match-full-lines %s
 //REQUIRES: check_native_stack
 
 var a = [1];
-for (var i = 0; i < 1000; ++i) {
+for (var i = 0; i < 3000; ++i) {
   a = [a];
 }
 try { a.flat(Infinity); } catch(e) { print('caught', e.name) }


### PR DESCRIPTION
Summary:
512 is too low to run InternalBytecode on handlesan builds,
but 1024 is too high to cause an overflow in release builds.

Increase the number of iterations and the stack size to handle both
these problems.

Differential Revision: D53107206


