### PR TITLE
Align the documented dependencies with those used in CI

### DIFF
--- a/doc/BuildingAndRunning.md
+++ b/doc/BuildingAndRunning.md
@@ -13,7 +13,7 @@ The Hermes REPL will also use libreadline, if available.
 
 To install dependencies on Ubuntu:
 
-    apt install cmake git ninja-build libicu-dev python3 zip libreadline-dev
+    apt install git openssh-client cmake build-essential libicu-dev zip python3 tzdata
 
 On Arch Linux:
 


### PR DESCRIPTION
## Summary

The docs' dependency list is incomplete and doesn't match what's in the CI

Ref. https://github.com/facebook/hermes/blob/static_h/.circleci/config.yml#L61