### PR TITLE
Fix compilation of sh_api_use and sh_debug_skel

### DIFF
--- a/tools/sh_api_use/sh_api_use.c
+++ b/tools/sh_api_use/sh_api_use.c
@@ -60,7 +60,8 @@ static SHLegacyValue sum(SHRuntime *shr) {
   locals.head.count = 5;
   locals.t4 = _sh_ljs_param(frame, 1);
   locals.t3 = _sh_ljs_param(frame, 2);
-  locals.t2 = _sh_ljs_get_env(shr, frame, 0);
+  locals.t2 =
+      _sh_ljs_get_env(shr, _sh_ljs_get_env_from_closure(shr, frame[-7]), 0);
   locals.t0 = _sh_ljs_double(0);
 
   if (!_sh_ljs_less_equal_rjs(shr, &locals.t4, &locals.t3))
@@ -85,7 +86,8 @@ static SHLegacyValue make(SHRuntime *shr) {
   locals.head.count = 1;
   locals.t0 = _sh_ljs_undefined();
 
-  _sh_ljs_create_environment(shr, frame, &locals.t0, 1);
+  _sh_ljs_create_environment(
+      shr, _sh_ljs_get_env_from_closure(shr, frame[-7]), &locals.t0, 1);
   _sh_ljs_store_to_env(shr, locals.t0, _sh_ljs_param(frame, 1), 0);
   locals.t0 =
       _sh_ljs_create_closure(shr, &locals.t0, sum, &s_function_info_table[1]);
@@ -107,7 +109,8 @@ static SHLegacyValue unit_main(SHRuntime *shr) {
   locals.t3 = _sh_ljs_undefined();
 
   _sh_ljs_declare_global_var(shr, s_symbols[2]);
-  _sh_ljs_create_environment(shr, frame, &locals.t0, 0);
+  _sh_ljs_create_environment(
+      shr, _sh_ljs_get_env_from_closure(shr, frame[-7]), &locals.t0, 0);
   locals.t1 =
       _sh_ljs_create_closure(shr, &locals.t0, make, &s_function_info_table[2]);
   locals.t0 = _sh_ljs_get_global_object(shr);

--- a/tools/sh_debug_skel/sh_debug_skel.c
+++ b/tools/sh_debug_skel/sh_debug_skel.c
@@ -23,11 +23,11 @@ print(make(1)(1, 100));
 static const char s_ascii_pool[] = "sum\0print\0make\0global\0";
 static const uint32_t s_strings[] = {0, 3, 0, 4, 5, 0, 10, 4, 0, 14, 6, 0};
 static SHSymbolID s_symbols[3];
+static SHNativeFuncInfo s_function_info_table[];
 // put "make"
 // get "print"
 // get "make"
 static SHPropertyCacheEntry s_prop_cache[3];
-static SHNativeFuncInfo s_function_info_table[];
 
 static SHLegacyValue unit_main(SHRuntime *shr);
 
@@ -60,7 +60,8 @@ static SHLegacyValue sum(SHRuntime *shr) {
   locals.head.count = 5;
   locals.t4 = _sh_ljs_param(frame, 1);
   locals.t3 = _sh_ljs_param(frame, 2);
-  locals.t2 = _sh_ljs_get_env(shr, frame, 0);
+  locals.t2 =
+      _sh_ljs_get_env(shr, _sh_ljs_get_env_from_closure(shr, frame[-7]), 0);
   locals.t0 = _sh_ljs_double(0);
 
   if (!_sh_ljs_less_equal_rjs(shr, &locals.t4, &locals.t3))
@@ -85,7 +86,8 @@ static SHLegacyValue make(SHRuntime *shr) {
   locals.head.count = 1;
   locals.t0 = _sh_ljs_undefined();
 
-  _sh_ljs_create_environment(shr, frame, &locals.t0, 1);
+  _sh_ljs_create_environment(
+      shr, _sh_ljs_get_env_from_closure(shr, frame[-7]), &locals.t0, 1);
   _sh_ljs_store_to_env(shr, locals.t0, _sh_ljs_param(frame, 1), 0);
   locals.t0 =
       _sh_ljs_create_closure(shr, &locals.t0, sum, &s_function_info_table[1]);
@@ -107,7 +109,8 @@ static SHLegacyValue unit_main(SHRuntime *shr) {
   locals.t3 = _sh_ljs_undefined();
 
   _sh_ljs_declare_global_var(shr, s_symbols[2]);
-  _sh_ljs_create_environment(shr, frame, &locals.t0, 0);
+  _sh_ljs_create_environment(
+      shr, _sh_ljs_get_env_from_closure(shr, frame[-7]), &locals.t0, 0);
   locals.t1 =
       _sh_ljs_create_closure(shr, &locals.t0, make, &s_function_info_table[2]);
   locals.t0 = _sh_ljs_get_global_object(shr);
@@ -139,6 +142,7 @@ static SHLegacyValue unit_main(SHRuntime *shr) {
 }
 
 int main(int argc, char **argv) {
+  _SH_MODEL();
   SHRuntime *shr = _sh_init(argc, argv);
   bool success = _sh_initialize_units(shr, 1, &s_this_unit);
   _sh_done(shr);


### PR DESCRIPTION
Summary:
Fix compilation with the new environment access functions.

These have actually been broken for a while now, because the stack
frame layout was changed to accommodate exception information in native
code. The aim here is just to fix CI until we can decide what to do
with these.

Differential Revision: D53597997


