### PR TITLE
Allocate HashMapEntry on OldGen

### DIFF
--- a/include/hermes/VM/OrderedHashMap.h
+++ b/include/hermes/VM/OrderedHashMap.h
@@ -9,8 +9,8 @@
 #define HERMES_VM_ORDERED_HASHMAP_H
 
 #include "hermes/Support/ErrorHandling.h"
-#include "hermes/VM/ArrayStorage.h"
 #include "hermes/VM/Runtime.h"
+#include "hermes/VM/SegmentedArray.h"
 
 #include <vector>
 
@@ -134,12 +134,14 @@ class OrderedHashMap final : public GCCell {
   HashMapEntry *iteratorNext(Runtime &runtime, HashMapEntry *entry = nullptr)
       const;
 
-  OrderedHashMap(Runtime &runtime, Handle<ArrayStorageSmall> hashTableStorage);
+  OrderedHashMap(
+      Runtime &runtime,
+      Handle<SegmentedArraySmall> hashTableStorage);
 
  private:
   /// The hashtable, with size always equal to capacity_. The number of
   /// reachable entries from hashTable_ should be equal to size_.
-  GCPointer<ArrayStorageSmall> hashTable_{nullptr};
+  GCPointer<SegmentedArraySmall> hashTable_{nullptr};
 
   /// The first entry ever inserted. We need this entry to begin an iteration.
   GCPointer<HashMapEntry> firstIterationEntry_{nullptr};
@@ -155,7 +157,7 @@ class OrderedHashMap final : public GCCell {
   // It needs to be less than 1/4th the max 32-bit integer in order to use an
   // integer-based load factor check of 0.75.
   static constexpr uint32_t MAX_CAPACITY =
-      std::min(ArrayStorageSmall::maxElements(), UINT32_MAX / 4);
+      std::min(SegmentedArraySmall::maxElements(), UINT32_MAX / 4);
 
   /// Capacity of the hash table.
   uint32_t capacity_{INITIAL_CAPACITY};

--- a/include/hermes/VM/OrderedHashMap.h
+++ b/include/hermes/VM/OrderedHashMap.h
@@ -49,6 +49,9 @@ class HashMapEntry final : public GCCell {
 
   static CallResult<PseudoHandle<HashMapEntry>> create(Runtime &runtime);
 
+  static CallResult<PseudoHandle<HashMapEntry>> createLongLived(
+      Runtime &runtime);
+
   /// Indicates whether this entry has been deleted.
   bool isDeleted() const {
     assert(key.isEmpty() == value.isEmpty() && "Inconsistent deleted status");


### PR DESCRIPTION
Summary:
Allocate HashMapEntry if the hash table is on OldGen. This gives us
much better performance when large number of entires (like 10M entries)
are inserted to Set or Map.
At early insertion, everything will be allocated on YoungGen, then at
some point, YoungGen collection happens and the hash table will be
moved to OldGen. After that, all the allocation and rehash will happen
on OldGen.

Reviewed By: neildhar

Differential Revision: D53293826


