### PR TITLE
feat: add visionOS support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ workflows:
 # Default settings for Apple jobs (apple-runtime, test-apple-runtime)
 apple_defaults: &apple_defaults
   macos:
-    xcode: 13.4.1
+    xcode: 15.3
   resource_class: macos.m1.medium.gen1
   working_directory: ~/hermes
   environment:
@@ -168,7 +168,10 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            brew install cmake ninja
+            brew install ninja
+            # TODO: See comment in build-apple-runtime.
+            brew update
+            brew install cmake
       - run:
           name: Build the test application
           command: |
@@ -189,8 +192,17 @@ jobs:
             xcodebuild test \
               -workspace ApplePlatformsIntegrationTests.xcworkspace \
               -configuration Debug \
-              -destination 'platform=iOS Simulator,name=iPhone 11' \
+              -destination 'platform=iOS Simulator,name=iPhone 15' \
               -scheme ApplePlatformsIntegrationMobileTests
+          working_directory: test/ApplePlatformsIntegrationTestApp
+      - run:
+          name: Test Apple Vision application
+          command: |
+            xcodebuild test \
+              -workspace ApplePlatformsIntegrationTests.xcworkspace \
+              -configuration Debug \
+              -destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
+              -scheme ApplePlatformsIntegrationVisionOSTests
           working_directory: test/ApplePlatformsIntegrationTestApp
 
   build-apple-runtime:
@@ -207,8 +219,13 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            brew install cmake ninja
+            brew install ninja
             sudo gem install cocoapods
+            # TODO: Building for Apple Vision Pro requires a newer version of
+            # CMake than is available by default. Remove "brew update" once the
+            # CircleCI image contains CMake > 3.29.2.
+            brew update
+            brew install cmake
       - run:
           name: Build the iOS frameworks
           command: ./utils/build-ios-framework.sh
@@ -222,6 +239,8 @@ jobs:
             - ~/hermes/build_catalyst
             - ~/hermes/build_iphonesimulator
             - ~/hermes/build_macosx
+            - ~/hermes/build_xros
+            - ~/hermes/build_xrsimulator
             - ~/hermes/destroot
 
   package-apple-runtime:
@@ -236,8 +255,10 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            brew install cmake ninja
             sudo gem install cocoapods
+            # TODO: See comment in build-apple-runtime.
+            brew update
+            brew install cmake
       - run:
           name: Package the framework
           command: |
@@ -265,7 +286,7 @@ jobs:
 
   macos:
     macos:
-      xcode: 13.4.1
+      xcode: 13.4.1 
     steps:
       - checkout:
           path: hermes
@@ -303,7 +324,7 @@ jobs:
 
   test-macos:
     macos:
-      xcode: 13.4.1
+      xcode: 13.4.1 
     steps:
       - checkout:
           path: hermes
@@ -680,7 +701,7 @@ jobs:
 
   test-macos-test262:
     macos:
-      xcode: 13.4.1
+      xcode: 13.4.1 
     steps:
       - checkout:
           path: hermes

--- a/API/hermes/CMakeLists.txt
+++ b/API/hermes/CMakeLists.txt
@@ -153,6 +153,14 @@ if(APPLE AND HERMES_BUILD_APPLE_FRAMEWORK)
     add_custom_command(TARGET libhermes POST_BUILD
       COMMAND /usr/libexec/PlistBuddy -c "Add :LSMinimumSystemVersion string ${CMAKE_OSX_DEPLOYMENT_TARGET}" $<TARGET_FILE_DIR:libhermes>/Resources/Info.plist
     )
+  elseif(HERMES_APPLE_TARGET_PLATFORM MATCHES "xr")
+    if(CMAKE_VERSION VERSION_LESS 3.28.4)
+      message("VisionOS Simulator requires CMake version >= 3.28.4")
+    endif()
+
+    add_custom_command(TARGET libhermes POST_BUILD
+      COMMAND /usr/libexec/PlistBuddy -c "Add :MinimumOSVersion string ${CMAKE_OSX_DEPLOYMENT_TARGET}" $<TARGET_FILE_DIR:libhermes>/Info.plist
+    )
   endif()
 endif()
 

