### PR TITLE
Update sampling profiler thread

### DIFF
--- a/API/hermes/hermes.cpp
+++ b/API/hermes/hermes.cpp
@@ -1326,10 +1326,10 @@ void HermesRuntime::registerForProfiling() {
 #if HERMESVM_SAMPLING_PROFILER_AVAILABLE
   vm::Runtime &runtime = impl(this)->runtime_;
   if (runtime.samplingProfiler) {
-    ::hermes::hermes_fatal(
-        "re-registering HermesVMs for profiling is not allowed");
+    runtime.samplingProfiler->setRuntimeThread();
+  } else {
+    runtime.samplingProfiler = ::hermes::vm::SamplingProfiler::create(runtime);
   }
-  runtime.samplingProfiler = ::hermes::vm::SamplingProfiler::create(runtime);
 #else
   throwHermesNotCompiledWithSamplingProfilerSupport();
 #endif // HERMESVM_SAMPLING_PROFILER_AVAILABLE

--- a/API/hermes/hermes.h
+++ b/API/hermes/hermes.h
@@ -177,7 +177,10 @@ class HERMES_EXPORT HermesRuntime : public jsi::Runtime {
       const DebugFlags &debugFlags);
 #endif
 
-  /// Register this runtime for sampling profiler.
+  /// Register this runtime and thread for sampling profiler. Before using the
+  /// runtime on another thread, invoke this function again from the new thread
+  /// to make the sampling profiler target the new thread (and forget the old
+  /// thread).
   void registerForProfiling();
   /// Unregister this runtime for sampling profiler.
   void unregisterForProfiling();

--- a/include/hermes/VM/Profiler/SamplingProfiler.h
+++ b/include/hermes/VM/Profiler/SamplingProfiler.h
@@ -109,9 +109,11 @@ class SamplingProfiler {
   };
 
   /// \return true if this SamplingProfiler belongs to the current running
-  /// thread. Does not acquire any locks, and as such should not be used in
-  /// production.
-  bool belongsToCurrentThread() const;
+  /// thread. The current thread can change (e.g. in the time between
+  /// this function returning and the caller inspecting the value), so the
+  /// usefulness of this method depends upon knowledge of when the runtime
+  /// will switch threads.
+  bool belongsToCurrentThread();
 
   /// \returns the NativeFunctionPtr for \p stackFrame. Caller must hold
   /// runtimeDataLock_.
@@ -149,8 +151,8 @@ class SamplingProfiler {
   /// Max size of sampleStorage_.
   static const int kMaxStackDepth = 500;
 
-  /// Protect data specific to a runtime, such as the sampled stacks and
-  /// domains.
+  /// Protect data specific to a runtime, such as the sampled stacks,
+  /// domains, and thread associated with the runtime.
   std::mutex runtimeDataLock_;
 
  protected:
@@ -273,6 +275,10 @@ class SamplingProfiler {
   /// Resumes the sample profiling. There must have been a previous call to
   /// suspend() that hansn't been resume()d yet.
   void resume();
+
+  /// Inform the sampling profiler that the runtime will now be executing
+  /// bytecode on the current thread.
+  void setRuntimeThread();
 
  protected:
   explicit SamplingProfiler(Runtime &runtime);

--- a/unittests/VMRuntime/SamplingProfilerTest.cpp
+++ b/unittests/VMRuntime/SamplingProfilerTest.cpp
@@ -9,6 +9,7 @@
 
 #if HERMESVM_SAMPLING_PROFILER_AVAILABLE
 
+#include "TestHelpers1.h"
 #include "hermes/VM/Runtime.h"
 
 #include <gtest/gtest.h>
@@ -62,6 +63,28 @@ TEST(SamplingProfilerTest, MultipleProfilers) {
   EXPECT_TRUE(sp2->belongsToCurrentThread());
 }
 #endif
+
+TEST(SamplingProfilerTest, RegisterDifferentThread) {
+  constexpr uint32_t kThreadCount = 3;
+
+  auto rt = makeRuntime(withSamplingProfilerEnabled);
+
+  for (uint32_t threadNumber = 0; threadNumber < kThreadCount; ++threadNumber) {
+    std::thread([&]() {
+      rt->samplingProfiler->setRuntimeThread();
+      EXPECT_TRUE(rt->samplingProfiler->belongsToCurrentThread());
+    }).join();
+  }
+}
+
+TEST(SamplingProfilerTest, RegisterIdenticalThread) {
+  auto rt = makeRuntime(withSamplingProfilerEnabled);
+
+  rt->samplingProfiler->setRuntimeThread();
+  EXPECT_TRUE(rt->samplingProfiler->belongsToCurrentThread());
+  rt->samplingProfiler->setRuntimeThread();
+  EXPECT_TRUE(rt->samplingProfiler->belongsToCurrentThread());
+}
 
 } // namespace
 


### PR DESCRIPTION
Summary:
Allow repeated calls to enable the sampling profiler,
updating the thread targeted by the profiler each time.

Previously, the sampling profiler would target only a
single thread. If the runtime was used from another
thread, multiple threads would be trying to use the
runtime in parallel, causing incorrect behavior.

Reviewed By: avp

Differential Revision: D57397716


