### PR TITLE
Add RuntimeDomainAgent tests

### DIFF
--- a/API/hermes/inspector/chrome/tests/ConnectionTests.cpp
+++ b/API/hermes/inspector/chrome/tests/ConnectionTests.cpp
@@ -1558,6 +1558,7 @@ TEST_F(ConnectionTests, testEvalOnCallFrame) {
   expectNotification<m::debugger::ResumedNotification>(conn);
 }
 
+// Also implemented as CDPAgentTest::TestRuntimeEnable
 TEST_F(ConnectionTests, testRuntimeEnable) {
   int msgId = 1;
 

--- a/unittests/API/CDPJSONHelpers.cpp
+++ b/unittests/API/CDPJSONHelpers.cpp
@@ -126,5 +126,32 @@ void ensurePaused(
   expectCallFrames(notification.callFrames, infos);
 }
 
+struct JSONScope::Private {
+  Private() : allocator(), factory(allocator) {}
+
+  JSLexer::Allocator allocator;
+  JSONFactory factory;
+};
+
+JSONScope::JSONScope() : private_(std::make_unique<Private>()) {}
+
+JSONScope::~JSONScope() {}
+
+JSONObject *JSONScope::parseObject(const std::string &json) {
+  return mustParseStrAsJsonObj(json, private_->factory);
+}
+
+std::string JSONScope::getString(
+    JSONObject *obj,
+    std::vector<std::string> paths) {
+  return *getValue<std::string>(obj, paths);
+}
+
+long long JSONScope::getNumber(
+    JSONObject *obj,
+    std::vector<std::string> paths) {
+  return *getValue<long long>(obj, paths);
+}
+
 } // namespace hermes
 } // namespace facebook

--- a/unittests/API/CDPJSONHelpers.h
+++ b/unittests/API/CDPJSONHelpers.h
@@ -8,8 +8,24 @@
 #ifndef HERMES_UNITTESTS_API_CDPJSONHELPERS_H
 #define HERMES_UNITTESTS_API_CDPJSONHELPERS_H
 
+#include <hermes/Parser/JSONParser.h>
+
 namespace facebook {
 namespace hermes {
+
+using namespace ::hermes::parser;
+
+struct JSONScope {
+  JSONScope();
+  ~JSONScope();
+
+  JSONObject *parseObject(const std::string &str);
+  std::string getString(JSONObject *obj, std::vector<std::string> paths);
+  long long getNumber(JSONObject *obj, std::vector<std::string> paths);
+
+  struct Private;
+  std::unique_ptr<Private> private_;
+};
 
 struct FrameInfo {
   FrameInfo(const std::string &functionName, int lineNumber, int scopeCount)


### PR DESCRIPTION
Summary: Add the initial tests for Runtime enable, disable, and execution context creation.

Differential Revision: D53018992