--- a/hermes-engine.podspec
+++ b/hermes-engine.podspec
@@ -24,13 +24,14 @@ Pod::Spec.new do |spec|
   # The podspec would be serialized to JSON and people will download prebuilt binaries instead of the source.
   # TODO(use the hash field as a validation mechanism when the process is stable)
   spec.source      = ENV['hermes-artifact-url'] ? { http: ENV['hermes-artifact-url'] } : { git: "https://github.com/facebook/hermes.git", tag: "v#{spec.version}" }
-  spec.platforms   = { :osx => "10.13", :ios => "11.0" }
+  spec.platforms   = { :osx => "10.13", :ios => "12.0", :visionos => "1.0" }
 
   spec.preserve_paths      = ["destroot/bin/*"].concat(HermesHelper::BUILD_TYPE == :debug ? ["**/*.{h,c,cpp}"] : [])
   spec.source_files        = "destroot/include/**/*.h"
   spec.header_mappings_dir = "destroot/include"
 
   spec.ios.vendored_frameworks = "destroot/Library/Frameworks/universal/hermes.xcframework"
+  spec.visionos.vendored_frameworks = "destroot/Library/Frameworks/universal/hermes.xcframework"
   spec.osx.vendored_frameworks = "destroot/Library/Frameworks/macosx/hermes.framework"
 
   spec.xcconfig            = { "CLANG_CXX_LANGUAGE_STANDARD" => "c++17", "CLANG_CXX_LIBRARY" => "compiler-default", "GCC_PREPROCESSOR_DEFINITIONS" => "HERMES_ENABLE_DEBUGGER=1" }

--- a/lib/Platform/Logging.cpp
+++ b/lib/Platform/Logging.cpp
@@ -11,6 +11,7 @@
 #include <android/log.h>
 #elif defined(__APPLE__)
 #include <os/log.h>
+#include <stdio.h>
 #else
 #include <cstdio>
 #endif

--- a/test/ApplePlatformsIntegrationTestApp/ApplePlatformsIntegrationTests.xcodeproj/project.pbxproj
+++ b/test/ApplePlatformsIntegrationTestApp/ApplePlatformsIntegrationTests.xcodeproj/project.pbxproj
@@ -3,15 +3,17 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		51D515AD24EE845300DD6638 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 51D515AC24EE845300DD6638 /* main.m */; };
+		76AD8E742BC69C5B006D4D81 /* ApplePlatformsIntegrationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = AD6479DA24EBE09200B0F41F /* ApplePlatformsIntegrationTests.mm */; };
+		ABDFBA9B70C3214214FBEECC /* Pods_ApplePlatformsIntegrationMacTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DB30C196BAC021705CFABEE /* Pods_ApplePlatformsIntegrationMacTests.framework */; };
 		AD6479DB24EBE09200B0F41F /* ApplePlatformsIntegrationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = AD6479DA24EBE09200B0F41F /* ApplePlatformsIntegrationTests.mm */; };
 		ADEC7BC524EC008E005AD0D1 /* ApplePlatformsIntegrationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = AD6479DA24EBE09200B0F41F /* ApplePlatformsIntegrationTests.mm */; };
