### PR TITLE
Run GitHub Actions continuously

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: facebook/hermes/build
 on:
+  push
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Summary:
Schedule test runs every 2 hours, starting at 30 minutes past the hour.
Under heavy load, builds may be gracefully delayed or skipped, so
having too short of an interval shouldn't cause any disruptions.

Differential Revision: D61042384
