### PR TITLE
Make queueMicrotask pure virtual

### DIFF
--- a/API/hermes_abi/HermesABIRuntimeWrapper.cpp
+++ b/API/hermes_abi/HermesABIRuntimeWrapper.cpp
@@ -710,6 +710,10 @@ class HermesABIRuntimeWrapper : public Runtime {
     return evaluateJavaScript(sjp, sjp->sourceURL());
   }
 
+  void queueMicrotask(const Function & /*callback*/) override {
+    THROW_UNIMPLEMENTED();
+  }
+
   bool drainMicrotasks(int maxMicrotasksHint = -1) override {
     return unwrap(vtable_->drain_microtasks(abiRt_, maxMicrotasksHint));
   }

--- a/API/hermes_sandbox/HermesSandboxRuntime.cpp
+++ b/API/hermes_sandbox/HermesSandboxRuntime.cpp
@@ -1701,6 +1701,10 @@ class HermesSandboxRuntimeImpl : public facebook::hermes::HermesSandboxRuntime,
     return evaluateJavaScript(sjp, sjp->sourceURL());
   }
 
+  void queueMicrotask(const Function & /*callback*/) override {
+    THROW_UNIMPLEMENTED();
+  }
+
   bool drainMicrotasks(int maxMicrotasksHint = -1) override {
     SandboxBoolOrError resBoolOrError{
         vt_.drain_microtasks(this, srt_, maxMicrotasksHint)};

--- a/API/jsi/jsi/jsi.cpp
+++ b/API/jsi/jsi/jsi.cpp
@@ -87,10 +87,6 @@ NativeState::~NativeState() {}
 
 Runtime::~Runtime() {}
 
-void Runtime::queueMicrotask(const jsi::Function& /*callback*/) {
-  throw JSINativeException("queueMicrotask is not implemented in this runtime");
-}
-
 Instrumentation& Runtime::instrumentation() {
   class NoInstrumentation : public Instrumentation {
     std::string getRecordedGCStats() override {

--- a/API/jsi/jsi/jsi.h
+++ b/API/jsi/jsi/jsi.h
@@ -214,7 +214,7 @@ class JSI_EXPORT Runtime {
   /// its event loop implementation.
   ///
   /// \param callback a function to be executed as a microtask.
-  virtual void queueMicrotask(const jsi::Function& callback);
+  virtual void queueMicrotask(const jsi::Function& callback) = 0;
 
   /// Drain the JavaScript VM internal Microtask (a.k.a. Job in ECMA262) queue.
   ///


### PR DESCRIPTION
Summary:
Changelog: [internal]

We've done this in a separate diff because the changes in Hermes don't propagate immediately to the React Native repository. We need to land the changes in JSI and Hermes first (in a backwards-compatible way) and then land this in a separate commit to make the method mandatory.

Reviewed By: neildhar

Differential Revision: D54413830


