### PR TITLE
Move destruction of RuntimeModule to the mutator

### DIFF
--- a/include/hermes/VM/Domain.h
+++ b/include/hermes/VM/Domain.h
@@ -90,7 +90,8 @@ class Domain final : public GCCell {
   llvh::DenseMap<SymbolID, uint32_t> cjsModuleTable_{};
 
   /// RuntimeModules owned by this Domain.
-  /// These will be freed from the Domain destructor.
+  /// These will be freed by Runtime when marking weak roots, if the Domain is
+  /// dead.
   CopyableVector<RuntimeModule *> runtimeModules_{};
 
   /// The require() function stub that is used when using requireFast() calls
@@ -217,8 +218,7 @@ class Domain final : public GCCell {
   PseudoHandle<NativeFunction> getThrowingRequire(Runtime &runtime) const;
 
  private:
-  /// Destroy associated RuntimeModules.
-  ~Domain();
+  ~Domain() = default;
 
   /// Free all non-GC managed resources associated with the object.
   static void _finalizeImpl(GCCell *cell, GC &gc);

--- a/include/hermes/VM/Runtime.h
+++ b/include/hermes/VM/Runtime.h
@@ -1011,6 +1011,11 @@ class HERMES_EMPTY_BASES Runtime : public PointerBase,
   void markWeakRoots(WeakRootAcceptor &weakAcceptor, bool markLongLived)
       override;
 
+  /// Iterate over runtimeModuleList_ and mark each RuntimeModule's WeakRoot to
+  /// its owning Domain. If the domain is dead, destroy the RuntimeModule and
+  /// remove it from runtimeModuleList_.
+  void markDomainRefInRuntimeModules(WeakRootAcceptor &weakRootAcceptor);
+
   /// See documentation on \c GCBase::GCCallbacks.
   void markRootsForCompleteMarking(
       RootAndSlotAcceptorWithNames &acceptor) override;
@@ -1233,7 +1238,9 @@ class HERMES_EMPTY_BASES Runtime : public PointerBase,
   RuntimeModule *specialCodeBlockRuntimeModule_{};
 
   /// A list of all active runtime modules. Each \c RuntimeModule adds itself
-  /// on construction and removes itself on destruction.
+  /// on construction and removes itself on destruction. When marking weak
+  /// roots, scan each RuntimeModule and destroy it if the owning Domain is
+  /// dead (each RuntimeModule has a WeakRoot to its owning Domain).
   RuntimeModuleList runtimeModuleList_{};
 
   /// Optional record of the last few executed bytecodes in case of a crash.

--- a/lib/VM/Domain.cpp
+++ b/lib/VM/Domain.cpp
@@ -57,12 +57,6 @@ void Domain::_finalizeImpl(GCCell *cell, GC &gc) {
   self->~Domain();
 }
 
-Domain::~Domain() {
-  for (RuntimeModule *rm : runtimeModules_) {
-    delete rm;
-  }
-}
-
 PseudoHandle<NativeFunction> Domain::getThrowingRequire(
     Runtime &runtime) const {
   return createPseudoHandle(throwingRequire_.get(runtime));

--- a/lib/VM/Runtime.cpp
+++ b/lib/VM/Runtime.cpp
@@ -421,6 +421,16 @@ Runtime::~Runtime() {
 #endif // HERMESVM_SAMPLING_PROFILER_AVAILABLE
 
   getHeap().finalizeAll();
+  // Remove inter-module dependencies so we can delete them in any order.
+  for (auto &module : runtimeModuleList_) {
+    module.prepareForDestruction();
+  }
+  // All RuntimeModules must be destroyed before the next assertion, to untrack
+  // all native IDs related to it (e.g., CodeBlock).
+  while (!runtimeModuleList_.empty()) {
+    // Calling delete will automatically remove it from the list.
+    delete &runtimeModuleList_.back();
+  }
   // Now that all objects are finalized, there shouldn't be any native memory
   // keys left in the ID tracker for memory profiling. Assert that the only IDs
   // left are JS heap pointers.
@@ -434,19 +444,10 @@ Runtime::~Runtime() {
     oscompat::vm_free(
         registerStackAllocation_.data(), registerStackAllocation_.size());
   }
-  // Remove inter-module dependencies so we can delete them in any order.
-  for (auto &module : runtimeModuleList_) {
-    module.prepareForRuntimeShutdown();
-  }
 
   assert(
       !formattingStackTrace_ &&
       "Runtime is being destroyed while exception is being formatted");
-
-  while (!runtimeModuleList_.empty()) {
-    // Calling delete will automatically remove it from the list.
-    delete &runtimeModuleList_.back();
-  }
 
   // Unwatch the runtime from the time limit monitor in case the latter still
   // has any references to this.
@@ -657,6 +658,9 @@ void Runtime::markRoots(
 void Runtime::markWeakRoots(WeakRootAcceptor &acceptor, bool markLongLived) {
   MarkRootsPhaseTimer timer(*this, RootAcceptor::Section::WeakRefs);
   acceptor.beginRootSection(RootAcceptor::Section::WeakRefs);
+  // Call this first so that it can remove RuntimeModules whose owning Domain is
+  // dead from runtimeModuleList_, before marking long-lived WeakRoots in them.
+  markDomainRefInRuntimeModules(acceptor);
   if (markLongLived) {
     for (auto &entry : fixedPropCache_) {
       acceptor.acceptWeak(entry.clazz);
@@ -664,11 +668,34 @@ void Runtime::markWeakRoots(WeakRootAcceptor &acceptor, bool markLongLived) {
     for (auto &rm : runtimeModuleList_)
       rm.markLongLivedWeakRoots(acceptor);
   }
-  for (auto &rm : runtimeModuleList_)
-    rm.markDomainRef(acceptor);
   for (auto &fn : customMarkWeakRootFuncs_)
     fn(&getHeap(), acceptor);
   acceptor.endRootSection();
+}
+
+void Runtime::markDomainRefInRuntimeModules(WeakRootAcceptor &acceptor) {
+  std::vector<RuntimeModule *> modulesToDelete;
+  for (auto &rm : runtimeModuleList_) {
+    rm.markDomainRef(acceptor);
+    // If the owning domain is dead, store the RuntimeModule pointer for
+    // destruction later.
+    if (LLVM_UNLIKELY(rm.isOwningDomainDead())) {
+      // Prepare these RuntimeModules for destruction so that we don't rely on
+      // their relative order in runtimeModuleList_.
+      rm.prepareForDestruction();
+      modulesToDelete.push_back(&rm);
+    }
+  }
+
+  // We need to destroy these RuntimeModules after we call
+  // prepareForDestruction() on all of them, otherwise, it may cause
+  // use-after-free when checking the ownership of a CodeBlock in the destructor
+  // of a RuntimeModule (which may refer a CodeBlock that is owned and deleted
+  // by another RuntimeModule).
+  for (auto *rm : modulesToDelete) {
+    // Calling delete will automatically remove it from the list.
+    delete rm;
+  }
 }
 
 void Runtime::markRootsForCompleteMarking(

--- a/lib/VM/RuntimeModule.cpp
+++ b/lib/VM/RuntimeModule.cpp
@@ -78,7 +78,7 @@ RuntimeModule::~RuntimeModule() {
   runtime_.getHeap().getIDTracker().untrackNative(&functionMap_);
 }
 
-void RuntimeModule::prepareForRuntimeShutdown() {
+void RuntimeModule::prepareForDestruction() {
   for (int i = 0, e = functionMap_.size(); i < e; i++) {
     if (functionMap_[i] != nullptr &&
         functionMap_[i]->getRuntimeModule() != this) {


### PR DESCRIPTION
Summary:
There is race condition between removing a RuntimeModule from the
Runtime in the background thread (triggered from Domain finalizer)
and adding a new RuntimeModule in the mutator.

After further investigation, we found that there is also race 
conditions between Debugger::willUnloadModule() called in the 
destructor of RuntimeModule and other Debugger actions.

This diff moves the destruction of RuntimeModule (and its removal from
the list in Runtime) to the time of marking weak roots in Runtime.

Reviewed By: neildhar

Differential Revision: D56094070


