### PR TITLE
console preview for Error objects

### DIFF
--- a/API/hermes/cdp/RemoteObjectConverters.cpp
+++ b/API/hermes/cdp/RemoteObjectConverters.cpp
@@ -18,6 +18,13 @@ namespace m = ::facebook::hermes::cdp::message;
 
 constexpr size_t kMaxPreviewProperties = 10;
 
+static bool isObjectInstanceOfError(
+    const jsi::Object &obj,
+    facebook::jsi::Runtime &runtime) {
+  return obj.instanceOf(
+      runtime, runtime.global().getPropertyAsFunction(runtime, "Error"));
+}
+
 static m::runtime::PropertyPreview generatePropertyPreview(
     facebook::jsi::Runtime &runtime,
     const std::string &name,
@@ -309,6 +316,11 @@ m::runtime::RemoteObject m::runtime::makeRemoteObject(
       if (options.generatePreview) {
         result.preview = generateArrayPreview(runtime, array);
       }
+    } else if (isObjectInstanceOfError(obj, runtime)) {
+      result.type = "object";
+      result.subtype = "error";
+      result.description =
+          obj.getProperty(runtime, "stack").toString(runtime).utf8(runtime);
     } else {
       result.type = "object";
       result.description = result.className = "Object";

--- a/API/hermes/cdp/RemoteObjectConverters.cpp
+++ b/API/hermes/cdp/RemoteObjectConverters.cpp
@@ -18,6 +18,16 @@ namespace m = ::facebook::hermes::cdp::message;
 
 constexpr size_t kMaxPreviewProperties = 10;
 
+static std::string abbreviateString(const std::string &str) {
+  const std::string::size_type kMaxLength = 100;
+  const std::string kEllipsis = "…";
+  if (str.length() <= kMaxLength) {
+    return str;
+  }
+
+  return str.substr(0, kMaxLength - 1) + kEllipsis;
+}
+
 static bool isObjectInstanceOfError(
     const jsi::Object &obj,
     facebook::jsi::Runtime &runtime) {
@@ -63,6 +73,11 @@ static m::runtime::PropertyPreview generatePropertyPreview(
       preview.subtype = "array";
       preview.value = "Array(" +
           std::to_string(obj.getArray(runtime).length(runtime)) + ")";
+    } else if (isObjectInstanceOfError(obj, runtime)) {
+      preview.type = "object";
+      preview.subtype = "error";
+      preview.value = abbreviateString(
+          obj.getProperty(runtime, "stack").toString(runtime).utf8(runtime));
     } else {
       preview.type = "object";
       preview.value = "Object";


### PR DESCRIPTION
Summary: On web, an array of Error objects have previews. This diff brings the parity to RN DevTools

Differential Revision: D61243518
