### PR TITLE
JSError: look for stack data in the prototype chain

### DIFF
--- a/lib/VM/JSError.cpp
+++ b/lib/VM/JSError.cpp
@@ -54,7 +54,11 @@ void JSErrorBuildMeta(const GCCell *cell, Metadata::Builder &mb) {
 CallResult<Handle<JSError>> JSError::getErrorFromStackTarget(
     Runtime &runtime,
     Handle<JSObject> targetHandle) {
-  if (targetHandle) {
+  MutableHandle<JSObject> mutHnd =
+      runtime.makeMutableHandle<JSObject>(targetHandle.get());
+  targetHandle = mutHnd;
+
+  while (targetHandle) {
     NamedPropertyDescriptor desc;
     bool exists = JSObject::getOwnNamedDescriptor(
         targetHandle,
@@ -68,6 +72,8 @@ CallResult<Handle<JSError>> JSError::getErrorFromStackTarget(
     if (vmisa<JSError>(*targetHandle)) {
       return Handle<JSError>::vmcast(targetHandle);
     }
+
+    mutHnd.set(targetHandle->getParent(runtime));
   }
   return runtime.raiseTypeError(
       "Error.stack getter called with an invalid receiver");

--- a/test/hermes/error-in-proto.js
+++ b/test/hermes/error-in-proto.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes %s | %FileCheck --match-full-lines %s
+// RUN: %shermes -exec %s | %FileCheck --match-full-lines %s
+
+const MyError = function(message) {
+  this.message = message;
+};
+MyError.prototype = new Error;
+MyError.prototype.name = 'MyError';
+
+
+try {
+  throw new MyError('1234')
+} catch (e) {
+    if (e instanceof Error)
+        print("Caught Error", e.stack);
+    else
+        print("Caught non-Error");
+}
+// CHECK: Caught Error MyError: 1234
+// CHECK-NEXT:     at global{{.*}}


### PR DESCRIPTION
Summary:
Look for stack data in the entire prototype chain in order to accommodate
usage like the one in the test.

See https://github.com/facebook/hermes/issues/1496

Differential Revision: D61870728
