### PR TITLE
[Debugger] Modify ES6 Method names instead of removing them

### DIFF
--- a/lib/AST/ES6Class.cpp
+++ b/lib/AST/ES6Class.cpp
@@ -714,9 +714,12 @@ class ES6ClassesTransformations {
 
         auto *functionExpr =
             llvh::cast<ESTree::FunctionExpressionNode>(srcNode->_value);
-        // Remove method name to prevent symbol resolution conflicts.
+        // Prefix and Suffix method name with # to prevent symbol resolution conflicts.
         // The function name will be re-added at runtime
-        functionExpr->_id = nullptr;
+        auto newIdentifierNode = cloneNode(identifierNode);
+        newIdentifierNode->_name = context_.getStringTable().getString(
+          ("#" + newIdentifierNode->_name->str() + "#").str());
+        functionExpr->_id = newIdentifierNode;
         parameters.append(functionExpr);
       } else {
         parameters.append(cloneNode(classMember.key));


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `main`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/HEAD/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.
-->

## Summary
The method names of ES6 classes were being stripped out to prevent name conflicts when there's both a function and method with identical names. However, when connecting the Debugger or Profiler, this causes all class methods to show up with the name `anonymous` instead of its actual function name.

This change modifies the ES6 method names to prefix and suffix them with '#' instead of removing it, so that the debugger and profiler give more detailed information, while still preventing the name conflicts.

Before:
![Screenshot 2024-03-28 at 2 46 57 PM](https://github.com/facebook/hermes/assets/34820577/ee8cd189-c5d6-479b-973b-22099088bc6d)


After:
![Screenshot 2024-03-28 at 2 42 36 PM](https://github.com/facebook/hermes/assets/34820577/6aea903d-caf0-4a97-96a5-39ca1897a973)

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
-->

## Test Plan

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes the user interface.
-->
