### PR TITLE
Implement generic type aliases

### DIFF
--- a/include/hermes/Sema/FlowContext.h
+++ b/include/hermes/Sema/FlowContext.h
@@ -29,6 +29,7 @@ namespace flow {
   _HERMES_SEMA_FLOW_DEFKIND(Boolean) \
   _HERMES_SEMA_FLOW_DEFKIND(String)  \
   _HERMES_SEMA_FLOW_DEFKIND(CPtr)    \
+  _HERMES_SEMA_FLOW_DEFKIND(Generic) \
   _HERMES_SEMA_FLOW_DEFKIND(Number)  \
   _HERMES_SEMA_FLOW_DEFKIND(BigInt)  \
   _HERMES_SEMA_FLOW_DEFKIND(Any)     \
@@ -224,6 +225,9 @@ using NullType = SingleType<TypeKind::Null, PrimaryType>;
 using BooleanType = SingleType<TypeKind::Boolean, PrimaryType>;
 using StringType = SingleType<TypeKind::String, PrimaryType>;
 using CPtrType = SingleType<TypeKind::CPtr, PrimaryType>;
+/// Placeholder for unspecialized generic class or type alias.
+/// Must not escape the FlowChecker, and will be replaced by a concrete type.
+using GenericType = SingleType<TypeKind::Generic, PrimaryType>;
 using NumberType = SingleType<TypeKind::Number, PrimaryType>;
 using BigIntType = SingleType<TypeKind::BigInt, PrimaryType>;
 

--- a/lib/IRGen/ESTreeIRGen-class.cpp
+++ b/lib/IRGen/ESTreeIRGen-class.cpp
@@ -284,6 +284,8 @@ Value *ESTreeIRGen::getDefaultInitValue(flow::Type *type) {
     case flow::TypeKind::Array:
     case flow::TypeKind::Tuple:
       return Builder.getLiteralPositiveZero();
+    case flow::TypeKind::Generic:
+      hermes_fatal("invalid typekind");
   }
 }
 
@@ -325,6 +327,8 @@ Type ESTreeIRGen::flowTypeToIRType(flow::Type *flowType) {
     case flow::TypeKind::Array:
     case flow::TypeKind::Tuple:
       return Type::createObject();
+    case flow::TypeKind::Generic:
+      hermes_fatal("invalid typekind");
   }
 }
 

