### PR TITLE
typed: exact object properties were stored twice

### DIFF
--- a/lib/IRGen/ESTreeIRGen-expr.cpp
+++ b/lib/IRGen/ESTreeIRGen-expr.cpp
@@ -1032,6 +1032,7 @@ void ESTreeIRGen::emitMemberStore(
           *optIndex,
           Builder.getLiteralString(propName),
           flowTypeToIRType(field.type).isNonPtr());
+      return;
     }
   }
 


### PR DESCRIPTION
Summary: There was a missing `return` in IRGen.

Reviewed By: avp

Differential Revision: D62676445
