### PR TITLE
Remove const template parameter from typeArgStorage_

### DIFF
--- a/lib/Sema/FlowChecker.h
+++ b/lib/Sema/FlowChecker.h
@@ -199,7 +199,7 @@ class FlowChecker : public ESTree::RecursionDepthTracker<FlowChecker> {
   /// \c GenericInfo::specializations.
   /// Once stored here, the TypeArgsVectors are not modified, so TypeArgsRef
   /// pointers into the vectors can be stored.
-  std::deque<const GenericInfo::TypeArgsVector> typeArgStorage_{};
+  std::deque<GenericInfo::TypeArgsVector> typeArgStorage_{};
 
   /// Stable storage for the GenericInfo.
   std::deque<GenericInfo> generics_;


### PR DESCRIPTION
Summary: The value in a deque has to be non-const, and this is enforced by GCC.

Differential Revision: D53621070


