### PR TITLE
Parse Member and TypeCast expressions in super class types

### DIFF
--- a/tools/hermes-parser/js/flow-api-translator/__tests__/flowToFlowDef-test.js
+++ b/tools/hermes-parser/js/flow-api-translator/__tests__/flowToFlowDef-test.js
@@ -510,6 +510,23 @@ describe('flowToFlowDef', () => {
          }`,
       );
     });
+    it('extends member expression', async () => {
+      await expectTranslateUnchanged(
+        `declare export class Foo<T> extends Bar.TClass<T> {}`,
+      );
+    });
+    it('extends type cast expression', async () => {
+      await expectTranslate(
+        `export class Foo<T> extends (Bar: X) {}`,
+        `declare export class Foo<T> extends X {}`,
+      );
+    });
+    it('extends type cast typeof expression', async () => {
+      await expectTranslate(
+        `export class Foo<T> extends (Bar: typeof X) {}`,
+        `declare export class Foo<T> extends X {}`,
+      );
+    });
   });
   describe('Expression', () => {
     async function expectTranslateExpression(


### PR DESCRIPTION
### Summary

Previously, member expressions in parent classes like `class A extends Foo.Bar`, and type casts such as `class A extends (Foo: Bar)`, were not parseable by flow-api-translator. This change adds support.

## Test Plan

Previously unparseable files in `react-native` are now parseable