### PR TITLE
Pass the pointer of owning object in GCHermesValueBase::set()

### DIFF
--- a/include/hermes/VM/AlignedHeapSegment.h
+++ b/include/hermes/VM/AlignedHeapSegment.h
@@ -80,6 +80,10 @@ class AlignedHeapSegmentBase {
     friend class AlignedHeapSegment;
     friend class AlignedHeapSegmentBase;
 
+    /// Pass segment size to CardTable constructor to allocate its data
+    /// separately if \p sz > kSegmentUnitSize.
+    Contents(size_t segmentSize) : cardTable_(segmentSize) {}
+
     /// Note that because of the Contents object, the first few bytes of the
     /// card table are unused, we instead use them to store a small
     /// SHSegmentInfo struct.
@@ -215,9 +219,9 @@ class AlignedHeapSegmentBase {
   AlignedHeapSegmentBase() = default;
 
   /// Construct Contents() at the address of \p lowLim.
-  AlignedHeapSegmentBase(void *lowLim)
+  AlignedHeapSegmentBase(void *lowLim, size_t segmentSize)
       : lowLim_(reinterpret_cast<char *>(lowLim)) {
-    new (contents()) Contents();
+    new (contents()) Contents(segmentSize);
     contents()->protectGuardPage(oscompat::ProtectMode::None);
   }
 

--- a/include/hermes/VM/AlignedHeapSegment.h
+++ b/include/hermes/VM/AlignedHeapSegment.h
@@ -194,6 +194,14 @@ class AlignedHeapSegmentBase {
     return contents()->cardTable_;
   }
 
+  /// Given a \p cell into the memory region of some valid segment \c s, returns
+  /// a pointer to the CardTable covering the segment containing the cell.
+  ///
+  /// \pre There exists a currently alive heap in which \p cell is allocated.
+  static CardTable *cardTableCovering(const GCCell *cell) {
+    return &contents(alignedStorageStart(cell))->cardTable_;
+  }
+
   /// Return a reference to the mark bit array covering the memory region
   /// managed by this segment.
   Contents::MarkBitArray &markBitArray() const {
@@ -214,6 +222,15 @@ class AlignedHeapSegmentBase {
     size_t ind = addressToMarkBitArrayIndex(cell);
     return markBits->at(ind);
   }
+
+#ifndef NDEBUG
+  /// Get the storage end of segment that \p cell resides in.
+  static char *storageEnd(const GCCell *cell) {
+    auto *start = alignedStorageStart(cell);
+    auto *segmentInfo = reinterpret_cast<const SHSegmentInfo *>(start);
+    return start + segmentInfo->segmentSize;
+  }
+#endif
 
  protected:
   AlignedHeapSegmentBase() = default;

--- a/include/hermes/VM/AlignedHeapSegment.h
+++ b/include/hermes/VM/AlignedHeapSegment.h
@@ -36,9 +36,9 @@ class StorageProvider;
 // TODO (T25527350): Debug Dump
 // TODO (T25527350): Heap Moving
 
-/// An \c AlignedHeapSegment is a contiguous chunk of memory aligned to its own
-/// storage size (which is a fixed power of two number of bytes).  The storage
-/// is further split up according to the diagram below:
+/// An \c AlignedHeapSegmentBase manages a contiguous chunk of memory aligned to
+/// kSegmentUnitSize. The storage is further split up according to the diagram
+/// below:
 ///
 /// +----------------------------------------+
 /// | (1) Card Table                         |
@@ -52,17 +52,223 @@ class StorageProvider;
 /// | (End)                                  |
 /// +----------------------------------------+
 ///
-/// The tables in (1), and (2) cover the contiguous allocation space (3)
-/// into which GCCells are bump allocated.
-class AlignedHeapSegment {
+/// The tables in (1), and (2) cover the contiguous allocation space (3) into
+/// which GCCells are bump allocated. They have fixed size computed from
+/// kSegmentUnitSize. For segments with larger size (which must be multiples of
+/// kSegmentUnitSize), card table allocates its internal arrays separately
+/// instead. Any segment size smaller than kSegmentUnitSize is not supported.
+class AlignedHeapSegmentBase {
+ public:
+  static constexpr size_t kLogSize = HERMESVM_LOG_HEAP_SEGMENT_SIZE;
+  static constexpr size_t kSegmentUnitSize = (1 << kLogSize);
+
+  /// Contents of the memory region managed by this segment.
+  class Contents {
+   public:
+    /// The number of bits representing the total number of heap-aligned
+    /// addresses in the segment storage.
+    static constexpr size_t kMarkBitArraySize =
+        kSegmentUnitSize >> LogHeapAlign;
+    /// BitArray for marking allocation region of a segment.
+    using MarkBitArray = BitArray<kMarkBitArraySize>;
+
+    /// Set the protection mode of paddedGuardPage_ (if system page size allows
+    /// it).
+    void protectGuardPage(oscompat::ProtectMode mode);
+
+   private:
+    friend class AlignedHeapSegment;
+    friend class AlignedHeapSegmentBase;
+
+    /// Note that because of the Contents object, the first few bytes of the
+    /// card table are unused, we instead use them to store a small
+    /// SHSegmentInfo struct.
+    CardTable cardTable_;
+
+    MarkBitArray markBitArray_;
+
+    static constexpr size_t kMetadataSize =
+        sizeof(cardTable_) + sizeof(MarkBitArray);
+    /// Padding to ensure that the guard page is aligned to a page boundary.
+    static constexpr size_t kGuardPagePadding =
+        llvh::alignTo<pagesize::kExpectedPageSize>(kMetadataSize) -
+        kMetadataSize;
+
+    /// Memory made inaccessible through protectGuardPage, for security and
+    /// earlier detection of corruption. Padded to contain at least one full
+    /// aligned page.
+    char paddedGuardPage_[pagesize::kExpectedPageSize + kGuardPagePadding];
+
+    static constexpr size_t kMetadataAndGuardSize =
+        kMetadataSize + sizeof(paddedGuardPage_);
+
+    /// The first byte of the allocation region, which extends past the "end" of
+    /// the struct, to the end of the memory region that contains it.
+    char allocRegion_[1];
+  };
+
+  static_assert(
+      offsetof(Contents, paddedGuardPage_) == Contents::kMetadataSize,
+      "Should not need padding after metadata.");
+
+  /// The total space at the start of the CardTable taken up by the metadata and
+  /// guard page in the Contents struct.
+  static constexpr size_t kCardTableUnusedPrefixBytes =
+      Contents::kMetadataAndGuardSize / CardTable::kHeapBytesPerCardByte;
+  static_assert(
+      sizeof(SHSegmentInfo) < kCardTableUnusedPrefixBytes,
+      "SHSegmentInfo does not fit in available unused CardTable space.");
+
+  /// The offset from the beginning of a segment of the allocatable region.
+  static constexpr size_t kOffsetOfAllocRegion{
+      offsetof(Contents, allocRegion_)};
+
+  static_assert(
+      isSizeHeapAligned(kOffsetOfAllocRegion),
+      "Allocation region must start at a heap aligned offset");
+
+  static_assert(
+      (offsetof(Contents, paddedGuardPage_) + Contents::kGuardPagePadding) %
+              pagesize::kExpectedPageSize ==
+          0,
+      "Guard page must be aligned to likely page size");
+
+  class HeapCellIterator : public llvh::iterator_facade_base<
+                               HeapCellIterator,
+                               std::forward_iterator_tag,
+                               GCCell *> {
+   public:
+    HeapCellIterator(GCCell *cell) : cell_(cell) {}
+
+    bool operator==(const HeapCellIterator &R) const {
+      return cell_ == R.cell_;
+    }
+
+    GCCell *const &operator*() const {
+      return cell_;
+    }
+
+    HeapCellIterator &operator++() {
+      cell_ = cell_->nextCell();
+      return *this;
+    }
+
+   private:
+    GCCell *cell_{nullptr};
+  };
+
+  /// Returns the address that is the lower bound of the segment.
+  /// \post The returned pointer is guaranteed to be aligned to
+  /// kSegmentUnitSize.
+  char *lowLim() const {
+    return lowLim_;
+  }
+
+  /// Returns the address at which the first allocation in this segment would
+  /// occur.
+  /// Disable UB sanitization because 'this' may be null during the tests.
+  char *start() const LLVM_NO_SANITIZE("undefined") {
+    return contents()->allocRegion_;
+  }
+
+  /// Return a reference to the card table covering the memory region managed by
+  /// this segment.
+  CardTable &cardTable() const {
+    return contents()->cardTable_;
+  }
+
+  /// Return a reference to the mark bit array covering the memory region
+  /// managed by this segment.
+  Contents::MarkBitArray &markBitArray() const {
+    return contents()->markBitArray_;
+  }
+
+  /// Mark the given \p cell.  Assumes the given address is a valid heap object.
+  static void setCellMarkBit(const GCCell *cell) {
+    auto *markBits = markBitArrayCovering(cell);
+    size_t ind = addressToMarkBitArrayIndex(cell);
+    markBits->set(ind, true);
+  }
+
+  /// Return whether the given \p cell is marked.  Assumes the given address is
+  /// a valid heap object.
+  static bool getCellMarkBit(const GCCell *cell) {
+    auto *markBits = markBitArrayCovering(cell);
+    size_t ind = addressToMarkBitArrayIndex(cell);
+    return markBits->at(ind);
+  }
+
+ protected:
+  AlignedHeapSegmentBase() = default;
+
+  /// Construct Contents() at the address of \p lowLim.
+  AlignedHeapSegmentBase(void *lowLim)
+      : lowLim_(reinterpret_cast<char *>(lowLim)) {
+    new (contents()) Contents();
+    contents()->protectGuardPage(oscompat::ProtectMode::None);
+  }
+
+  /// Return a pointer to the contents of the memory region managed by this
+  /// segment.
+  Contents *contents() const {
+    return reinterpret_cast<Contents *>(lowLim_);
+  }
+
+  /// Given the \p lowLim of some valid segment's memory region, returns a
+  /// pointer to the Contents laid out in the storage, assuming it exists.
+  static Contents *contents(void *lowLim) {
+    return reinterpret_cast<Contents *>(lowLim);
+  }
+
+  /// The start of the aligned segment.
+  char *lowLim_{nullptr};
+
+ private:
+  /// Return the starting address for aligned region of size kSegmentUnitSize
+  /// that \p cell resides in. If \c cell resides in a JumboSegment, it's the
+  /// only cell there, this essentially returns its segment starting address.
+  static char *alignedStorageStart(const GCCell *cell) {
+    return reinterpret_cast<char *>(
+        reinterpret_cast<uintptr_t>(cell) & ~(kSegmentUnitSize - 1));
+  }
+
+  /// Given a \p cell, returns a pointer to the MarkBitArray covering the
+  /// segment that \p cell resides in.
+  ///
+  /// \pre There exists a currently alive heap that claims to contain \c ptr.
+  static Contents::MarkBitArray *markBitArrayCovering(const GCCell *cell) {
+    auto *segStart = alignedStorageStart(cell);
+    return &contents(segStart)->markBitArray_;
+  }
+
+  /// Translate the given address to a 0-based index in the MarkBitArray of its
+  /// segment. The base address is the start of the storage of this segment. For
+  /// JumboSegment, this should always return a constant index
+  /// kOffsetOfAllocRegion >> LogHeapAlign.
+  static size_t addressToMarkBitArrayIndex(const GCCell *cell) {
+    auto *cp = reinterpret_cast<const char *>(cell);
+    auto *base = reinterpret_cast<const char *>(alignedStorageStart(cell));
+    return (cp - base) >> LogHeapAlign;
+  }
+};
+
+/// JumboHeapSegment has custom storage size that must be a multiple of
+/// kSegmentUnitSize. Each such segment can only allocate a single object that
+/// occupies the entire allocation space. Therefore, the inline MarkBitArray is
+/// large enough, while the CardTable is stored separately.
+class JumboHeapSegment : public AlignedHeapSegmentBase {};
+
+/// AlignedHeapSegment has fixed storage size kSegmentUnitSize. Its CardTable
+/// and MarkBitArray are stored inline right before the allocation space. This
+/// is used for all normal object allcations in YoungGen and OldGen.
+class AlignedHeapSegment : public AlignedHeapSegmentBase {
  public:
   /// @name Constants and utility functions for the aligned storage of \c
   /// AlignedHeapSegment.
   ///
   /// @{
   /// The size and the alignment of the storage, in bytes.
-  static constexpr unsigned kLogSize = HERMESVM_LOG_HEAP_SEGMENT_SIZE;
-  static constexpr size_t kSize{1 << kLogSize};
+  static constexpr size_t kSize = kSegmentUnitSize;
   /// Mask for isolating the offset into a storage for a pointer.
   static constexpr size_t kLowMask{kSize - 1};
   /// Mask for isolating the storage being pointed into by a pointer.
@@ -123,98 +329,6 @@ class AlignedHeapSegment {
       StorageProvider *provider,
       const char *name);
 
-  /// Contents of the memory region managed by this segment.
-  class Contents {
-   public:
-    /// The number of bits representing the total number of heap-aligned
-    /// addresses in the segment storage.
-    static constexpr size_t kMarkBitArraySize = kSize >> LogHeapAlign;
-    /// BitArray for marking allocation region of a segment.
-    using MarkBitArray = BitArray<kMarkBitArraySize>;
-
-    /// Set the protection mode of paddedGuardPage_ (if system page size allows
-    /// it).
-    void protectGuardPage(oscompat::ProtectMode mode);
-
-   private:
-    friend class AlignedHeapSegment;
-
-    /// Note that because of the Contents object, the first few bytes of the
-    /// card table are unused, we instead use them to store a small
-    /// SHSegmentInfo struct.
-    CardTable cardTable_;
-
-    MarkBitArray markBitArray_;
-
-    static constexpr size_t kMetadataSize =
-        sizeof(cardTable_) + sizeof(MarkBitArray);
-    /// Padding to ensure that the guard page is aligned to a page boundary.
-    static constexpr size_t kGuardPagePadding =
-        llvh::alignTo<pagesize::kExpectedPageSize>(kMetadataSize) -
-        kMetadataSize;
-
-    /// Memory made inaccessible through protectGuardPage, for security and
-    /// earlier detection of corruption. Padded to contain at least one full
-    /// aligned page.
-    char paddedGuardPage_[pagesize::kExpectedPageSize + kGuardPagePadding];
-
-    static constexpr size_t kMetadataAndGuardSize =
-        kMetadataSize + sizeof(paddedGuardPage_);
-
-    /// The first byte of the allocation region, which extends past the "end" of
-    /// the struct, to the end of the memory region that contains it.
-    char allocRegion_[1];
-  };
-
-  static_assert(
-      offsetof(Contents, paddedGuardPage_) == Contents::kMetadataSize,
-      "Should not need padding after metadata.");
-
-  /// The total space at the start of the CardTable taken up by the metadata and
-  /// guard page in the Contents struct.
-  static constexpr size_t kCardTableUnusedPrefixBytes =
-      Contents::kMetadataAndGuardSize / CardTable::kHeapBytesPerCardByte;
-  static_assert(
-      sizeof(SHSegmentInfo) < kCardTableUnusedPrefixBytes,
-      "SHSegmentInfo does not fit in available unused CardTable space.");
-
-  /// The offset from the beginning of a segment of the allocatable region.
-  static constexpr size_t offsetOfAllocRegion{offsetof(Contents, allocRegion_)};
-
-  static_assert(
-      isSizeHeapAligned(offsetOfAllocRegion),
-      "Allocation region must start at a heap aligned offset");
-
-  static_assert(
-      (offsetof(Contents, paddedGuardPage_) + Contents::kGuardPagePadding) %
-              pagesize::kExpectedPageSize ==
-          0,
-      "Guard page must be aligned to likely page size");
-
-  class HeapCellIterator : public llvh::iterator_facade_base<
-                               HeapCellIterator,
-                               std::forward_iterator_tag,
-                               GCCell *> {
-   public:
-    HeapCellIterator(GCCell *cell) : cell_(cell) {}
-
-    bool operator==(const HeapCellIterator &R) const {
-      return cell_ == R.cell_;
-    }
-
-    GCCell *const &operator*() const {
-      return cell_;
-    }
-
-    HeapCellIterator &operator++() {
-      cell_ = cell_->nextCell();
-      return *this;
-    }
-
-   private:
-    GCCell *cell_{nullptr};
-  };
-
   /// Returns the index of the segment containing \p lowLim, which is required
   /// to be the start of its containing segment.  (This can allow extra
   /// efficiency, in cases where the segment start has already been computed.)
@@ -238,39 +352,11 @@ class AlignedHeapSegment {
   /// space, returns {nullptr, false}.
   inline AllocResult alloc(uint32_t size);
 
-  /// Given the \p lowLim of some valid segment's memory region, returns a
-  /// pointer to the AlignedHeapSegment::Contents laid out in that storage,
-  /// assuming it exists.
-  inline static Contents *contents(void *lowLim);
-  inline static const Contents *contents(const void *lowLim);
-
   /// Given a \p ptr into the memory region of some valid segment \c s, returns
   /// a pointer to the CardTable covering the segment containing the pointer.
   ///
   /// \pre There exists a currently alive heap that claims to contain \c ptr.
   inline static CardTable *cardTableCovering(const void *ptr);
-
-  /// Given a \p ptr into the memory region of some valid segment \c s, returns
-  /// a pointer to the MarkBitArray covering the segment containing the
-  /// pointer.
-  ///
-  /// \pre There exists a currently alive heap that claims to contain \c ptr.
-  inline static Contents::MarkBitArray *markBitArrayCovering(const void *ptr);
-
-  /// Translate the given address to a 0-based index in the MarkBitArray of its
-  /// segment. The base address is the start of the storage of this segment.
-  static size_t addressToMarkBitArrayIndex(const void *ptr) {
-    auto *cp = reinterpret_cast<const char *>(ptr);
-    auto *base = reinterpret_cast<const char *>(storageStart(cp));
-    return (cp - base) >> LogHeapAlign;
-  }
-
-  /// Mark the given \p cell.  Assumes the given address is a valid heap object.
-  inline static void setCellMarkBit(const GCCell *cell);
-
-  /// Return whether the given \p cell is marked.  Assumes the given address is
-  /// a valid heap object.
-  inline static bool getCellMarkBit(const GCCell *cell);
 
   /// Find the head of the first cell that extends into the card at index
   /// \p cardIdx.
@@ -294,22 +380,10 @@ class AlignedHeapSegment {
   /// The number of bytes in the segment that are available for allocation.
   inline size_t available() const;
 
-  /// Returns the address that is the lower bound of the segment.
-  /// \post The returned pointer is guaranteed to be aligned to a segment
-  ///   boundary.
-  char *lowLim() const {
-    return lowLim_;
-  }
-
   /// Returns the address that is the upper bound of the segment.
   char *hiLim() const {
     return lowLim() + storageSize();
   }
-
-  /// Returns the address at which the first allocation in this segment would
-  /// occur.
-  /// Disable UB sanitization because 'this' may be null during the tests.
-  inline char *start() const LLVM_NO_SANITIZE("undefined");
 
   /// Returns the first address after the region in which allocations can occur,
   /// taking external memory credits into a account (they decrease the effective
@@ -339,15 +413,6 @@ class AlignedHeapSegment {
   /// Returns whether \p a and \p b are contained in the same
   /// AlignedHeapSegment.
   inline static bool containedInSame(const void *a, const void *b);
-
-  /// Return a reference to the card table covering the memory region managed by
-  /// this segment.
-  /// Disable sanitization because 'this' may be null in the tests.
-  inline CardTable &cardTable() const LLVM_NO_SANITIZE("null");
-
-  /// Return a reference to the mark bit array covering the memory region
-  /// managed by this segment.
-  inline Contents::MarkBitArray &markBitArray() const;
 
   explicit operator bool() const {
     return lowLim();
@@ -390,20 +455,11 @@ class AlignedHeapSegment {
 
   /// Set the contents of the segment to a dead value.
   void clear();
-  /// Set the given range [start, end) to a dead value.
-  static void clear(char *start, char *end);
   /// Checks that dead values are present in the [start, end) range.
   static void checkUnwritten(char *start, char *end);
 #endif
 
- protected:
-  /// Return a pointer to the contents of the memory region managed by this
-  /// segment.
-  inline Contents *contents() const;
-
-  /// The start of the aligned segment.
-  char *lowLim_{nullptr};
-
+ private:
   /// The provider that created this segment. It will be used to properly
   /// destroy this.
   StorageProvider *provider_{nullptr};
@@ -419,7 +475,6 @@ class AlignedHeapSegment {
   /// and swap idiom.
   friend void swap(AlignedHeapSegment &a, AlignedHeapSegment &b);
 
- private:
   AlignedHeapSegment(StorageProvider *provider, void *lowLim);
 };
 
@@ -459,26 +514,6 @@ AllocResult AlignedHeapSegment::alloc(uint32_t size) {
   return {cell, true};
 }
 
-/*static*/
-AlignedHeapSegment::Contents::MarkBitArray *
-AlignedHeapSegment::markBitArrayCovering(const void *ptr) {
-  return &contents(storageStart(ptr))->markBitArray_;
-}
-
-/*static*/
-void AlignedHeapSegment::setCellMarkBit(const GCCell *cell) {
-  auto *markBits = markBitArrayCovering(cell);
-  size_t ind = addressToMarkBitArrayIndex(cell);
-  markBits->set(ind, true);
-}
-
-/*static*/
-bool AlignedHeapSegment::getCellMarkBit(const GCCell *cell) {
-  auto *markBits = markBitArrayCovering(cell);
-  size_t ind = addressToMarkBitArrayIndex(cell);
-  return markBits->at(ind);
-}
-
 GCCell *AlignedHeapSegment::getFirstCellHead(size_t cardIdx) {
   CardTable &cards = cardTable();
   GCCell *cell = cards.firstObjForCard(cardIdx);
@@ -499,16 +534,6 @@ void AlignedHeapSegment::setCellHead(const GCCell *cellStart, const size_t sz) {
   }
 }
 
-/* static */ AlignedHeapSegment::Contents *AlignedHeapSegment::contents(
-    void *lowLim) {
-  return reinterpret_cast<Contents *>(lowLim);
-}
-
-/* static */ const AlignedHeapSegment::Contents *AlignedHeapSegment::contents(
-    const void *lowLim) {
-  return reinterpret_cast<const Contents *>(lowLim);
-}
-
 /* static */ CardTable *AlignedHeapSegment::cardTableCovering(const void *ptr) {
   return &AlignedHeapSegment::contents(storageStart(ptr))->cardTable_;
 }
@@ -527,10 +552,6 @@ size_t AlignedHeapSegment::used() const {
 
 size_t AlignedHeapSegment::available() const {
   return effectiveEnd() - level();
-}
-
-char *AlignedHeapSegment::start() const {
-  return contents()->allocRegion_;
 }
 
 char *AlignedHeapSegment::effectiveEnd() const {
@@ -556,19 +577,6 @@ AlignedHeapSegment::cells() {
 bool AlignedHeapSegment::containedInSame(const void *a, const void *b) {
   return (reinterpret_cast<uintptr_t>(a) ^ reinterpret_cast<uintptr_t>(b)) <
       storageSize();
-}
-
-CardTable &AlignedHeapSegment::cardTable() const {
-  return contents()->cardTable_;
-}
-
-AlignedHeapSegment::Contents::MarkBitArray &AlignedHeapSegment::markBitArray()
-    const {
-  return contents()->markBitArray_;
-}
-
-AlignedHeapSegment::Contents *AlignedHeapSegment::contents() const {
-  return contents(lowLim());
 }
 
 } // namespace vm

--- a/include/hermes/VM/ArrayStorage.h
+++ b/include/hermes/VM/ArrayStorage.h
@@ -151,7 +151,7 @@ class ArrayStorageBase final
   template <Inline inl = Inline::No>
   void set(size_type index, HVType val, GC &gc) {
     assert(index < size() && "index out of range");
-    data()[index].set(val, gc);
+    data()[index].set(val, gc, this);
   }
 
   /// \return the element at index \p index

--- a/include/hermes/VM/ArrayStorage.h
+++ b/include/hermes/VM/ArrayStorage.h
@@ -237,7 +237,7 @@ class ArrayStorageBase final
     auto *fromStart = other->data();
     auto *fromEnd = fromStart + otherSz;
     GCHVType::uninitialized_copy(
-        fromStart, fromEnd, data() + sz, runtime.getHeap());
+        fromStart, fromEnd, data() + sz, runtime.getHeap(), this);
     size_.store(sz + otherSz, std::memory_order_release);
   }
 

--- a/include/hermes/VM/CardTableNC.h
+++ b/include/hermes/VM/CardTableNC.h
@@ -63,11 +63,9 @@ class CardTable {
   static constexpr size_t kCardSize = 1 << kLogCardSize; // ==> 512-byte cards.
   static constexpr size_t kSegmentSize = 1 << HERMESVM_LOG_HEAP_SEGMENT_SIZE;
 
-  /// The number of valid indices into the card table.
-  static constexpr size_t kValidIndices = kSegmentSize >> kLogCardSize;
-
-  /// The size of the card table.
-  static constexpr size_t kCardTableSize = kValidIndices;
+  /// The size of the maximum inline card table. CardStatus array and boundary
+  /// array for larger segment has larger size and is storage separately.
+  static constexpr size_t kInlineCardTableSize = kSegmentSize >> kLogCardSize;
 
   /// For convenience, this is a conversion factor to determine how many bytes
   /// in the heap correspond to a single byte in the card table. This is
@@ -91,10 +89,14 @@ class CardTable {
   /// Note that the total size of the card table is 2 times kCardTableSize,
   /// since the CardTable contains two byte arrays of that size (cards_ and
   /// boundaries_).
-  static constexpr size_t kFirstUsedIndex =
-      std::max(sizeof(SHSegmentInfo), (2 * kCardTableSize) >> kLogCardSize);
+  static constexpr size_t kFirstUsedIndex = std::max(
+      sizeof(SHSegmentInfo),
+      (2 * kInlineCardTableSize) >> kLogCardSize);
 
-  CardTable() = default;
+  CardTable() {
+    // Preserve the segment size.
+    segmentInfo_.segmentSize = kSegmentSize;
+  }
   /// CardTable is not copyable or movable: It must be constructed in-place.
   CardTable(const CardTable &) = delete;
   CardTable(CardTable &&) = delete;
@@ -185,6 +187,11 @@ class CardTable {
   /// is the first object.)
   GCCell *firstObjForCard(unsigned index) const;
 
+  /// The end index of the card table (all valid indices should be smaller).
+  size_t getEndIndex() const {
+    return getSegmentSize() >> kLogCardSize;
+  }
+
 #ifdef HERMES_EXTRA_DEBUG
   /// Temporary debugging hack: yield the numeric value of the boundaries_ array
   /// for the given \p index.
@@ -215,10 +222,16 @@ class CardTable {
 #endif // HERMES_SLOW_DEBUG
 
  private:
+  unsigned getSegmentSize() const {
+    return segmentInfo_.segmentSize;
+  }
+
 #ifndef NDEBUG
-  /// Returns the pointer to the end of the storage containing \p ptr
-  /// (exclusive).
-  static void *storageEnd(const void *ptr);
+  /// Returns the pointer to the end of the storage starting at \p lowLim.
+  void *storageEnd(const void *lowLim) const {
+    return reinterpret_cast<char *>(
+        reinterpret_cast<uintptr_t>(lowLim) + getSegmentSize());
+  }
 #endif
 
   enum class CardStatus : char { Clean = 0, Dirty = 1 };
@@ -262,7 +275,7 @@ class CardTable {
     SHSegmentInfo segmentInfo_;
     /// This needs to be atomic so that the background thread in Hades can
     /// safely dirty cards when compacting.
-    std::array<AtomicIfConcurrentGC<CardStatus>, kCardTableSize> cards_{};
+    std::array<AtomicIfConcurrentGC<CardStatus>, kInlineCardTableSize> cards_{};
   };
 
   /// See the comment at kHeapBytesPerCardByte above to see why this is
@@ -281,7 +294,7 @@ class CardTable {
   /// time:  If we allocate a large object that crosses many cards, the first
   /// crossed cards gets a non-negative value, and each subsequent one uses the
   /// maximum exponent that stays within the card range for the object.
-  int8_t boundaries_[kCardTableSize];
+  int8_t boundaries_[kInlineCardTableSize];
 };
 
 /// Implementations of inlines.
@@ -311,7 +324,7 @@ inline size_t CardTable::addressToIndex(const void *addr) const {
 }
 
 inline const char *CardTable::indexToAddress(size_t index) const {
-  assert(index <= kValidIndices && "index must be within the index range");
+  assert(index <= getEndIndex() && "index must be within the index range");
   const char *res = base() + (index << kLogCardSize);
   assert(
       base() <= res && res <= storageEnd(base()) &&
@@ -329,7 +342,7 @@ inline bool CardTable::isCardForAddressDirty(const void *addr) const {
 }
 
 inline bool CardTable::isCardForIndexDirty(size_t index) const {
-  assert(index < kValidIndices && "index is required to be in range.");
+  assert(index < getEndIndex() && "index is required to be in range.");
   return cards_[index].load(std::memory_order_relaxed) == CardStatus::Dirty;
 }
 

--- a/include/hermes/VM/CardTableNC.h
+++ b/include/hermes/VM/CardTableNC.h
@@ -77,21 +77,22 @@ class CardTable {
   /// guaranteed by a static_assert below.
   static constexpr size_t kHeapBytesPerCardByte = kCardSize;
 
-  /// A prefix of every segment is occupied by auxilary data
-  /// structures.  The card table is the first such data structure.
-  /// The card table maps to the segment.  Only the suffix of the card
-  /// table that maps to the suffix of entire segment that is used for
-  /// allocation is ever used; the prefix that maps to the card table
-  /// itself is not used.  (Nor is the portion that of the card table
-  /// that maps to the other auxiliary data structure, the mark bit
-  /// array, but we don't attempt to calculate that here.)
-  /// It is useful to know the size of this unused region of
-  /// the card table, so it can be used for other purposes.
-  /// Note that the total size of the card table is 2 times
-  /// kCardTableSize, since the CardTable contains two byte arrays of
-  /// that size (cards_ and _boundaries_).
+  /// A prefix of every segment is occupied by auxiliary data structures. The
+  /// card table is the first such data structure. The card table maps to the
+  /// segment. Only the suffix of the card table that maps to the suffix of
+  /// entire segment that is used for allocation is ever used; the prefix that
+  /// maps to the card table itself is not used, nor is the portion of the card
+  /// table that maps to the other auxiliary data structure: the mark bit array
+  /// and guard pages. This small space can be used for other purpose, such as
+  /// storing the SHSegmentInfo. The actual first used index should take into
+  /// account of this. Here we only calculate for CardTable and size of
+  /// SHSegmentInfo. It's only used as starting index for clearing/dirtying
+  /// range of bits.
+  /// Note that the total size of the card table is 2 times kCardTableSize,
+  /// since the CardTable contains two byte arrays of that size (cards_ and
+  /// boundaries_).
   static constexpr size_t kFirstUsedIndex =
-      (2 * kCardTableSize) >> kLogCardSize;
+      std::max(sizeof(SHSegmentInfo), (2 * kCardTableSize) >> kLogCardSize);
 
   CardTable() = default;
   /// CardTable is not copyable or movable: It must be constructed in-place.
@@ -255,9 +256,14 @@ class CardTable {
 
   void cleanOrDirtyRange(size_t from, size_t to, CardStatus cleanOrDirty);
 
-  /// This needs to be atomic so that the background thread in Hades can safely
-  /// dirty cards when compacting.
-  std::array<AtomicIfConcurrentGC<CardStatus>, kCardTableSize> cards_{};
+  union {
+    /// The bytes occupied by segmentInfo_ are guaranteed to be not override by
+    /// writes to cards_ array. See static assertions in AlignedHeapSegmentBase.
+    SHSegmentInfo segmentInfo_;
+    /// This needs to be atomic so that the background thread in Hades can
+    /// safely dirty cards when compacting.
+    std::array<AtomicIfConcurrentGC<CardStatus>, kCardTableSize> cards_{};
+  };
 
   /// See the comment at kHeapBytesPerCardByte above to see why this is
   /// necessary.

--- a/include/hermes/VM/GCBase.h
+++ b/include/hermes/VM/GCBase.h
@@ -1152,29 +1152,25 @@ class GCBase {
 
 #ifdef HERMESVM_GC_RUNTIME
   /// Default implementations for read and write barriers: do nothing.
-  void writeBarrier(const GCHermesValue *loc, HermesValue value);
-  void writeBarrier(const GCSmallHermesValue *loc, SmallHermesValue value);
+  template <typename HVType>
+  void writeBarrier(const GCHermesValueBase<HVType> *loc, HVType value);
   void writeBarrier(const GCPointerBase *loc, const GCCell *value);
-  void constructorWriteBarrier(const GCHermesValue *loc, HermesValue value);
+  template <typename HVType>
   void constructorWriteBarrier(
-      const GCSmallHermesValue *loc,
-      SmallHermesValue value);
+      const GCHermesValueBase<HVType> *loc,
+      HVType value);
   void constructorWriteBarrier(const GCPointerBase *loc, const GCCell *value);
-  void writeBarrierRange(const GCHermesValue *start, uint32_t numHVs);
-  void writeBarrierRange(const GCSmallHermesValue *start, uint32_t numHVs);
+  template <typename HVType>
   void constructorWriteBarrierRange(
-      const GCHermesValue *start,
+      const GCHermesValueBase<HVType> *start,
       uint32_t numHVs);
-  void constructorWriteBarrierRange(
-      const GCSmallHermesValue *start,
-      uint32_t numHVs);
-  void snapshotWriteBarrier(const GCHermesValue *loc);
-  void snapshotWriteBarrier(const GCSmallHermesValue *loc);
+  template <typename HVType>
+  void snapshotWriteBarrier(const GCHermesValueBase<HVType> *loc);
   void snapshotWriteBarrier(const GCPointerBase *loc);
   void snapshotWriteBarrier(const GCSymbolID *symbol);
-  void snapshotWriteBarrierRange(const GCHermesValue *start, uint32_t numHVs);
+  template <typename HVType>
   void snapshotWriteBarrierRange(
-      const GCSmallHermesValue *start,
+      const GCHermesValueBase<HVType> *start,
       uint32_t numHVs);
   void weakRefReadBarrier(HermesValue value);
   void weakRefReadBarrier(GCCell *value);

--- a/include/hermes/VM/GCBase.h
+++ b/include/hermes/VM/GCBase.h
@@ -1162,6 +1162,7 @@ class GCBase {
   void constructorWriteBarrier(const GCPointerBase *loc, const GCCell *value);
   template <typename HVType>
   void constructorWriteBarrierRange(
+      const GCCell *cell,
       const GCHermesValueBase<HVType> *start,
       uint32_t numHVs);
   template <typename HVType>

--- a/include/hermes/VM/HadesGC.h
+++ b/include/hermes/VM/HadesGC.h
@@ -152,7 +152,8 @@ class HadesGC final : public GCBase {
   /// be in the heap). If value is a pointer, execute a write barrier.
   /// NOTE: The write barrier call must be placed *before* the write to the
   /// pointer, so that the current value can be fetched.
-  void writeBarrier(const GCHermesValue *loc, HermesValue value) {
+  template <typename HVType>
+  void writeBarrier(const GCHermesValueBase<HVType> *loc, HVType value) {
     assert(
         !calledByBackgroundThread() &&
         "Write barrier invoked by background thread.");
@@ -160,17 +161,16 @@ class HadesGC final : public GCBase {
     if (LLVM_UNLIKELY(!inYoungGen(loc)))
       writeBarrierSlow(loc, value);
   }
-  void writeBarrierSlow(const GCHermesValue *loc, HermesValue value);
-
-  void writeBarrier(const GCSmallHermesValue *loc, SmallHermesValue value) {
-    assert(
-        !calledByBackgroundThread() &&
-        "Write barrier invoked by background thread.");
-    // A pointer that lives in YG never needs any write barriers.
-    if (LLVM_UNLIKELY(!inYoungGen(loc)))
-      writeBarrierSlow(loc, value);
+  template <typename HVType>
+  void writeBarrierSlow(const GCHermesValueBase<HVType> *loc, HVType value) {
+    if (ogMarkingBarriers_) {
+      snapshotWriteBarrierInternal(*loc);
+    }
+    if (!value.isPointer()) {
+      return;
+    }
+    relocationWriteBarrier(loc, value.getPointer(getPointerBase()));
   }
-  void writeBarrierSlow(const GCSmallHermesValue *loc, SmallHermesValue value);
 
   /// The given pointer value is being written at the given loc (required to
   /// be in the heap). The value may be null. Execute a write barrier.
@@ -188,23 +188,25 @@ class HadesGC final : public GCBase {
 
   /// Special versions of \p writeBarrier for when there was no previous value
   /// initialized into the space.
-  void constructorWriteBarrier(const GCHermesValue *loc, HermesValue value) {
-    // A pointer that lives in YG never needs any write barriers.
-    if (LLVM_UNLIKELY(!inYoungGen(loc)))
-      constructorWriteBarrierSlow(loc, value);
-  }
-  void constructorWriteBarrierSlow(const GCHermesValue *loc, HermesValue value);
-
+  template <typename HVType>
   void constructorWriteBarrier(
-      const GCSmallHermesValue *loc,
-      SmallHermesValue value) {
+      const GCHermesValueBase<HVType> *loc,
+      HVType value) {
     // A pointer that lives in YG never needs any write barriers.
     if (LLVM_UNLIKELY(!inYoungGen(loc)))
       constructorWriteBarrierSlow(loc, value);
   }
+  template <typename HVType>
   void constructorWriteBarrierSlow(
-      const GCSmallHermesValue *loc,
-      SmallHermesValue value);
+      const GCHermesValueBase<HVType> *loc,
+      HVType value) {
+    // A constructor never needs to execute a SATB write barrier, since its
+    // previous value was definitely not live.
+    if (!value.isPointer()) {
+      return;
+    }
+    relocationWriteBarrier(loc, value.getPointer(getPointerBase()));
+  }
 
   void constructorWriteBarrier(const GCPointerBase *loc, const GCCell *value) {
     // A pointer that lives in YG never needs any write barriers.
@@ -212,33 +214,34 @@ class HadesGC final : public GCBase {
       relocationWriteBarrier(loc, value);
   }
 
+  template <typename HVType>
   void constructorWriteBarrierRange(
-      const GCHermesValue *start,
+      const GCHermesValueBase<HVType> *start,
       uint32_t numHVs) {
     // A pointer that lives in YG never needs any write barriers.
     if (LLVM_UNLIKELY(!inYoungGen(start)))
       constructorWriteBarrierRangeSlow(start, numHVs);
   }
+  template <typename HVType>
   void constructorWriteBarrierRangeSlow(
-      const GCHermesValue *start,
-      uint32_t numHVs);
-
-  void constructorWriteBarrierRange(
-      const GCSmallHermesValue *start,
+      const GCHermesValueBase<HVType> *start,
       uint32_t numHVs) {
-    // A pointer that lives in YG never needs any write barriers.
-    if (LLVM_UNLIKELY(!inYoungGen(start)))
-      constructorWriteBarrierRangeSlow(start, numHVs);
-  }
-  void constructorWriteBarrierRangeSlow(
-      const GCSmallHermesValue *start,
-      uint32_t numHVs);
+    assert(
+        AlignedHeapSegment::containedInSame(start, start + numHVs) &&
+        "Range must start and end within a heap segment.");
 
-  void snapshotWriteBarrier(const GCHermesValue *loc) {
-    if (LLVM_UNLIKELY(!inYoungGen(loc) && ogMarkingBarriers_))
-      snapshotWriteBarrierInternal(*loc);
+    // Most constructors should be running in the YG, so in the common case, we
+    // can avoid doing anything for the whole range. If the range is in the OG,
+    // then just dirty all the cards corresponding to it, and we can scan them
+    // for pointers later. This is less precise but makes the write barrier
+    // faster.
+
+    AlignedHeapSegment::cardTableCovering(start)->dirtyCardsForAddressRange(
+        start, start + numHVs);
   }
-  void snapshotWriteBarrier(const GCSmallHermesValue *loc) {
+
+  template <typename HVType>
+  void snapshotWriteBarrier(const GCHermesValueBase<HVType> *loc) {
     if (LLVM_UNLIKELY(!inYoungGen(loc) && ogMarkingBarriers_))
       snapshotWriteBarrierInternal(*loc);
   }
@@ -252,23 +255,21 @@ class HadesGC final : public GCBase {
       snapshotWriteBarrierInternal(*loc);
   }
 
-  void snapshotWriteBarrierRange(const GCHermesValue *start, uint32_t numHVs) {
-    if (LLVM_UNLIKELY(!inYoungGen(start) && ogMarkingBarriers_))
-      snapshotWriteBarrierRangeSlow(start, numHVs);
-  }
-  void snapshotWriteBarrierRangeSlow(
-      const GCHermesValue *start,
-      uint32_t numHVs);
-
+  template <typename HVType>
   void snapshotWriteBarrierRange(
-      const GCSmallHermesValue *start,
+      const GCHermesValueBase<HVType> *start,
       uint32_t numHVs) {
     if (LLVM_UNLIKELY(!inYoungGen(start) && ogMarkingBarriers_))
       snapshotWriteBarrierRangeSlow(start, numHVs);
   }
+  template <typename HVType>
   void snapshotWriteBarrierRangeSlow(
-      const GCSmallHermesValue *start,
-      uint32_t numHVs);
+      const GCHermesValueBase<HVType> *start,
+      uint32_t numHVs) {
+    for (uint32_t i = 0; i < numHVs; ++i) {
+      snapshotWriteBarrierInternal(start[i]);
+    }
+  }
 
   /// Add read barrier for \p value. This is only used when reading entry
   /// value from WeakMap/WeakSet.

--- a/include/hermes/VM/HeapRuntime.h
+++ b/include/hermes/VM/HeapRuntime.h
@@ -22,7 +22,7 @@ class HeapRuntime {
  public:
   ~HeapRuntime() {
     runtime_->~RT();
-    sp_->deleteStorage(runtime_);
+    sp_->deleteStorage(runtime_, kHeapRuntimeStorageSize);
   }
 
   /// Allocate a segment and create an aliased shared_ptr that points to the
@@ -36,16 +36,17 @@ class HeapRuntime {
 
  private:
   HeapRuntime(std::shared_ptr<StorageProvider> sp) : sp_{std::move(sp)} {
-    auto ptrOrError = sp_->newStorage("hermes-rt");
+    auto ptrOrError = sp_->newStorage("hermes-rt", kHeapRuntimeStorageSize);
     if (!ptrOrError)
       hermes_fatal("Cannot initialize Runtime storage.", ptrOrError.getError());
-    static_assert(
-        sizeof(RT) < AlignedHeapSegment::storageSize(), "Segments too small.");
+    static_assert(sizeof(RT) < kHeapRuntimeStorageSize, "Segments too small.");
     runtime_ = static_cast<RT *>(*ptrOrError);
   }
 
   std::shared_ptr<StorageProvider> sp_;
   RT *runtime_;
+  static constexpr size_t kHeapRuntimeStorageSize =
+      AlignedHeapSegment::storageSize();
 };
 } // namespace vm
 } // namespace hermes

--- a/include/hermes/VM/HermesValue-inline.h
+++ b/include/hermes/VM/HermesValue-inline.h
@@ -182,7 +182,8 @@ inline GCHermesValueBase<HVType> *GCHermesValueBase<HVType>::uninitialized_copy(
     GCHermesValueBase<HVType> *first,
     GCHermesValueBase<HVType> *last,
     GCHermesValueBase<HVType> *result,
-    GC &gc) {
+    GC &gc,
+    const GCCell *cell) {
 #ifndef NDEBUG
   uintptr_t fromFirst = reinterpret_cast<uintptr_t>(first),
             fromLast = reinterpret_cast<uintptr_t>(last);
@@ -194,7 +195,7 @@ inline GCHermesValueBase<HVType> *GCHermesValueBase<HVType>::uninitialized_copy(
       "Uninitialized range cannot overlap with an initialized one.");
 #endif
 
-  gc.constructorWriteBarrierRange(result, last - first);
+  gc.constructorWriteBarrierRange(cell, result, last - first);
   // memcpy is fine for an uninitialized copy.
   std::memcpy(
       reinterpret_cast<void *>(result), first, (last - first) * sizeof(HVType));

--- a/include/hermes/VM/HermesValue.h
+++ b/include/hermes/VM/HermesValue.h
@@ -590,7 +590,8 @@ class GCHermesValueBase final : public HVType {
       GCHermesValueBase<HVType> *first,
       GCHermesValueBase<HVType> *last,
       GCHermesValueBase<HVType> *result,
-      GC &gc);
+      GC &gc,
+      const GCCell *cell);
 
   /// Copies a range of values and performs a write barrier on each.
   template <typename InputIt, typename OutputIt>

--- a/include/hermes/VM/HermesValue.h
+++ b/include/hermes/VM/HermesValue.h
@@ -531,10 +531,11 @@ class GCHermesValueBase final : public HVType {
   GCHermesValueBase(HVType hv, GC &gc, std::nullptr_t);
   GCHermesValueBase(const HVType &) = delete;
 
-  /// The HermesValue \p hv may be an object pointer.  Assign the
-  /// value, and perform any necessary write barriers.
+  /// The HermesValue \p hv may be an object pointer. Assign the value, and
+  /// perform any necessary write barriers. \p cell is the object that contains
+  /// this GCHermesValueBase. It's needed by the write barrier.
   template <typename NeedsBarriers = std::true_type>
-  inline void set(HVType hv, GC &gc);
+  inline void set(HVType hv, GC &gc, const GCCell *owningObj);
 
   /// The HermesValue \p hv must not be an object pointer.  Assign the
   /// value.
@@ -552,7 +553,12 @@ class GCHermesValueBase final : public HVType {
   /// value \p fill.  If the fill value is an object pointer, must
   /// provide a non-null \p gc argument, to perform write barriers.
   template <typename InputIt>
-  static inline void fill(InputIt first, InputIt last, HVType fill, GC &gc);
+  static inline void fill(
+      InputIt first,
+      InputIt last,
+      HVType fill,
+      GC &gc,
+      const GCCell *owningObj);
 
   /// Same as \p fill except the range expressed by  [\p first, \p last) has not
   /// been previously initialized. Cannot use this on previously initialized
@@ -573,14 +579,13 @@ class GCHermesValueBase final : public HVType {
   static inline OutputIt
   uninitialized_copy(InputIt first, InputIt last, OutputIt result, GC &gc);
 
-#if !defined(HERMESVM_GC_HADES) && !defined(HERMESVM_GC_RUNTIME)
   /// Same as \p copy, but specialized for raw pointers.
   static inline GCHermesValueBase<HVType> *copy(
       GCHermesValueBase<HVType> *first,
       GCHermesValueBase<HVType> *last,
       GCHermesValueBase<HVType> *result,
-      GC &gc);
-#endif
+      GC &gc,
+      const GCCell *owningObj);
 
   /// Same as \p uninitialized_copy, but specialized for raw pointers. This is
   /// unsafe to use if the memory region being copied into (pointed to by
@@ -591,12 +596,16 @@ class GCHermesValueBase final : public HVType {
       GCHermesValueBase<HVType> *last,
       GCHermesValueBase<HVType> *result,
       GC &gc,
-      const GCCell *cell);
+      const GCCell *owningObj);
 
   /// Copies a range of values and performs a write barrier on each.
   template <typename InputIt, typename OutputIt>
-  static inline OutputIt
-  copy_backward(InputIt first, InputIt last, OutputIt result, GC &gc);
+  static inline OutputIt copy_backward(
+      InputIt first,
+      InputIt last,
+      OutputIt result,
+      GC &gc,
+      const GCCell *owningObj);
 
   /// Same as \c unreachableWriteBarrier, but for a range of values all becoming
   /// unreachable.

--- a/include/hermes/VM/JSObject.h
+++ b/include/hermes/VM/JSObject.h
@@ -1736,7 +1736,7 @@ template <SlotIndex index>
 inline void
 JSObject::setDirectSlotValue(JSObject *self, SmallHermesValue value, GC &gc) {
   static_assert(index < DIRECT_PROPERTY_SLOTS, "Must be a direct property");
-  self->directProps()[index].set(value, gc);
+  self->directProps()[index].set(value, gc, self);
 }
 
 inline SmallHermesValue JSObject::getNamedSlotValueUnsafe(
@@ -1839,7 +1839,7 @@ inline void JSObject::setNamedSlotValueDirectUnsafe(
   // to namedSlotRef(), it is a slight performance regression, which is not
   // entirely unexpected.
   return self->directProps()[index].set<NeedsBarriers>(
-      value, runtime.getHeap());
+      value, runtime.getHeap(), self);
 }
 
 inline void JSObject::setNamedSlotValueIndirectUnsafe(

--- a/include/hermes/VM/LimitedStorageProvider.h
+++ b/include/hermes/VM/LimitedStorageProvider.h
@@ -29,9 +29,9 @@ class LimitedStorageProvider final : public StorageProvider {
       : delegate_(std::move(provider)), limit_(limit) {}
 
  protected:
-  llvh::ErrorOr<void *> newStorageImpl(const char *name) override;
+  llvh::ErrorOr<void *> newStorageImpl(const char *name, size_t sz) override;
 
-  void deleteStorageImpl(void *storage) override;
+  void deleteStorageImpl(void *storage, size_t sz) override;
 };
 
 } // namespace vm

--- a/include/hermes/VM/MallocGC.h
+++ b/include/hermes/VM/MallocGC.h
@@ -233,22 +233,24 @@ class MallocGC final : public GCBase {
   virtual void creditExternalMemory(GCCell *alloc, uint32_t size) override;
   virtual void debitExternalMemory(GCCell *alloc, uint32_t size) override;
 
-  void writeBarrier(const GCHermesValue *, HermesValue) {}
-  void writeBarrier(const GCSmallHermesValue *, SmallHermesValue) {}
+  template <typename HVType>
+  void writeBarrier(const GCHermesValueBase<HVType> *, HVType) {}
   void writeBarrier(const GCPointerBase *, const GCCell *) {}
-  void constructorWriteBarrier(const GCHermesValue *, HermesValue) {}
-  void constructorWriteBarrier(const GCSmallHermesValue *, SmallHermesValue) {}
+  template <typename HVType>
+  void constructorWriteBarrier(const GCHermesValueBase<HVType> *, HVType) {}
   void constructorWriteBarrier(const GCPointerBase *, const GCCell *) {}
-  void writeBarrierRange(const GCHermesValue *, uint32_t) {}
-  void writeBarrierRange(const GCSmallHermesValue *, uint32_t) {}
-  void constructorWriteBarrierRange(const GCHermesValue *, uint32_t) {}
-  void constructorWriteBarrierRange(const GCSmallHermesValue *, uint32_t) {}
-  void snapshotWriteBarrier(const GCHermesValue *) {}
-  void snapshotWriteBarrier(const GCSmallHermesValue *) {}
+  template <typename HVType>
+  void writeBarrierRange(const GCHermesValueBase<HVType> *, uint32_t) {}
+  template <typename HVType>
+  void constructorWriteBarrierRange(
+      const GCHermesValueBase<HVType> *,
+      uint32_t) {}
+  template <typename HVType>
+  void snapshotWriteBarrier(const GCHermesValueBase<HVType> *) {}
   void snapshotWriteBarrier(const GCPointerBase *) {}
   void snapshotWriteBarrier(const GCSymbolID *) {}
-  void snapshotWriteBarrierRange(const GCHermesValue *, uint32_t) {}
-  void snapshotWriteBarrierRange(const GCSmallHermesValue *, uint32_t) {}
+  template <typename HVType>
+  void snapshotWriteBarrierRange(const GCHermesValueBase<HVType> *, uint32_t) {}
   void weakRefReadBarrier(HermesValue) {}
   void weakRefReadBarrier(GCCell *) {}
 

--- a/include/hermes/VM/MallocGC.h
+++ b/include/hermes/VM/MallocGC.h
@@ -243,6 +243,7 @@ class MallocGC final : public GCBase {
   void writeBarrierRange(const GCHermesValueBase<HVType> *, uint32_t) {}
   template <typename HVType>
   void constructorWriteBarrierRange(
+      const GCCell *cell,
       const GCHermesValueBase<HVType> *,
       uint32_t) {}
   template <typename HVType>

--- a/include/hermes/VM/StorageProvider.h
+++ b/include/hermes/VM/StorageProvider.h
@@ -37,20 +37,21 @@ class StorageProvider {
 
   /// @}
 
-  /// Create a new segment memory space.
-  llvh::ErrorOr<void *> newStorage() {
-    return newStorage(nullptr);
+  /// Create a new segment memory space with given size \p sz.
+  llvh::ErrorOr<void *> newStorage(size_t sz) {
+    return newStorage(nullptr, sz);
   }
-  /// Create a new segment memory space and give this memory the name \p name.
-  /// \return A pointer to a block of memory that has
-  /// AlignedHeapSegment::storageSize() bytes, and is aligned on
-  /// AlignedHeapSegment::storageSize().
-  llvh::ErrorOr<void *> newStorage(const char *name);
+  /// \return A pointer to a block of memory that has \p sz bytes, and is
+  /// aligned on AlignedHeapSegmentBase::kSegmentUnitSize. Note that \p sz
+  /// must be equals to or a multiple of
+  /// AlignedHeapSegmentBase::kSegmentUnitSize.
+  llvh::ErrorOr<void *> newStorage(const char *name, size_t sz);
 
   /// Delete the given segment's memory space, and make it available for re-use.
-  /// \post Nothing in the range [storage, storage +
-  /// AlignedHeapSegment::storageSize()) is valid memory to be read or written.
-  void deleteStorage(void *storage);
+  /// Note that \p sz must be the same as used to allocating \p storage.
+  /// \post Nothing in the range [storage, storage + sz) is valid memory to be
+  /// read or written.
+  void deleteStorage(void *storage, size_t sz);
 
   /// The number of storages this provider has allocated in its lifetime.
   size_t numSucceededAllocs() const;
@@ -67,8 +68,8 @@ class StorageProvider {
   size_t numLiveAllocs() const;
 
  protected:
-  virtual llvh::ErrorOr<void *> newStorageImpl(const char *name) = 0;
-  virtual void deleteStorageImpl(void *storage) = 0;
+  virtual llvh::ErrorOr<void *> newStorageImpl(const char *name, size_t sz) = 0;
+  virtual void deleteStorageImpl(void *storage, size_t sz) = 0;
 
  private:
   size_t numSucceededAllocs_{0};

--- a/include/hermes/VM/StringPrimitive.h
+++ b/include/hermes/VM/StringPrimitive.h
@@ -743,7 +743,7 @@ class BufferedStringPrimitive final : public StringPrimitive {
       Handle<ExternalStringPrimitive<T>> concatBuffer)
       : StringPrimitive(length) {
     concatBufferHV_.set(
-        HermesValue::encodeObjectValue(*concatBuffer), runtime.getHeap());
+        HermesValue::encodeObjectValue(*concatBuffer), runtime.getHeap(), this);
     assert(
         concatBuffer->contents_.size() >= length &&
         "length exceeds size of concatenation buffer");

--- a/include/hermes/VM/sh_segment_info.h
+++ b/include/hermes/VM/sh_segment_info.h
@@ -12,6 +12,9 @@
 /// contain segment-specific information.
 typedef struct SHSegmentInfo {
   unsigned index;
+  /// The storage size for this segment. We practically don't support segment
+  /// with size larger than UINT32_MAX.
+  unsigned segmentSize;
 } SHSegmentInfo;
 
 #endif

--- a/include/hermes/VM/sh_segment_info.h
+++ b/include/hermes/VM/sh_segment_info.h
@@ -15,6 +15,12 @@ typedef struct SHSegmentInfo {
   /// The storage size for this segment. We practically don't support segment
   /// with size larger than UINT32_MAX.
   unsigned segmentSize;
+  /// Pointer that points to the CardStatus array for this segment.
+  /// Erase the actual type AtomicIfConcurrent<CardStatus> here to avoid using
+  /// C++ type and forward declaring nested type.
+  void *cards;
+  /// Pointer that points to the boundary array for this segment.
+  int8_t *boundaries;
 } SHSegmentInfo;
 
 #endif

--- a/lib/VM/ArrayStorage.cpp
+++ b/lib/VM/ArrayStorage.cpp
@@ -185,7 +185,8 @@ ExecutionStatus ArrayStorageBase<HVType>::shift(
           self->data() + fromFirst,
           self->data() + fromFirst + copySize,
           self->data() + toFirst,
-          runtime.getHeap());
+          runtime.getHeap(),
+          self);
     } else if (fromFirst < toFirst) {
       // Copying to the right, need to copy backwards to avoid overwriting what
       // is being copied.
@@ -193,7 +194,8 @@ ExecutionStatus ArrayStorageBase<HVType>::shift(
           self->data() + fromFirst,
           self->data() + fromFirst + copySize,
           self->data() + toFirst + copySize,
-          runtime.getHeap());
+          runtime.getHeap(),
+          self);
     }
 
     // Initialize the elements which were emptied in front.
@@ -201,7 +203,8 @@ ExecutionStatus ArrayStorageBase<HVType>::shift(
         self->data(),
         self->data() + toFirst,
         HVType::encodeEmptyValue(),
-        runtime.getHeap());
+        runtime.getHeap(),
+        self);
 
     // Initialize the elements between the last copied element and toLast.
     if (toFirst + copySize < toLast) {

--- a/lib/VM/ArrayStorage.cpp
+++ b/lib/VM/ArrayStorage.cpp
@@ -103,7 +103,8 @@ ExecutionStatus ArrayStorageBase<HVType>::reallocateToLarger(
   {
     GCHVType *from = self->data() + fromFirst;
     GCHVType *to = newSelf->data() + toFirst;
-    GCHVType::uninitialized_copy(from, from + copySize, to, runtime.getHeap());
+    GCHVType::uninitialized_copy(
+        from, from + copySize, to, runtime.getHeap(), self);
   }
 
   // Initialize the elements before the first copied element.

--- a/lib/VM/GCBase.cpp
+++ b/lib/VM/GCBase.cpp
@@ -979,9 +979,14 @@ GCBASE_BARRIER_2(
     const GCCell *);
 GCBASE_BARRIER_2(writeBarrierRange, const GCHermesValue *, uint32_t);
 GCBASE_BARRIER_2(writeBarrierRange, const GCSmallHermesValue *, uint32_t);
-GCBASE_BARRIER_2(constructorWriteBarrierRange, const GCHermesValue *, uint32_t);
 GCBASE_BARRIER_2(
     constructorWriteBarrierRange,
+    const GCCell *,
+    const GCHermesValue *,
+    uint32_t);
+GCBASE_BARRIER_2(
+    constructorWriteBarrierRange,
+    const GCCell *,
     const GCSmallHermesValue *,
     uint32_t);
 GCBASE_BARRIER_1(snapshotWriteBarrier, const GCHermesValue *);

--- a/lib/VM/Interpreter.cpp
+++ b/lib/VM/Interpreter.cpp
@@ -2077,16 +2077,16 @@ tailCall:
       }
 
       CASE(StoreToEnvironment) {
-        vmcast<Environment>(O1REG(StoreToEnvironment))
-            ->slot(ip->iStoreToEnvironment.op2)
-            .set(O3REG(StoreToEnvironment), runtime.getHeap());
+        auto *environment = vmcast<Environment>(O1REG(StoreToEnvironment));
+        environment->slot(ip->iStoreToEnvironment.op2)
+            .set(O3REG(StoreToEnvironment), runtime.getHeap(), environment);
         ip = NEXTINST(StoreToEnvironment);
         DISPATCH;
       }
       CASE(StoreToEnvironmentL) {
-        vmcast<Environment>(O1REG(StoreToEnvironmentL))
-            ->slot(ip->iStoreToEnvironmentL.op2)
-            .set(O3REG(StoreToEnvironmentL), runtime.getHeap());
+        auto *environment = vmcast<Environment>(O1REG(StoreToEnvironmentL));
+        environment->slot(ip->iStoreToEnvironmentL.op2)
+            .set(O3REG(StoreToEnvironmentL), runtime.getHeap(), environment);
         ip = NEXTINST(StoreToEnvironmentL);
         DISPATCH;
       }

--- a/lib/VM/JSObject.cpp
+++ b/lib/VM/JSObject.cpp
@@ -237,7 +237,8 @@ void JSObject::allocateNewSlotStorage(
   // If it is a direct property, just store the value and we are done.
   if (LLVM_LIKELY(newSlotIndex < DIRECT_PROPERTY_SLOTS)) {
     auto shv = SmallHermesValue::encodeHermesValue(*valueHandle, runtime);
-    selfHandle->directProps()[newSlotIndex].set(shv, runtime.getHeap());
+    selfHandle->directProps()[newSlotIndex].set(
+        shv, runtime.getHeap(), *selfHandle);
     return;
   }
 

--- a/lib/VM/LimitedStorageProvider.cpp
+++ b/lib/VM/LimitedStorageProvider.cpp
@@ -13,20 +13,22 @@
 namespace hermes {
 namespace vm {
 
-llvh::ErrorOr<void *> LimitedStorageProvider::newStorageImpl(const char *name) {
+llvh::ErrorOr<void *> LimitedStorageProvider::newStorageImpl(
+    const char *name,
+    size_t sz) {
   if (limit_ < AlignedHeapSegment::storageSize()) {
     return make_error_code(OOMError::TestVMLimitReached);
   }
-  limit_ -= AlignedHeapSegment::storageSize();
-  return delegate_->newStorage(name);
+  limit_ -= sz;
+  return delegate_->newStorage(name, sz);
 }
 
-void LimitedStorageProvider::deleteStorageImpl(void *storage) {
+void LimitedStorageProvider::deleteStorageImpl(void *storage, size_t sz) {
   if (!storage) {
     return;
   }
-  delegate_->deleteStorage(storage);
-  limit_ += AlignedHeapSegment::storageSize();
+  delegate_->deleteStorage(storage, sz);
+  limit_ += sz;
 }
 
 } // namespace vm

--- a/lib/VM/OrderedHashMap.cpp
+++ b/lib/VM/OrderedHashMap.cpp
@@ -270,7 +270,7 @@ ExecutionStatus OrderedHashMapBase<BucketType, Derived>::insert(
         self->lookupInBucket(runtime, bucket, key.getHermesValue());
     if (entry) {
       // Element for the key already exists, update value and return.
-      entry->value.set(shv, runtime.getHeap());
+      entry->value.set(shv, runtime.getHeap(), entry);
       return ExecutionStatus::RETURNED;
     }
   }
@@ -337,11 +337,11 @@ ExecutionStatus OrderedHashMapBase<BucketType, Derived>::doInsert(
   // call it and set to newMapEntry one at a time.
   auto newMapEntry = runtime.makeHandle(std::move(*crtRes));
   auto k = SmallHermesValue::encodeHermesValue(key.getHermesValue(), runtime);
-  newMapEntry->key.set(k, runtime.getHeap());
+  newMapEntry->key.set(k, runtime.getHeap(), *newMapEntry);
   if constexpr (std::is_same_v<BucketType, HashMapEntry>) {
     auto v =
         SmallHermesValue::encodeHermesValue(value.getHermesValue(), runtime);
-    newMapEntry->value.set(v, runtime.getHeap());
+    newMapEntry->value.set(v, runtime.getHeap(), *newMapEntry);
   }
 
   // After here, no allocation

--- a/lib/VM/SegmentedArray.cpp
+++ b/lib/VM/SegmentedArray.cpp
@@ -265,7 +265,7 @@ void SegmentedArrayBase<HVType>::allocateSegment(
       "Allocating into a non-empty segment");
   PseudoHandle<Segment> c = Segment::create(runtime);
   self->segmentAtPossiblyUnallocated(segment)->set(
-      HVType::encodeObjectValue(c.get(), runtime), runtime.getHeap());
+      HVType::encodeObjectValue(c.get(), runtime), runtime.getHeap(), *self);
 }
 
 template <typename HVType>
@@ -348,13 +348,15 @@ void SegmentedArrayBase<HVType>::growLeftWithinCapacity(
       self->begin(runtime),
       self->end(runtime) - amount,
       self->end(runtime),
-      runtime.getHeap());
+      runtime.getHeap(),
+      self.get());
   // Fill the beginning with empty values.
   GCHVType::fill(
       self->begin(runtime),
       self->begin(runtime) + amount,
       HVType::encodeEmptyValue(),
-      runtime.getHeap());
+      runtime.getHeap(),
+      self.get());
 }
 
 template <typename HVType>

--- a/lib/VM/SegmentedArray.cpp
+++ b/lib/VM/SegmentedArray.cpp
@@ -292,7 +292,8 @@ ExecutionStatus SegmentedArrayBase<HVType>::growRight(
       self->inlineStorage(),
       self->inlineStorage() + numSlotsUsed,
       newSegmentedArray->inlineStorage(),
-      runtime.getHeap());
+      runtime.getHeap(),
+      *self);
   // Set the size of the new array to be the same as the old array's size.
   newSegmentedArray->numSlotsUsed_.store(
       numSlotsUsed, std::memory_order_release);

--- a/lib/VM/StaticH.cpp
+++ b/lib/VM/StaticH.cpp
@@ -519,9 +519,10 @@ extern "C" void _sh_ljs_store_to_env(
     SHLegacyValue env,
     SHLegacyValue val,
     uint32_t index) {
-  vmcast<Environment>(HermesValue::fromRaw(env.raw))
-      ->slot(index)
-      .set(HermesValue::fromRaw(val.raw), getRuntime(shr).getHeap());
+  auto *environment = vmcast<Environment>(HermesValue::fromRaw(env.raw));
+
+  environment->slot(index).set(
+      HermesValue::fromRaw(val.raw), getRuntime(shr).getHeap(), environment);
 }
 
 extern "C" void _sh_ljs_store_np_to_env(

--- a/lib/VM/StorageProvider.cpp
+++ b/lib/VM/StorageProvider.cpp
@@ -7,11 +7,13 @@
 
 #include "hermes/VM/StorageProvider.h"
 
+#include "hermes/ADT/BitArray.h"
 #include "hermes/Support/CheckedMalloc.h"
 #include "hermes/Support/Compiler.h"
 #include "hermes/Support/OSCompat.h"
 #include "hermes/VM/AlignedHeapSegment.h"
 
+#include "llvh/ADT/BitVector.h"
 #include "llvh/ADT/DenseMap.h"
 #include "llvh/Support/ErrorHandling.h"
 #include "llvh/Support/MathExtras.h"
@@ -55,14 +57,18 @@ namespace vm {
 
 namespace {
 
+/// Minimum segment storage size. Any larger segment size should be a multiple
+/// of it.
+static constexpr size_t kSegmentUnitSize =
+    AlignedHeapSegmentBase::kSegmentUnitSize;
+
 bool isAligned(void *p) {
-  return (reinterpret_cast<uintptr_t>(p) &
-          (AlignedHeapSegment::storageSize() - 1)) == 0;
+  return (reinterpret_cast<uintptr_t>(p) & (kSegmentUnitSize - 1)) == 0;
 }
 
 char *alignAlloc(void *p) {
-  return reinterpret_cast<char *>(llvh::alignTo(
-      reinterpret_cast<uintptr_t>(p), AlignedHeapSegment::storageSize()));
+  return reinterpret_cast<char *>(
+      llvh::alignTo(reinterpret_cast<uintptr_t>(p), kSegmentUnitSize));
 }
 
 void *getMmapHint() {
@@ -78,67 +84,104 @@ void *getMmapHint() {
 
 class VMAllocateStorageProvider final : public StorageProvider {
  public:
-  llvh::ErrorOr<void *> newStorageImpl(const char *name) override;
-  void deleteStorageImpl(void *storage) override;
+  llvh::ErrorOr<void *> newStorageImpl(const char *name, size_t sz) override;
+  void deleteStorageImpl(void *storage, size_t sz) override;
 };
 
 class ContiguousVAStorageProvider final : public StorageProvider {
  public:
   ContiguousVAStorageProvider(size_t size)
-      : size_(llvh::alignTo<AlignedHeapSegment::storageSize()>(size)) {
-    auto result = oscompat::vm_reserve_aligned(
-        size_, AlignedHeapSegment::storageSize(), getMmapHint());
+      : size_(llvh::alignTo<kSegmentUnitSize>(size)),
+        statusBits_(size_ / kSegmentUnitSize) {
+    auto result =
+        oscompat::vm_reserve_aligned(size_, kSegmentUnitSize, getMmapHint());
     if (!result)
       hermes_fatal("Contiguous storage allocation failed.", result.getError());
-    level_ = start_ = static_cast<char *>(*result);
+    start_ = static_cast<char *>(*result);
     oscompat::vm_name(start_, size_, kFreeRegionName);
   }
   ~ContiguousVAStorageProvider() override {
     oscompat::vm_release_aligned(start_, size_);
   }
 
-  llvh::ErrorOr<void *> newStorageImpl(const char *name) override {
-    void *storage;
-    if (!freelist_.empty()) {
-      storage = freelist_.back();
-      freelist_.pop_back();
-    } else if (level_ < start_ + size_) {
-      storage =
-          std::exchange(level_, level_ + AlignedHeapSegment::storageSize());
-    } else {
+ private:
+  llvh::ErrorOr<void *> newStorageImpl(const char *name, size_t sz) override {
+    // No available space to use.
+    if (LLVM_UNLIKELY(firstFreeBit_ == -1)) {
       return make_error_code(OOMError::MaxStorageReached);
     }
-    auto res = oscompat::vm_commit(storage, AlignedHeapSegment::storageSize());
+
+    assert(
+        statusBits_.find_first_unset() == firstFreeBit_ &&
+        "firstFreeBit_ should always be the first unset bit");
+
+    void *storage;
+    int numUnits = sz / kSegmentUnitSize;
+    int nextUsedBit = statusBits_.find_next(firstFreeBit_);
+    int curFreeBit = firstFreeBit_;
+    // Search for a large enough continuous bit range.
+    while (nextUsedBit != -1 && (nextUsedBit - curFreeBit < numUnits)) {
+      curFreeBit = statusBits_.find_next_unset(nextUsedBit);
+      if (curFreeBit == -1) {
+        return make_error_code(OOMError::MaxStorageReached);
+      }
+      nextUsedBit = statusBits_.find_next(curFreeBit);
+    }
+    // nextUsedBit could be -1, so check if there is enough space left.
+    if (nextUsedBit == -1 && curFreeBit + numUnits > (int)statusBits_.size()) {
+      return make_error_code(OOMError::MaxStorageReached);
+    }
+
+    storage = start_ + curFreeBit * kSegmentUnitSize;
+    statusBits_.set(curFreeBit, curFreeBit + numUnits);
+    // Reset it to the new leftmost free bit.
+    firstFreeBit_ = statusBits_.find_first_unset();
+
+    auto res = oscompat::vm_commit(storage, sz);
     if (res) {
-      oscompat::vm_name(storage, AlignedHeapSegment::storageSize(), name);
+      oscompat::vm_name(storage, sz, name);
     }
     return res;
   }
 
-  void deleteStorageImpl(void *storage) override {
+  void deleteStorageImpl(void *storage, size_t sz) override {
     assert(
-        !llvh::alignmentAdjustment(
-            storage, AlignedHeapSegment::storageSize()) &&
+        !llvh::alignmentAdjustment(storage, kSegmentUnitSize) &&
         "Storage not aligned");
-    assert(storage >= start_ && storage < level_ && "Storage not in region");
-    oscompat::vm_name(
-        storage, AlignedHeapSegment::storageSize(), kFreeRegionName);
-    oscompat::vm_uncommit(storage, AlignedHeapSegment::storageSize());
-    freelist_.push_back(storage);
+    assert(
+        storage >= start_ && storage < start_ + size_ &&
+        "Storage not in region");
+    size_t numUnits = sz / kSegmentUnitSize;
+    oscompat::vm_name(storage, sz, kFreeRegionName);
+    oscompat::vm_uncommit(storage, sz);
+    // Reset all bits for this storage.
+    int startIndex = (static_cast<char *>(storage) - start_) / kSegmentUnitSize;
+    statusBits_.reset(startIndex, startIndex + numUnits);
+    if (startIndex < firstFreeBit_)
+      firstFreeBit_ = startIndex;
   }
 
  private:
   static constexpr const char *kFreeRegionName = "hermes-free-heap";
   size_t size_;
   char *start_;
-  char *level_;
-  llvh::SmallVector<void *, 0> freelist_;
+  /// First free bit in \c statusBits_. We always make new allocation from the
+  /// leftmost free bit, based on heuristics:
+  /// 1. Usually the reserved address space is not full.
+  /// 2. Storage with size kSegmentUnitSize is allocated and deleted more
+  /// frequently than larger storage.
+  /// 3. Likely small storage will find space available from leftmost free bit,
+  /// leaving enough space at the right side for large storage.
+  int firstFreeBit_{0};
+  /// One bit for each kSegmentUnitSize space in the entire reserved virtual
+  /// address space. A bit is set if the corresponding space is used.
+  llvh::BitVector statusBits_;
 };
 
 class MallocStorageProvider final : public StorageProvider {
  public:
-  llvh::ErrorOr<void *> newStorageImpl(const char *name) override;
-  void deleteStorageImpl(void *storage) override;
+  llvh::ErrorOr<void *> newStorageImpl(const char *name, size_t sz) override;
+  void deleteStorageImpl(void *storage, size_t sz) override;
 
  private:
   /// Map aligned starts to actual starts for freeing.
@@ -148,13 +191,12 @@ class MallocStorageProvider final : public StorageProvider {
 };
 
 llvh::ErrorOr<void *> VMAllocateStorageProvider::newStorageImpl(
-    const char *name) {
-  assert(AlignedHeapSegment::storageSize() % oscompat::page_size() == 0);
+    const char *name,
+    size_t sz) {
+  assert(kSegmentUnitSize % oscompat::page_size() == 0);
   // Allocate the space, hoping it will be the correct alignment.
-  auto result = oscompat::vm_allocate_aligned(
-      AlignedHeapSegment::storageSize(),
-      AlignedHeapSegment::storageSize(),
-      getMmapHint());
+  auto result =
+      oscompat::vm_allocate_aligned(sz, kSegmentUnitSize, getMmapHint());
   if (!result) {
     return result;
   }
@@ -162,32 +204,36 @@ llvh::ErrorOr<void *> VMAllocateStorageProvider::newStorageImpl(
   assert(isAligned(mem));
   (void)&isAligned;
 #ifdef HERMESVM_ALLOW_HUGE_PAGES
-  oscompat::vm_hugepage(mem, AlignedHeapSegment::storageSize());
+  oscompat::vm_hugepage(mem, sz);
 #endif
 
   // Name the memory region on platforms that support naming.
-  oscompat::vm_name(mem, AlignedHeapSegment::storageSize(), name);
+  oscompat::vm_name(mem, sz, name);
   return mem;
 }
 
-void VMAllocateStorageProvider::deleteStorageImpl(void *storage) {
+void VMAllocateStorageProvider::deleteStorageImpl(void *storage, size_t sz) {
   if (!storage) {
     return;
   }
-  oscompat::vm_free_aligned(storage, AlignedHeapSegment::storageSize());
+  oscompat::vm_free_aligned(storage, sz);
 }
 
-llvh::ErrorOr<void *> MallocStorageProvider::newStorageImpl(const char *name) {
+llvh::ErrorOr<void *> MallocStorageProvider::newStorageImpl(
+    const char *name,
+    size_t sz) {
   // name is unused, can't name malloc memory.
   (void)name;
-  void *mem = checkedMalloc2(AlignedHeapSegment::storageSize(), 2u);
+  void *mem = checkedMalloc2(2u, sz);
   void *lowLim = alignAlloc(mem);
   assert(isAligned(lowLim) && "New storage should be aligned");
   lowLimToAllocHandle_[lowLim] = mem;
   return lowLim;
 }
 
-void MallocStorageProvider::deleteStorageImpl(void *storage) {
+void MallocStorageProvider::deleteStorageImpl(void *storage, size_t sz) {
+  // free() does not need the memory size.
+  (void)sz;
   if (!storage) {
     return;
   }
@@ -217,8 +263,11 @@ std::unique_ptr<StorageProvider> StorageProvider::mallocProvider() {
   return std::unique_ptr<StorageProvider>(new MallocStorageProvider);
 }
 
-llvh::ErrorOr<void *> StorageProvider::newStorage(const char *name) {
-  auto res = newStorageImpl(name);
+llvh::ErrorOr<void *> StorageProvider::newStorage(const char *name, size_t sz) {
+  assert(
+      sz && (sz % kSegmentUnitSize == 0) &&
+      "Allocated storage size must be multiples of kSegmentUnitSize");
+  auto res = newStorageImpl(name, sz);
 
   if (res) {
     numSucceededAllocs_++;
@@ -229,13 +278,13 @@ llvh::ErrorOr<void *> StorageProvider::newStorage(const char *name) {
   return res;
 }
 
-void StorageProvider::deleteStorage(void *storage) {
+void StorageProvider::deleteStorage(void *storage, size_t sz) {
   if (!storage) {
     return;
   }
 
   numDeletedAllocs_++;
-  deleteStorageImpl(storage);
+  return deleteStorageImpl(storage, sz);
 }
 
 llvh::ErrorOr<std::pair<void *, size_t>>

--- a/lib/VM/gcs/AlignedHeapSegment.cpp
+++ b/lib/VM/gcs/AlignedHeapSegment.cpp
@@ -52,7 +52,7 @@ llvh::ErrorOr<AlignedHeapSegment> AlignedHeapSegment::create(
 llvh::ErrorOr<AlignedHeapSegment> AlignedHeapSegment::create(
     StorageProvider *provider,
     const char *name) {
-  auto result = provider->newStorage(name);
+  auto result = provider->newStorage(name, storageSize());
   if (!result) {
     return result.getError();
   }
@@ -103,7 +103,7 @@ AlignedHeapSegment::~AlignedHeapSegment() {
   __asan_unpoison_memory_region(start(), end() - start());
 
   if (provider_) {
-    provider_->deleteStorage(lowLim_);
+    provider_->deleteStorage(lowLim_, storageSize());
   }
 }
 

--- a/lib/VM/gcs/AlignedHeapSegment.cpp
+++ b/lib/VM/gcs/AlignedHeapSegment.cpp
@@ -61,7 +61,7 @@ llvh::ErrorOr<AlignedHeapSegment> AlignedHeapSegment::create(
 }
 
 AlignedHeapSegment::AlignedHeapSegment(StorageProvider *provider, void *lowLim)
-    : AlignedHeapSegmentBase(lowLim), provider_(provider) {
+    : AlignedHeapSegmentBase(lowLim, kSize), provider_(provider) {
   assert(
       storageStart(lowLim_) == lowLim_ &&
       "The lower limit of this storage must be aligned");

--- a/lib/VM/gcs/CardTableNC.cpp
+++ b/lib/VM/gcs/CardTableNC.cpp
@@ -20,12 +20,6 @@
 namespace hermes {
 namespace vm {
 
-#ifndef NDEBUG
-/* static */ void *CardTable::storageEnd(const void *ptr) {
-  return AlignedHeapSegment::storageEnd(ptr);
-}
-#endif
-
 void CardTable::dirtyCardsForAddressRange(const void *low, const void *high) {
   // If high is in the middle of some card, ensure that we dirty that card.
   high = reinterpret_cast<const char *>(high) + kCardSize - 1;
@@ -44,19 +38,19 @@ OptValue<size_t> CardTable::findNextCardWithStatus(
 }
 
 void CardTable::clear() {
-  cleanRange(kFirstUsedIndex, kValidIndices);
+  cleanRange(kFirstUsedIndex, getEndIndex());
 }
 
 void CardTable::updateAfterCompaction(const void *newLevel) {
   const char *newLevelPtr = static_cast<const char *>(newLevel);
   size_t firstCleanCardIndex = addressToIndex(newLevelPtr + kCardSize - 1);
   assert(
-      firstCleanCardIndex <= kValidIndices &&
+      firstCleanCardIndex <= getEndIndex() &&
       firstCleanCardIndex >= kFirstUsedIndex && "Invalid index.");
   // Dirty the occupied cards (below the level), and clean the cards above the
   // level.
   dirtyRange(kFirstUsedIndex, firstCleanCardIndex);
-  cleanRange(firstCleanCardIndex, kValidIndices);
+  cleanRange(firstCleanCardIndex, getEndIndex());
 }
 
 void CardTable::cleanRange(size_t from, size_t to) {
@@ -147,12 +141,12 @@ protectBoundaryTableWork(void *table, size_t sz, oscompat::ProtectMode mode) {
 
 void CardTable::protectBoundaryTable() {
   protectBoundaryTableWork(
-      &boundaries_[0], kValidIndices, oscompat::ProtectMode::None);
+      &boundaries_[0], getEndIndex(), oscompat::ProtectMode::None);
 }
 
 void CardTable::unprotectBoundaryTable() {
   protectBoundaryTableWork(
-      &boundaries_[0], kValidIndices, oscompat::ProtectMode::ReadWrite);
+      &boundaries_[0], getEndIndex(), oscompat::ProtectMode::ReadWrite);
 }
 #endif // HERMES_EXTRA_DEBUG
 
@@ -160,7 +154,7 @@ void CardTable::unprotectBoundaryTable() {
 void CardTable::verifyBoundaries(char *start, char *level) const {
   // Start should be card-aligned.
   assert(isCardAligned(start));
-  for (unsigned index = addressToIndex(start); index < kValidIndices; index++) {
+  for (unsigned index = addressToIndex(start); index < getEndIndex(); index++) {
     const char *boundary = indexToAddress(index);
     if (level <= boundary) {
       break;

--- a/unittests/VMRuntime/AlignedHeapSegmentTest.cpp
+++ b/unittests/VMRuntime/AlignedHeapSegmentTest.cpp
@@ -115,7 +115,8 @@ TEST_F(AlignedHeapSegmentTest, AdviseUnused) {
 
   // We can't use the storage of s here since it contains guard pages and also
   // s.start() may not align to actual page boundary.
-  void *storage = provider_->newStorage().get();
+  void *storage =
+      provider_->newStorage(AlignedHeapSegment::storageSize()).get();
   char *start = reinterpret_cast<char *>(storage);
   char *end = start + AlignedHeapSegment::storageSize();
 
@@ -139,7 +140,7 @@ TEST_F(AlignedHeapSegmentTest, AdviseUnused) {
   EXPECT_EQ(*initial + TOTAL_PAGES, *touched);
   EXPECT_EQ(*touched - FREED_PAGES, *marked);
 
-  provider_->deleteStorage(storage);
+  provider_->deleteStorage(storage, AlignedHeapSegment::storageSize());
 #endif
 }
 

--- a/unittests/VMRuntime/CardTableNCTest.cpp
+++ b/unittests/VMRuntime/CardTableNCTest.cpp
@@ -58,9 +58,10 @@ void CardTableNCTest::dirtyRangeTest(
 
 CardTableNCTest::CardTableNCTest() {
   // For purposes of this test, we'll assume the first writeable byte of
-  // the segment comes just after the card table (which is at the
-  // start of the segment).
-  auto first = seg.lowLim() + sizeof(CardTable);
+  // the segment comes just after the memory region that can be mapped by
+  // kFirstUsedIndex bytes.
+  auto first = seg.lowLim() +
+      CardTable::kFirstUsedIndex * CardTable::kHeapBytesPerCardByte;
   auto last = reinterpret_cast<char *>(llvh::alignDown(
       reinterpret_cast<uintptr_t>(seg.hiLim() - 1), CardTable::kCardSize));
 

--- a/unittests/VMRuntime/MarkBitArrayNCTest.cpp
+++ b/unittests/VMRuntime/MarkBitArrayNCTest.cpp
@@ -27,6 +27,13 @@ namespace {
 struct MarkBitArrayTest : public ::testing::Test {
   MarkBitArrayTest();
 
+  static size_t addressToMarkBitArrayIndex(const void *addr) {
+    auto *cp = reinterpret_cast<const char *>(addr);
+    auto *base =
+        reinterpret_cast<const char *>(AlignedHeapSegment::storageStart(addr));
+    return (cp - base) >> LogHeapAlign;
+  }
+
  protected:
   std::unique_ptr<StorageProvider> provider;
   AlignedHeapSegment seg;
@@ -66,7 +73,7 @@ TEST_F(MarkBitArrayTest, AddressToIndex) {
     char *addr = addrs.at(i);
     size_t ind = indices.at(i);
 
-    EXPECT_EQ(ind, AlignedHeapSegment::addressToMarkBitArrayIndex(addr))
+    EXPECT_EQ(ind, addressToMarkBitArrayIndex(addr))
         << "0x" << std::hex << (void *)addr << " -> " << ind;
     char *toAddr = seg.lowLim() + (ind << LogHeapAlign);
     EXPECT_EQ(toAddr, addr)
@@ -78,7 +85,7 @@ TEST_F(MarkBitArrayTest, MarkGet) {
   const size_t lastIx = mba.size() - 1;
 
   for (char *addr : addrs) {
-    size_t ind = AlignedHeapSegment::addressToMarkBitArrayIndex(addr);
+    size_t ind = addressToMarkBitArrayIndex(addr);
 
     EXPECT_FALSE(ind > 0 && mba.at(ind - 1)) << "initial " << ind << " - 1";
     EXPECT_FALSE(mba.at(ind)) << "initial " << ind;
@@ -97,37 +104,37 @@ TEST_F(MarkBitArrayTest, MarkGet) {
 
 TEST_F(MarkBitArrayTest, Initial) {
   for (char *addr : addrs) {
-    size_t ind = AlignedHeapSegment::addressToMarkBitArrayIndex(addr);
+    size_t ind = addressToMarkBitArrayIndex(addr);
     EXPECT_FALSE(mba.at(ind));
   }
 }
 
 TEST_F(MarkBitArrayTest, Clear) {
   for (char *addr : addrs) {
-    size_t ind = AlignedHeapSegment::addressToMarkBitArrayIndex(addr);
+    size_t ind = addressToMarkBitArrayIndex(addr);
     ASSERT_FALSE(mba.at(ind));
   }
 
   for (char *addr : addrs) {
-    size_t ind = AlignedHeapSegment::addressToMarkBitArrayIndex(addr);
+    size_t ind = addressToMarkBitArrayIndex(addr);
     mba.set(ind, true);
   }
 
   for (char *addr : addrs) {
-    size_t ind = AlignedHeapSegment::addressToMarkBitArrayIndex(addr);
+    size_t ind = addressToMarkBitArrayIndex(addr);
     ASSERT_TRUE(mba.at(ind));
   }
 
   mba.reset();
   for (char *addr : addrs) {
-    size_t ind = AlignedHeapSegment::addressToMarkBitArrayIndex(addr);
+    size_t ind = addressToMarkBitArrayIndex(addr);
     EXPECT_FALSE(mba.at(ind));
   }
 }
 
 TEST_F(MarkBitArrayTest, NextMarkedBitImmediate) {
   char *addr = addrs.at(addrs.size() / 2);
-  size_t ind = AlignedHeapSegment::addressToMarkBitArrayIndex(addr);
+  size_t ind = addressToMarkBitArrayIndex(addr);
 
   mba.set(ind, true);
   EXPECT_EQ(ind, mba.findNextSetBitFrom(ind));
@@ -140,7 +147,7 @@ TEST_F(MarkBitArrayTest, NextMarkedBit) {
   EXPECT_EQ(FOUND_NONE, mba.findNextSetBitFrom(0));
   std::queue<size_t> indices;
   for (char *addr : addrs) {
-    auto ind = AlignedHeapSegment::addressToMarkBitArrayIndex(addr);
+    auto ind = addressToMarkBitArrayIndex(addr);
     mba.set(ind, true);
     indices.push(ind);
   }
@@ -154,7 +161,7 @@ TEST_F(MarkBitArrayTest, NextMarkedBit) {
 
 TEST_F(MarkBitArrayTest, NextUnmarkedBitImmediate) {
   char *addr = addrs.at(addrs.size() / 2);
-  size_t ind = AlignedHeapSegment::addressToMarkBitArrayIndex(addr);
+  size_t ind = addressToMarkBitArrayIndex(addr);
   mba.set();
   mba.set(ind, false);
   EXPECT_EQ(ind, mba.findNextZeroBitFrom(ind));
@@ -167,7 +174,7 @@ TEST_F(MarkBitArrayTest, NextUnmarkedBit) {
   EXPECT_EQ(FOUND_NONE, mba.findNextZeroBitFrom(0));
   std::queue<size_t> indices;
   for (char *addr : addrs) {
-    auto ind = AlignedHeapSegment::addressToMarkBitArrayIndex(addr);
+    auto ind = addressToMarkBitArrayIndex(addr);
     mba.set(ind, false);
     indices.push(ind);
   }
@@ -182,7 +189,7 @@ TEST_F(MarkBitArrayTest, NextUnmarkedBit) {
 
 TEST_F(MarkBitArrayTest, PrevMarkedBitImmediate) {
   char *addr = addrs.at(addrs.size() / 2);
-  size_t ind = AlignedHeapSegment::addressToMarkBitArrayIndex(addr);
+  size_t ind = addressToMarkBitArrayIndex(addr);
   mba.set(ind, true);
   EXPECT_EQ(ind, mba.findPrevSetBitFrom(ind + 1));
 }
@@ -196,7 +203,7 @@ TEST_F(MarkBitArrayTest, PrevMarkedBit) {
   std::queue<size_t> indices;
   size_t addrIdx = addrs.size();
   while (addrIdx-- > 0) {
-    auto ind = AlignedHeapSegment::addressToMarkBitArrayIndex(addrs[addrIdx]);
+    auto ind = addressToMarkBitArrayIndex(addrs[addrIdx]);
     mba.set(ind, true);
     indices.push(ind);
   }
@@ -209,7 +216,7 @@ TEST_F(MarkBitArrayTest, PrevMarkedBit) {
 
 TEST_F(MarkBitArrayTest, PrevUnmarkedBitImmediate) {
   char *addr = addrs.at(addrs.size() / 2);
-  size_t ind = AlignedHeapSegment::addressToMarkBitArrayIndex(addr);
+  size_t ind = addressToMarkBitArrayIndex(addr);
   mba.set();
   mba.set(ind, false);
   EXPECT_EQ(ind, mba.findPrevZeroBitFrom(ind + 1));
@@ -225,7 +232,7 @@ TEST_F(MarkBitArrayTest, PrevUnmarkedBit) {
   std::queue<size_t> indices;
   size_t addrIdx = addrs.size();
   while (addrIdx-- > 0) {
-    auto ind = AlignedHeapSegment::addressToMarkBitArrayIndex(addrs[addrIdx]);
+    auto ind = addressToMarkBitArrayIndex(addrs[addrIdx]);
     mba.set(ind, false);
     indices.push(ind);
   }

--- a/unittests/VMRuntime/StorageProviderTest.cpp
+++ b/unittests/VMRuntime/StorageProviderTest.cpp
@@ -12,8 +12,6 @@
 #include "hermes/VM/AlignedHeapSegment.h"
 #include "hermes/VM/LimitedStorageProvider.h"
 
-#include "llvh/ADT/STLExtras.h"
-
 using namespace hermes;
 using namespace hermes::vm;
 
@@ -24,8 +22,8 @@ struct NullStorageProvider : public StorageProvider {
   static std::unique_ptr<NullStorageProvider> create();
 
  protected:
-  llvh::ErrorOr<void *> newStorageImpl(const char *) override;
-  void deleteStorageImpl(void *) override;
+  llvh::ErrorOr<void *> newStorageImpl(const char *, size_t sz) override;
+  void deleteStorageImpl(void *, size_t sz) override;
 };
 
 /* static */
@@ -33,7 +31,9 @@ std::unique_ptr<NullStorageProvider> NullStorageProvider::create() {
   return std::make_unique<NullStorageProvider>();
 }
 
-llvh::ErrorOr<void *> NullStorageProvider::newStorageImpl(const char *) {
+llvh::ErrorOr<void *> NullStorageProvider::newStorageImpl(
+    const char *,
+    size_t sz) {
   // Doesn't matter what code is returned here.
   return make_error_code(OOMError::TestVMLimitReached);
 }
@@ -43,33 +43,43 @@ enum StorageProviderType {
   ContiguousVAProvider,
 };
 
+struct StorageProviderParam {
+  StorageProviderType providerType;
+  size_t storageSize;
+  size_t vaSize;
+};
+
 static std::unique_ptr<StorageProvider> GetStorageProvider(
-    StorageProviderType type) {
+    StorageProviderType type,
+    size_t vaSize) {
   switch (type) {
     case MmapProvider:
       return StorageProvider::mmapProvider();
     case ContiguousVAProvider:
-      return StorageProvider::contiguousVAProvider(
-          AlignedHeapSegment::storageSize());
+      return StorageProvider::contiguousVAProvider(vaSize);
     default:
       return nullptr;
   }
 }
 
 class StorageProviderTest
-    : public ::testing::TestWithParam<StorageProviderType> {};
+    : public ::testing::TestWithParam<StorageProviderParam> {};
 
-void NullStorageProvider::deleteStorageImpl(void *) {}
+void NullStorageProvider::deleteStorageImpl(void *, size_t sz) {}
+
+/// Minimum segment storage size.
+static constexpr size_t SIZE = AlignedHeapSegment::storageSize();
 
 TEST_P(StorageProviderTest, StorageProviderSucceededAllocsLogCount) {
-  auto provider{GetStorageProvider(GetParam())};
+  auto &params = GetParam();
+  auto provider{GetStorageProvider(params.providerType, params.vaSize)};
 
   ASSERT_EQ(0, provider->numSucceededAllocs());
   ASSERT_EQ(0, provider->numFailedAllocs());
   ASSERT_EQ(0, provider->numDeletedAllocs());
   ASSERT_EQ(0, provider->numLiveAllocs());
 
-  auto result = provider->newStorage("Test");
+  auto result = provider->newStorage("Test", params.storageSize);
   ASSERT_TRUE(result);
   void *s = result.get();
 
@@ -78,7 +88,7 @@ TEST_P(StorageProviderTest, StorageProviderSucceededAllocsLogCount) {
   EXPECT_EQ(0, provider->numDeletedAllocs());
   EXPECT_EQ(1, provider->numLiveAllocs());
 
-  provider->deleteStorage(s);
+  provider->deleteStorage(s, params.storageSize);
 
   EXPECT_EQ(1, provider->numSucceededAllocs());
   EXPECT_EQ(0, provider->numFailedAllocs());
@@ -94,7 +104,7 @@ TEST(StorageProviderTest, StorageProviderFailedAllocsLogCount) {
   ASSERT_EQ(0, provider->numDeletedAllocs());
   ASSERT_EQ(0, provider->numLiveAllocs());
 
-  auto result = provider->newStorage("Test");
+  auto result = provider->newStorage("Test", SIZE);
   ASSERT_FALSE(result);
 
   EXPECT_EQ(0, provider->numSucceededAllocs());
@@ -107,20 +117,20 @@ TEST(StorageProviderTest, LimitedStorageProviderEnforce) {
   constexpr size_t LIM = 2;
   LimitedStorageProvider provider{
       StorageProvider::mmapProvider(),
-      AlignedHeapSegment::storageSize() * LIM,
+      SIZE * LIM,
   };
   void *live[LIM];
   for (size_t i = 0; i < LIM; ++i) {
-    auto result = provider.newStorage("Live");
+    auto result = provider.newStorage("Live", SIZE);
     ASSERT_TRUE(result);
     live[i] = result.get();
   }
 
-  EXPECT_FALSE(provider.newStorage("Dead"));
+  EXPECT_FALSE(provider.newStorage("Dead", SIZE));
 
   // Clean-up
   for (auto s : live) {
-    provider.deleteStorage(s);
+    provider.deleteStorage(s, SIZE);
   }
 }
 
@@ -128,16 +138,16 @@ TEST(StorageProviderTest, LimitedStorageProviderTrackDelete) {
   constexpr size_t LIM = 2;
   LimitedStorageProvider provider{
       StorageProvider::mmapProvider(),
-      AlignedHeapSegment::storageSize() * LIM,
+      SIZE * LIM,
   };
 
   // If the storage gets deleted, we should be able to re-allocate it, even if
   // the total number of allocations exceeds the limit.
   for (size_t i = 0; i < LIM + 1; ++i) {
-    auto result = provider.newStorage("Live");
+    auto result = provider.newStorage("Live", SIZE);
     ASSERT_TRUE(result);
     auto *s = result.get();
-    provider.deleteStorage(s);
+    provider.deleteStorage(s, SIZE);
   }
 }
 
@@ -145,13 +155,13 @@ TEST(StorageProviderTest, LimitedStorageProviderDeleteNull) {
   constexpr size_t LIM = 2;
   LimitedStorageProvider provider{
       StorageProvider::mmapProvider(),
-      AlignedHeapSegment::storageSize() * LIM,
+      SIZE * LIM,
   };
 
   void *live[LIM];
 
   for (size_t i = 0; i < LIM; ++i) {
-    auto result = provider.newStorage("Live");
+    auto result = provider.newStorage("Live", SIZE);
     ASSERT_TRUE(result);
     live[i] = result.get();
   }
@@ -159,27 +169,25 @@ TEST(StorageProviderTest, LimitedStorageProviderDeleteNull) {
   // The allocations should fail because we have hit the limit, and the
   // deletions should not affect the limit, because they are of null storages.
   for (size_t i = 0; i < 2; ++i) {
-    auto result = provider.newStorage("Live");
+    auto result = provider.newStorage("Live", SIZE);
     EXPECT_FALSE(result);
   }
 
   // Clean-up
   for (auto s : live) {
-    provider.deleteStorage(s);
+    provider.deleteStorage(s, SIZE);
   }
 }
 
 TEST(StorageProviderTest, StorageProviderAllocsCount) {
   constexpr size_t LIM = 2;
-  auto provider =
-      std::unique_ptr<LimitedStorageProvider>{new LimitedStorageProvider{
-          StorageProvider::mmapProvider(),
-          AlignedHeapSegment::storageSize() * LIM}};
+  auto provider = std::unique_ptr<LimitedStorageProvider>{
+      new LimitedStorageProvider{StorageProvider::mmapProvider(), SIZE * LIM}};
 
   constexpr size_t FAILS = 3;
   void *storages[LIM];
   for (size_t i = 0; i < LIM; ++i) {
-    auto result = provider->newStorage();
+    auto result = provider->newStorage(SIZE);
     ASSERT_TRUE(result);
     storages[i] = result.get();
   }
@@ -188,7 +196,7 @@ TEST(StorageProviderTest, StorageProviderAllocsCount) {
   EXPECT_EQ(LIM, provider->numLiveAllocs());
 
   for (size_t i = 0; i < FAILS; ++i) {
-    auto result = provider->newStorage();
+    auto result = provider->newStorage(SIZE);
     ASSERT_FALSE(result);
   }
 
@@ -196,21 +204,63 @@ TEST(StorageProviderTest, StorageProviderAllocsCount) {
 
   // Clean-up
   for (auto s : storages) {
-    provider->deleteStorage(s);
+    provider->deleteStorage(s, SIZE);
   }
 
   EXPECT_EQ(0, provider->numLiveAllocs());
   EXPECT_EQ(LIM, provider->numDeletedAllocs());
 }
 
+TEST(StorageProviderTest, ContinuousProviderTest) {
+  auto provider =
+      GetStorageProvider(StorageProviderType::ContiguousVAProvider, SIZE * 10);
+
+  size_t sz1 = SIZE * 5;
+  auto result = provider->newStorage(sz1);
+  ASSERT_TRUE(result);
+  auto *s1 = *result;
+
+  size_t sz2 = SIZE * 3;
+  result = provider->newStorage(sz2);
+  ASSERT_TRUE(result);
+  auto *s2 = *result;
+
+  size_t sz3 = SIZE * 3;
+  result = provider->newStorage(sz3);
+  ASSERT_FALSE(result);
+
+  provider->deleteStorage(s1, sz1);
+
+  result = provider->newStorage(sz3);
+  ASSERT_TRUE(result);
+  auto *s3 = *result;
+
+  size_t sz4 = SIZE * 2;
+  result = provider->newStorage(sz4);
+  ASSERT_TRUE(result);
+  auto *s4 = *result;
+
+  result = provider->newStorage(sz4);
+  ASSERT_TRUE(result);
+  auto *s5 = *result;
+
+  provider->deleteStorage(s2, sz2);
+  provider->deleteStorage(s3, sz3);
+  provider->deleteStorage(s4, sz4);
+  provider->deleteStorage(s5, sz4);
+}
+
 /// StorageGuard will free storage on scope exit.
 class StorageGuard final {
  public:
-  StorageGuard(std::shared_ptr<StorageProvider> provider, void *storage)
-      : provider_(std::move(provider)), storage_(storage) {}
+  StorageGuard(
+      std::shared_ptr<StorageProvider> provider,
+      void *storage,
+      size_t sz)
+      : provider_(std::move(provider)), storage_(storage), sz_(sz) {}
 
   ~StorageGuard() {
-    provider_->deleteStorage(storage_);
+    provider_->deleteStorage(storage_, sz_);
   }
 
   void *raw() const {
@@ -220,6 +270,7 @@ class StorageGuard final {
  private:
   std::shared_ptr<StorageProvider> provider_;
   void *storage_;
+  size_t sz_;
 };
 
 #ifndef NDEBUG
@@ -235,8 +286,8 @@ class SetVALimit final {
   }
 };
 
-static const size_t KB = 1 << 10;
-static const size_t MB = KB * KB;
+static constexpr size_t KB = 1 << 10;
+static constexpr size_t MB = KB * KB;
 
 TEST(StorageProviderTest, SucceedsWithoutReducing) {
   // Should succeed without reducing the size at all.
@@ -261,16 +312,13 @@ TEST(StorageProviderTest, SucceedsAfterReducing) {
   }
   {
     // Test using the aligned storage alignment
-    SetVALimit limit{50 * AlignedHeapSegment::storageSize()};
-    auto result = vmAllocateAllowLess(
-        100 * AlignedHeapSegment::storageSize(),
-        30 * AlignedHeapSegment::storageSize(),
-        AlignedHeapSegment::storageSize());
+    SetVALimit limit{50 * SIZE};
+    auto result = vmAllocateAllowLess(100 * SIZE, 30 * SIZE, SIZE);
     ASSERT_TRUE(result);
     auto memAndSize = result.get();
     EXPECT_TRUE(memAndSize.first != nullptr);
-    EXPECT_GE(memAndSize.second, 30 * AlignedHeapSegment::storageSize());
-    EXPECT_LE(memAndSize.second, 50 * AlignedHeapSegment::storageSize());
+    EXPECT_GE(memAndSize.second, 30 * SIZE);
+    EXPECT_LE(memAndSize.second, 50 * SIZE);
   }
 }
 
@@ -282,11 +330,14 @@ TEST(StorageProviderTest, FailsDueToLimitLowerThanMin) {
 }
 
 TEST_P(StorageProviderTest, VirtualMemoryFreed) {
-  SetVALimit limit{10 * MB};
+  SetVALimit limit{25 * MB};
 
+  auto &params = GetParam();
   for (size_t i = 0; i < 20; i++) {
-    std::shared_ptr<StorageProvider> sp = GetStorageProvider(GetParam());
-    StorageGuard sg{sp, *sp->newStorage()};
+    std::shared_ptr<StorageProvider> sp =
+        GetStorageProvider(params.providerType, params.vaSize);
+    StorageGuard sg{
+        sp, *sp->newStorage(params.storageSize), params.storageSize};
   }
 }
 
@@ -295,6 +346,17 @@ TEST_P(StorageProviderTest, VirtualMemoryFreed) {
 INSTANTIATE_TEST_CASE_P(
     StorageProviderTests,
     StorageProviderTest,
-    ::testing::Values(MmapProvider, ContiguousVAProvider));
+    ::testing::Values(
+        StorageProviderParam{
+            MmapProvider,
+            SIZE,
+            0,
+        },
+        StorageProviderParam{
+            ContiguousVAProvider,
+            SIZE,
+            SIZE,
+        },
+        StorageProviderParam{ContiguousVAProvider, SIZE * 5, SIZE * 5}));
 
 } // namespace


### PR DESCRIPTION
Summary:
Add this parameter so that it could be passed to write barrier function
in following diffs. For not it's unused.

We don't create a overload or make a default parameter value because
it's error prone: new code may call wrong functions (unless reasoning
whether the object lives in normal segment or large segment), or forget
to update existing calls. It's actually easier to just always pass in
the owning object pointer, which in most cases is obvious to get.

Differential Revision: D62196480