--- a/lib/IRGen/ESTreeIRGen-class.cpp
+++ b/lib/IRGen/ESTreeIRGen-class.cpp
@@ -13,6 +13,11 @@ namespace irgen {
 void ESTreeIRGen::genClassDeclaration(ESTree::ClassDeclarationNode *node) {
   auto *id = llvh::cast<ESTree::IdentifierNode>(node->_id);
   sema::Decl *decl = getIDDecl(id);
+  if (decl->generic) {
+    // Skip generics that aren't specialized.
+    return;
+  }
+
   flow::Type *declType = flowContext_.findDeclType(decl);
   flow::ClassConstructorType *consType =
       llvh::dyn_cast_or_null<flow::ClassConstructorType>(

--- a/lib/Sema/FlowChecker.h
+++ b/lib/Sema/FlowChecker.h
@@ -337,6 +337,11 @@ class FlowChecker : public ESTree::RecursionDepthTracker<FlowChecker> {
   /// may be reached. Report an error if it isn't valid.
   void checkImplicitReturnType(ESTree::FunctionLikeNode *node);
 
+  /// Forward declaration information for generic type instantiations in
+  /// aliases.
+  /// Needed by both DeclareScopeTypes and FindLoopingTypes.
+  class GenericTypeInstantiation;
+
   /// Resolve and declare all types named in a scope.
   class DeclareScopeTypes;
 

--- a/lib/Sema/FlowChecker.h
+++ b/lib/Sema/FlowChecker.h
@@ -81,7 +81,7 @@ class FlowChecker : public ESTree::RecursionDepthTracker<FlowChecker> {
     sema::LexicalScope *scope;
     /// Optional AST node for reporting re-declarations.
     ESTree::Node *astNode;
-    /// When this is a generic declaration, the Decl of the class.
+    /// When this is a class generic declaration, the Decl of the class.
     sema::Decl *genericClassDecl;
     explicit TypeDecl(
         Type *type,
@@ -92,9 +92,11 @@ class FlowChecker : public ESTree::RecursionDepthTracker<FlowChecker> {
           scope(scope),
           astNode(astNode),
           genericClassDecl(genericClassDecl) {
-      assert(
-          (!type ^ !genericClassDecl) && "either we have a type or a generic");
+#ifndef NDEBUG
+      if (genericClassDecl)
+        assert(!type && "generic type must be null");
       assert(scope && "scope must be non-null");
+#endif
     }
   };
 

--- a/lib/Sema/FlowContext.cpp
+++ b/lib/Sema/FlowContext.cpp
@@ -124,6 +124,8 @@ llvh::StringRef TypeInfo::getKindName() const {
       return "array";
     case TypeKind::Tuple:
       return "tuple";
+    case TypeKind::Generic:
+      return "generic";
   }
   llvm_unreachable("invalid TypeKind");
 }

--- a/lib/Sema/FlowTypesDumper.cpp
+++ b/lib/Sema/FlowTypesDumper.cpp
@@ -58,6 +58,7 @@ void FlowTypesDumper::printTypeDescription(
     case TypeKind::Boolean:
     case TypeKind::String:
     case TypeKind::CPtr:
+    case TypeKind::Generic:
     case TypeKind::Number:
     case TypeKind::BigInt:
     case TypeKind::Any:
@@ -204,6 +205,8 @@ void FlowTypesDumper::printAllTypes(
   auto printAll = [&os, this, &printed](const auto &all) {
     for (const Type &t : all) {
       // Don't print duplicate types.
+      if (!t.info)
+        continue;
       size_t number = getNumber(t.info);
       auto [it, inserted] = printed.insert(number);
       if (!inserted)

--- a/test/IRGen/flow/generic-class-id.js
+++ b/test/IRGen/flow/generic-class-id.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %shermes -O0 -typed -dump-ir -Xno-dump-functions=global %s | %FileCheckOrRegen %s --match-full-lines
+
+class ID<T> {
+  val: T;
+
+  constructor(val: T) {
+    this.val = val;
+  }
+}
+
+const i1: ID<number> = new ID<number>(1);
+const n: number = i1.val;
+
+const i2: ID<string> = new ID<string>('abc');
+const s: string = i2.val;
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:function ""(exports: any): any
+// CHECK-NEXT:frame = [exports: any, ID: any, i1: any, n: any, i2: any, s: any, ID#1: any, ID#2: any, ?ID.prototype: object, ?ID.prototype#1: object]
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = LoadParamInst (:any) %exports: any
+// CHECK-NEXT:       StoreFrameInst %0: any, [exports]: any
+// CHECK-NEXT:       StoreFrameInst undefined: undefined, [ID]: any
+// CHECK-NEXT:       StoreFrameInst undefined: undefined, [i1]: any
+// CHECK-NEXT:       StoreFrameInst undefined: undefined, [n]: any
+// CHECK-NEXT:       StoreFrameInst undefined: undefined, [i2]: any
+// CHECK-NEXT:       StoreFrameInst undefined: undefined, [s]: any
+// CHECK-NEXT:       StoreFrameInst undefined: undefined, [ID#1]: any
+// CHECK-NEXT:       StoreFrameInst undefined: undefined, [ID#2]: any
+// CHECK-NEXT:  %9 = CreateFunctionInst (:object) %ID(): functionCode
+// CHECK-NEXT:        StoreFrameInst %9: object, [ID#1]: any
+// CHECK-NEXT:  %11 = AllocObjectInst (:object) 0: number, empty: any
+// CHECK-NEXT:        StoreFrameInst %11: object, [?ID.prototype]: object
+// CHECK-NEXT:        StorePropertyStrictInst %11: object, %9: object, "prototype": string
+// CHECK-NEXT:  %14 = CreateFunctionInst (:object) %"ID 1#"(): functionCode
+// CHECK-NEXT:        StoreFrameInst %14: object, [ID#2]: any
+// CHECK-NEXT:  %16 = AllocObjectInst (:object) 0: number, empty: any
+// CHECK-NEXT:        StoreFrameInst %16: object, [?ID.prototype#1]: object
+// CHECK-NEXT:        StorePropertyStrictInst %16: object, %14: object, "prototype": string
+// CHECK-NEXT:  %19 = LoadFrameInst (:any) [ID#1]: any
+// CHECK-NEXT:  %20 = CheckedTypeCastInst (:object) %19: any, type(object)
+// CHECK-NEXT:  %21 = LoadFrameInst (:object) [?ID.prototype]: object
+// CHECK-NEXT:  %22 = UnionNarrowTrustedInst (:object) %21: object
+// CHECK-NEXT:  %23 = AllocObjectLiteralInst (:object) "val": string, 0: number
+// CHECK-NEXT:        StoreParentInst %22: object, %23: object
+// CHECK-NEXT:  %25 = CallInst (:any) %20: object, %ID(): functionCode, empty: any, %20: object, %23: object, 1: number
+// CHECK-NEXT:        StoreFrameInst %23: object, [i1]: any
+// CHECK-NEXT:  %27 = LoadFrameInst (:any) [i1]: any
+// CHECK-NEXT:  %28 = CheckedTypeCastInst (:object) %27: any, type(object)
+// CHECK-NEXT:  %29 = PrLoadInst (:number) %28: object, 0: number, "val": string
+// CHECK-NEXT:        StoreFrameInst %29: number, [n]: any
+// CHECK-NEXT:  %31 = LoadFrameInst (:any) [ID#2]: any
+// CHECK-NEXT:  %32 = CheckedTypeCastInst (:object) %31: any, type(object)
+// CHECK-NEXT:  %33 = LoadFrameInst (:object) [?ID.prototype#1]: object
+// CHECK-NEXT:  %34 = UnionNarrowTrustedInst (:object) %33: object
+// CHECK-NEXT:  %35 = AllocObjectLiteralInst (:object) "val": string, "": string
+// CHECK-NEXT:        StoreParentInst %34: object, %35: object
+// CHECK-NEXT:  %37 = CallInst (:any) %32: object, %"ID 1#"(): functionCode, empty: any, %32: object, %35: object, "abc": string
+// CHECK-NEXT:        StoreFrameInst %35: object, [i2]: any
+// CHECK-NEXT:  %39 = LoadFrameInst (:any) [i2]: any
+// CHECK-NEXT:  %40 = CheckedTypeCastInst (:object) %39: any, type(object)
+// CHECK-NEXT:  %41 = PrLoadInst (:string) %40: object, 0: number, "val": string
+// CHECK-NEXT:        StoreFrameInst %41: string, [s]: any
+// CHECK-NEXT:        ReturnInst undefined: undefined
+// CHECK-NEXT:function_end
+
+// CHECK:function ID(val: number): any [typed]
+// CHECK-NEXT:frame = [val: any]
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = LoadParamInst (:object) %<this>: object
+// CHECK-NEXT:  %1 = LoadParamInst (:number) %val: number
+// CHECK-NEXT:       StoreFrameInst %1: number, [val]: any
+// CHECK-NEXT:  %3 = LoadFrameInst (:any) [val]: any
+// CHECK-NEXT:  %4 = CheckedTypeCastInst (:number) %3: any, type(number)
+// CHECK-NEXT:       PrStoreInst %4: number, %0: object, 0: number, "val": string, true: boolean
+// CHECK-NEXT:       ReturnInst undefined: undefined
+// CHECK-NEXT:function_end
+
+// CHECK:function "ID 1#"(val: string): any [typed]
+// CHECK-NEXT:frame = [val: any]
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = LoadParamInst (:object) %<this>: object
+// CHECK-NEXT:  %1 = LoadParamInst (:string) %val: string
+// CHECK-NEXT:       StoreFrameInst %1: string, [val]: any
+// CHECK-NEXT:  %3 = LoadFrameInst (:any) [val]: any
+// CHECK-NEXT:  %4 = CheckedTypeCastInst (:string) %3: any, type(string)
+// CHECK-NEXT:       PrStoreInst %4: string, %0: object, 0: number, "val": string, false: boolean
+// CHECK-NEXT:       ReturnInst undefined: undefined
+// CHECK-NEXT:function_end

--- a/test/Sema/flow/generic-class-alias.js
+++ b/test/Sema/flow/generic-class-alias.js
@@ -1,0 +1,257 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %shermes -fno-std-globals -typed -dump-sema %s | %FileCheckOrRegen %s --match-full-lines
+
+type A = number|string;
+type X = string | B<number> | B<string> | B<number> | B<number>[] | B<A> | B<number|string>;
+
+class B<T> {
+  bval: T;
+  x: X;
+}
+
+type Y = X;
+
+class C<T> {
+  cval: T;
+}
+
+type Z = C<number> | C<number> | C<C<number>> | C<C<string>>;
+
+let y: Y;
+let z: Z;
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:%untyped_function.1 = untyped_function()
+// CHECK-NEXT:%union.2 = union(string | number)
+// CHECK-NEXT:%union.3 = union(string | %array.4 | %class.5 | %class.6 | %class.7)
+// CHECK-NEXT:%union.8 = union(%class.9 | %class.10 | %class.11)
+// CHECK-NEXT:%class.5 = class(B {
+// CHECK-NEXT:  %homeObject: %class.12
+// CHECK-NEXT:  bval: number
+// CHECK-NEXT:  x: %union.3
+// CHECK-NEXT:})
+// CHECK-NEXT:%class.6 = class(B {
+// CHECK-NEXT:  %homeObject: %class.13
+// CHECK-NEXT:  bval: string
+// CHECK-NEXT:  x: %union.3
+// CHECK-NEXT:})
+// CHECK-NEXT:%array.4 = array(%class.5)
+// CHECK-NEXT:%class.7 = class(B {
+// CHECK-NEXT:  %homeObject: %class.14
+// CHECK-NEXT:  bval: %union.2
+// CHECK-NEXT:  x: %union.3
+// CHECK-NEXT:})
+// CHECK-NEXT:%class.9 = class(C {
+// CHECK-NEXT:  %homeObject: %class.15
+// CHECK-NEXT:  cval: number
+// CHECK-NEXT:})
+// CHECK-NEXT:%class.10 = class(C {
+// CHECK-NEXT:  %homeObject: %class.16
+// CHECK-NEXT:  cval: %class.9
+// CHECK-NEXT:})
+// CHECK-NEXT:%class.11 = class(C {
+// CHECK-NEXT:  %homeObject: %class.17
+// CHECK-NEXT:  cval: %class.18
+// CHECK-NEXT:})
+// CHECK-NEXT:%class.18 = class(C {
+// CHECK-NEXT:  %homeObject: %class.19
+// CHECK-NEXT:  cval: string
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.20 = class_constructor(%class.5)
+// CHECK-NEXT:%class_constructor.21 = class_constructor(%class.6)
+// CHECK-NEXT:%class_constructor.22 = class_constructor(%class.7)
+// CHECK-NEXT:%class_constructor.23 = class_constructor(%class.9)
+// CHECK-NEXT:%class_constructor.24 = class_constructor(%class.10)
+// CHECK-NEXT:%class_constructor.25 = class_constructor(%class.18)
+// CHECK-NEXT:%class_constructor.26 = class_constructor(%class.11)
+// CHECK-NEXT:%class.12 = class( {
+// CHECK-NEXT:})
+// CHECK-NEXT:%class.13 = class( {
+// CHECK-NEXT:})
+// CHECK-NEXT:%class.14 = class( {
+// CHECK-NEXT:})
+// CHECK-NEXT:%class.15 = class( {
+// CHECK-NEXT:})
+// CHECK-NEXT:%class.16 = class( {
+// CHECK-NEXT:})
+// CHECK-NEXT:%class.19 = class( {
+// CHECK-NEXT:})
+// CHECK-NEXT:%class.17 = class( {
+// CHECK-NEXT:})
+
+// CHECK:SemContext
+// CHECK-NEXT:Func strict
+// CHECK-NEXT:    Scope %s.1
+// CHECK-NEXT:    Func strict
+// CHECK-NEXT:        Scope %s.2
+// CHECK-NEXT:            Decl %d.1 'exports' Parameter : any
+// CHECK-NEXT:            Decl %d.2 'B' Class
+// CHECK-NEXT:            Decl %d.3 'C' Class
+// CHECK-NEXT:            Decl %d.4 'y' Let : %union.3
+// CHECK-NEXT:            Decl %d.5 'z' Let : %union.8
+// CHECK-NEXT:            Decl %d.6 'arguments' Var Arguments
+// CHECK-NEXT:            Decl %d.7 'B' Class : %class_constructor.20
+// CHECK-NEXT:            Decl %d.8 'B' Class : %class_constructor.21
+// CHECK-NEXT:            Decl %d.9 'B' Class : %class_constructor.22
+// CHECK-NEXT:            Decl %d.10 'C' Class : %class_constructor.23
+// CHECK-NEXT:            Decl %d.11 'C' Class : %class_constructor.24
+// CHECK-NEXT:            Decl %d.12 'C' Class : %class_constructor.25
+// CHECK-NEXT:            Decl %d.13 'C' Class : %class_constructor.26
+
+// CHECK:Program Scope %s.1
+// CHECK-NEXT:    ExpressionStatement
+// CHECK-NEXT:        CallExpression : any
+// CHECK-NEXT:            FunctionExpression : %untyped_function.1
+// CHECK-NEXT:                Id 'exports' [D:E:%d.1 'exports']
+// CHECK-NEXT:                BlockStatement
+// CHECK-NEXT:                    TypeAlias
+// CHECK-NEXT:                        Id 'A'
+// CHECK-NEXT:                        UnionTypeAnnotation
+// CHECK-NEXT:                            NumberTypeAnnotation
+// CHECK-NEXT:                            StringTypeAnnotation
+// CHECK-NEXT:                    TypeAlias
+// CHECK-NEXT:                        Id 'X'
+// CHECK-NEXT:                        UnionTypeAnnotation
+// CHECK-NEXT:                            StringTypeAnnotation
+// CHECK-NEXT:                            GenericTypeAnnotation
+// CHECK-NEXT:                                Id 'B'
+// CHECK-NEXT:                                TypeParameterInstantiation
+// CHECK-NEXT:                                    NumberTypeAnnotation
+// CHECK-NEXT:                            GenericTypeAnnotation
+// CHECK-NEXT:                                Id 'B'
+// CHECK-NEXT:                                TypeParameterInstantiation
+// CHECK-NEXT:                                    StringTypeAnnotation
+// CHECK-NEXT:                            GenericTypeAnnotation
+// CHECK-NEXT:                                Id 'B'
+// CHECK-NEXT:                                TypeParameterInstantiation
+// CHECK-NEXT:                                    NumberTypeAnnotation
+// CHECK-NEXT:                            ArrayTypeAnnotation
+// CHECK-NEXT:                                GenericTypeAnnotation
+// CHECK-NEXT:                                    Id 'B'
+// CHECK-NEXT:                                    TypeParameterInstantiation
+// CHECK-NEXT:                                        NumberTypeAnnotation
+// CHECK-NEXT:                            GenericTypeAnnotation
+// CHECK-NEXT:                                Id 'B'
+// CHECK-NEXT:                                TypeParameterInstantiation
+// CHECK-NEXT:                                    GenericTypeAnnotation
+// CHECK-NEXT:                                        Id 'A'
+// CHECK-NEXT:                            GenericTypeAnnotation
+// CHECK-NEXT:                                Id 'B'
+// CHECK-NEXT:                                TypeParameterInstantiation
+// CHECK-NEXT:                                    UnionTypeAnnotation
+// CHECK-NEXT:                                        NumberTypeAnnotation
+// CHECK-NEXT:                                        StringTypeAnnotation
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'B' [D:E:%d.7 'B']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty : number
+// CHECK-NEXT:                                Id 'bval'
+// CHECK-NEXT:                            ClassProperty : %union.3
+// CHECK-NEXT:                                Id 'x'
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'B' [D:E:%d.8 'B']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty : string
+// CHECK-NEXT:                                Id 'bval'
+// CHECK-NEXT:                            ClassProperty : %union.3
+// CHECK-NEXT:                                Id 'x'
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'B' [D:E:%d.9 'B']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty : %union.2
+// CHECK-NEXT:                                Id 'bval'
+// CHECK-NEXT:                            ClassProperty : %union.3
+// CHECK-NEXT:                                Id 'x'
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'B' [D:E:%d.2 'B']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty
+// CHECK-NEXT:                                Id 'bval'
+// CHECK-NEXT:                            ClassProperty
+// CHECK-NEXT:                                Id 'x'
+// CHECK-NEXT:                    TypeAlias
+// CHECK-NEXT:                        Id 'Y'
+// CHECK-NEXT:                        GenericTypeAnnotation
+// CHECK-NEXT:                            Id 'X'
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'C' [D:E:%d.10 'C']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty : number
+// CHECK-NEXT:                                Id 'cval'
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'C' [D:E:%d.11 'C']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty : %class.9
+// CHECK-NEXT:                                Id 'cval'
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'C' [D:E:%d.12 'C']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty : string
+// CHECK-NEXT:                                Id 'cval'
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'C' [D:E:%d.13 'C']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty : %class.18
+// CHECK-NEXT:                                Id 'cval'
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'C' [D:E:%d.3 'C']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty
+// CHECK-NEXT:                                Id 'cval'
+// CHECK-NEXT:                    TypeAlias
+// CHECK-NEXT:                        Id 'Z'
+// CHECK-NEXT:                        UnionTypeAnnotation
+// CHECK-NEXT:                            GenericTypeAnnotation
+// CHECK-NEXT:                                Id 'C'
+// CHECK-NEXT:                                TypeParameterInstantiation
+// CHECK-NEXT:                                    NumberTypeAnnotation
+// CHECK-NEXT:                            GenericTypeAnnotation
+// CHECK-NEXT:                                Id 'C'
+// CHECK-NEXT:                                TypeParameterInstantiation
+// CHECK-NEXT:                                    NumberTypeAnnotation
+// CHECK-NEXT:                            GenericTypeAnnotation
+// CHECK-NEXT:                                Id 'C'
+// CHECK-NEXT:                                TypeParameterInstantiation
+// CHECK-NEXT:                                    GenericTypeAnnotation
+// CHECK-NEXT:                                        Id 'C'
+// CHECK-NEXT:                                        TypeParameterInstantiation
+// CHECK-NEXT:                                            NumberTypeAnnotation
+// CHECK-NEXT:                            GenericTypeAnnotation
+// CHECK-NEXT:                                Id 'C'
+// CHECK-NEXT:                                TypeParameterInstantiation
+// CHECK-NEXT:                                    GenericTypeAnnotation
+// CHECK-NEXT:                                        Id 'C'
+// CHECK-NEXT:                                        TypeParameterInstantiation
+// CHECK-NEXT:                                            StringTypeAnnotation
+// CHECK-NEXT:                    VariableDeclaration
+// CHECK-NEXT:                        VariableDeclarator
+// CHECK-NEXT:                            Id 'y' [D:E:%d.4 'y']
+// CHECK-NEXT:                    VariableDeclaration
+// CHECK-NEXT:                        VariableDeclarator
+// CHECK-NEXT:                            Id 'z' [D:E:%d.5 'z']
+// CHECK-NEXT:            ObjectExpression

--- a/test/Sema/flow/generic-class-chained-inheritance.js
+++ b/test/Sema/flow/generic-class-chained-inheritance.js
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %shermes -fno-std-globals -typed -dump-sema %s | %FileCheckOrRegen %s --match-full-lines
+
+let outer: C<number> | null = null;
+
+class A {
+  foo(val: B<number>): void {}
+}
+
+class B<T> extends A {
+  x: T;
+  constructor() {
+    super();
+  }
+}
+
+class C<T> extends B<T> {
+  y: T;
+  constructor() {
+    super();
+  }
+}
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:%untyped_function.1 = untyped_function()
+// CHECK-NEXT:%class.2 = class(A {
+// CHECK-NEXT:  %homeObject: %class.3
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.4 = class_constructor(%class.2)
+// CHECK-NEXT:%class.5 = class(B extends %class.2 {
+// CHECK-NEXT:  %constructor: %function.6
+// CHECK-NEXT:  %homeObject: %class.7
+// CHECK-NEXT:  x: number
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.8 = class_constructor(%class.5)
+// CHECK-NEXT:%function.9 = function(this: %class.2, val: %class.5): void
+// CHECK-NEXT:%class.3 = class( {
+// CHECK-NEXT:  foo [final]: %function.9
+// CHECK-NEXT:})
+// CHECK-NEXT:%function.6 = function(this: %class.5): void
+// CHECK-NEXT:%class.7 = class( extends %class.3 {
+// CHECK-NEXT:})
+// CHECK-NEXT:%class.10 = class(C extends %class.5 {
+// CHECK-NEXT:  %constructor: %function.11
+// CHECK-NEXT:  %homeObject: %class.12
+// CHECK-NEXT:  y: number
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.13 = class_constructor(%class.10)
+// CHECK-NEXT:%function.11 = function(this: %class.10): void
+// CHECK-NEXT:%class.12 = class( extends %class.7 {
+// CHECK-NEXT:})
+// CHECK-NEXT:%union.14 = union(null | %class.10)
+
+// CHECK:SemContext
+// CHECK-NEXT:Func strict
+// CHECK-NEXT:    Scope %s.1
+// CHECK-NEXT:    Func strict
+// CHECK-NEXT:        Scope %s.2
+// CHECK-NEXT:            Decl %d.1 'exports' Parameter : any
+// CHECK-NEXT:            Decl %d.2 'outer' Let : %union.14
+// CHECK-NEXT:            Decl %d.3 'A' Class : %class_constructor.4
+// CHECK-NEXT:            Decl %d.4 'B' Class
+// CHECK-NEXT:            Decl %d.5 'C' Class
+// CHECK-NEXT:            Decl %d.6 'arguments' Var Arguments
+// CHECK-NEXT:            Decl %d.7 'B' Class : %class_constructor.8
+// CHECK-NEXT:            Decl %d.8 'C' Class : %class_constructor.13
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.3
+// CHECK-NEXT:                Decl %d.9 'val' Parameter : %class.5
+// CHECK-NEXT:                Decl %d.10 'arguments' Var Arguments
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.4
+// CHECK-NEXT:                Decl %d.11 'arguments' Var Arguments
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.5
+// CHECK-NEXT:                Decl %d.12 'arguments' Var Arguments
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.6
+// CHECK-NEXT:                Decl %d.13 'arguments' Var Arguments
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.7
+// CHECK-NEXT:                Decl %d.14 'arguments' Var Arguments
+
+// CHECK:Program Scope %s.1
+// CHECK-NEXT:    ExpressionStatement
+// CHECK-NEXT:        CallExpression : any
+// CHECK-NEXT:            FunctionExpression : %untyped_function.1
+// CHECK-NEXT:                Id 'exports' [D:E:%d.1 'exports']
+// CHECK-NEXT:                BlockStatement
+// CHECK-NEXT:                    VariableDeclaration
+// CHECK-NEXT:                        VariableDeclarator
+// CHECK-NEXT:                            NullLiteral : null
+// CHECK-NEXT:                            Id 'outer' [D:E:%d.2 'outer']
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'A' [D:E:%d.3 'A']
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            MethodDefinition : %function.9
+// CHECK-NEXT:                                Id 'foo'
+// CHECK-NEXT:                                FunctionExpression : %function.9
+// CHECK-NEXT:                                    Id 'val' [D:E:%d.9 'val']
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'B' [D:E:%d.7 'B']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        Id 'A' [D:E:%d.3 'A'] : %class_constructor.4
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty : number
+// CHECK-NEXT:                                Id 'x'
+// CHECK-NEXT:                            MethodDefinition : %function.6
+// CHECK-NEXT:                                Id 'constructor'
+// CHECK-NEXT:                                FunctionExpression : %function.6
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                                        ExpressionStatement
+// CHECK-NEXT:                                            CallExpression
+// CHECK-NEXT:                                                Super
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'B' [D:E:%d.4 'B']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        Id 'A' [D:E:%d.3 'A']
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty
+// CHECK-NEXT:                                Id 'x'
+// CHECK-NEXT:                            MethodDefinition
+// CHECK-NEXT:                                Id 'constructor'
+// CHECK-NEXT:                                FunctionExpression
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                                        ExpressionStatement
+// CHECK-NEXT:                                            CallExpression
+// CHECK-NEXT:                                                Super
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'C' [D:E:%d.8 'C']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        Id 'B' [D:E:%d.7 'B'] : %class_constructor.8
+// CHECK-NEXT:                        TypeParameterInstantiation
+// CHECK-NEXT:                            GenericTypeAnnotation
+// CHECK-NEXT:                                Id 'T'
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty : number
+// CHECK-NEXT:                                Id 'y'
+// CHECK-NEXT:                            MethodDefinition : %function.11
+// CHECK-NEXT:                                Id 'constructor'
+// CHECK-NEXT:                                FunctionExpression : %function.11
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                                        ExpressionStatement
+// CHECK-NEXT:                                            CallExpression : void
+// CHECK-NEXT:                                                Super : %function.6
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'C' [D:E:%d.5 'C']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        Id 'B' [D:E:%d.4 'B']
+// CHECK-NEXT:                        TypeParameterInstantiation
+// CHECK-NEXT:                            GenericTypeAnnotation
+// CHECK-NEXT:                                Id 'T'
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty
+// CHECK-NEXT:                                Id 'y'
+// CHECK-NEXT:                            MethodDefinition
+// CHECK-NEXT:                                Id 'constructor'
+// CHECK-NEXT:                                FunctionExpression
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                                        ExpressionStatement
+// CHECK-NEXT:                                            CallExpression
+// CHECK-NEXT:                                                Super
+// CHECK-NEXT:            ObjectExpression

--- a/test/Sema/flow/generic-class-chained.js
+++ b/test/Sema/flow/generic-class-chained.js
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %shermes -fno-std-globals -typed -dump-sema %s | %FileCheckOrRegen %s --match-full-lines
+
+class A {
+  x: B<number>;
+}
+
+class B<T> {
+  foo() {
+    let c: C<number> = new C<number>();
+    c.run();
+  }
+}
+
+class C<T> {
+  run(): void {}
+}
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:%untyped_function.1 = untyped_function()
+// CHECK-NEXT:%class.2 = class(A {
+// CHECK-NEXT:  %homeObject: %class.3
+// CHECK-NEXT:  x: %class.4
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.5 = class_constructor(%class.2)
+// CHECK-NEXT:%class.4 = class(B {
+// CHECK-NEXT:  %homeObject: %class.6
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.7 = class_constructor(%class.4)
+// CHECK-NEXT:%class.3 = class( {
+// CHECK-NEXT:})
+// CHECK-NEXT:%class.6 = class( {
+// CHECK-NEXT:  foo [final]: %untyped_function.1
+// CHECK-NEXT:})
+// CHECK-NEXT:%class.8 = class(C {
+// CHECK-NEXT:  %homeObject: %class.9
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.10 = class_constructor(%class.8)
+// CHECK-NEXT:%function.11 = function(this: %class.8): void
+// CHECK-NEXT:%class.9 = class( {
+// CHECK-NEXT:  run [final]: %function.11
+// CHECK-NEXT:})
+
+// CHECK:SemContext
+// CHECK-NEXT:Func strict
+// CHECK-NEXT:    Scope %s.1
+// CHECK-NEXT:    Func strict
+// CHECK-NEXT:        Scope %s.2
+// CHECK-NEXT:            Decl %d.1 'exports' Parameter : any
+// CHECK-NEXT:            Decl %d.2 'A' Class : %class_constructor.5
+// CHECK-NEXT:            Decl %d.3 'B' Class
+// CHECK-NEXT:            Decl %d.4 'C' Class
+// CHECK-NEXT:            Decl %d.5 'arguments' Var Arguments
+// CHECK-NEXT:            Decl %d.6 'B' Class : %class_constructor.7
+// CHECK-NEXT:            Decl %d.7 'C' Class : %class_constructor.10
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.3
+// CHECK-NEXT:                Decl %d.8 'c' Let
+// CHECK-NEXT:                Decl %d.9 'arguments' Var Arguments
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.4
+// CHECK-NEXT:                Decl %d.10 'arguments' Var Arguments
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.5
+// CHECK-NEXT:                Decl %d.11 'c' Let : %class.8
+// CHECK-NEXT:                Decl %d.12 'arguments' Var Arguments
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.6
+// CHECK-NEXT:                Decl %d.13 'arguments' Var Arguments
+
+// CHECK:Program Scope %s.1
+// CHECK-NEXT:    ExpressionStatement
+// CHECK-NEXT:        CallExpression : any
+// CHECK-NEXT:            FunctionExpression : %untyped_function.1
+// CHECK-NEXT:                Id 'exports' [D:E:%d.1 'exports']
+// CHECK-NEXT:                BlockStatement
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'A' [D:E:%d.2 'A']
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty : %class.4
+// CHECK-NEXT:                                Id 'x'
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'B' [D:E:%d.6 'B']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            MethodDefinition : %untyped_function.1
+// CHECK-NEXT:                                Id 'foo'
+// CHECK-NEXT:                                FunctionExpression : %untyped_function.1
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                                        VariableDeclaration
+// CHECK-NEXT:                                            VariableDeclarator
+// CHECK-NEXT:                                                NewExpression : %class.8
+// CHECK-NEXT:                                                    Id 'C' [D:E:%d.7 'C'] : %class_constructor.10
+// CHECK-NEXT:                                                    TypeParameterInstantiation
+// CHECK-NEXT:                                                        NumberTypeAnnotation
+// CHECK-NEXT:                                                Id 'c' [D:E:%d.11 'c']
+// CHECK-NEXT:                                        ExpressionStatement
+// CHECK-NEXT:                                            CallExpression : void
+// CHECK-NEXT:                                                MemberExpression : %function.11
+// CHECK-NEXT:                                                    Id 'c' [D:E:%d.11 'c'] : %class.8
+// CHECK-NEXT:                                                    Id 'run'
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'B' [D:E:%d.3 'B']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            MethodDefinition
+// CHECK-NEXT:                                Id 'foo'
+// CHECK-NEXT:                                FunctionExpression
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                                        VariableDeclaration
+// CHECK-NEXT:                                            VariableDeclarator
+// CHECK-NEXT:                                                NewExpression
+// CHECK-NEXT:                                                    Id 'C' [D:E:%d.4 'C']
+// CHECK-NEXT:                                                    TypeParameterInstantiation
+// CHECK-NEXT:                                                        NumberTypeAnnotation
+// CHECK-NEXT:                                                Id 'c' [D:E:%d.8 'c']
+// CHECK-NEXT:                                        ExpressionStatement
+// CHECK-NEXT:                                            CallExpression
+// CHECK-NEXT:                                                MemberExpression
+// CHECK-NEXT:                                                    Id 'c' [D:E:%d.8 'c']
+// CHECK-NEXT:                                                    Id 'run'
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'C' [D:E:%d.7 'C']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            MethodDefinition : %function.11
+// CHECK-NEXT:                                Id 'run'
+// CHECK-NEXT:                                FunctionExpression : %function.11
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'C' [D:E:%d.4 'C']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            MethodDefinition
+// CHECK-NEXT:                                Id 'run'
+// CHECK-NEXT:                                FunctionExpression
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:            ObjectExpression

--- a/test/Sema/flow/generic-class-cycle-inherited.js
+++ b/test/Sema/flow/generic-class-cycle-inherited.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %shermes -fno-std-globals -typed -dump-sema %s | %FileCheckOrRegen %s --match-full-lines
+
+class A {
+  foo(b: B<number>): void {}
+}
+
+class B<T> extends A {}
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:%untyped_function.1 = untyped_function()
+// CHECK-NEXT:%class.2 = class(A {
+// CHECK-NEXT:  %homeObject: %class.3
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.4 = class_constructor(%class.2)
+// CHECK-NEXT:%class.5 = class(B extends %class.2 {
+// CHECK-NEXT:  %homeObject: %class.6
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.7 = class_constructor(%class.5)
+// CHECK-NEXT:%function.8 = function(this: %class.2, b: %class.5): void
+// CHECK-NEXT:%class.3 = class( {
+// CHECK-NEXT:  foo [final]: %function.8
+// CHECK-NEXT:})
+// CHECK-NEXT:%class.6 = class( extends %class.3 {
+// CHECK-NEXT:})
+
+// CHECK:SemContext
+// CHECK-NEXT:Func strict
+// CHECK-NEXT:    Scope %s.1
+// CHECK-NEXT:    Func strict
+// CHECK-NEXT:        Scope %s.2
+// CHECK-NEXT:            Decl %d.1 'exports' Parameter : any
+// CHECK-NEXT:            Decl %d.2 'A' Class : %class_constructor.4
+// CHECK-NEXT:            Decl %d.3 'B' Class
+// CHECK-NEXT:            Decl %d.4 'arguments' Var Arguments
+// CHECK-NEXT:            Decl %d.5 'B' Class : %class_constructor.7
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.3
+// CHECK-NEXT:                Decl %d.6 'b' Parameter : %class.5
+// CHECK-NEXT:                Decl %d.7 'arguments' Var Arguments
+
+// CHECK:Program Scope %s.1
+// CHECK-NEXT:    ExpressionStatement
+// CHECK-NEXT:        CallExpression : any
+// CHECK-NEXT:            FunctionExpression : %untyped_function.1
+// CHECK-NEXT:                Id 'exports' [D:E:%d.1 'exports']
+// CHECK-NEXT:                BlockStatement
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'A' [D:E:%d.2 'A']
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            MethodDefinition : %function.8
+// CHECK-NEXT:                                Id 'foo'
+// CHECK-NEXT:                                FunctionExpression : %function.8
+// CHECK-NEXT:                                    Id 'b' [D:E:%d.6 'b']
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'B' [D:E:%d.5 'B']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        Id 'A' [D:E:%d.2 'A'] : %class_constructor.4
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'B' [D:E:%d.3 'B']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        Id 'A' [D:E:%d.2 'A']
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:            ObjectExpression

--- a/test/Sema/flow/generic-class-cycle.js
+++ b/test/Sema/flow/generic-class-cycle.js
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %shermes -fno-std-globals -typed -dump-sema %s | %FileCheckOrRegen %s --match-full-lines
+
+class AAA {
+  // Instantiating B<number> here shouldn't fail.
+  x: BBB<number> | null;
+
+  constructor() {
+    this.x = null;
+  }
+}
+
+class BBB<T> {
+  root: AAA;
+
+  constructor(root: AAA, val: T) {
+    root.x;
+  }
+}
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:%untyped_function.1 = untyped_function()
+// CHECK-NEXT:%class.2 = class(AAA {
+// CHECK-NEXT:  %constructor: %function.3
+// CHECK-NEXT:  %homeObject: %class.4
+// CHECK-NEXT:  x: %union.5
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.6 = class_constructor(%class.2)
+// CHECK-NEXT:%class.7 = class(BBB {
+// CHECK-NEXT:  %constructor: %function.8
+// CHECK-NEXT:  %homeObject: %class.9
+// CHECK-NEXT:  root: %class.2
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.10 = class_constructor(%class.7)
+// CHECK-NEXT:%union.5 = union(null | %class.7)
+// CHECK-NEXT:%function.3 = function(this: %class.2): void
+// CHECK-NEXT:%class.4 = class( {
+// CHECK-NEXT:})
+// CHECK-NEXT:%function.8 = function(this: %class.7, root: %class.2, val: number): void
+// CHECK-NEXT:%class.9 = class( {
+// CHECK-NEXT:})
+
+// CHECK:SemContext
+// CHECK-NEXT:Func strict
+// CHECK-NEXT:    Scope %s.1
+// CHECK-NEXT:    Func strict
+// CHECK-NEXT:        Scope %s.2
+// CHECK-NEXT:            Decl %d.1 'exports' Parameter : any
+// CHECK-NEXT:            Decl %d.2 'AAA' Class : %class_constructor.6
+// CHECK-NEXT:            Decl %d.3 'BBB' Class
+// CHECK-NEXT:            Decl %d.4 'arguments' Var Arguments
+// CHECK-NEXT:            Decl %d.5 'BBB' Class : %class_constructor.10
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.3
+// CHECK-NEXT:                Decl %d.6 'arguments' Var Arguments
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.4
+// CHECK-NEXT:                Decl %d.7 'root' Parameter
+// CHECK-NEXT:                Decl %d.8 'val' Parameter
+// CHECK-NEXT:                Decl %d.9 'arguments' Var Arguments
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.5
+// CHECK-NEXT:                Decl %d.10 'root' Parameter : %class.2
+// CHECK-NEXT:                Decl %d.11 'val' Parameter : number
+// CHECK-NEXT:                Decl %d.12 'arguments' Var Arguments
+
+// CHECK:Program Scope %s.1
+// CHECK-NEXT:    ExpressionStatement
+// CHECK-NEXT:        CallExpression : any
+// CHECK-NEXT:            FunctionExpression : %untyped_function.1
+// CHECK-NEXT:                Id 'exports' [D:E:%d.1 'exports']
+// CHECK-NEXT:                BlockStatement
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'AAA' [D:E:%d.2 'AAA']
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty : %union.5
+// CHECK-NEXT:                                Id 'x'
+// CHECK-NEXT:                            MethodDefinition : %function.3
+// CHECK-NEXT:                                Id 'constructor'
+// CHECK-NEXT:                                FunctionExpression : %function.3
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                                        ExpressionStatement
+// CHECK-NEXT:                                            AssignmentExpression : null
+// CHECK-NEXT:                                                MemberExpression : %union.5
+// CHECK-NEXT:                                                    ThisExpression : %class.2
+// CHECK-NEXT:                                                    Id 'x'
+// CHECK-NEXT:                                                NullLiteral : null
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'BBB' [D:E:%d.5 'BBB']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty : %class.2
+// CHECK-NEXT:                                Id 'root'
+// CHECK-NEXT:                            MethodDefinition : %function.8
+// CHECK-NEXT:                                Id 'constructor'
+// CHECK-NEXT:                                FunctionExpression : %function.8
+// CHECK-NEXT:                                    Id 'root' [D:E:%d.10 'root']
+// CHECK-NEXT:                                    Id 'val' [D:E:%d.11 'val']
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                                        ExpressionStatement
+// CHECK-NEXT:                                            MemberExpression : %union.5
+// CHECK-NEXT:                                                Id 'root' [D:E:%d.10 'root'] : %class.2
+// CHECK-NEXT:                                                Id 'x'
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'BBB' [D:E:%d.3 'BBB']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty
+// CHECK-NEXT:                                Id 'root'
+// CHECK-NEXT:                            MethodDefinition
+// CHECK-NEXT:                                Id 'constructor'
+// CHECK-NEXT:                                FunctionExpression
+// CHECK-NEXT:                                    Id 'root' [D:E:%d.7 'root']
+// CHECK-NEXT:                                    Id 'val' [D:E:%d.8 'val']
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                                        ExpressionStatement
+// CHECK-NEXT:                                            MemberExpression
+// CHECK-NEXT:                                                Id 'root' [D:E:%d.7 'root']
+// CHECK-NEXT:                                                Id 'x'
+// CHECK-NEXT:            ObjectExpression

--- a/test/Sema/flow/generic-class-dedup.js
+++ b/test/Sema/flow/generic-class-dedup.js
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %shermes -fno-std-globals -typed -dump-sema %s | %FileCheckOrRegen %s --match-full-lines
+
+class C<T> {
+  x: T;
+
+  constructor(x: T) {
+    this.x = x;
+  }
+}
+
+// All of this should result in only one specialization of C<number | string>.
+var c1: C<number | string> = new C<number | string>(3);
+c1 = new C<number | string>('abc');
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:%untyped_function.1 = untyped_function()
+// CHECK-NEXT:%union.2 = union(string | number)
+// CHECK-NEXT:%class.3 = class(C {
+// CHECK-NEXT:  %constructor: %function.4
+// CHECK-NEXT:  %homeObject: %class.5
+// CHECK-NEXT:  x: %union.2
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.6 = class_constructor(%class.3)
+// CHECK-NEXT:%function.4 = function(this: %class.3, x: %union.2): void
+// CHECK-NEXT:%class.5 = class( {
+// CHECK-NEXT:})
+
+// CHECK:SemContext
+// CHECK-NEXT:Func strict
+// CHECK-NEXT:    Scope %s.1
+// CHECK-NEXT:    Func strict
+// CHECK-NEXT:        Scope %s.2
+// CHECK-NEXT:            Decl %d.1 'exports' Parameter : any
+// CHECK-NEXT:            Decl %d.2 'C' Class
+// CHECK-NEXT:            Decl %d.3 'c1' Var : %class.3
+// CHECK-NEXT:            Decl %d.4 'arguments' Var Arguments
+// CHECK-NEXT:            Decl %d.5 'C' Class : %class_constructor.6
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.3
+// CHECK-NEXT:                Decl %d.6 'x' Parameter
+// CHECK-NEXT:                Decl %d.7 'arguments' Var Arguments
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.4
+// CHECK-NEXT:                Decl %d.8 'x' Parameter : %union.2
+// CHECK-NEXT:                Decl %d.9 'arguments' Var Arguments
+
+// CHECK:Program Scope %s.1
+// CHECK-NEXT:    ExpressionStatement
+// CHECK-NEXT:        CallExpression : any
+// CHECK-NEXT:            FunctionExpression : %untyped_function.1
+// CHECK-NEXT:                Id 'exports' [D:E:%d.1 'exports']
+// CHECK-NEXT:                BlockStatement
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'C' [D:E:%d.5 'C']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty : %union.2
+// CHECK-NEXT:                                Id 'x'
+// CHECK-NEXT:                            MethodDefinition : %function.4
+// CHECK-NEXT:                                Id 'constructor'
+// CHECK-NEXT:                                FunctionExpression : %function.4
+// CHECK-NEXT:                                    Id 'x' [D:E:%d.8 'x']
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                                        ExpressionStatement
+// CHECK-NEXT:                                            AssignmentExpression : %union.2
+// CHECK-NEXT:                                                MemberExpression : %union.2
+// CHECK-NEXT:                                                    ThisExpression : %class.3
+// CHECK-NEXT:                                                    Id 'x'
+// CHECK-NEXT:                                                Id 'x' [D:E:%d.8 'x'] : %union.2
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'C' [D:E:%d.2 'C']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty
+// CHECK-NEXT:                                Id 'x'
+// CHECK-NEXT:                            MethodDefinition
+// CHECK-NEXT:                                Id 'constructor'
+// CHECK-NEXT:                                FunctionExpression
+// CHECK-NEXT:                                    Id 'x' [D:E:%d.6 'x']
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                                        ExpressionStatement
+// CHECK-NEXT:                                            AssignmentExpression
+// CHECK-NEXT:                                                MemberExpression
+// CHECK-NEXT:                                                    ThisExpression
+// CHECK-NEXT:                                                    Id 'x'
+// CHECK-NEXT:                                                Id 'x' [D:E:%d.6 'x']
+// CHECK-NEXT:                    VariableDeclaration
+// CHECK-NEXT:                        VariableDeclarator
+// CHECK-NEXT:                            NewExpression : %class.3
+// CHECK-NEXT:                                Id 'C' [D:E:%d.5 'C'] : %class_constructor.6
+// CHECK-NEXT:                                TypeParameterInstantiation
+// CHECK-NEXT:                                    UnionTypeAnnotation
+// CHECK-NEXT:                                        NumberTypeAnnotation
+// CHECK-NEXT:                                        StringTypeAnnotation
+// CHECK-NEXT:                                NumericLiteral : number
+// CHECK-NEXT:                            Id 'c1' [D:E:%d.3 'c1']
+// CHECK-NEXT:                    ExpressionStatement
+// CHECK-NEXT:                        AssignmentExpression : %class.3
+// CHECK-NEXT:                            Id 'c1' [D:E:%d.3 'c1'] : %class.3
+// CHECK-NEXT:                            NewExpression : %class.3
+// CHECK-NEXT:                                Id 'C' [D:E:%d.5 'C'] : %class_constructor.6
+// CHECK-NEXT:                                TypeParameterInstantiation
+// CHECK-NEXT:                                    UnionTypeAnnotation
+// CHECK-NEXT:                                        NumberTypeAnnotation
+// CHECK-NEXT:                                        StringTypeAnnotation
+// CHECK-NEXT:                                StringLiteral : string
+// CHECK-NEXT:            ObjectExpression

--- a/test/Sema/flow/generic-class-id.js
+++ b/test/Sema/flow/generic-class-id.js
@@ -1,0 +1,161 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %shermes -fno-std-globals -typed -dump-sema %s | %FileCheckOrRegen %s --match-full-lines
+
+class ID<T> {
+  val: T;
+
+  constructor(val: T) {
+    this.val = val;
+  }
+}
+
+const i1: ID<number> = new ID<number>(1);
+const n: number = i1.val;
+
+const i2: ID<string> = new ID<string>('abc');
+const s: string = i2.val;
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:%untyped_function.1 = untyped_function()
+// CHECK-NEXT:%class.2 = class(ID {
+// CHECK-NEXT:  %constructor: %function.3
+// CHECK-NEXT:  %homeObject: %class.4
+// CHECK-NEXT:  val: number
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.5 = class_constructor(%class.2)
+// CHECK-NEXT:%function.3 = function(this: %class.2, val: number): void
+// CHECK-NEXT:%class.4 = class( {
+// CHECK-NEXT:})
+// CHECK-NEXT:%class.6 = class(ID {
+// CHECK-NEXT:  %constructor: %function.7
+// CHECK-NEXT:  %homeObject: %class.8
+// CHECK-NEXT:  val: string
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.9 = class_constructor(%class.6)
+// CHECK-NEXT:%function.7 = function(this: %class.6, val: string): void
+// CHECK-NEXT:%class.8 = class( {
+// CHECK-NEXT:})
+
+// CHECK:SemContext
+// CHECK-NEXT:Func strict
+// CHECK-NEXT:    Scope %s.1
+// CHECK-NEXT:    Func strict
+// CHECK-NEXT:        Scope %s.2
+// CHECK-NEXT:            Decl %d.1 'exports' Parameter : any
+// CHECK-NEXT:            Decl %d.2 'ID' Class
+// CHECK-NEXT:            Decl %d.3 'i1' Const : %class.2
+// CHECK-NEXT:            Decl %d.4 'n' Const : number
+// CHECK-NEXT:            Decl %d.5 'i2' Const : %class.6
+// CHECK-NEXT:            Decl %d.6 's' Const : string
+// CHECK-NEXT:            Decl %d.7 'arguments' Var Arguments
+// CHECK-NEXT:            Decl %d.8 'ID' Class : %class_constructor.5
+// CHECK-NEXT:            Decl %d.9 'ID' Class : %class_constructor.9
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.3
+// CHECK-NEXT:                Decl %d.10 'val' Parameter
+// CHECK-NEXT:                Decl %d.11 'arguments' Var Arguments
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.4
+// CHECK-NEXT:                Decl %d.12 'val' Parameter : number
+// CHECK-NEXT:                Decl %d.13 'arguments' Var Arguments
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.5
+// CHECK-NEXT:                Decl %d.14 'val' Parameter : string
+// CHECK-NEXT:                Decl %d.15 'arguments' Var Arguments
+
+// CHECK:Program Scope %s.1
+// CHECK-NEXT:    ExpressionStatement
+// CHECK-NEXT:        CallExpression : any
+// CHECK-NEXT:            FunctionExpression : %untyped_function.1
+// CHECK-NEXT:                Id 'exports' [D:E:%d.1 'exports']
+// CHECK-NEXT:                BlockStatement
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'ID' [D:E:%d.8 'ID']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty : number
+// CHECK-NEXT:                                Id 'val'
+// CHECK-NEXT:                            MethodDefinition : %function.3
+// CHECK-NEXT:                                Id 'constructor'
+// CHECK-NEXT:                                FunctionExpression : %function.3
+// CHECK-NEXT:                                    Id 'val' [D:E:%d.12 'val']
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                                        ExpressionStatement
+// CHECK-NEXT:                                            AssignmentExpression : number
+// CHECK-NEXT:                                                MemberExpression : number
+// CHECK-NEXT:                                                    ThisExpression : %class.2
+// CHECK-NEXT:                                                    Id 'val'
+// CHECK-NEXT:                                                Id 'val' [D:E:%d.12 'val'] : number
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'ID' [D:E:%d.9 'ID']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty : string
+// CHECK-NEXT:                                Id 'val'
+// CHECK-NEXT:                            MethodDefinition : %function.7
+// CHECK-NEXT:                                Id 'constructor'
+// CHECK-NEXT:                                FunctionExpression : %function.7
+// CHECK-NEXT:                                    Id 'val' [D:E:%d.14 'val']
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                                        ExpressionStatement
+// CHECK-NEXT:                                            AssignmentExpression : string
+// CHECK-NEXT:                                                MemberExpression : string
+// CHECK-NEXT:                                                    ThisExpression : %class.6
+// CHECK-NEXT:                                                    Id 'val'
+// CHECK-NEXT:                                                Id 'val' [D:E:%d.14 'val'] : string
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'ID' [D:E:%d.2 'ID']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty
+// CHECK-NEXT:                                Id 'val'
+// CHECK-NEXT:                            MethodDefinition
+// CHECK-NEXT:                                Id 'constructor'
+// CHECK-NEXT:                                FunctionExpression
+// CHECK-NEXT:                                    Id 'val' [D:E:%d.10 'val']
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                                        ExpressionStatement
+// CHECK-NEXT:                                            AssignmentExpression
+// CHECK-NEXT:                                                MemberExpression
+// CHECK-NEXT:                                                    ThisExpression
+// CHECK-NEXT:                                                    Id 'val'
+// CHECK-NEXT:                                                Id 'val' [D:E:%d.10 'val']
+// CHECK-NEXT:                    VariableDeclaration
+// CHECK-NEXT:                        VariableDeclarator
+// CHECK-NEXT:                            NewExpression : %class.2
+// CHECK-NEXT:                                Id 'ID' [D:E:%d.8 'ID'] : %class_constructor.5
+// CHECK-NEXT:                                TypeParameterInstantiation
+// CHECK-NEXT:                                    NumberTypeAnnotation
+// CHECK-NEXT:                                NumericLiteral : number
+// CHECK-NEXT:                            Id 'i1' [D:E:%d.3 'i1']
+// CHECK-NEXT:                    VariableDeclaration
+// CHECK-NEXT:                        VariableDeclarator
+// CHECK-NEXT:                            MemberExpression : number
+// CHECK-NEXT:                                Id 'i1' [D:E:%d.3 'i1'] : %class.2
+// CHECK-NEXT:                                Id 'val'
+// CHECK-NEXT:                            Id 'n' [D:E:%d.4 'n']
+// CHECK-NEXT:                    VariableDeclaration
+// CHECK-NEXT:                        VariableDeclarator
+// CHECK-NEXT:                            NewExpression : %class.6
+// CHECK-NEXT:                                Id 'ID' [D:E:%d.9 'ID'] : %class_constructor.9
+// CHECK-NEXT:                                TypeParameterInstantiation
+// CHECK-NEXT:                                    StringTypeAnnotation
+// CHECK-NEXT:                                StringLiteral : string
+// CHECK-NEXT:                            Id 'i2' [D:E:%d.5 'i2']
+// CHECK-NEXT:                    VariableDeclaration
+// CHECK-NEXT:                        VariableDeclarator
+// CHECK-NEXT:                            MemberExpression : string
+// CHECK-NEXT:                                Id 'i2' [D:E:%d.5 'i2'] : %class.6
+// CHECK-NEXT:                                Id 'val'
+// CHECK-NEXT:                            Id 's' [D:E:%d.6 's']
+// CHECK-NEXT:            ObjectExpression

--- a/test/Sema/flow/generic-class-method.js
+++ b/test/Sema/flow/generic-class-method.js
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %shermes -fno-std-globals -typed -dump-sema %s | %FileCheckOrRegen %s --match-full-lines
+
+class A {
+  c: C<number> | null;
+}
+class B {
+  func(): void {}
+}
+class C<Props> {
+  vals: B[];
+  foo(): void {
+    let b: B = this.vals[0];
+    b.func();
+  }
+}
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:%untyped_function.1 = untyped_function()
+// CHECK-NEXT:%class.2 = class(A {
+// CHECK-NEXT:  %homeObject: %class.3
+// CHECK-NEXT:  c: %union.4
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.5 = class_constructor(%class.2)
+// CHECK-NEXT:%class.6 = class(B {
+// CHECK-NEXT:  %homeObject: %class.7
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.8 = class_constructor(%class.6)
+// CHECK-NEXT:%class.9 = class(C {
+// CHECK-NEXT:  %homeObject: %class.10
+// CHECK-NEXT:  vals: %array.11
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.12 = class_constructor(%class.9)
+// CHECK-NEXT:%union.4 = union(null | %class.9)
+// CHECK-NEXT:%class.3 = class( {
+// CHECK-NEXT:})
+// CHECK-NEXT:%function.13 = function(this: %class.6): void
+// CHECK-NEXT:%class.7 = class( {
+// CHECK-NEXT:  func [final]: %function.13
+// CHECK-NEXT:})
+// CHECK-NEXT:%array.11 = array(%class.6)
+// CHECK-NEXT:%function.14 = function(this: %class.9): void
+// CHECK-NEXT:%class.10 = class( {
+// CHECK-NEXT:  foo [final]: %function.14
+// CHECK-NEXT:})
+
+// CHECK:SemContext
+// CHECK-NEXT:Func strict
+// CHECK-NEXT:    Scope %s.1
+// CHECK-NEXT:    Func strict
+// CHECK-NEXT:        Scope %s.2
+// CHECK-NEXT:            Decl %d.1 'exports' Parameter : any
+// CHECK-NEXT:            Decl %d.2 'A' Class : %class_constructor.5
+// CHECK-NEXT:            Decl %d.3 'B' Class : %class_constructor.8
+// CHECK-NEXT:            Decl %d.4 'C' Class
+// CHECK-NEXT:            Decl %d.5 'arguments' Var Arguments
+// CHECK-NEXT:            Decl %d.6 'C' Class : %class_constructor.12
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.3
+// CHECK-NEXT:                Decl %d.7 'arguments' Var Arguments
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.4
+// CHECK-NEXT:                Decl %d.8 'b' Let
+// CHECK-NEXT:                Decl %d.9 'arguments' Var Arguments
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.5
+// CHECK-NEXT:                Decl %d.10 'b' Let : %class.6
+// CHECK-NEXT:                Decl %d.11 'arguments' Var Arguments
+
+// CHECK:Program Scope %s.1
+// CHECK-NEXT:    ExpressionStatement
+// CHECK-NEXT:        CallExpression : any
+// CHECK-NEXT:            FunctionExpression : %untyped_function.1
+// CHECK-NEXT:                Id 'exports' [D:E:%d.1 'exports']
+// CHECK-NEXT:                BlockStatement
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'A' [D:E:%d.2 'A']
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty : %union.4
+// CHECK-NEXT:                                Id 'c'
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'B' [D:E:%d.3 'B']
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            MethodDefinition : %function.13
+// CHECK-NEXT:                                Id 'func'
+// CHECK-NEXT:                                FunctionExpression : %function.13
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'C' [D:E:%d.6 'C']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty : %array.11
+// CHECK-NEXT:                                Id 'vals'
+// CHECK-NEXT:                            MethodDefinition : %function.14
+// CHECK-NEXT:                                Id 'foo'
+// CHECK-NEXT:                                FunctionExpression : %function.14
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                                        VariableDeclaration
+// CHECK-NEXT:                                            VariableDeclarator
+// CHECK-NEXT:                                                MemberExpression : %class.6
+// CHECK-NEXT:                                                    MemberExpression : %array.11
+// CHECK-NEXT:                                                        ThisExpression : %class.9
+// CHECK-NEXT:                                                        Id 'vals'
+// CHECK-NEXT:                                                    NumericLiteral : number
+// CHECK-NEXT:                                                Id 'b' [D:E:%d.10 'b']
+// CHECK-NEXT:                                        ExpressionStatement
+// CHECK-NEXT:                                            CallExpression : void
+// CHECK-NEXT:                                                MemberExpression : %function.13
+// CHECK-NEXT:                                                    Id 'b' [D:E:%d.10 'b'] : %class.6
+// CHECK-NEXT:                                                    Id 'func'
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'C' [D:E:%d.4 'C']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty
+// CHECK-NEXT:                                Id 'vals'
+// CHECK-NEXT:                            MethodDefinition
+// CHECK-NEXT:                                Id 'foo'
+// CHECK-NEXT:                                FunctionExpression
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                                        VariableDeclaration
+// CHECK-NEXT:                                            VariableDeclarator
+// CHECK-NEXT:                                                MemberExpression
+// CHECK-NEXT:                                                    MemberExpression
+// CHECK-NEXT:                                                        ThisExpression
+// CHECK-NEXT:                                                        Id 'vals'
+// CHECK-NEXT:                                                    NumericLiteral
+// CHECK-NEXT:                                                Id 'b' [D:E:%d.8 'b']
+// CHECK-NEXT:                                        ExpressionStatement
+// CHECK-NEXT:                                            CallExpression
+// CHECK-NEXT:                                                MemberExpression
+// CHECK-NEXT:                                                    Id 'b' [D:E:%d.8 'b']
+// CHECK-NEXT:                                                    Id 'func'
+// CHECK-NEXT:            ObjectExpression

--- a/test/Sema/flow/generic-class-superclass-ordering.js
+++ b/test/Sema/flow/generic-class-superclass-ordering.js
@@ -1,0 +1,208 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %shermes -fno-std-globals -typed -dump-sema %s | %FileCheckOrRegen %s --match-full-lines
+
+let outer: B<any>;
+
+// Notice that A<any> is constructed from multiple locations.
+// Make sure that it is initialized before B<any> is parsed.
+class A<T> {
+  constructor() {
+  }
+  foo(a: A<any>): void {}
+}
+
+class B<T> extends A<T> {
+  constructor() {
+    super();
+  }
+}
+
+class D {
+  constructor(val: A<string>) {
+  }
+}
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:%untyped_function.1 = untyped_function()
+// CHECK-NEXT:%class.2 = class(D {
+// CHECK-NEXT:  %constructor: %function.3
+// CHECK-NEXT:  %homeObject: %class.4
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.5 = class_constructor(%class.2)
+// CHECK-NEXT:%class.6 = class(A {
+// CHECK-NEXT:  %constructor: %function.7
+// CHECK-NEXT:  %homeObject: %class.8
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.9 = class_constructor(%class.6)
+// CHECK-NEXT:%function.3 = function(this: %class.2, val: %class.6): void
+// CHECK-NEXT:%class.4 = class( {
+// CHECK-NEXT:})
+// CHECK-NEXT:%function.7 = function(this: %class.6): void
+// CHECK-NEXT:%class.10 = class(A {
+// CHECK-NEXT:  %constructor: %function.11
+// CHECK-NEXT:  %homeObject: %class.12
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.13 = class_constructor(%class.10)
+// CHECK-NEXT:%function.14 = function(this: %class.6, a: %class.10): void
+// CHECK-NEXT:%class.8 = class( {
+// CHECK-NEXT:  foo [final]: %function.14
+// CHECK-NEXT:})
+// CHECK-NEXT:%function.11 = function(this: %class.10): void
+// CHECK-NEXT:%function.15 = function(this: %class.10, a: %class.10): void
+// CHECK-NEXT:%class.12 = class( {
+// CHECK-NEXT:  foo [final]: %function.15
+// CHECK-NEXT:})
+// CHECK-NEXT:%class.16 = class(B extends %class.10 {
+// CHECK-NEXT:  %constructor: %function.17
+// CHECK-NEXT:  %homeObject: %class.18
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.19 = class_constructor(%class.16)
+// CHECK-NEXT:%function.17 = function(this: %class.16): void
+// CHECK-NEXT:%class.18 = class( extends %class.12 {
+// CHECK-NEXT:})
+
+// CHECK:SemContext
+// CHECK-NEXT:Func strict
+// CHECK-NEXT:    Scope %s.1
+// CHECK-NEXT:    Func strict
+// CHECK-NEXT:        Scope %s.2
+// CHECK-NEXT:            Decl %d.1 'exports' Parameter : any
+// CHECK-NEXT:            Decl %d.2 'outer' Let : %class.16
+// CHECK-NEXT:            Decl %d.3 'A' Class
+// CHECK-NEXT:            Decl %d.4 'B' Class
+// CHECK-NEXT:            Decl %d.5 'D' Class : %class_constructor.5
+// CHECK-NEXT:            Decl %d.6 'arguments' Var Arguments
+// CHECK-NEXT:            Decl %d.7 'A' Class : %class_constructor.9
+// CHECK-NEXT:            Decl %d.8 'A' Class : %class_constructor.13
+// CHECK-NEXT:            Decl %d.9 'B' Class : %class_constructor.19
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.3
+// CHECK-NEXT:                Decl %d.10 'arguments' Var Arguments
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.4
+// CHECK-NEXT:                Decl %d.11 'a' Parameter
+// CHECK-NEXT:                Decl %d.12 'arguments' Var Arguments
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.5
+// CHECK-NEXT:                Decl %d.13 'arguments' Var Arguments
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.6
+// CHECK-NEXT:                Decl %d.14 'val' Parameter : %class.6
+// CHECK-NEXT:                Decl %d.15 'arguments' Var Arguments
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.7
+// CHECK-NEXT:                Decl %d.16 'arguments' Var Arguments
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.8
+// CHECK-NEXT:                Decl %d.17 'a' Parameter : %class.10
+// CHECK-NEXT:                Decl %d.18 'arguments' Var Arguments
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.9
+// CHECK-NEXT:                Decl %d.19 'arguments' Var Arguments
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.10
+// CHECK-NEXT:                Decl %d.20 'a' Parameter : %class.10
+// CHECK-NEXT:                Decl %d.21 'arguments' Var Arguments
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.11
+// CHECK-NEXT:                Decl %d.22 'arguments' Var Arguments
+
+// CHECK:Program Scope %s.1
+// CHECK-NEXT:    ExpressionStatement
+// CHECK-NEXT:        CallExpression : any
+// CHECK-NEXT:            FunctionExpression : %untyped_function.1
+// CHECK-NEXT:                Id 'exports' [D:E:%d.1 'exports']
+// CHECK-NEXT:                BlockStatement
+// CHECK-NEXT:                    VariableDeclaration
+// CHECK-NEXT:                        VariableDeclarator
+// CHECK-NEXT:                            Id 'outer' [D:E:%d.2 'outer']
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'A' [D:E:%d.7 'A']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            MethodDefinition : %function.7
+// CHECK-NEXT:                                Id 'constructor'
+// CHECK-NEXT:                                FunctionExpression : %function.7
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                            MethodDefinition : %function.14
+// CHECK-NEXT:                                Id 'foo'
+// CHECK-NEXT:                                FunctionExpression : %function.14
+// CHECK-NEXT:                                    Id 'a' [D:E:%d.17 'a']
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'A' [D:E:%d.8 'A']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            MethodDefinition : %function.11
+// CHECK-NEXT:                                Id 'constructor'
+// CHECK-NEXT:                                FunctionExpression : %function.11
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                            MethodDefinition : %function.15
+// CHECK-NEXT:                                Id 'foo'
+// CHECK-NEXT:                                FunctionExpression : %function.15
+// CHECK-NEXT:                                    Id 'a' [D:E:%d.20 'a']
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'A' [D:E:%d.3 'A']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            MethodDefinition
+// CHECK-NEXT:                                Id 'constructor'
+// CHECK-NEXT:                                FunctionExpression
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                            MethodDefinition
+// CHECK-NEXT:                                Id 'foo'
+// CHECK-NEXT:                                FunctionExpression
+// CHECK-NEXT:                                    Id 'a' [D:E:%d.11 'a']
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'B' [D:E:%d.9 'B']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        Id 'A' [D:E:%d.8 'A'] : %class_constructor.13
+// CHECK-NEXT:                        TypeParameterInstantiation
+// CHECK-NEXT:                            GenericTypeAnnotation
+// CHECK-NEXT:                                Id 'T'
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            MethodDefinition : %function.17
+// CHECK-NEXT:                                Id 'constructor'
+// CHECK-NEXT:                                FunctionExpression : %function.17
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                                        ExpressionStatement
+// CHECK-NEXT:                                            CallExpression : void
+// CHECK-NEXT:                                                Super : %function.11
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'B' [D:E:%d.4 'B']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        Id 'A' [D:E:%d.3 'A']
+// CHECK-NEXT:                        TypeParameterInstantiation
+// CHECK-NEXT:                            GenericTypeAnnotation
+// CHECK-NEXT:                                Id 'T'
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            MethodDefinition
+// CHECK-NEXT:                                Id 'constructor'
+// CHECK-NEXT:                                FunctionExpression
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                                        ExpressionStatement
+// CHECK-NEXT:                                            CallExpression
+// CHECK-NEXT:                                                Super
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'D' [D:E:%d.5 'D']
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            MethodDefinition : %function.3
+// CHECK-NEXT:                                Id 'constructor'
+// CHECK-NEXT:                                FunctionExpression : %function.3
+// CHECK-NEXT:                                    Id 'val' [D:E:%d.14 'val']
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:            ObjectExpression

--- a/test/Sema/flow/generic-class-union.js
+++ b/test/Sema/flow/generic-class-union.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %shermes -fno-std-globals -typed -dump-sema %s | %FileCheckOrRegen %s --match-full-lines
+
+type Union = string | number;
+
+class A<T> {}
+
+class B {
+  val: A<Union> | null;
+}
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:%untyped_function.1 = untyped_function()
+// CHECK-NEXT:%union.2 = union(string | number)
+// CHECK-NEXT:%class.3 = class(B {
+// CHECK-NEXT:  %homeObject: %class.4
+// CHECK-NEXT:  val: %union.5
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.6 = class_constructor(%class.3)
+// CHECK-NEXT:%class.7 = class(A {
+// CHECK-NEXT:  %homeObject: %class.8
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.9 = class_constructor(%class.7)
+// CHECK-NEXT:%union.5 = union(null | %class.7)
+// CHECK-NEXT:%class.4 = class( {
+// CHECK-NEXT:})
+// CHECK-NEXT:%class.8 = class( {
+// CHECK-NEXT:})
+
+// CHECK:SemContext
+// CHECK-NEXT:Func strict
+// CHECK-NEXT:    Scope %s.1
+// CHECK-NEXT:    Func strict
+// CHECK-NEXT:        Scope %s.2
+// CHECK-NEXT:            Decl %d.1 'exports' Parameter : any
+// CHECK-NEXT:            Decl %d.2 'A' Class
+// CHECK-NEXT:            Decl %d.3 'B' Class : %class_constructor.6
+// CHECK-NEXT:            Decl %d.4 'arguments' Var Arguments
+// CHECK-NEXT:            Decl %d.5 'A' Class : %class_constructor.9
+
+// CHECK:Program Scope %s.1
+// CHECK-NEXT:    ExpressionStatement
+// CHECK-NEXT:        CallExpression : any
+// CHECK-NEXT:            FunctionExpression : %untyped_function.1
+// CHECK-NEXT:                Id 'exports' [D:E:%d.1 'exports']
+// CHECK-NEXT:                BlockStatement
+// CHECK-NEXT:                    TypeAlias
+// CHECK-NEXT:                        Id 'Union'
+// CHECK-NEXT:                        UnionTypeAnnotation
+// CHECK-NEXT:                            StringTypeAnnotation
+// CHECK-NEXT:                            NumberTypeAnnotation
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'A' [D:E:%d.5 'A']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'A' [D:E:%d.2 'A']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'B' [D:E:%d.3 'B']
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty : %union.5
+// CHECK-NEXT:                                Id 'val'
+// CHECK-NEXT:            ObjectExpression

--- a/test/Sema/flow/generic-class-var-type.js
+++ b/test/Sema/flow/generic-class-var-type.js
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %shermes -fno-std-globals -typed -dump-sema %s | %FileCheckOrRegen %s --match-full-lines
+
+// All specializations should realize that counter is a number.
+let counter: number = 0;
+
+class A {
+  f: F<boolean>;
+}
+
+class F<T> {
+  x: T;
+  inc(): void {
+    ++counter; // make sure this is number.
+  }
+}
+
+let fString: F<string>;
+
+new F<number>();
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:%untyped_function.1 = untyped_function()
+// CHECK-NEXT:%class.2 = class(A {
+// CHECK-NEXT:  %homeObject: %class.3
+// CHECK-NEXT:  f: %class.4
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.5 = class_constructor(%class.2)
+// CHECK-NEXT:%class.4 = class(F {
+// CHECK-NEXT:  %homeObject: %class.6
+// CHECK-NEXT:  x: boolean
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.7 = class_constructor(%class.4)
+// CHECK-NEXT:%class.3 = class( {
+// CHECK-NEXT:})
+// CHECK-NEXT:%function.8 = function(this: %class.4): void
+// CHECK-NEXT:%class.6 = class( {
+// CHECK-NEXT:  inc [final]: %function.8
+// CHECK-NEXT:})
+// CHECK-NEXT:%class.9 = class(F {
+// CHECK-NEXT:  %homeObject: %class.10
+// CHECK-NEXT:  x: string
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.11 = class_constructor(%class.9)
+// CHECK-NEXT:%function.12 = function(this: %class.9): void
+// CHECK-NEXT:%class.10 = class( {
+// CHECK-NEXT:  inc [final]: %function.12
+// CHECK-NEXT:})
+// CHECK-NEXT:%class.13 = class(F {
+// CHECK-NEXT:  %homeObject: %class.14
+// CHECK-NEXT:  x: number
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.15 = class_constructor(%class.13)
+// CHECK-NEXT:%function.16 = function(this: %class.13): void
+// CHECK-NEXT:%class.14 = class( {
+// CHECK-NEXT:  inc [final]: %function.16
+// CHECK-NEXT:})
+
+// CHECK:SemContext
+// CHECK-NEXT:Func strict
+// CHECK-NEXT:    Scope %s.1
+// CHECK-NEXT:    Func strict
+// CHECK-NEXT:        Scope %s.2
+// CHECK-NEXT:            Decl %d.1 'exports' Parameter : any
+// CHECK-NEXT:            Decl %d.2 'counter' Let : number
+// CHECK-NEXT:            Decl %d.3 'A' Class : %class_constructor.5
+// CHECK-NEXT:            Decl %d.4 'F' Class
+// CHECK-NEXT:            Decl %d.5 'fString' Let : %class.9
+// CHECK-NEXT:            Decl %d.6 'arguments' Var Arguments
+// CHECK-NEXT:            Decl %d.7 'F' Class : %class_constructor.7
+// CHECK-NEXT:            Decl %d.8 'F' Class : %class_constructor.11
+// CHECK-NEXT:            Decl %d.9 'F' Class : %class_constructor.15
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.3
+// CHECK-NEXT:                Decl %d.10 'arguments' Var Arguments
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.4
+// CHECK-NEXT:                Decl %d.11 'arguments' Var Arguments
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.5
+// CHECK-NEXT:                Decl %d.12 'arguments' Var Arguments
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.6
+// CHECK-NEXT:                Decl %d.13 'arguments' Var Arguments
+
+// CHECK:Program Scope %s.1
+// CHECK-NEXT:    ExpressionStatement
+// CHECK-NEXT:        CallExpression : any
+// CHECK-NEXT:            FunctionExpression : %untyped_function.1
+// CHECK-NEXT:                Id 'exports' [D:E:%d.1 'exports']
+// CHECK-NEXT:                BlockStatement
+// CHECK-NEXT:                    VariableDeclaration
+// CHECK-NEXT:                        VariableDeclarator
+// CHECK-NEXT:                            NumericLiteral : number
+// CHECK-NEXT:                            Id 'counter' [D:E:%d.2 'counter']
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'A' [D:E:%d.3 'A']
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty : %class.4
+// CHECK-NEXT:                                Id 'f'
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'F' [D:E:%d.7 'F']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty : boolean
+// CHECK-NEXT:                                Id 'x'
+// CHECK-NEXT:                            MethodDefinition : %function.8
+// CHECK-NEXT:                                Id 'inc'
+// CHECK-NEXT:                                FunctionExpression : %function.8
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                                        ExpressionStatement
+// CHECK-NEXT:                                            UpdateExpression : number
+// CHECK-NEXT:                                                Id 'counter' [D:E:%d.2 'counter'] : number
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'F' [D:E:%d.8 'F']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty : string
+// CHECK-NEXT:                                Id 'x'
+// CHECK-NEXT:                            MethodDefinition : %function.12
+// CHECK-NEXT:                                Id 'inc'
+// CHECK-NEXT:                                FunctionExpression : %function.12
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                                        ExpressionStatement
+// CHECK-NEXT:                                            UpdateExpression : number
+// CHECK-NEXT:                                                Id 'counter' [D:E:%d.2 'counter'] : number
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'F' [D:E:%d.9 'F']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty : number
+// CHECK-NEXT:                                Id 'x'
+// CHECK-NEXT:                            MethodDefinition : %function.16
+// CHECK-NEXT:                                Id 'inc'
+// CHECK-NEXT:                                FunctionExpression : %function.16
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                                        ExpressionStatement
+// CHECK-NEXT:                                            UpdateExpression : number
+// CHECK-NEXT:                                                Id 'counter' [D:E:%d.2 'counter'] : number
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'F' [D:E:%d.4 'F']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty
+// CHECK-NEXT:                                Id 'x'
+// CHECK-NEXT:                            MethodDefinition
+// CHECK-NEXT:                                Id 'inc'
+// CHECK-NEXT:                                FunctionExpression
+// CHECK-NEXT:                                    BlockStatement
+// CHECK-NEXT:                                        ExpressionStatement
+// CHECK-NEXT:                                            UpdateExpression
+// CHECK-NEXT:                                                Id 'counter' [D:E:%d.2 'counter']
+// CHECK-NEXT:                    VariableDeclaration
+// CHECK-NEXT:                        VariableDeclarator
+// CHECK-NEXT:                            Id 'fString' [D:E:%d.5 'fString']
+// CHECK-NEXT:                    ExpressionStatement
+// CHECK-NEXT:                        NewExpression : %class.13
+// CHECK-NEXT:                            Id 'F' [D:E:%d.9 'F'] : %class_constructor.15
+// CHECK-NEXT:                            TypeParameterInstantiation
+// CHECK-NEXT:                                NumberTypeAnnotation
+// CHECK-NEXT:            ObjectExpression

--- a/test/Sema/flow/generic-type-alias-cycle-error.js
+++ b/test/Sema/flow/generic-type-alias-cycle-error.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: (! %shermes -Werror -ferror-limit=0 -typed -dump-sema %s 2>&1 ) | %FileCheckOrRegen --match-full-lines %s
+
+type A<T> = B<T> | null;
+type B<T> = A<T> | null;
+
+type C = A<number>;
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:{{.*}}generic-type-alias-cycle-error.js:10:13: error: ft: type contains a circular reference to itself
+// CHECK-NEXT:type A<T> = B<T> | null;
+// CHECK-NEXT:            ^~~~
+// CHECK-NEXT:Emitted 1 errors. exiting.

--- a/test/Sema/flow/generic-type-alias-unions.js
+++ b/test/Sema/flow/generic-type-alias-unions.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %shermes -fno-std-globals -typed -dump-sema %s | %FileCheckOrRegen %s --match-full-lines
+
+class Foo {}
+class Bar {}
+type C<T> = (T | Foo | Bar) | null;
+type C_crazy = C<number | Foo | Bar> | null;
+
+// Observe that this type collapses the duplicate Foo, Bar, null together.
+var c2: C_crazy;
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:%untyped_function.1 = untyped_function()
+// CHECK-NEXT:%class.2 = class(Foo {
+// CHECK-NEXT:  %homeObject: %class.3
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.4 = class_constructor(%class.2)
+// CHECK-NEXT:%class.5 = class(Bar {
+// CHECK-NEXT:  %homeObject: %class.6
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.7 = class_constructor(%class.5)
+// CHECK-NEXT:%union.8 = union(null | number | %class.2 | %class.5)
+// CHECK-NEXT:%union.9 = union(number | %class.2 | %class.5)
+// CHECK-NEXT:%class.3 = class( {
+// CHECK-NEXT:})
+// CHECK-NEXT:%class.6 = class( {
+// CHECK-NEXT:})
+
+// CHECK:SemContext
+// CHECK-NEXT:Func strict
+// CHECK-NEXT:    Scope %s.1
+// CHECK-NEXT:    Func strict
+// CHECK-NEXT:        Scope %s.2
+// CHECK-NEXT:            Decl %d.1 'exports' Parameter : any
+// CHECK-NEXT:            Decl %d.2 'Foo' Class : %class_constructor.4
+// CHECK-NEXT:            Decl %d.3 'Bar' Class : %class_constructor.7
+// CHECK-NEXT:            Decl %d.4 'c2' Var : %union.8
+// CHECK-NEXT:            Decl %d.5 'arguments' Var Arguments
+
+// CHECK:Program Scope %s.1
+// CHECK-NEXT:    ExpressionStatement
+// CHECK-NEXT:        CallExpression : any
+// CHECK-NEXT:            FunctionExpression : %untyped_function.1
+// CHECK-NEXT:                Id 'exports' [D:E:%d.1 'exports']
+// CHECK-NEXT:                BlockStatement
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'Foo' [D:E:%d.2 'Foo']
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'Bar' [D:E:%d.3 'Bar']
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                    TypeAlias
+// CHECK-NEXT:                        Id 'C'
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        UnionTypeAnnotation
+// CHECK-NEXT:                            UnionTypeAnnotation
+// CHECK-NEXT:                                GenericTypeAnnotation
+// CHECK-NEXT:                                    Id 'T'
+// CHECK-NEXT:                                GenericTypeAnnotation
+// CHECK-NEXT:                                    Id 'Foo'
+// CHECK-NEXT:                                GenericTypeAnnotation
+// CHECK-NEXT:                                    Id 'Bar'
+// CHECK-NEXT:                            NullLiteralTypeAnnotation
+// CHECK-NEXT:                    TypeAlias
+// CHECK-NEXT:                        Id 'C_crazy'
+// CHECK-NEXT:                        UnionTypeAnnotation
+// CHECK-NEXT:                            GenericTypeAnnotation
+// CHECK-NEXT:                                Id 'C'
+// CHECK-NEXT:                                TypeParameterInstantiation
+// CHECK-NEXT:                                    UnionTypeAnnotation
+// CHECK-NEXT:                                        NumberTypeAnnotation
+// CHECK-NEXT:                                        GenericTypeAnnotation
+// CHECK-NEXT:                                            Id 'Foo'
+// CHECK-NEXT:                                        GenericTypeAnnotation
+// CHECK-NEXT:                                            Id 'Bar'
+// CHECK-NEXT:                            NullLiteralTypeAnnotation
+// CHECK-NEXT:                    VariableDeclaration
+// CHECK-NEXT:                        VariableDeclarator
+// CHECK-NEXT:                            Id 'c2' [D:E:%d.4 'c2']
+// CHECK-NEXT:            ObjectExpression

--- a/test/Sema/flow/generic-type-alias.js
+++ b/test/Sema/flow/generic-type-alias.js
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %shermes -fno-std-globals -typed -dump-sema %s | %FileCheckOrRegen %s --match-full-lines
+
+type Array<T> = T[];
+var arr: Array<number>;
+
+type A<T> = B<T>[] | T | Cls<T>;
+type B<T> = A<T>[] | T;
+
+class Cls<T> {
+  x: T;
+  y: A<T>;
+}
+
+type C = A<number>;
+var c: C;
+var d: A<string>;
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:%untyped_function.1 = untyped_function()
+// CHECK-NEXT:%union.2 = union(number | %array.3 | %class.4)
+// CHECK-NEXT:%union.5 = union(number | %array.6)
+// CHECK-NEXT:%array.3 = array(%union.5)
+// CHECK-NEXT:%class.4 = class(Cls {
+// CHECK-NEXT:  %homeObject: %class.7
+// CHECK-NEXT:  x: number
+// CHECK-NEXT:  y: %union.2
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.8 = class_constructor(%class.4)
+// CHECK-NEXT:%array.6 = array(%union.2)
+// CHECK-NEXT:%class.7 = class( {
+// CHECK-NEXT:})
+// CHECK-NEXT:%array.9 = array(number)
+// CHECK-NEXT:%union.10 = union(string | %array.11 | %class.12)
+// CHECK-NEXT:%union.13 = union(string | %array.14)
+// CHECK-NEXT:%array.11 = array(%union.13)
+// CHECK-NEXT:%class.12 = class(Cls {
+// CHECK-NEXT:  %homeObject: %class.15
+// CHECK-NEXT:  x: string
+// CHECK-NEXT:  y: %union.10
+// CHECK-NEXT:})
+// CHECK-NEXT:%class_constructor.16 = class_constructor(%class.12)
+// CHECK-NEXT:%class.15 = class( {
+// CHECK-NEXT:})
+// CHECK-NEXT:%array.14 = array(%union.10)
+
+// CHECK:SemContext
+// CHECK-NEXT:Func strict
+// CHECK-NEXT:    Scope %s.1
+// CHECK-NEXT:    Func strict
+// CHECK-NEXT:        Scope %s.2
+// CHECK-NEXT:            Decl %d.1 'exports' Parameter : any
+// CHECK-NEXT:            Decl %d.2 'arr' Var : %array.9
+// CHECK-NEXT:            Decl %d.3 'Cls' Class
+// CHECK-NEXT:            Decl %d.4 'c' Var : %union.2
+// CHECK-NEXT:            Decl %d.5 'd' Var : %union.10
+// CHECK-NEXT:            Decl %d.6 'arguments' Var Arguments
+// CHECK-NEXT:            Decl %d.7 'Cls' Class : %class_constructor.8
+// CHECK-NEXT:            Decl %d.8 'Cls' Class : %class_constructor.16
+
+// CHECK:Program Scope %s.1
+// CHECK-NEXT:    ExpressionStatement
+// CHECK-NEXT:        CallExpression : any
+// CHECK-NEXT:            FunctionExpression : %untyped_function.1
+// CHECK-NEXT:                Id 'exports' [D:E:%d.1 'exports']
+// CHECK-NEXT:                BlockStatement
+// CHECK-NEXT:                    TypeAlias
+// CHECK-NEXT:                        Id 'Array'
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ArrayTypeAnnotation
+// CHECK-NEXT:                            GenericTypeAnnotation
+// CHECK-NEXT:                                Id 'T'
+// CHECK-NEXT:                    VariableDeclaration
+// CHECK-NEXT:                        VariableDeclarator
+// CHECK-NEXT:                            Id 'arr' [D:E:%d.2 'arr']
+// CHECK-NEXT:                    TypeAlias
+// CHECK-NEXT:                        Id 'A'
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        UnionTypeAnnotation
+// CHECK-NEXT:                            ArrayTypeAnnotation
+// CHECK-NEXT:                                GenericTypeAnnotation
+// CHECK-NEXT:                                    Id 'B'
+// CHECK-NEXT:                                    TypeParameterInstantiation
+// CHECK-NEXT:                                        GenericTypeAnnotation
+// CHECK-NEXT:                                            Id 'T'
+// CHECK-NEXT:                            GenericTypeAnnotation
+// CHECK-NEXT:                                Id 'T'
+// CHECK-NEXT:                            GenericTypeAnnotation
+// CHECK-NEXT:                                Id 'Cls'
+// CHECK-NEXT:                                TypeParameterInstantiation
+// CHECK-NEXT:                                    GenericTypeAnnotation
+// CHECK-NEXT:                                        Id 'T'
+// CHECK-NEXT:                    TypeAlias
+// CHECK-NEXT:                        Id 'B'
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        UnionTypeAnnotation
+// CHECK-NEXT:                            ArrayTypeAnnotation
+// CHECK-NEXT:                                GenericTypeAnnotation
+// CHECK-NEXT:                                    Id 'A'
+// CHECK-NEXT:                                    TypeParameterInstantiation
+// CHECK-NEXT:                                        GenericTypeAnnotation
+// CHECK-NEXT:                                            Id 'T'
+// CHECK-NEXT:                            GenericTypeAnnotation
+// CHECK-NEXT:                                Id 'T'
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'Cls' [D:E:%d.7 'Cls']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty : number
+// CHECK-NEXT:                                Id 'x'
+// CHECK-NEXT:                            ClassProperty : %union.2
+// CHECK-NEXT:                                Id 'y'
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'Cls' [D:E:%d.8 'Cls']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty : string
+// CHECK-NEXT:                                Id 'x'
+// CHECK-NEXT:                            ClassProperty : %union.10
+// CHECK-NEXT:                                Id 'y'
+// CHECK-NEXT:                    ClassDeclaration
+// CHECK-NEXT:                        Id 'Cls' [D:E:%d.3 'Cls']
+// CHECK-NEXT:                        TypeParameterDeclaration
+// CHECK-NEXT:                            TypeParameter
+// CHECK-NEXT:                        ClassBody
+// CHECK-NEXT:                            ClassProperty
+// CHECK-NEXT:                                Id 'x'
+// CHECK-NEXT:                            ClassProperty
+// CHECK-NEXT:                                Id 'y'
+// CHECK-NEXT:                    TypeAlias
+// CHECK-NEXT:                        Id 'C'
+// CHECK-NEXT:                        GenericTypeAnnotation
+// CHECK-NEXT:                            Id 'A'
+// CHECK-NEXT:                            TypeParameterInstantiation
+// CHECK-NEXT:                                NumberTypeAnnotation
+// CHECK-NEXT:                    VariableDeclaration
+// CHECK-NEXT:                        VariableDeclarator
+// CHECK-NEXT:                            Id 'c' [D:E:%d.4 'c']
+// CHECK-NEXT:                    VariableDeclaration
+// CHECK-NEXT:                        VariableDeclarator
+// CHECK-NEXT:                            Id 'd' [D:E:%d.5 'd']
+// CHECK-NEXT:            ObjectExpression

--- a/test/shermes/flow/generic-class-chained-typecast.js
+++ b/test/shermes/flow/generic-class-chained-typecast.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %shermes -O0 -typed -exec %s | %FileCheck %s --match-full-lines
+// RUN: %shermes -typed -exec %s | %FileCheck %s --match-full-lines
+
+let outer: A<number> | null = null;
+
+class B<T> {
+  constructor() {}
+  read(): void {
+    (globalThis.a as A<boolean>).foo();
+  }
+}
+
+class A<T> extends B<T> {
+  constructor() {
+    super();
+  }
+  foo(): void {
+    print('foo')
+  }
+}
+
+globalThis.a = new A<boolean>();
+new B<number>().read();
+// CHECK: foo

--- a/test/shermes/flow/generic-class-cycle-nested.js
+++ b/test/shermes/flow/generic-class-cycle-nested.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %shermes -O0 -typed -exec %s | %FileCheck %s --match-full-lines
+// RUN: %shermes -typed -exec %s | %FileCheck %s --match-full-lines
+
+class AAA {
+  constructor() {}
+  foo() {
+    class CCC<T> extends AAA {
+      x: T;
+      constructor(x: T) {
+        super();
+        this.x = x;
+      }
+    }
+    let cn: CCC<number> = new CCC<number>(2);
+    print(cn.x);
+    let cs: CCC<string> = new CCC<string>('abc');
+    print(cs.x);
+  }
+}
+
+print('start');
+// CHECK-LABEL: start
+
+new AAA().foo();
+// CHECK-NEXT: 2
+// CHECK-NEXT: abc

--- a/test/shermes/flow/generic-class-id.js
+++ b/test/shermes/flow/generic-class-id.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %shermes -O0 -typed -exec %s | %FileCheck %s --match-full-lines
+// RUN: %shermes -typed -exec %s | %FileCheck %s --match-full-lines
+
+class ID<T> {
+  val: T;
+
+  constructor(val: T) {
+    this.val = val;
+  }
+}
+
+print('generic class');
+// CHECK-LABEL: generic class
+
+const i1: ID<number> = new ID<number>(1);
+const n: number = i1.val;
+print(n);
+// CHECK-NEXT: 1
+
+const i2: ID<string> = new ID<string>('abc');
+const s: string = i2.val;
+print(s);
+// CHECK-NEXT: abc

--- a/test/shermes/flow/generic-class-inherited.js
+++ b/test/shermes/flow/generic-class-inherited.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %shermes -O0 -typed -exec %s | %FileCheck %s --match-full-lines
+// RUN: %shermes -typed -exec %s | %FileCheck %s --match-full-lines
+
+class A<T> {
+  x: T;
+
+  constructor(x: T) {
+    this.x = x;
+  }
+}
+
+class B<T, U> extends A<T> {
+  y: U;
+
+  constructor(x: T, y: U) {
+    super(x);
+    this.y = y;
+  }
+
+  getX(): T {
+    return super.x;
+  }
+
+  getY(): U {
+    return this.y;
+  }
+}
+
+class C extends A<number> {
+  constructor(x: number) {
+    super(x);
+  }
+
+  getX(): number {
+    return super.x;
+  }
+}
+
+class NonGeneric {}
+
+class D<T> extends NonGeneric {
+  x: T;
+
+  constructor(x: T) {
+    super();
+    this.x = x;
+  }
+}
+
+print('generic class');
+// CHECK-LABEL: generic class
+
+var b: B<number, string> = new B<number, string>(123, 'abc');
+print(b.x, b.y);
+// CHECK-NEXT: 123 abc
+print(b.getX(), b.getY());
+// CHECK-NEXT: 123 abc
+
+var c: C = new C(192);
+print(c.getX());
+// CHECK-NEXT: 192
+
+var d: D<number> = new D<number>(1282);
+print(d.x);
+// CHECK-NEXT: 1282

--- a/test/shermes/flow/generic-class-linkedlist.js
+++ b/test/shermes/flow/generic-class-linkedlist.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %shermes -O0 -typed -exec %s | %FileCheck %s --match-full-lines
+// RUN: %shermes -typed -exec %s | %FileCheck %s --match-full-lines
+
+function CHECKED_CAST<T>(x: mixed): T {
+  return ((x: any): T);
+}
+
+class LinkedList<T> {
+  x: T;
+  next: LinkedList<T> | null;
+  constructor(x: T, next: LinkedList<T> | null) {
+    this.x = x;
+    this.next = next;
+  }
+  getNext(): LinkedList<T> {
+    if (this.next !== null) {
+      return CHECKED_CAST<LinkedList<T>>(this.next);
+    }
+    throw Error('empty list');
+  }
+}
+
+print('linkedlist');
+// CHECK-LABEL: linkedlist
+
+let n1: LinkedList<number> = new LinkedList<number>(1, null);
+let n2: LinkedList<number> = new LinkedList<number>(2, n1);
+print(n2.x);
+// CHECK-NEXT: 2
+print(n1.x);
+// CHECK-NEXT: 1
+print(n2.getNext().x);
+// CHECK-NEXT: 1

--- a/test/shermes/flow/generic-class-via-func.js
+++ b/test/shermes/flow/generic-class-via-func.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %shermes -O0 -typed -exec %s | %FileCheck %s --match-full-lines
+// RUN: %shermes -typed -exec %s | %FileCheck %s --match-full-lines
+
+function get<T>(x: T): A<T> {
+  return new A<T>(x);
+}
+class A<T> {
+  x: T;
+  constructor(x: T) {
+    this.x = x;
+  }
+  bar(): string {
+    return 'bar';
+  }
+}
+class B {
+  foo(): void {
+    const text = get<string>('foo');
+    print(text.x);
+    const other = text.bar();
+    print(other);
+  }
+}
+
+print('generic class');
+// CHECK-LABEL: generic class
+
+let val = get<string>('abc');
+print(val.x);
+// CHECK-NEXT: abc
+new B().foo();
+// CHECK-NEXT: foo
+// CHECK-NEXT: bar


### PR DESCRIPTION
Summary:
Generic type aliases are registered in a similar way to generic classes.

Their specializations are Type instead of ESTree::Node, and they need to
be resolved through other aliases (unlike classes, which are nominally
typed).

Two important parts of this diff:

## `completeForwardDeclarations`

Instantiating a forward generic may introduce new forward generics,
which means we have to continue rerunning the type completion
until they've all been resolved.

Other than that, the completion pass operates as it did previously,
with extra logic in `completeForwardGeneric` to resolve generic type
aliases.

## `DeclareScopeTypes::resolveGenericTypeAlias`

`DeclareScopeTypes` has all the relevant logic for actually handling
all the interdependency between type aliases, so add a second function
to it to make it possible to instantiate a generic type alias from the
typechecking visitor.

This does the same steps as DeclareScopeTypes, just uses a single
generic type instantiation instead of a list of decls as the starting
point.

Reviewed By: tmikov

Differential Revision: D53449068

