### PR TITLE
Make fallthroughs in regcomp.c explicit

### DIFF
--- a/external/llvh/lib/Support/regcomp.c
+++ b/external/llvh/lib/Support/regcomp.c
@@ -537,7 +537,7 @@ p_ere_exp(struct parse *p)
 		break;
 	case '{':		/* okay as ordinary except if digit follows */
 		REQUIRE(!MORE() || !isdigit((uch)PEEK()), REG_BADRPT);
-		/* FALLTHROUGH */
+		__attribute__((fallthrough));
 	default:
 		ordinary(p, c);
 		break;
@@ -733,7 +733,7 @@ p_simp_re(struct parse *p,
 		break;
 	case '*':
 		REQUIRE(starordinary, REG_BADRPT);
-		/* FALLTHROUGH */
+		__attribute__((fallthrough));
 	default:
 		ordinary(p, (char)c);
 		break;
@@ -1635,7 +1635,7 @@ findmust(struct parse *p, struct re_guts *g)
 					return;
 				}
 			} while (OP(s) != O_QUEST && OP(s) != O_CH);
-			/* fallthrough */
+			__attribute__((fallthrough));
 		default:		/* things that break a sequence */
 			if (newlen > g->mlen) {		/* ends one */
 				start = newstart;


### PR DESCRIPTION
## Summary

Explicit fallthroughs are safer and allow folks to enable `-Wimplicit-fallthrough` for their code to avoid unintentional fallthroughs.

## Test Plan

If it builds, it works.