-		BD7F5A0B694325283B2814D0 /* Pods_ApplePlatformsIntegrationMobileTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6619CF7A1ECB0F579C45302C /* Pods_ApplePlatformsIntegrationMobileTests.framework */; platformFilter = ios; settings = {ATTRIBUTES = (Required, ); }; };
-		D90DCAA1728B38F09D8C1AB2 /* Pods_ApplePlatformsIntegrationMacTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B4A83CBA7E5D07AC8857DD8 /* Pods_ApplePlatformsIntegrationMacTests.framework */; };
+		D3070DFF96F680027F2D0F67 /* Pods_ApplePlatformsIntegrationVisionOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 959104DAB07D5ABBD7244E1A /* Pods_ApplePlatformsIntegrationVisionOSTests.framework */; };
+		F09A3B3B07FCC32280BDA7AA /* Pods_ApplePlatformsIntegrationMobileTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2A2FB0AB3E2304D20C83ADF3 /* Pods_ApplePlatformsIntegrationMobileTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -22,29 +24,35 @@
 			remoteGlobalIDString = 51D5159724EE845200DD6638;
 			remoteInfo = iOSDeviceTestHostApp;
 		};
+		76AD8E722BC69C55006D4D81 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 51387F3024B4D93100BDA32A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 51D5159724EE845200DD6638;
+			remoteInfo = iOSDeviceTestHostApp;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0B4A83CBA7E5D07AC8857DD8 /* Pods_ApplePlatformsIntegrationMacTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ApplePlatformsIntegrationMacTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		1C38019945AA9814D0B91781 /* Pods_ApplePlatformsIntegrationTestMobileApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ApplePlatformsIntegrationTestMobileApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		367A118885A42674684FEA4A /* Pods-ApplePlatformsIntegrationTestMobileApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ApplePlatformsIntegrationTestMobileApp.debug.xcconfig"; path = "Target Support Files/Pods-ApplePlatformsIntegrationTestMobileApp/Pods-ApplePlatformsIntegrationTestMobileApp.debug.xcconfig"; sourceTree = "<group>"; };
-		389F549E68F2869589934C24 /* Pods-ApplePlatformsIntegrationMobileTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ApplePlatformsIntegrationMobileTests.debug.xcconfig"; path = "Target Support Files/Pods-ApplePlatformsIntegrationMobileTests/Pods-ApplePlatformsIntegrationMobileTests.debug.xcconfig"; sourceTree = "<group>"; };
+		2A2FB0AB3E2304D20C83ADF3 /* Pods_ApplePlatformsIntegrationMobileTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ApplePlatformsIntegrationMobileTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3484C3483F82824EABC061AB /* Pods-ApplePlatformsIntegrationMacTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ApplePlatformsIntegrationMacTests.debug.xcconfig"; path = "Target Support Files/Pods-ApplePlatformsIntegrationMacTests/Pods-ApplePlatformsIntegrationMacTests.debug.xcconfig"; sourceTree = "<group>"; };
+		3DB30C196BAC021705CFABEE /* Pods_ApplePlatformsIntegrationMacTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ApplePlatformsIntegrationMacTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		51D5159824EE845200DD6638 /* iOSDeviceTestHostApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSDeviceTestHostApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		51D515AB24EE845300DD6638 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		51D515AC24EE845300DD6638 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
-		6619CF7A1ECB0F579C45302C /* Pods_ApplePlatformsIntegrationMobileTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ApplePlatformsIntegrationMobileTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		7185E82510338F98E6D5ABAE /* Pods-ApplePlatformsIntegrationTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ApplePlatformsIntegrationTestApp.release.xcconfig"; path = "Target Support Files/Pods-ApplePlatformsIntegrationTestApp/Pods-ApplePlatformsIntegrationTestApp.release.xcconfig"; sourceTree = "<group>"; };
-		7C198466C93A1B0680744E8F /* Pods-ApplePlatformsIntegrationMobileTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ApplePlatformsIntegrationMobileTests.release.xcconfig"; path = "Target Support Files/Pods-ApplePlatformsIntegrationMobileTests/Pods-ApplePlatformsIntegrationMobileTests.release.xcconfig"; sourceTree = "<group>"; };
-		808C67B4B919AA215848168C /* Pods-ApplePlatformsIntegrationMacTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ApplePlatformsIntegrationMacTests.release.xcconfig"; path = "Target Support Files/Pods-ApplePlatformsIntegrationMacTests/Pods-ApplePlatformsIntegrationMacTests.release.xcconfig"; sourceTree = "<group>"; };
-		A1B2AE6857A1A970726F1351 /* Pods-ApplePlatformsIntegrationTestApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ApplePlatformsIntegrationTestApp.debug.xcconfig"; path = "Target Support Files/Pods-ApplePlatformsIntegrationTestApp/Pods-ApplePlatformsIntegrationTestApp.debug.xcconfig"; sourceTree = "<group>"; };
-		A2510A8F9FC45E606FF4D99F /* Pods-ApplePlatformsIntegrationTestMobileApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ApplePlatformsIntegrationTestMobileApp.release.xcconfig"; path = "Target Support Files/Pods-ApplePlatformsIntegrationTestMobileApp/Pods-ApplePlatformsIntegrationTestMobileApp.release.xcconfig"; sourceTree = "<group>"; };
+		545B51FE6D7C4360E145151A /* Pods-ApplePlatformsIntegrationVisionOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ApplePlatformsIntegrationVisionOSTests.debug.xcconfig"; path = "Target Support Files/Pods-ApplePlatformsIntegrationVisionOSTests/Pods-ApplePlatformsIntegrationVisionOSTests.debug.xcconfig"; sourceTree = "<group>"; };
+		63E1B3A0FF5569D351477D67 /* Pods-ApplePlatformsIntegrationVisionOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ApplePlatformsIntegrationVisionOSTests.release.xcconfig"; path = "Target Support Files/Pods-ApplePlatformsIntegrationVisionOSTests/Pods-ApplePlatformsIntegrationVisionOSTests.release.xcconfig"; sourceTree = "<group>"; };
+		76AD8E6B2BC69B33006D4D81 /* ApplePlatformsIntegrationVisionOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ApplePlatformsIntegrationVisionOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		76D799DD2BB406C300010E8B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		85B686DE614F823455E0B178 /* Pods-ApplePlatformsIntegrationMobileTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ApplePlatformsIntegrationMobileTests.release.xcconfig"; path = "Target Support Files/Pods-ApplePlatformsIntegrationMobileTests/Pods-ApplePlatformsIntegrationMobileTests.release.xcconfig"; sourceTree = "<group>"; };
+		959104DAB07D5ABBD7244E1A /* Pods_ApplePlatformsIntegrationVisionOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ApplePlatformsIntegrationVisionOSTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AD6479D824EBE09200B0F41F /* ApplePlatformsIntegrationMobileTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ApplePlatformsIntegrationMobileTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AD6479DA24EBE09200B0F41F /* ApplePlatformsIntegrationTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ApplePlatformsIntegrationTests.mm; sourceTree = "<group>"; };
 		AD6479DC24EBE09200B0F41F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AD650CEBB8250E8060A081F8 /* Pods-ApplePlatformsIntegrationMacTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ApplePlatformsIntegrationMacTests.release.xcconfig"; path = "Target Support Files/Pods-ApplePlatformsIntegrationMacTests/Pods-ApplePlatformsIntegrationMacTests.release.xcconfig"; sourceTree = "<group>"; };
 		ADEC7BBD24EBFF44005AD0D1 /* ApplePlatformsIntegrationMacTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ApplePlatformsIntegrationMacTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		ADEC7BC124EBFF44005AD0D1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		C07B9F4D127D4B52FF9015AB /* Pods_ApplePlatformsIntegrationTestApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ApplePlatformsIntegrationTestApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		DE11AB7B823CE538F06589B8 /* Pods-ApplePlatformsIntegrationMacTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ApplePlatformsIntegrationMacTests.debug.xcconfig"; path = "Target Support Files/Pods-ApplePlatformsIntegrationMacTests/Pods-ApplePlatformsIntegrationMacTests.debug.xcconfig"; sourceTree = "<group>"; };
+		F41AC3FD54EB83A245051563 /* Pods-ApplePlatformsIntegrationMobileTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ApplePlatformsIntegrationMobileTests.debug.xcconfig"; path = "Target Support Files/Pods-ApplePlatformsIntegrationMobileTests/Pods-ApplePlatformsIntegrationMobileTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -55,11 +63,19 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		76AD8E682BC69B33006D4D81 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D3070DFF96F680027F2D0F67 /* Pods_ApplePlatformsIntegrationVisionOSTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		AD6479D524EBE09200B0F41F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BD7F5A0B694325283B2814D0 /* Pods_ApplePlatformsIntegrationMobileTests.framework in Frameworks */,
+				F09A3B3B07FCC32280BDA7AA /* Pods_ApplePlatformsIntegrationMobileTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -67,7 +83,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D90DCAA1728B38F09D8C1AB2 /* Pods_ApplePlatformsIntegrationMacTests.framework in Frameworks */,
+				ABDFBA9B70C3214214FBEECC /* Pods_ApplePlatformsIntegrationMacTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -81,9 +97,10 @@
 				AD6479D924EBE09200B0F41F /* ApplePlatformsIntegrationMobileTests */,
 				ADEC7BBE24EBFF44005AD0D1 /* ApplePlatformsIntegrationMacTests */,
 				51D5159924EE845200DD6638 /* iOSDeviceTestHostApp */,
