### PR TITLE
Remove global ID from trace

### DIFF
--- a/API/hermes/SynthTrace.cpp
+++ b/API/hermes/SynthTrace.cpp
@@ -98,15 +98,14 @@ bool SynthTrace::TraceValue::operator==(const TraceValue &that) const {
 }
 
 SynthTrace::SynthTrace(
-    ObjectID globalObjID,
     const ::hermes::vm::RuntimeConfig &conf,
-    std::unique_ptr<llvh::raw_ostream> traceStream)
+    std::unique_ptr<llvh::raw_ostream> traceStream,
+    std::optional<ObjectID> globalObjID)
     : traceStream_(std::move(traceStream)), globalObjID_(globalObjID) {
   if (traceStream_) {
     json_ = std::make_unique<JSONEmitter>(*traceStream_, /*pretty*/ true);
     json_->openDict();
     json_->emitKeyValue("version", synthVersion());
-    json_->emitKeyValue("globalObjID", globalObjID_);
 
     // RuntimeConfig section.
     json_->emitKey("runtimeConfig");

--- a/API/hermes/SynthTrace.h
+++ b/API/hermes/SynthTrace.h
@@ -17,6 +17,7 @@
 #include <chrono>
 #include <cstdlib>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -275,9 +276,9 @@ class SynthTrace {
   /// If \p traceStream is non-null, the trace will be written to that
   /// stream.  Otherwise, no trace is written.
   explicit SynthTrace(
-      ObjectID globalObjID,
       const ::hermes::vm::RuntimeConfig &conf,
-      std::unique_ptr<llvh::raw_ostream> traceStream = nullptr);
+      std::unique_ptr<llvh::raw_ostream> traceStream = nullptr,
+      std::optional<ObjectID> = {});
 
   template <typename T, typename... Args>
   void emplace_back(Args &&...args) {
@@ -289,7 +290,7 @@ class SynthTrace {
     return records_;
   }
 
-  ObjectID globalObjID() const {
+  std::optional<ObjectID> globalObjID() const {
     return globalObjID_;
   }
 
@@ -353,7 +354,11 @@ class SynthTrace {
   /// written to the file.
   std::vector<std::unique_ptr<Record>> records_;
   /// The id of the global object.
-  const ObjectID globalObjID_;
+  /// Note: Keeping this as optional to support replaying the older trace
+  /// records before the change of TracingRuntime's PointerValue based ObjectID.
+  /// We can remove this once we remove old traces.
+  /// TODO: T189113203
+  const std::optional<ObjectID> globalObjID_;
 
  public:
   /// @name Record classes

--- a/API/hermes/TraceInterpreter.cpp
+++ b/API/hermes/TraceInterpreter.cpp
@@ -221,7 +221,9 @@ TraceInterpreter::TraceInterpreter(
       trace_(trace),
       gom_() {
   // Add the global object to the global object map
-  gom_.emplace(trace.globalObjID(), rt.global());
+  if (trace.globalObjID()) {
+    gom_.emplace(*trace.globalObjID(), rt.global());
+  }
 
   auto [lastUsePerObj, lastUses] = createLastUseMaps(trace.records());
   lastUsePerObj_ = std::move(lastUsePerObj);

--- a/API/hermes/TracingRuntime.h
+++ b/API/hermes/TracingRuntime.h
@@ -24,7 +24,6 @@ class TracingRuntime : public jsi::RuntimeDecorator<jsi::Runtime> {
 
   TracingRuntime(
       std::unique_ptr<jsi::Runtime> runtime,
-      uint64_t globalID,
       const ::hermes::vm::RuntimeConfig &conf,
       std::unique_ptr<llvh::raw_ostream> traceStream);
 
@@ -229,21 +228,6 @@ class TracingHermesRuntime final : public TracingRuntime {
   }
 
  private:
-  // Why do we have a private ctor executed from the public one,
-  // instead of just having a single public ctor which calls
-  // getUniqueID() to initialize the base class?  This one weird trick
-  // is needed to avoid undefined behavior in that case.  Otherwise,
-  // when calling the base class ctor, the order of evaluating the
-  // globalID value and the side effect of moving the runtime would be
-  // unspecified.
-  TracingHermesRuntime(
-      std::unique_ptr<HermesRuntime> &runtime,
-      uint64_t globalID,
-      const ::hermes::vm::RuntimeConfig &runtimeConfig,
-      std::unique_ptr<llvh::raw_ostream> traceStream,
-      std::function<std::string()> commitAction,
-      std::function<void()> rollbackAction);
-
   void crashCallback(int fd);
 
   const ::hermes::vm::RuntimeConfig conf_;

--- a/unittests/API/SynthTraceSerializationTest.cpp
+++ b/unittests/API/SynthTraceSerializationTest.cpp
@@ -258,8 +258,6 @@ TEST_F(SynthTraceSerializationTest, TraceHeader) {
   std::unique_ptr<TracingHermesRuntime> rt(makeTracingHermesRuntime(
       makeHermesRuntime(conf), conf, std::move(resultStream)));
 
-  SynthTrace::ObjectID globalObjID = rt->getUniqueID(rt->global());
-
   rt->flushAndDisableTrace();
 
   auto optTrace = rt->global()
@@ -271,7 +269,6 @@ TEST_F(SynthTraceSerializationTest, TraceHeader) {
   EXPECT_EQ(
       SynthTrace::synthVersion(),
       optTrace.getProperty(*rt, "version").asNumber());
-  EXPECT_EQ(globalObjID, optTrace.getProperty(*rt, "globalObjID").asNumber());
 
   auto rtConfig = optTrace.getPropertyAsObject(*rt, "runtimeConfig");
 


### PR DESCRIPTION
Summary:
With the new TraceInterpreter and TracingRuntime implementations, we no
longer need special handling for global's ObjectID. Remove it while
keeping the support of running existing traces that needs special
handling in SynthTraceParser and TraceInterpreter.

Reviewed By: neildhar

Differential Revision: D57300956


