### PR TITLE
Fix linux tests build

### DIFF
--- a/unittests/API/CDPAgentTest.cpp
+++ b/unittests/API/CDPAgentTest.cpp
@@ -364,9 +364,6 @@ void CDPAgentTest::expectErrorMessageContaining(
 void CDPAgentTest::expectHeapSnapshot(
     int messageID,
     bool ignoreTrackingNotifications) {
-  JSLexer::Allocator jsonAlloc;
-  JSONFactory factory(jsonAlloc);
-
   // Expect chunk notifications until the snapshot object is complete. Fail if
   // the object is invalid (e.g. truncated data, excess data, malformed JSON).
   // There is no indication of how many segments there will be, so just receive
@@ -383,7 +380,7 @@ void CDPAgentTest::expectHeapSnapshot(
 
     ASSERT_EQ(method, "HeapProfiler.addHeapSnapshotChunk");
     snapshot << jsonScope_.getString(note, {"params", "chunk"});
-  } while (!parseStrAsJsonObj(snapshot.str(), factory).has_value());
+  } while (!jsonScope_.tryParseObject(snapshot.str()).has_value());
 
   // Expect the snapshot response after all chunks have been received.
   ensureOkResponse(waitForMessage(), messageID);

--- a/unittests/API/CDPJSONHelpers.cpp
+++ b/unittests/API/CDPJSONHelpers.cpp
@@ -398,6 +398,10 @@ JSONObject *JSONScope::parseObject(const std::string &json) {
   return mustParseStrAsJsonObj(json, private_->factory);
 }
 
+std::optional<JSONObject *> JSONScope::tryParseObject(const std::string &json) {
+  return parseStrAsJsonObj(json, private_->factory);
+}
+
 std::string JSONScope::getString(
     JSONObject *obj,
     std::vector<std::string> paths) {

--- a/unittests/API/CDPJSONHelpers.h
+++ b/unittests/API/CDPJSONHelpers.h
@@ -23,6 +23,7 @@ struct JSONScope {
 
   JSONValue *parse(const std::string &str);
   JSONObject *parseObject(const std::string &str);
+  std::optional<JSONObject *> tryParseObject(const std::string &json);
   std::string getString(JSONObject *obj, std::vector<std::string> paths);
   long long getNumber(JSONObject *obj, std::vector<std::string> paths);
   bool getBoolean(JSONObject *obj, std::vector<std::string> paths);


### PR DESCRIPTION
Summary:
Move JSON parsing into the JSON helper, fixing
the linux test build.

Differential Revision: D56733388
