### PR TITLE
Fix equality of NaNs in isSameValue

### DIFF
--- a/include/hermes/VM/HermesValue.h
+++ b/include/hermes/VM/HermesValue.h
@@ -327,6 +327,13 @@ class HermesValue : public HermesValueBase {
   inline bool isNumber() const {
     return isDouble();
   }
+  inline bool isNaN() const {
+    // Mask out the sign bit since it does not affect whether the value is a
+    // NaN. All the other bits must be equal to the NaN bit pattern, since we
+    // only use the quiet NaN to represent NaN.
+    uint64_t kMask = llvh::maskLeadingZeros<uint64_t>(1);
+    return (this->raw & kMask) == (encodeNaNValue().raw & kMask);
+  }
 
   inline RawType getRaw() const {
     return this->raw;

--- a/lib/VM/Operations.cpp
+++ b/lib/VM/Operations.cpp
@@ -113,6 +113,12 @@ OptValue<uint32_t> toArrayIndex(StringView str) {
 }
 
 bool isSameValue(HermesValue x, HermesValue y) {
+  // Check for NaN before checking the tag. We have to do this because NaNs may
+  // differ in the sign bit, which may result in the tag comparison below
+  // incorrectly returning false.
+  if (LLVM_UNLIKELY(x.isNaN()) && y.isNaN())
+    return true;
+
   if (x.getTag() != y.getTag()) {
     // If the tags are different, they must be different.
     return false;

--- a/test/hermes/regress-issamevalue-nan.js
+++ b/test/hermes/regress-issamevalue-nan.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes %s | %FileCheck --match-full-lines %s
+
+// Test that different NaN representations are considered equal by isSameValue.
+function foo(){
+    // This will get optimized to the NaN constant used by the compiler.
+    var staticNan = 0/0;
+    globalThis.zero = 0;
+    // This will produce the default NaN on the platform.
+    var dynamicNan = 0/globalThis.zero;
+    print([staticNan].includes(dynamicNan));
+}
+
+foo();
+
+//CHECK: true


### PR DESCRIPTION
Summary:
Original Author: neildhar@meta.com
Original Reviewed By: tmikov
Original Revision: D54179136

`isSameValue` and `isSameValueZero` need to return true if both the
arguments are `NaN`. Our current implementation does this by falling
back to a bitwise comparison in the case that both arguments are
numbers.

However, this is insufficient. There are two possible encodings for the
quiet NaN (with and without the sign bit), and it is easy to end up
with a mix of them in a single program. For example, the constant
`std::numeric_limits<double>::quiet_NaN` sets the sign bit to 0,
whereas `hermesc` currently always sets it to 1. On x86, operations
that produce NaN will set the sign bit to 1 if neither operand is a
NaN, whereas on ARM the default seems to be 0.

In principle, we could use that information to impose a canonical
encoding at runtime (using 1 on x86 and 0 on ARM), with checks during
deserialisation from bytecode to make sure we get the correct one for
the platform. But this would likely be fragile and complicated.

This diff patches `isSameValue` to check explicitly for NaN with
`std::isnan`, and make sure it always compares equal.

Note that this issue is further complicated in Hermes today because the
interpreter decodes the serialised NaN with
`encodeUntrustedNumberValue`, which means that the sign bit added by
`hermesc` is removed at runtime. This means that the added test case
only fails on x86, since on ARM, all NaNs end up without the sign bit.

Differential Revision: D54293380


