### PR TITLE
Fixed ES6 classes not inheriting Object prototype

### DIFF
--- a/lib/InternalBytecode/03-ES6Class.js
+++ b/lib/InternalBytecode/03-ES6Class.js
@@ -5,7 +5,8 @@
   var objectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
 
   function defineClass(ctor, superClass) {
-    ctor.prototype = objCreate(superClass && superClass.prototype, {
+    const resolvedSuperClass = superClass || Object;
+    ctor.prototype = objCreate(resolvedSuperClass.prototype, {
       constructor: {
         value: ctor,
         writable: true,

--- a/test/hermes/es6-inherit-obj-prototype.js
+++ b/test/hermes/es6-inherit-obj-prototype.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -Xes6-class %s | %FileCheck --match-full-lines %s
+// REQUIRES: es6_class
+
+class Test {
+}
+
+
+print(Object.getPrototypeOf(Test) === Object.getPrototypeOf(Object));
+//CHECK: true
+
+print(Object.getPrototypeOf(Test.prototype) === Object.prototype);
+//CHECK: true
+
+const obj = new Test();
+
+print(obj.propertyIsEnumerable('test'));
+// CHECK: false


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `main`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/HEAD/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.
-->

## Summary

This change fixes an issue with ES6 class support where classes did not inherit the Object prototype. This make ES6 object instances not have access to the functions that are usually available on all objects like propertyIsEnumerable().


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
-->

## Test Plan

- Added a new test case showcasing the bug
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes the user interface.
-->

## Changes
- When defining an ES6 class, its prototype is either SuperClass.prototype or Object.prototype
