### PR TITLE
Makes HermesRuntimeImpl::isArray proxy-compatible

### DIFF
--- a/API/hermes/hermes.cpp
+++ b/API/hermes/hermes.cpp
@@ -2030,9 +2030,7 @@ void HermesRuntimeImpl::setPropertyValue(
 
 bool HermesRuntimeImpl::isArray(const jsi::Object &obj) const {
   auto res = llvh::isArray(runtime_, llvh::dyn_vmcast<vm::JSObject>(phv(obj)));
-  if (LLVM_UNLIKELY(res == llvh::ExecutionStatus::EXCEPTION)) {
-    return false;
-  }
+  const_cast<HermesRuntimeImpl *>(this)->checkStatus(res.getStatus());
   return *res;
 }
 

--- a/API/hermes/hermes.cpp
+++ b/API/hermes/hermes.cpp
@@ -29,6 +29,8 @@
 #include "hermes/VM/JSArrayBuffer.h"
 #include "hermes/VM/JSLib.h"
 #include "hermes/VM/JSLib/RuntimeJSONUtils.h"
+#include "hermes/VM/JSObject.h"
+#include "hermes/VM/JSProxy.h"
 #include "hermes/VM/NativeState.h"
 #include "hermes/VM/Operations.h"
 #include "hermes/VM/Profiler/CodeCoverageProfiler.h"
@@ -2029,7 +2031,20 @@ void HermesRuntimeImpl::setPropertyValue(
 }
 
 bool HermesRuntimeImpl::isArray(const jsi::Object &obj) const {
-  return vm::vmisa<vm::JSArray>(phv(obj));
+  vm::JSObject *jsobj = static_cast<vm::JSObject *>(phv(obj).getPointer());
+  while (true) {
+    if (vm::vmisa<vm::JSArray>(jsobj)) {
+      return true;
+    }
+    if (LLVM_LIKELY(!jsobj->isProxyObject())) {
+      return false;
+    }
+    if (vm::JSProxy::isRevoked(jsobj, runtime_)) {
+      return false;
+    }
+    jsobj = vm::JSProxy::getTarget(jsobj, runtime_).get();
+    assert(jsobj && "target of non-revoked Proxy is null");
+  }
 }
 
 bool HermesRuntimeImpl::isArrayBuffer(const jsi::Object &obj) const {


### PR DESCRIPTION
When using hermes engine, [`dynamicFromValue` in React Native](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactCommon/jsi/jsi/JSIDynamic.cpp#L166) calls `isArray` here to check if the input object is an array.

Consider this piece of code:
```js
const list = ['a', 'b', 'c', 'd'];
const proxyed_list = new Proxy(list, {});
```

The `proxyed_list` behaves exactly the same as list in Javascript. But when been passed to native and converted to `folly::dynamic` by `dynamicFromValue`, `proxyed_list` will be converted to `{"0": "a", "1": "b", "2": "c", "3": "d"}` but not the expected `["a", "b", "c", "d"]`.

This patch implements similar routines in commit [26840ed441d614a07809c612521074ca9544086c](https://github.com/facebook/hermes/commit/26840ed441d614a07809c612521074ca9544086c#diff-059b8f2fcb0235b35582efc591e065bd8caa898c3ea2ef2a3e453bff97584e4dR1575) and makes `isArray` proxy-compatible.

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `main`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/HEAD/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.
-->

## Summary

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
-->

## Test Plan

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes the user interface.
-->