+				76AD8E6C2BC69B33006D4D81 /* ApplePlatformsIntegrationVisionOSTests */,
 				51387F3924B4D93100BDA32A /* Products */,
 				5B15161F422A44367877CB3E /* Pods */,
-				95D715CE5183719D082A4A7B /* Frameworks */,
+				9DDEB7C3C03AE4D3DA511C8D /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -93,6 +110,7 @@
 				AD6479D824EBE09200B0F41F /* ApplePlatformsIntegrationMobileTests.xctest */,
 				ADEC7BBD24EBFF44005AD0D1 /* ApplePlatformsIntegrationMacTests.xctest */,
 				51D5159824EE845200DD6638 /* iOSDeviceTestHostApp.app */,
+				76AD8E6B2BC69B33006D4D81 /* ApplePlatformsIntegrationVisionOSTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -109,25 +127,30 @@
 		5B15161F422A44367877CB3E /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				A1B2AE6857A1A970726F1351 /* Pods-ApplePlatformsIntegrationTestApp.debug.xcconfig */,
-				7185E82510338F98E6D5ABAE /* Pods-ApplePlatformsIntegrationTestApp.release.xcconfig */,
-				367A118885A42674684FEA4A /* Pods-ApplePlatformsIntegrationTestMobileApp.debug.xcconfig */,
-				A2510A8F9FC45E606FF4D99F /* Pods-ApplePlatformsIntegrationTestMobileApp.release.xcconfig */,
-				389F549E68F2869589934C24 /* Pods-ApplePlatformsIntegrationMobileTests.debug.xcconfig */,
-				7C198466C93A1B0680744E8F /* Pods-ApplePlatformsIntegrationMobileTests.release.xcconfig */,
-				DE11AB7B823CE538F06589B8 /* Pods-ApplePlatformsIntegrationMacTests.debug.xcconfig */,
-				808C67B4B919AA215848168C /* Pods-ApplePlatformsIntegrationMacTests.release.xcconfig */,
+				3484C3483F82824EABC061AB /* Pods-ApplePlatformsIntegrationMacTests.debug.xcconfig */,
+				AD650CEBB8250E8060A081F8 /* Pods-ApplePlatformsIntegrationMacTests.release.xcconfig */,
+				F41AC3FD54EB83A245051563 /* Pods-ApplePlatformsIntegrationMobileTests.debug.xcconfig */,
+				85B686DE614F823455E0B178 /* Pods-ApplePlatformsIntegrationMobileTests.release.xcconfig */,
+				545B51FE6D7C4360E145151A /* Pods-ApplePlatformsIntegrationVisionOSTests.debug.xcconfig */,
+				63E1B3A0FF5569D351477D67 /* Pods-ApplePlatformsIntegrationVisionOSTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
 		};
-		95D715CE5183719D082A4A7B /* Frameworks */ = {
+		76AD8E6C2BC69B33006D4D81 /* ApplePlatformsIntegrationVisionOSTests */ = {
 			isa = PBXGroup;
 			children = (
-				C07B9F4D127D4B52FF9015AB /* Pods_ApplePlatformsIntegrationTestApp.framework */,
-				1C38019945AA9814D0B91781 /* Pods_ApplePlatformsIntegrationTestMobileApp.framework */,
-				6619CF7A1ECB0F579C45302C /* Pods_ApplePlatformsIntegrationMobileTests.framework */,
-				0B4A83CBA7E5D07AC8857DD8 /* Pods_ApplePlatformsIntegrationMacTests.framework */,
+				76D799DD2BB406C300010E8B /* Info.plist */,
+			);
+			path = ApplePlatformsIntegrationVisionOSTests;
+			sourceTree = "<group>";
+		};
+		9DDEB7C3C03AE4D3DA511C8D /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				3DB30C196BAC021705CFABEE /* Pods_ApplePlatformsIntegrationMacTests.framework */,
+				2A2FB0AB3E2304D20C83ADF3 /* Pods_ApplePlatformsIntegrationMobileTests.framework */,
+				959104DAB07D5ABBD7244E1A /* Pods_ApplePlatformsIntegrationVisionOSTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -168,15 +191,35 @@
 			productReference = 51D5159824EE845200DD6638 /* iOSDeviceTestHostApp.app */;
 			productType = "com.apple.product-type.application";
 		};
