### PR TITLE
Use open address for collision resolution in OrderedHashMap

### DIFF
--- a/include/hermes/VM/OrderedHashMap.h
+++ b/include/hermes/VM/OrderedHashMap.h
@@ -9,8 +9,8 @@
 #define HERMES_VM_ORDERED_HASHMAP_H
 
 #include "hermes/Support/ErrorHandling.h"
-#include "hermes/VM/ArrayStorage.h"
 #include "hermes/VM/Runtime.h"
+#include "hermes/VM/SegmentedArray.h"
 
 #include <vector>
 
@@ -134,12 +134,14 @@ class OrderedHashMap final : public GCCell {
   HashMapEntry *iteratorNext(Runtime &runtime, HashMapEntry *entry = nullptr)
       const;
 
-  OrderedHashMap(Runtime &runtime, Handle<ArrayStorageSmall> hashTableStorage);
+  OrderedHashMap(
+      Runtime &runtime,
+      Handle<SegmentedArraySmall> hashTableStorage);
 
  private:
   /// The hashtable, with size always equal to capacity_. The number of
   /// reachable entries from hashTable_ should be equal to size_.
-  GCPointer<ArrayStorageSmall> hashTable_{nullptr};
+  GCPointer<SegmentedArraySmall> hashTable_{nullptr};
 
   /// The first entry ever inserted. We need this entry to begin an iteration.
   GCPointer<HashMapEntry> firstIterationEntry_{nullptr};
@@ -155,7 +157,7 @@ class OrderedHashMap final : public GCCell {
   // It needs to be less than 1/4th the max 32-bit integer in order to use an
   // integer-based load factor check of 0.75.
   static constexpr uint32_t MAX_CAPACITY =
-      std::min(ArrayStorageSmall::maxElements(), UINT32_MAX / 4);
+      std::min(SegmentedArraySmall::maxElements(), UINT32_MAX / 4);
 
   /// Capacity of the hash table.
   uint32_t capacity_{INITIAL_CAPACITY};

--- a/include/hermes/VM/OrderedHashMap.h
+++ b/include/hermes/VM/OrderedHashMap.h
@@ -49,6 +49,9 @@ class HashMapEntry final : public GCCell {
 
   static CallResult<PseudoHandle<HashMapEntry>> create(Runtime &runtime);
 
+  static CallResult<PseudoHandle<HashMapEntry>> createLongLived(
+      Runtime &runtime);
+
   /// Indicates whether this entry has been deleted.
   bool isDeleted() const {
     assert(key.isEmpty() == value.isEmpty() && "Inconsistent deleted status");


### PR DESCRIPTION
Summary:
Change the way OrderedHashMap handles collision; Use linear probing
instead of chaining.

Couple of things are also modified to make it work.

1. In case for erasing an entry, mark the bucket as deleted and remove
it during rehash. We cannot simply make the bucket empty because it
will cause "find" to fail when there was collision and do linear
probing.

2. rehashIfNecessary is changed to rehash, which now always run rehash
even if the new capacity ends up the same size. This is necessary to
wipe the deleted buckets. And so, we also use the deleted count to
decide whether to rehash or not.

3. Instead, introduce shouldShrink, shouldRehash to decide whether to
invoke rehash.

4. In insert(), run rehash before actually inserting the new entry.
This is necessary to make sure that there is a room for insert.

5. The inner loop of rehash function iterates on the linked list
instead of the hash array. This not only is necessary for reusing the
same hash array when the size is the same, but also reduces the
iteration count. This can reduce the memory access locality during
rehash, but still faster than accessing the entire array.

Reviewed By: avp

Differential Revision: D53447832


