### PR TITLE
Add fast path for Array.prototype.indexOf/lastIndexOf

### DIFF
--- a/include/hermes/VM/SmallHermesValue-inline.h
+++ b/include/hermes/VM/SmallHermesValue-inline.h
@@ -89,6 +89,11 @@ double HermesValue32::getNumber(PointerBase &pb) const {
   return vmcast<BoxedDouble>(getPointer(pb))->get();
 }
 
+double HermesValue32::getBoxedDouble(PointerBase &pb) const {
+  assert(isBoxedDouble());
+  return vmcast<BoxedDouble>(getPointer(pb))->get();
+}
+
 /* static */ HermesValue32 HermesValue32::encodeHermesValue(
     HermesValue hv,
     Runtime &runtime) {

--- a/lib/VM/JSLib/Array.cpp
+++ b/lib/VM/JSLib/Array.cpp
@@ -15,6 +15,7 @@
 #include "hermes/VM/HandleRootOwner-inline.h"
 #include "hermes/VM/JSLib/Sorting.h"
 #include "hermes/VM/Operations.h"
+#include "hermes/VM/SmallHermesValue.h"
 #include "hermes/VM/StringBuilder.h"
 #include "hermes/VM/StringRefUtils.h"
 #include "hermes/VM/StringView.h"
@@ -2571,16 +2572,25 @@ indexOfHelper(Runtime &runtime, NativeArgs args, const bool reverse) {
   }
   auto O = runtime.makeHandle<JSObject>(objRes.getValue());
 
-  auto propRes = JSObject::getNamed_RJS(
-      O, runtime, Predefined::getSymbolID(Predefined::length));
-  if (LLVM_UNLIKELY(propRes == ExecutionStatus::EXCEPTION)) {
-    return ExecutionStatus::EXCEPTION;
+  // Array length is less than 2^32, length of array-like object is less than
+  // 2^53.
+  int64_t len = 0;
+  auto arrHandle = Handle<JSArray>::dyn_vmcast(O);
+  if (LLVM_LIKELY(arrHandle)) {
+    // Fast path: get array length.
+    len = JSArray::getLength(arrHandle.get(), runtime);
+  } else {
+    auto propRes = JSObject::getNamed_RJS(
+        O, runtime, Predefined::getSymbolID(Predefined::length));
+    if (LLVM_UNLIKELY(propRes == ExecutionStatus::EXCEPTION)) {
+      return ExecutionStatus::EXCEPTION;
+    }
+    auto lenRes = toLengthU64(runtime, runtime.makeHandle(std::move(*propRes)));
+    if (LLVM_UNLIKELY(lenRes == ExecutionStatus::EXCEPTION)) {
+      return ExecutionStatus::EXCEPTION;
+    }
+    len = *lenRes;
   }
-  auto lenRes = toLengthU64(runtime, runtime.makeHandle(std::move(*propRes)));
-  if (LLVM_UNLIKELY(lenRes == ExecutionStatus::EXCEPTION)) {
-    return ExecutionStatus::EXCEPTION;
-  }
-  double len = *lenRes;
 
   // Early return before running into any coercions on args.
   // 2. Let len be ? LengthOfArrayLike(O).
@@ -2591,71 +2601,182 @@ indexOfHelper(Runtime &runtime, NativeArgs args, const bool reverse) {
 
   // Relative index to start the search at.
   auto intRes = toIntegerOrInfinity(runtime, args.getArgHandle(1));
-  double n;
+  int64_t n;
   if (args.getArgCount() > 1) {
     if (LLVM_UNLIKELY(intRes == ExecutionStatus::EXCEPTION)) {
       return ExecutionStatus::EXCEPTION;
     }
-    n = intRes->getNumber();
-    if (LLVM_UNLIKELY(n == 0)) {
+    double val = intRes->getNumber();
+    static constexpr double INF = std::numeric_limits<double>::infinity();
+    if (LLVM_UNLIKELY(val == -INF)) {
+      if (reverse) {
+        // lastIndexOf: 5. If n = -inf, return -1.
+        return HermesValue::encodeTrustedNumberValue(-1);
+      } else {
+        // 7. If n = -inf, set n to 0.
+        n = 0;
+      }
+    } else if (LLVM_UNLIKELY(val == INF)) {
+      if (reverse) {
+        n = len - 1;
+      } else {
+        // 6. If n = +inf, return -1.
+        return HermesValue::encodeTrustedNumberValue(-1);
+      }
+    } else if (LLVM_UNLIKELY(val == 0)) {
       // To handle the special case when n is -0, we need to make sure it's 0.
       n = 0;
+    } else {
+      n = val;
     }
   } else {
     n = !reverse ? 0 : len - 1;
   }
 
   // Actual index to start the search at.
-  MutableHandle<> k{runtime};
+  int64_t k = 0;
   if (!reverse) {
     if (n >= 0) {
-      k = HermesValue::encodeTrustedNumberValue(n);
+      k = n;
     } else {
-      // If len - abs(n) < 0, set k=0. Otherwise set k = len - abs(n).
-      k = HermesValue::encodeTrustedNumberValue(
-          std::max(len - std::abs(n), 0.0));
+      // 9. k = len + n. If k < 0, set k = 0.
+      k = std::max(len + n, INT64_C(0));
     }
   } else {
     if (n >= 0) {
-      k = HermesValue::encodeTrustedNumberValue(std::min(n, len - 1));
+      k = std::min(n, len - 1);
     } else {
-      k = HermesValue::encodeTrustedNumberValue(len - std::abs(n));
+      k = len + n;
     }
   }
 
-  MutableHandle<SymbolID> tmpPropNameStorage{runtime};
-  MutableHandle<JSObject> descObjHandle{runtime};
-
   // Search for the element.
   auto searchElement = args.getArgHandle(0);
+  // If the range of Array IndexedStorage is not [0, len), there could be holes
+  // at some indices.
+  if (LLVM_LIKELY(
+          arrHandle && (0 == arrHandle->getBeginIndex()) &&
+          (len == arrHandle->getEndIndex()))) {
+    // Fast path: access array storage directly.
+    auto searchElementVal =
+        SmallHermesValue::encodeHermesValue(searchElement.get(), runtime);
+    NoAllocScope noAlloc{runtime};
+    bool hasHole = false;
+    auto *arrStorage = arrHandle->getIndexedStorage(runtime);
+    int step = reverse ? -1 : 1;
+
+#define SEARCH_ARRAY_DIRECTED(LOOP_COND)               \
+  for (; LOOP_COND; k += step) {                       \
+    auto element = arrStorage->at(runtime, k);         \
+    if (LLVM_UNLIKELY(element.isEmpty())) {            \
+      hasHole = true;                                  \
+      break;                                           \
+    }                                                  \
+    if (COMPARE_EXPR(element))                         \
+      return HermesValue::encodeTrustedNumberValue(k); \
+  }
+
+    // Specialize the loop with search direction.
+#define SEARCH_ARRAY               \
+  if (reverse) {                   \
+    SEARCH_ARRAY_DIRECTED(k >= 0)  \
+  } else {                         \
+    SEARCH_ARRAY_DIRECTED(k < len) \
+  }
+
+    // Specialize the search loop with the type of the target value.
+    if (searchElementVal.isInlinedDouble()) {
+      auto searchNum = searchElementVal.getNumber(runtime);
+      // If it's NaN, no need to do any comparison.
+      if (LLVM_UNLIKELY(std::isnan(searchNum))) {
+        return HermesValue::encodeTrustedNumberValue(-1);
+      }
+      // If it's +0.0/-0.0.
+      if (searchNum == 0) {
+        static const auto NEGATIVE_ZERO =
+            SmallHermesValue::encodeNumberValue(-0.0, runtime).getRaw();
+        static const auto POSITIVE_ZERO =
+            SmallHermesValue::encodeNumberValue(+0.0, runtime).getRaw();
+        // Compare bits with +0.0/-0.0 directly.
+#define COMPARE_EXPR(element) \
+  element.getRaw() == NEGATIVE_ZERO || element.getRaw() == POSITIVE_ZERO
+        SEARCH_ARRAY
+#undef COMPARE_EXPR
+      } else {
+        // If it's not +0.0/-0.0/NaN, compare raw bits directly.
+#define COMPARE_EXPR(element) searchElementVal.getRaw() == element.getRaw()
+        SEARCH_ARRAY
+#undef COMPARE_EXPR
+      }
+    } else if (searchElementVal.isBoxedDouble()) {
+      // Only HV32 can have boxed doubles, compare the double value.
+      auto searchNum = searchElementVal.getBoxedDouble(runtime);
+#define COMPARE_EXPR(element) \
+  element.isBoxedDouble() && searchNum == element.getBoxedDouble(runtime)
+      SEARCH_ARRAY
+#undef COMPARE_EXPR
+    } else if (searchElementVal.isString()) {
+      auto searchStr = searchElementVal.getString(runtime);
+
+#define COMPARE_EXPR(element) \
+  element.isString() && searchStr->equals(element.getString(runtime))
+      SEARCH_ARRAY
+#undef COMPARE_EXPR
+    } else if (searchElementVal.isBigInt()) {
+      auto searchBigInt = searchElementVal.getBigInt(runtime);
+
+#define COMPARE_EXPR(element) \
+  element.isBigInt() && !searchBigInt->compare(element.getBigInt(runtime))
+      SEARCH_ARRAY
+#undef COMPARE_EXPR
+    } else {
+      // For all other types (e.g., Object), compare the exact bits.
+#define COMPARE_EXPR(element) searchElementVal.getRaw() == element.getRaw()
+      SEARCH_ARRAY
+#undef COMPARE_EXPR
+    }
+
+#undef SEARCH_ARRAY_DIRECTED
+#undef SEARCH_ARRAY
+
+    // If array has no hole and target is not found, return -1.
+    if (!hasHole) {
+      return HermesValue::encodeTrustedNumberValue(-1);
+    }
+  }
+
+  // Slow path for non-array objects or arrays with holes.
+  MutableHandle<SymbolID> tmpPropNameStorage{runtime};
+  MutableHandle<JSObject> descObjHandle{runtime};
+  MutableHandle<> kHandle{runtime, HermesValue::encodeTrustedNumberValue(k)};
   auto marker = gcScope.createMarker();
   while (true) {
     gcScope.flushToMarker(marker);
     // Check that we're not done yet.
     if (!reverse) {
-      if (k->getDouble() >= len) {
+      if (kHandle->getDouble() >= len) {
         break;
       }
     } else {
-      if (k->getDouble() < 0) {
+      if (kHandle->getDouble() < 0) {
         break;
       }
     }
     ComputedPropertyDescriptor desc;
     JSObject::getComputedPrimitiveDescriptor(
-        O, runtime, k, descObjHandle, tmpPropNameStorage, desc);
+        O, runtime, kHandle, descObjHandle, tmpPropNameStorage, desc);
     CallResult<PseudoHandle<>> propRes = JSObject::getComputedPropertyValue_RJS(
-        O, runtime, descObjHandle, tmpPropNameStorage, desc, k);
+        O, runtime, descObjHandle, tmpPropNameStorage, desc, kHandle);
     if (LLVM_UNLIKELY(propRes == ExecutionStatus::EXCEPTION)) {
       return ExecutionStatus::EXCEPTION;
     }
     if (!(*propRes)->isEmpty() &&
         strictEqualityTest(searchElement.get(), propRes->get())) {
-      return k.get();
+      return kHandle.get();
     }
     // Update the index based on the direction of the search.
-    k = HermesValue::encodeTrustedNumberValue(
-        k->getDouble() + (reverse ? -1 : 1));
+    kHandle = HermesValue::encodeTrustedNumberValue(
+        kHandle->getDouble() + (reverse ? -1 : 1));
   }
 
   // Not found, return -1.

--- a/test/hermes/array-functions.js
+++ b/test/hermes/array-functions.js
@@ -685,7 +685,18 @@ print(a.indexOf('a', 4));
 print(a.indexOf('a'));
 // CHECK-NEXT: -1
 print(1 / [true].indexOf(true, -0));
-//CHECK-NEXT: Infinity
+// CHECK-NEXT: Infinity
+var a = [1, +0.0, -0.0, NaN, Infinity, 2 ** 32];
+print(a.indexOf(+0.0));
+// CHECK-NEXT: 1
+print(a.indexOf(-0.0))
+// CHECK-NEXT: 1
+print(a.indexOf(NaN));
+// CHECK-NEXT: -1
+print(a.indexOf(Infinity));
+// CHECK-NEXT: 4
+print(a.indexOf(2 ** 32));
+// CHECK-NEXT: 5
 
 print('lastIndexOf');
 // CHECK-LABEL: lastIndexOf
@@ -711,6 +722,17 @@ print(a.lastIndexOf('a', 4));
 // CHECK-NEXT: -1
 print(a.lastIndexOf('a'));
 // CHECK-NEXT: -1
+var a = [1, +0.0, -0.0, NaN, Infinity, 2 ** 32];
+print(a.lastIndexOf(+0.0));
+// CHECK-NEXT: 2
+print(a.lastIndexOf(-0.0))
+// CHECK-NEXT: 2
+print(a.lastIndexOf(NaN));
+// CHECK-NEXT: -1
+print(a.lastIndexOf(Infinity));
+// CHECK-NEXT: 4
+print(a.lastIndexOf(2 ** 32));
+// CHECK-NEXT: 5
 
 print('every');
 // CHECK-LABEL: every


### PR DESCRIPTION
Summary:
If `this` is truly an Array object, go fast path, otherwise, falls to
slow path. In fast path, use specialized loop given the type of search
value and reverse mode. For checking Number, add a new function that
returns double value if the HV is a number and returns NaN if it's not.
This avoids repeated tag checking in `isNumber()` and `getNumber()`
for HV32 mode.

On the given benchmark it's ~12X faster on both HV32 and HV64 mode.

Differential Revision: D58201521
