### PR TITLE
[Windows] Fix incorrect use of GetProcessMemoryInfo's return value.

### DIFF
--- a/lib/Support/OSCompatWindows.cpp
+++ b/lib/Support/OSCompatWindows.cpp
@@ -356,7 +356,7 @@ int pages_in_ram(const void *p, size_t sz, llvh::SmallVectorImpl<int> *runs) {
 uint64_t peak_rss() {
   PROCESS_MEMORY_COUNTERS pmc;
   auto ret = GetProcessMemoryInfo(GetCurrentProcess(), &pmc, sizeof(pmc));
-  if (ret != 0) {
+  if (ret == 0) {
     // failed
     return 0;
   }
@@ -366,7 +366,7 @@ uint64_t peak_rss() {
 uint64_t current_rss() {
   PROCESS_MEMORY_COUNTERS pmc;
   auto ret = GetProcessMemoryInfo(GetCurrentProcess(), &pmc, sizeof(pmc));
-  if (ret != 0) {
+  if (ret == 0) {
     // failed
     return 0;
   }


### PR DESCRIPTION
## Summary

According to the API documentation [GetProcessMemoryInfo function (psapi.h)
](https://learn.microsoft.com/en-us/windows/win32/api/psapi/nf-psapi-getprocessmemoryinfo)


> If the function succeeds, the return value is nonzero.
> If the function fails, the return value is zero. To get extended error information, call [GetLastError](https://learn.microsoft.com/en-us/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror).



## Test Plan

- Turn on ShouldRecordStats ( GCConfig.h )
- Be able to get the actual value instead of 0