### PR TITLE
Migrate google java format from 1.7 -> 1.19.2

### DIFF
--- a/lib/Platform/Intl/java/com/facebook/hermes/intl/LocaleIdentifier.java
+++ b/lib/Platform/Intl/java/com/facebook/hermes/intl/LocaleIdentifier.java
@@ -457,7 +457,8 @@ class LocaleIdTokenizer {
     for (mCurrentSubtagEnd = mCurrentSubtagStart;
         mCurrentSubtagEnd < mLocaleIdBuffer.length()
             && !isSubtagSeparator(mLocaleIdBuffer.charAt(mCurrentSubtagEnd));
-        mCurrentSubtagEnd++) ;
+        mCurrentSubtagEnd++)
+      ;
 
     if (mCurrentSubtagEnd > mCurrentSubtagStart) {
       mCurrentSubtagEnd--;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/SoLoader/pull/122

This diff migrates google java format form 1.7 to 1.19.2. This update will allow for new language features from java 17 and 21. This diff also formats all necessary files.

 Changelog:
    [Internal][Changed] - Updated format from google-java-format 1.7 -> 1.19.2

Reviewed By: IanChilds

Differential Revision: D52786052


