### PR TITLE
RFC[SH]: implement double to int32 truncation without UB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,6 +303,9 @@ set(HERMESVM_INTERNAL_JAVASCRIPT_NATIVE OFF CACHE BOOL
 # 2: JIT is enabled
 set(HERMESVM_ALLOW_JIT 0 CACHE STRING "JIT mode: 0 (off), 1 (auto) or 2 (force on)")
 
+set(HERMES_FP_TRUNC_ENABLE_UNSUPPORTED 0 CACHE STRING
+  "Enable fp_trunc on unsupported platforms: 0 (off), 1 (slow), or 2 (fast with UB)")
+
 # This definition is used by source that must be kept identical between Hermes and
 # Static Hermes, but needs to behave differently in each case.
 add_definitions(-DSTATIC_HERMES)
@@ -529,6 +532,10 @@ endif()
 
 if (HERMESVM_ALLOW_JIT)
   add_definitions(-DHERMESVM_ALLOW_JIT=${HERMESVM_ALLOW_JIT})
+endif ()
+
+if (HERMES_FP_TRUNC_ENABLE_UNSUPPORTED)
+  add_definitions(-DHERMES_FP_TRUNC_ENABLE_UNSUPPORTED=${HERMES_FP_TRUNC_ENABLE_UNSUPPORTED})
 endif ()
 
 if (GCC_COMPATIBLE)

--- a/include/hermes/Support/sh_fp_trunc.h
+++ b/include/hermes/Support/sh_fp_trunc.h
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#if (defined(__GNUC__) && defined(__x86_64__)) || \
+    (defined(_MSC_VER) && defined(_M_X64))
+// =============================================================================
+//
+// Clang/GCC/MSVC x86-64
+//
+
+#include <emmintrin.h>
+
+static inline int _sh_trunc_f64_to_i32(double x) {
+  return _mm_cvttsd_si32(_mm_set_sd(x));
+}
+static inline unsigned _sh_trunc_f64_to_u32(double x) {
+  return _mm_cvttsd_si64(_mm_set_sd(x));
+}
+
+#elif (defined(__GNUC__) && defined(__i386__) && defined(__SSE2__)) || \
+    (defined(_MSC_VER) && defined(_M_IX86) && defined(_M_IX86_FP) &&   \
+     _M_IX86_FP >= 2)
+// =============================================================================
+//
+// Clang/GCC/MSVC x86+SSE2
+//
+
+#include <emmintrin.h>
+
+static inline int _sh_trunc_f64_to_i32(double x) {
+  return _mm_cvttsd_si32(_mm_set_sd(x));
+}
+
+static inline unsigned _sh_trunc_f64_to_u32(double x) {
+  __m128d val = _mm_set_sd(x);
+  // The truncated x, or 1 << 31 on overflow.
+  int truncOrTwo31 = _mm_cvttsd_si32(val);
+  // The truncated (x - (1 << 31))
+  int truncMinusTwo31 = _mm_cvttsd_si32(_mm_sub_sd(val, _mm_set_sd(1u << 31)));
+  // If truncOrTwo31 overflowed, (truncMinusTwo31 | 2**31), otherwise
+  // truncOrTwo31
+  return (truncMinusTwo31 & (truncOrTwo31 >> 31)) | truncOrTwo31;
+}
+
+#elif defined(__GNUC__) && defined(__i386__)
+// =============================================================================
+//
+// Clang/GCC x86+FP
+//
+
+static inline int _sh_trunc_f64_to_i32(double x) {
+  int result;
+  unsigned short control_word, new_control_word;
+
+  // Read the current FPU control word
+  asm volatile("fnstcw %0" : "=m"(control_word));
+
+  // Modify the control word to set rounding mode to truncation (round toward
+  // zero)
+  new_control_word = control_word | 0x0C00;
+
+  // Load the new control word
+  asm volatile("fldcw %0" : : "m"(new_control_word));
+
+  // Perform the conversion
+  asm volatile(
+      "fldl %1\n\t" // Load the double value onto the FPU stack
+      "fistpl %0" // Convert the top of the FPU stack to int (truncation)
+      : "=m"(result) // Output: store result in memory
+      : "m"(x) // Input: the double value in memory
+      : "st");
+
+  // Restore the original control word
+  asm volatile("fldcw %0" : : "m"(control_word));
+
+  return result;
+}
+
+static inline unsigned _sh_trunc_f64_to_u32(double x) {
+  unsigned long long result;
+  unsigned short control_word, new_control_word;
+
+  // Read the current FPU control word
+  asm volatile("fnstcw %0" : "=m"(control_word));
+
+  // Modify the control word to set rounding mode to truncation (round toward
+  // zero)
+  new_control_word = control_word | 0x0C00;
+
+  // Load the new control word
+  asm volatile("fldcw %0" : : "m"(new_control_word));
+
+  // Perform the conversion
+  asm volatile(
+      "fldl %1\n\t" // Load the double value onto the FPU stack
+      "fistpll %0" // Convert the top of the FPU stack to int (truncation)
+      : "=m"(result) // Output: store result in memory
+      : "m"(x) // Input: the double value in memory
+      : "st");
+
+  // Restore the original control word
+  asm volatile("fldcw %0" : : "m"(control_word));
+
+  return result;
+}
+
+#elif defined(_MSC_VER) && defined(_M_IX86)
+// =============================================================================
+//
+// MSVC x86+FP
+//
+
+static inline int _sh_trunc_f64_to_i32(double x) {
+  int result;
+  unsigned short control_word, new_control_word;
+
+  __asm {
+    // Save the current FPU control word
+        fnstcw control_word
+
+        // Modify control word: set rounding mode to truncation (11b)
+        mov ax, control_word
+        or  ax, 0x0C00 // Set bits 10 and 11 to 11 (truncate)
+        mov new_control_word, ax
+
+        // Load the modified control word
+        fldcw new_control_word
+
+            // Perform the conversion
+        fld qword ptr [x] // Load the double value onto the FPU stack
+        fistp dword ptr [result] // Convert the top FPU value to int (truncation)
+
+    // Restore the original FPU control word
+        fldcw control_word
+  }
+
+  return result;
+}
+
+static inline unsigned _sh_trunc_f64_to_u32(double x) {
+  unsigned __int64 result;
+  unsigned short control_word, new_control_word;
+
+  __asm {
+    // Save the current FPU control word
+        fnstcw control_word
+
+        // Modify control word: set rounding mode to truncation (11b)
+        mov ax, control_word
+        or  ax, 0x0C00 // Set bits 10 and 11 to 11 (truncate)
+        mov new_control_word, ax
+
+        // Load the modified control word
+        fldcw new_control_word
+
+            // Perform the conversion
+        fld qword ptr [x] // Load the double value onto the FPU stack
+        fistp qword ptr [result] // Convert the top FPU value to int (truncation)
+
+    // Restore the original FPU control word
+        fldcw control_word
+  }
+
+  return result;
+}
+
+#elif (defined(__GNUC__) && defined(__aarch64__)) || \
+    (defined(_MSC_VER) && defined(_M_ARM64))
+// =============================================================================
+//
+// Clang/GCC/MSVC aarch64
+//
+
+#include <arm_neon.h>
+
+#ifdef __clang__
+/*
+ NOTE: the intrinsics work in Clang, but generate an extra asm instruction.
+        fcvtzs	d0, d0
+        fmov	w0, s0
+
+ GCC produces what we expect. Not sure if it makes a difference.
+ */
+
+static inline int _sh_trunc_f64_to_i32(double x) {
+  int result;
+  asm volatile("fcvtzs %w0, %d1" // Convert double to int32
+               : "=r"(result) // Output: result in a general-purpose register
+               : "w"(x) // Input: double in a floating-point register
+  );
+  return result;
+}
+static inline unsigned _sh_trunc_f64_to_u32(double x) {
+  unsigned result;
+  asm volatile("fcvtzu %w0, %d1" // Convert double to uint32
+               : "=r"(result) // Output: result in a general-purpose register
+               : "w"(x) // Input: double in a floating-point register
+  );
+  return result;
+}
+#else
+static inline int _sh_trunc_f64_to_i32(double x) {
+  return (int)vget_lane_s64(vcvt_s64_f64(vdup_n_f64(x)), 0);
+}
+static inline unsigned _sh_trunc_f64_to_u32(double x) {
+  return (unsigned)vget_lane_u64(vcvt_u64_f64(vdup_n_f64(x)), 0);
+}
+#endif
+
+#elif defined(__GNUC__) && defined(__ARM_ARCH_7A__) && defined(__VFP_FP__)
+// =============================================================================
+//
+// Clang/GCC armv7-a
+//
+
+static inline int _sh_trunc_f64_to_i32(double x) {
+  int result;
+  asm volatile(
+      "vcvt.s32.f64 s0, %P1\n\t" // Convert double to int32 with truncation
+      "vmov %0, s0" // Move the lower part of d0 (s0) to the result
+      : "=r"(result) // Output: result in a general-purpose register
+      : "w"(x) // Input: the double value
+      : "d0" // Clobbers: NEON register d0
+  );
+  return result;
+}
+static inline unsigned _sh_trunc_f64_to_u32(double x) {
+  unsigned result;
+  asm volatile(
+      "vcvt.u32.f64 s0, %P1\n\t" // Convert double to uint32 with truncation
+      "vmov %0, s0" // Move the lower part of d0 (s0) to the result
+      : "=r"(result) // Output: result in a general-purpose register
+      : "w"(x) // Input: the double value
+      : "d0" // Clobbers: NEON register d0
+  );
+  return result;
+}
+
+#else
+// =============================================================================
+//
+// Unsupported compiler/platform
+//
+
+#if HERMES_FP_TRUNC_ENABLE_UNSUPPORTED
+#include <stdint.h>
+
+#if HERMES_FP_TRUNC_ENABLE_UNSUPPORTED == 1
+static inline int32_t _sh_trunc_f64_to_i32(double x) {
+  return x < INT32_MIN ? 0 : x > INT32_MAX ? 0 : (int32_t)x;
+}
+static inline uint32_t _sh_trunc_f64_to_u32(double x) {
+  return x < 0 ? 0 : x > UINT32_MAX ? 0 : (uint32_t)x;
+}
+#else
+#include "llvh/Support/Compiler.h"
+
+static inline int32_t _sh_trunc_f64_to_i32(double x)
+    LLVM_NO_SANITIZE("float-cast-overflow");
+static inline int32_t _sh_trunc_f64_to_i32(double x) {
+  return (int32_t)x;
+}
+static inline uint32_t _sh_trunc_f64_to_u32(double x)
+    LLVM_NO_SANITIZE("float-cast-overflow");
+static inline uint32_t _sh_trunc_f64_to_u32(double x) {
+  return (uint32_t)x;
+}
+#endif
+#else
+#error Unsupported compiler platform for _sh_trunc_f64
+#endif
+
+#endif

--- a/include/hermes/VM/JSTypedArray.h
+++ b/include/hermes/VM/JSTypedArray.h
@@ -310,7 +310,7 @@ inline float JSTypedArray<float, CellKind::Float32ArrayKind>::toDestType(
     const HermesValue &numeric) {
   // This can overflow a float, but float overflow goes to Infinity
   // (the correct behavior) on all modern platforms.
-  return unsafeTruncateDouble<float>(numeric.getNumber());
+  return truncDoubleToFloat(numeric.getNumber());
 }
 
 template <>

--- a/lib/BCGen/SH/SH.cpp
+++ b/lib/BCGen/SH/SH.cpp
@@ -639,7 +639,7 @@ class InstrGen {
     } else if (auto LN = llvh::dyn_cast<LiteralNumber>(&val)) {
       os_ << "_sh_ljs_double(";
       if (!LN->isNegativeZero() &&
-          LN->getValue() == unsafeTruncateDouble<int>(LN->getValue())) {
+          LN->getValue() == _sh_trunc_f64_to_i32(LN->getValue())) {
         os_ << static_cast<int>(LN->getValue());
       } else {
         os_ << "((struct HermesValueBase){.raw = "

--- a/lib/IRGen/ESTreeIRGen-expr.cpp
+++ b/lib/IRGen/ESTreeIRGen-expr.cpp
@@ -919,7 +919,7 @@ ESTreeIRGen::MemberExpressionResult ESTreeIRGen::emitMemberLoad(
         idx && mem->_computed) {
       double d = idx->_value;
       // Safe cast because this has been typechecked.
-      uint32_t ulen = hermes::unsafeTruncateDouble<uint32_t>(d);
+      uint32_t ulen = _sh_trunc_f64_to_u32(d);
       return MemberExpressionResult{
           Builder.createPrLoadInst(
               baseValue,
@@ -1055,7 +1055,7 @@ void ESTreeIRGen::emitMemberStore(
         idx && mem->_computed) {
       double d = idx->_value;
       // Safe cast because this has been typechecked.
-      uint32_t ulen = hermes::unsafeTruncateDouble<uint32_t>(d);
+      uint32_t ulen = _sh_trunc_f64_to_u32(d);
       Builder.createPrStoreInst(
           storedValue,
           baseValue,

--- a/lib/VM/JSArray.cpp
+++ b/lib/VM/JSArray.cpp
@@ -641,7 +641,7 @@ CallResult<bool> JSArray::setLength(
   double d;
   if (LLVM_LIKELY(newLength->isNumber())) {
     d = newLength->getNumber();
-    ulen = unsafeTruncateDouble<uint32_t>(d);
+    ulen = _sh_trunc_f64_to_u32(d);
   } else {
     // According to the spec, toNumber() has to be called twice.
     // https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-arraysetlength
@@ -653,7 +653,7 @@ CallResult<bool> JSArray::setLength(
     if (LLVM_UNLIKELY(res == ExecutionStatus::EXCEPTION))
       return ExecutionStatus::EXCEPTION;
     d = res->getNumber();
-    ulen = unsafeTruncateDouble<uint32_t>(d);
+    ulen = _sh_trunc_f64_to_u32(d);
     // If it is a string, no need to convert again, since it is pretty
     // expensive. Other types are not so important, since their conversions are
     // either fast (bool) or slow (object).

--- a/lib/VM/JSLib/Math.cpp
+++ b/lib/VM/JSLib/Math.cpp
@@ -74,10 +74,12 @@ static double roundHalfwaysTowardsInfinity(double x) {
 enum class MathKind {
 #define MATHFUNC_1ARG(name, func) name,
 #include "MathStdFunctions.def"
+
 #undef MATHFUNC_1ARG
   Num1ArgKinds,
 #define MATHFUNC_2ARG(name, func) name,
 #include "MathStdFunctions.def"
+
 #undef MATHFUNC_2ARG
   Num2ArgKinds
 };
@@ -91,6 +93,7 @@ runContextFunc1Arg(void *ctx, Runtime &runtime, NativeArgs args) {
   static Math1ArgFuncPtr math1ArgFuncs[] = {
 #define MATHFUNC_1ARG(name, func) func,
 #include "MathStdFunctions.def"
+
 #undef MATHFUNC_1ARG
   };
   assert(
@@ -114,6 +117,7 @@ runContextFunc2Arg(void *ctx, Runtime &runtime, NativeArgs args) {
   static Math2ArgFuncPtr math2ArgFuncs[] = {
 #define MATHFUNC_2ARG(name, func) func,
 #include "MathStdFunctions.def"
+
 #undef MATHFUNC_2ARG
   };
   assert(
@@ -234,12 +238,7 @@ CallResult<HermesValue> mathFround(void *, Runtime &runtime, NativeArgs args) {
 
   // Make the double x into a 32-bit float,
   // and then recast it back to a 64-bit float to return it.
-  // This is UB for values outside of the range of a float, but this works on
-  // our current compilers.
-  // TODO(T43892577): Find an alternative that doesn't use UB (or validate that
-  // the UB is ok).
-  return HermesValue::encodeTrustedNumberValue(
-      static_cast<double>(unsafeTruncateDouble<float>(x)));
+  return HermesValue::encodeTrustedNumberValue(truncDoubleToFloat(x));
 }
 
 // ES2022 21.3.2.18

--- a/lib/VM/Operations.cpp
+++ b/lib/VM/Operations.cpp
@@ -297,7 +297,7 @@ static CallResult<PseudoHandle<StringPrimitive>> numberToString(
   char buf8[hermes::NUMBER_TO_STRING_BUF_SIZE];
 
   // Optimization: Fast-case for positive integers < 2^31
-  int32_t n = unsafeTruncateDouble<int32_t>(m);
+  int32_t n = _sh_trunc_f64_to_i32(m);
   if (m == static_cast<double>(n) && n > 0) {
     // Write base 10 digits in reverse from end of buf8.
     char *p = buf8 + sizeof(buf8);

--- a/lib/VM/StaticH.cpp
+++ b/lib/VM/StaticH.cpp
@@ -1835,7 +1835,7 @@ _sh_fastarray_load(SHRuntime *shr, SHLegacyValue *array, double index) {
   auto *arr = vmcast<FastArray>(*toPHV(array));
   ArrayStorageSmall *storage = arr->unsafeGetIndexedStorage(runtime);
 
-  uint32_t intIndex = unsafeTruncateDouble<uint32_t>(index);
+  uint32_t intIndex = _sh_trunc_f64_to_u32(index);
   // Check that the index is an unsigned integer that is within range.
   if (LLVM_UNLIKELY(intIndex >= storage->size() || intIndex != index))
     _sh_throw_array_oob(shr);
@@ -1853,7 +1853,7 @@ extern "C" void _sh_fastarray_store(
   auto *arr = vmcast<FastArray>(*toPHV(array));
   ArrayStorageSmall *storage = arr->unsafeGetIndexedStorage(runtime);
 
-  uint32_t intIndex = unsafeTruncateDouble<uint32_t>(index);
+  uint32_t intIndex = _sh_trunc_f64_to_u32(index);
   // Check that the index is an unsigned integer that is within range.
   if (LLVM_UNLIKELY(intIndex >= storage->size() || intIndex != index))
     _sh_throw_array_oob(shr);

--- a/unittests/VMRuntime/CMakeLists.txt
+++ b/unittests/VMRuntime/CMakeLists.txt
@@ -72,6 +72,7 @@ set(RTSources
   TwineChar16Test.cpp
   WeakValueMapTest.cpp
   MetadataTest.cpp
+  test_sh_fp_trunc.cpp
   )
 
 add_hermes_unittest(HermesVMRuntimeTests

--- a/unittests/VMRuntime/test_sh_fp_trunc.cpp
+++ b/unittests/VMRuntime/test_sh_fp_trunc.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "hermes/Support/sh_fp_trunc.h"
+
+#include <cstdint>
+
+#include "gtest/gtest.h"
+
+namespace {
+
+TEST(test_sh_fp_trunc, SmokeTest) {
+  ASSERT_EQ(100, _sh_trunc_f64_to_i32(100.0));
+  ASSERT_EQ(100, _sh_trunc_f64_to_u32(100.0));
+  ASSERT_EQ(UINT32_MAX, _sh_trunc_f64_to_u32((double)UINT32_MAX));
+}
+
+} // namespace


### PR DESCRIPTION
Summary:
On the platforms we support, implement double truncation either with the
available intrinsics or with inline assembly.

Differential Revision: D63240632
