### PR TITLE
Allow using `babel-plugin-syntax-hermes-parser` with Babel 8 alpha

### DIFF
--- a/tools/hermes-parser/js/babel-plugin-syntax-hermes-parser/src/index.js
+++ b/tools/hermes-parser/js/babel-plugin-syntax-hermes-parser/src/index.js
@@ -18,7 +18,7 @@ export default function BabelPluginSyntaxHermesParser(
   // $FlowExpectedError[unclear-type] We don't have types for this.
   api: any,
 ): $ReadOnly<{...}> {
-  api.assertVersion(7);
+  api.assertVersion("^7.0.0 || ^8.0.0-alpha.6");
 
   let curParserOpts: ParserOptions = {};
   let curFilename: ?string = null;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `main`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/HEAD/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.
-->

## Summary

The plugin currently requires Babel 7. Babel 8 alpha has no changes to the API that the plugin is using, so it will work if we allow it.

Note that there are some AST breaking changes in Babel 8, so the plugin will have to be updated to fully support it: https://next.babeljs.io/docs/v8-migration-api#ast-changes. However, this PR at least allows experimenting with the plugin in Babel 8 (and making sure that everything else works) for people not affected by those AST changes.

## Test Plan

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes the user interface.
-->

Existing tests pass.