### PR TITLE
Expose a way to create a JSI HernesRuntime instance from an existing Hermes VM instance

### DIFF
--- a/API/hermes/DebuggerAPI.h
+++ b/API/hermes/DebuggerAPI.h
@@ -271,6 +271,9 @@ class HERMES_EXPORT Debugger {
  private:
   friend std::unique_ptr<HermesRuntime> hermes::makeHermesRuntime(
       const ::hermes::vm::RuntimeConfig &);
+  friend std::unique_ptr<HermesRuntime> hermes::adoptHermesRuntime(
+      const std::shared_ptr<::hermes::vm::Runtime> &,
+      const ::hermes::vm::RuntimeConfig &);
   friend std::unique_ptr<jsi::ThreadSafeRuntime>
   hermes::makeThreadSafeHermesRuntime(const ::hermes::vm::RuntimeConfig &);
   friend ProgramState;

--- a/API/hermes/hermes.cpp
+++ b/API/hermes/hermes.cpp
@@ -150,9 +150,16 @@ class HermesRuntimeImpl final : public HermesRuntime,
   static constexpr uint32_t kSentinelNativeValue = 0x6ef71fe1;
 
   HermesRuntimeImpl(const vm::RuntimeConfig &runtimeConfig)
+      : HermesRuntimeImpl(
+            runtimeConfig,
+            ::hermes::vm::Runtime::create(runtimeConfig)) {}
+
+  HermesRuntimeImpl(
+      const vm::RuntimeConfig &runtimeConfig,
+      const std::shared_ptr<::hermes::vm::Runtime> &rt)
       : hermesValues_(runtimeConfig.getGCConfig().getOccupancyTarget()),
         weakHermesValues_(runtimeConfig.getGCConfig().getOccupancyTarget()),
-        rt_(::hermes::vm::Runtime::create(runtimeConfig)),
+        rt_(rt),
         runtime_(*rt_),
         vmExperimentFlags_(runtimeConfig.getVMExperimentFlags()) {
 #ifdef HERMES_ENABLE_DEBUGGER
@@ -2451,6 +2458,24 @@ std::unique_ptr<HermesRuntime> makeHermesRuntime(
 #else
   auto ret = std::make_unique<HermesRuntimeImpl>(runtimeConfig);
 #endif
+
+#ifdef HERMES_ENABLE_DEBUGGER
+  // Only HermesRuntime can create a debugger instance.  This requires
+  // the setter and not using make_unique, so the call to new is here
+  // in this function, which is a friend of debugger::Debugger.
+  ret->setDebugger(std::unique_ptr<debugger::Debugger>(
+      new debugger::Debugger(ret.get(), ret->runtime_)));
+#else
+  ret->setDebugger(std::make_unique<debugger::Debugger>());
+#endif
+
+  return ret;
+}
+
+std::unique_ptr<HermesRuntime> adoptHermesRuntime(
+    const std::shared_ptr<::hermes::vm::Runtime> &runtime,
+    const vm::RuntimeConfig &runtimeConfig) {
+  auto ret = std::make_unique<HermesRuntimeImpl>(runtimeConfig, runtime);
 
 #ifdef HERMES_ENABLE_DEBUGGER
   // Only HermesRuntime can create a debugger instance.  This requires

--- a/API/hermes/hermes.h
+++ b/API/hermes/hermes.h
@@ -25,6 +25,7 @@ struct HermesTestHelper;
 namespace hermes {
 namespace vm {
 class GCExecTrace;
+class Runtime;
 } // namespace vm
 } // namespace hermes
 
@@ -238,6 +239,9 @@ HERMES_EXPORT ::hermes::vm::RuntimeConfig hardenedHermesRuntimeConfig();
 HERMES_EXPORT std::unique_ptr<HermesRuntime> makeHermesRuntime(
     const ::hermes::vm::RuntimeConfig &runtimeConfig =
         ::hermes::vm::RuntimeConfig());
+HERMES_EXPORT std::unique_ptr<HermesRuntime> adoptHermesRuntime(
+    const std::shared_ptr<::hermes::vm::Runtime> &runtime,
+    const ::hermes::vm::RuntimeConfig &runtimeConfig);
 HERMES_EXPORT std::unique_ptr<jsi::ThreadSafeRuntime>
 makeThreadSafeHermesRuntime(
     const ::hermes::vm::RuntimeConfig &runtimeConfig =


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `main`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/HEAD/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.
-->

## Summary

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
-->

I understand this change might be a bit contentious, but please hear me out.

Our Hermes integration does not use the JSI API, we integrate with the Hermes Runtime C++ API directly. There are a few reasons for this:
- We already have an API that is similar to JSI for which we have 4 different JS engines integrated with it. If we were integrating Hermes through JSI we would be implementing an abstraction on top of an abstraction, which adds performance and memory overhead. We want our Hermes integration to be as fast as it can be, and for that we need our bridge layer to have minimal overhead so that it can compete on a performance level against our other JS engine integrations that are also based on lower level JS engine primitives.
- There are APIs we need to integrate that can't be implemented with JSI.
- We don't have C++ exceptions enabled, and the JSI Hermes integration makes heavy use of them and forces its consumers to handle errors through exceptions.

The Hermes Debugger implementation is however based on the JSI API, so in order for us to leverage the Hermes Debugger, this change adds a small shim that can create a JSI Runtime instance from an existing Hermes Runtime C++, so that we can pass it to the Debugger. This makes it possible for us to keep the rest of our integration intact, and just call `hermes::adoptHermesRuntime()` on debug builds to create a debugger instance. Through that system, the linker is able to strip out all the JSI code for us on release builds.

## Test Plan

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes the user interface.
-->
