### PR TITLE
Implement Runtime.globalLexicalScopeNames

### DIFF
--- a/API/hermes/cdp/CDPAgent.cpp
+++ b/API/hermes/cdp/CDPAgent.cpp
@@ -223,6 +223,9 @@ void CDPAgentImpl::DomainAgents::handleCommand(
   } else if (command->method == "Runtime.getHeapUsage") {
     runtimeAgent_->getHeapUsage(
         static_cast<m::runtime::GetHeapUsageRequest &>(*command));
+  } else if (command->method == "Runtime.globalLexicalScopeNames") {
+    runtimeAgent_->globalLexicalScopeNames(
+        static_cast<m::runtime::GlobalLexicalScopeNamesRequest &>(*command));
   } else {
     messageCallback_(message::makeErrorResponse(
                          command->id,

--- a/API/hermes/cdp/RuntimeDomainAgent.h
+++ b/API/hermes/cdp/RuntimeDomainAgent.h
@@ -34,6 +34,9 @@ class RuntimeDomainAgent : public DomainAgent {
   void disable(const m::runtime::DisableRequest &req);
   /// Handles Runtime.getHeapUsage request
   void getHeapUsage(const m::runtime::GetHeapUsageRequest &req);
+  /// Handles Runtime.globalLexicalScopeNames request
+  void globalLexicalScopeNames(
+      const m::runtime::GlobalLexicalScopeNamesRequest &req);
 
  private:
   bool checkRuntimeEnabled(const m::Request &req);

--- a/API/hermes/inspector/chrome/tests/ConnectionTests.cpp
+++ b/API/hermes/inspector/chrome/tests/ConnectionTests.cpp
@@ -3345,6 +3345,7 @@ TEST_F(ConnectionTests, DISABLED_testBasicProfilerOperation) {
   asyncRuntime.stop();
 }
 
+// Also implemented as CDPAgentTest::TestRuntimeGlobalLexicalScopeNames
 TEST_F(ConnectionTests, testGlobalLexicalScopeNames) {
   int msgId = 1;
   asyncRuntime.executeScriptAsync(R"(

--- a/unittests/API/CDPJSONHelpers.cpp
+++ b/unittests/API/CDPJSONHelpers.cpp
@@ -37,11 +37,18 @@ void ensureOkResponse(const std::string &message, int id) {
 }
 
 template <typename T>
-std::unique_ptr<T> getValue(JSONValue *value, std::vector<std::string> paths) {
+std::unique_ptr<T> getValue(
+    const JSONValue *value,
+    std::vector<std::string> paths) {
   int numPaths = paths.size();
   for (int i = 0; i < numPaths; i++) {
-    EXPECT_TRUE(JSONObject::classof(value));
-    value = static_cast<JSONObject *>(value)->get(paths[i]);
+    if (JSONObject::classof(value)) {
+      value = static_cast<const JSONObject *>(value)->get(paths[i]);
+    } else if (JSONArray::classof(value)) {
+      value = static_cast<const JSONArray *>(value)->at(std::stoi(paths[i]));
+    } else {
+      EXPECT_TRUE(false);
+    }
 
     if (i != numPaths - 1) {
       EXPECT_TRUE(value != nullptr);


### PR DESCRIPTION
Summary: Implement Runtime.globalLexicalScopeNames

Reviewed By: dannysu

Differential Revision: D53059570