+		76AD8E6A2BC69B33006D4D81 /* ApplePlatformsIntegrationVisionOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 76AD8E6F2BC69B33006D4D81 /* Build configuration list for PBXNativeTarget "ApplePlatformsIntegrationVisionOSTests" */;
+			buildPhases = (
+				F3C4D99ABC137FAB10A08FB5 /* [CP] Check Pods Manifest.lock */,
+				76AD8E672BC69B33006D4D81 /* Sources */,
+				76AD8E682BC69B33006D4D81 /* Frameworks */,
+				76AD8E692BC69B33006D4D81 /* Resources */,
+				9F7B636D8B92D8EBA08ACDE1 /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				76AD8E732BC69C55006D4D81 /* PBXTargetDependency */,
+			);
+			name = ApplePlatformsIntegrationVisionOSTests;
+			productName = ApplePlatformsIntegrationVisionOSTests;
+			productReference = 76AD8E6B2BC69B33006D4D81 /* ApplePlatformsIntegrationVisionOSTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		AD6479D724EBE09200B0F41F /* ApplePlatformsIntegrationMobileTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = AD6479DF24EBE09200B0F41F /* Build configuration list for PBXNativeTarget "ApplePlatformsIntegrationMobileTests" */;
 			buildPhases = (
-				26837883FBFEF6D4E7150AD1 /* [CP] Check Pods Manifest.lock */,
+				06450B58B8E8CDF179289270 /* [CP] Check Pods Manifest.lock */,
 				AD6479D424EBE09200B0F41F /* Sources */,
 				AD6479D524EBE09200B0F41F /* Frameworks */,
 				AD6479D624EBE09200B0F41F /* Resources */,
-				B83CBB0FF9F9715EFD4AA32A /* [CP] Embed Pods Frameworks */,
+				B1199676C5CDA7C1F34E2D12 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -192,11 +235,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = ADEC7BC224EBFF44005AD0D1 /* Build configuration list for PBXNativeTarget "ApplePlatformsIntegrationMacTests" */;
 			buildPhases = (
-				1E973DDFB6FAE5F4973319B2 /* [CP] Check Pods Manifest.lock */,
+				24800000CA50DCEF77918938 /* [CP] Check Pods Manifest.lock */,
 				ADEC7BB924EBFF44005AD0D1 /* Sources */,
 				ADEC7BBA24EBFF44005AD0D1 /* Frameworks */,
 				ADEC7BBB24EBFF44005AD0D1 /* Resources */,
-				22B5AC04C28FCCE8323CA719 /* [CP] Embed Pods Frameworks */,
+				6772485C417179DBD8C1C99E /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -218,6 +261,9 @@
 				TargetAttributes = {
 					51D5159724EE845200DD6638 = {
 						CreatedOnToolsVersion = 11.6;
+					};
+					76AD8E6A2BC69B33006D4D81 = {
+						CreatedOnToolsVersion = 15.2;
 					};
 					AD6479D724EBE09200B0F41F = {
 						CreatedOnToolsVersion = 11.6;
@@ -243,12 +289,20 @@
 				AD6479D724EBE09200B0F41F /* ApplePlatformsIntegrationMobileTests */,
 				ADEC7BBC24EBFF44005AD0D1 /* ApplePlatformsIntegrationMacTests */,
 				51D5159724EE845200DD6638 /* iOSDeviceTestHostApp */,
+				76AD8E6A2BC69B33006D4D81 /* ApplePlatformsIntegrationVisionOSTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		51D5159624EE845200DD6638 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		76AD8E692BC69B33006D4D81 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -272,46 +326,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		1E973DDFB6FAE5F4973319B2 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-ApplePlatformsIntegrationMacTests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		22B5AC04C28FCCE8323CA719 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ApplePlatformsIntegrationMacTests/Pods-ApplePlatformsIntegrationMacTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ApplePlatformsIntegrationMacTests/Pods-ApplePlatformsIntegrationMacTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ApplePlatformsIntegrationMacTests/Pods-ApplePlatformsIntegrationMacTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		26837883FBFEF6D4E7150AD1 /* [CP] Check Pods Manifest.lock */ = {
+		06450B58B8E8CDF179289270 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -333,7 +348,63 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		B83CBB0FF9F9715EFD4AA32A /* [CP] Embed Pods Frameworks */ = {
+		24800000CA50DCEF77918938 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-ApplePlatformsIntegrationMacTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		6772485C417179DBD8C1C99E /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ApplePlatformsIntegrationMacTests/Pods-ApplePlatformsIntegrationMacTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ApplePlatformsIntegrationMacTests/Pods-ApplePlatformsIntegrationMacTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ApplePlatformsIntegrationMacTests/Pods-ApplePlatformsIntegrationMacTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		9F7B636D8B92D8EBA08ACDE1 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ApplePlatformsIntegrationVisionOSTests/Pods-ApplePlatformsIntegrationVisionOSTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ApplePlatformsIntegrationVisionOSTests/Pods-ApplePlatformsIntegrationVisionOSTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ApplePlatformsIntegrationVisionOSTests/Pods-ApplePlatformsIntegrationVisionOSTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B1199676C5CDA7C1F34E2D12 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -350,6 +421,28 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ApplePlatformsIntegrationMobileTests/Pods-ApplePlatformsIntegrationMobileTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		F3C4D99ABC137FAB10A08FB5 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-ApplePlatformsIntegrationVisionOSTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -358,6 +451,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				51D515AD24EE845300DD6638 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		76AD8E672BC69B33006D4D81 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				76AD8E742BC69C5B006D4D81 /* ApplePlatformsIntegrationTests.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -384,6 +485,11 @@
 			isa = PBXTargetDependency;
 			target = 51D5159724EE845200DD6638 /* iOSDeviceTestHostApp */;
 			targetProxy = 51D515B124EE84BE00DD6638 /* PBXContainerItemProxy */;
+		};
+		76AD8E732BC69C55006D4D81 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 51D5159724EE845200DD6638 /* iOSDeviceTestHostApp */;
+			targetProxy = 76AD8E722BC69C55006D4D81 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -438,7 +544,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -491,7 +597,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -513,7 +619,10 @@
 				PRODUCT_BUNDLE_IDENTIFIER = dev.hermesengine.iOSDeviceTestHostApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
 			};
 			name = Debug;
 		};
@@ -531,14 +640,52 @@
 				PRODUCT_BUNDLE_IDENTIFIER = dev.hermesengine.iOSDeviceTestHostApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
 				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		76AD8E702BC69B33006D4D81 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 545B51FE6D7C4360E145151A /* Pods-ApplePlatformsIntegrationVisionOSTests.debug.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				INFOPLIST_FILE = ApplePlatformsIntegrationVisionOSTests/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.hermesengine.ApplePlatformsIntegrationMobileTests.ApplePlatformsIntegrationVisionOSTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = xros;
+				SUPPORTED_PLATFORMS = "xros xrsimulator";
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				XROS_DEPLOYMENT_TARGET = 1.0;
+			};
+			name = Debug;
+		};
+		76AD8E712BC69B33006D4D81 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 63E1B3A0FF5569D351477D67 /* Pods-ApplePlatformsIntegrationVisionOSTests.release.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				INFOPLIST_FILE = ApplePlatformsIntegrationVisionOSTests/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.hermesengine.ApplePlatformsIntegrationMobileTests.ApplePlatformsIntegrationVisionOSTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = xros;
+				SUPPORTED_PLATFORMS = "xros xrsimulator";
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				VALIDATE_PRODUCT = YES;
+				XROS_DEPLOYMENT_TARGET = 1.0;
 			};
 			name = Release;
 		};
 		AD6479DD24EBE09200B0F41F /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 389F549E68F2869589934C24 /* Pods-ApplePlatformsIntegrationMobileTests.debug.xcconfig */;
+			baseConfigurationReference = F41AC3FD54EB83A245051563 /* Pods-ApplePlatformsIntegrationMobileTests.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
@@ -558,7 +705,7 @@
 		};
 		AD6479DE24EBE09200B0F41F /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7C198466C93A1B0680744E8F /* Pods-ApplePlatformsIntegrationMobileTests.release.xcconfig */;
+			baseConfigurationReference = 85B686DE614F823455E0B178 /* Pods-ApplePlatformsIntegrationMobileTests.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
@@ -579,7 +726,7 @@
 		};
 		ADEC7BC324EBFF44005AD0D1 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DE11AB7B823CE538F06589B8 /* Pods-ApplePlatformsIntegrationMacTests.debug.xcconfig */;
+			baseConfigurationReference = 3484C3483F82824EABC061AB /* Pods-ApplePlatformsIntegrationMacTests.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -596,7 +743,7 @@
 		};
 		ADEC7BC424EBFF44005AD0D1 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 808C67B4B919AA215848168C /* Pods-ApplePlatformsIntegrationMacTests.release.xcconfig */;
+			baseConfigurationReference = AD650CEBB8250E8060A081F8 /* Pods-ApplePlatformsIntegrationMacTests.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -628,6 +775,15 @@
 			buildConfigurations = (
 				51D515AE24EE845300DD6638 /* Debug */,
 				51D515AF24EE845300DD6638 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		76AD8E6F2BC69B33006D4D81 /* Build configuration list for PBXNativeTarget "ApplePlatformsIntegrationVisionOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				76AD8E702BC69B33006D4D81 /* Debug */,
+				76AD8E712BC69B33006D4D81 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/test/ApplePlatformsIntegrationTestApp/ApplePlatformsIntegrationTests.xcodeproj/xcshareddata/xcschemes/ApplePlatformsIntegrationVisionOSTests.xcscheme
+++ b/test/ApplePlatformsIntegrationTestApp/ApplePlatformsIntegrationTests.xcodeproj/xcshareddata/xcschemes/ApplePlatformsIntegrationVisionOSTests.xcscheme
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "76AD8E6A2BC69B33006D4D81"
+               BuildableName = "ApplePlatformsIntegrationVisionOSTests.xctest"
+               BlueprintName = "ApplePlatformsIntegrationVisionOSTests"
+               ReferencedContainer = "container:ApplePlatformsIntegrationTests.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/test/ApplePlatformsIntegrationTestApp/ApplePlatformsIntegrationVisionOSTests/Info.plist
+++ b/test/ApplePlatformsIntegrationTestApp/ApplePlatformsIntegrationVisionOSTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/test/ApplePlatformsIntegrationTestApp/Podfile
+++ b/test/ApplePlatformsIntegrationTestApp/Podfile
@@ -2,7 +2,13 @@ source 'https://cdn.cocoapods.org/'
 
 target 'ApplePlatformsIntegrationMobileTests' do
   use_frameworks!
-  platform :ios, '11'
+  platform :ios, '12.0'
+  pod 'hermes-engine', :path => '../../'
+end
+
+target 'ApplePlatformsIntegrationVisionOSTests' do
+  use_frameworks!
+  platform :visionos, '1.0'
   pod 'hermes-engine', :path => '../../'
 end
 

--- a/utils/build-apple-framework.sh
+++ b/utils/build-apple-framework.sh
@@ -33,6 +33,10 @@ function get_ios_deployment_target {
   ruby -rcocoapods-core -rjson -e "puts Pod::Specification.from_file('hermes-engine.podspec').deployment_target('ios')"
 }
 
+function get_visionos_deployment_target {
+  ruby -rcocoapods-core -rjson -e "puts Pod::Specification.from_file('hermes-engine.podspec').deployment_target('visionos')"
+}
+
 function get_mac_deployment_target {
   ruby -rcocoapods-core -rjson -e "puts Pod::Specification.from_file('hermes-engine.podspec').deployment_target('osx')"
 }
@@ -47,7 +51,7 @@ function build_host_hermesc {
 function configure_apple_framework {
   local build_cli_tools enable_bitcode
 
-  if [[ $1 == iphoneos || $1 == catalyst ]]; then
+  if [[ $1 == iphoneos || $1 == catalyst || $1 == visionos ]]; then
     enable_bitcode="true"
   else
     enable_bitcode="false"

--- a/utils/build-ios-framework.sh
+++ b/utils/build-ios-framework.sh
@@ -8,12 +8,15 @@
 
 if [ ! -d destroot/Library/Frameworks/universal/hermes.xcframework ]; then
     ios_deployment_target=$(get_ios_deployment_target)
+    visionos_deployment_target=$(get_visionos_deployment_target)
 
     build_apple_framework "iphoneos" "arm64" "$ios_deployment_target"
     build_apple_framework "iphonesimulator" "x86_64;arm64" "$ios_deployment_target"
     build_apple_framework "catalyst" "x86_64;arm64" "$ios_deployment_target"
+    build_apple_framework "xros" "arm64" "$visionos_deployment_target"
+    build_apple_framework "xrsimulator" "arm64" "$visionos_deployment_target"
 
-    create_universal_framework "iphoneos" "iphonesimulator" "catalyst"
+    create_universal_framework "iphoneos" "iphonesimulator" "catalyst" "xros" "xrsimulator"
 else
     echo "Skipping; Clean \"destroot\" to rebuild".
 fi


### PR DESCRIPTION
## Summary

This PR adds support for visionOS. 

Note: Unreleased version of [CMake 3.28.4](https://gitlab.kitware.com/cmake/cmake/-/milestones/144#tab-issues) is required to build for visionOS. We might need to wait until it gets released.

### Things to sort out:
- [x] Add CI 

## Test Plan

Build test app for visionOS