### PR TITLE
Avoid emitting LoadConst for new target of HBCCallN

### DIFF
--- a/lib/BCGen/HBC/Passes.cpp
+++ b/lib/BCGen/HBC/Passes.cpp
@@ -154,6 +154,13 @@ bool LoadConstants::operandMustBeLiteral(Instruction *Inst, unsigned opIndex) {
     return llvh::isa<LiteralUndefined>(CI->getNewTarget());
   }
 
+  // HBCCallNInst does not use its NewTarget operand because it is always
+  // undefined.
+  if (auto *HCNI = llvh::dyn_cast<HBCCallNInst>(Inst);
+      HCNI && opIndex == HBCCallNInst::NewTargetIdx) {
+    return true;
+  }
+
   /// GetBuiltinClosureInst's builtin index is always literal.
   if (llvh::isa<GetBuiltinClosureInst>(Inst) &&
       opIndex == GetBuiltinClosureInst::BuiltinIndexIdx)

--- a/lib/IR/IRVerifier.cpp
+++ b/lib/IR/IRVerifier.cpp
@@ -874,6 +874,10 @@ bool Verifier::visitHBCCallNInst(const HBCCallNInst &Inst) {
       HBCCallNInst::kMinArgs <= Inst.getNumArguments() &&
           Inst.getNumArguments() <= HBCCallNInst::kMaxArgs,
       "CallNInst has too many args");
+  AssertIWithMsg(
+      Inst,
+      llvh::isa<LiteralUndefined>(Inst.getNewTarget()),
+      "CallNInst NewTarget must be undefined");
   return true;
 }
 

--- a/test/BCGen/HBC/RA/callee.js
+++ b/test/BCGen/HBC/RA/callee.js
@@ -59,17 +59,16 @@ function foo(x) {
 
 // CHECK:function foo(x: any): any
 // CHECK-NEXT:%BB0:
-// CHECK-NEXT:  $Reg3 = GetParentScopeInst (:environment) %VS0: any, %parentScope: environment
-// CHECK-NEXT:  $Reg3 = CreateScopeInst (:environment) %VS1: any, $Reg3
+// CHECK-NEXT:  $Reg2 = GetParentScopeInst (:environment) %VS0: any, %parentScope: environment
+// CHECK-NEXT:  $Reg2 = CreateScopeInst (:environment) %VS1: any, $Reg2
 // CHECK-NEXT:  $Reg1 = LoadParamInst (:any) %x: any
-// CHECK-NEXT:  $Reg0 = StoreFrameInst $Reg3, $Reg1, [%VS1.x]: any
-// CHECK-NEXT:  $Reg3 = LoadFrameInst (:any) $Reg3, [%VS1.x]: any
-// CHECK-NEXT:  $Reg1 = LoadPropertyInst (:any) $Reg3, "sink": string
-// CHECK-NEXT:  $Reg2 = HBCLoadConstInst (:undefined) undefined: undefined
-// CHECK-NEXT:  $Reg4 = HBCLoadConstInst (:number) 1: number
-// CHECK-NEXT:  $Reg5 = HBCLoadConstInst (:number) 2: number
-// CHECK-NEXT:  $Reg6 = HBCLoadConstInst (:number) 3: number
-// CHECK-NEXT:  $Reg0 = HBCCallNInst (:any) $Reg1, empty: any, false: boolean, empty: any, $Reg2, $Reg3, $Reg4, $Reg5, $Reg6
+// CHECK-NEXT:  $Reg0 = StoreFrameInst $Reg2, $Reg1, [%VS1.x]: any
+// CHECK-NEXT:  $Reg2 = LoadFrameInst (:any) $Reg2, [%VS1.x]: any
+// CHECK-NEXT:  $Reg1 = LoadPropertyInst (:any) $Reg2, "sink": string
+// CHECK-NEXT:  $Reg3 = HBCLoadConstInst (:number) 1: number
+// CHECK-NEXT:  $Reg4 = HBCLoadConstInst (:number) 2: number
+// CHECK-NEXT:  $Reg5 = HBCLoadConstInst (:number) 3: number
+// CHECK-NEXT:  $Reg0 = HBCCallNInst (:any) $Reg1, empty: any, false: boolean, empty: any, undefined: undefined, $Reg2, $Reg3, $Reg4, $Reg5
 // CHECK-NEXT:  $Reg1 = HBCLoadConstInst (:undefined) undefined: undefined
 // CHECK-NEXT:  $Reg0 = ReturnInst $Reg1
 // CHECK-NEXT:function_end

--- a/test/BCGen/HBC/RA/phi_regress1.js
+++ b/test/BCGen/HBC/RA/phi_regress1.js
@@ -54,13 +54,13 @@ print(glob);
 // CHKRA-NEXT:  $Reg3 = LoadPropertyInst (:any) $Reg0, "bad": string
 // CHKRA-NEXT:  $Reg2 = HBCLoadConstInst (:undefined) undefined: undefined
 // CHKRA-NEXT:  $Reg1 = HBCLoadConstInst (:string) "foo": string
-// CHKRA-NEXT:  $Reg1 = HBCCallNInst (:any) $Reg3, empty: any, false: boolean, empty: any, $Reg2, $Reg2, $Reg1, $Reg4
+// CHKRA-NEXT:  $Reg1 = HBCCallNInst (:any) $Reg3, empty: any, false: boolean, empty: any, undefined: undefined, $Reg2, $Reg1, $Reg4
 // CHKRA-NEXT:  $Reg3 = TryLoadGlobalPropertyInst (:any) $Reg0, "print": string
 // CHKRA-NEXT:  $Reg1 = HBCLoadConstInst (:string) "phi": string
-// CHKRA-NEXT:  $Reg1 = HBCCallNInst (:any) $Reg3, empty: any, false: boolean, empty: any, $Reg2, $Reg2, $Reg1
+// CHKRA-NEXT:  $Reg1 = HBCCallNInst (:any) $Reg3, empty: any, false: boolean, empty: any, undefined: undefined, $Reg2, $Reg1
 // CHKRA-NEXT:  $Reg1 = TryLoadGlobalPropertyInst (:any) $Reg0, "print": string
 // CHKRA-NEXT:  $Reg0 = LoadPropertyInst (:any) $Reg0, "glob": string
-// CHKRA-NEXT:  $Reg0 = HBCCallNInst (:any) $Reg1, empty: any, false: boolean, empty: any, $Reg2, $Reg2, $Reg0
+// CHKRA-NEXT:  $Reg0 = HBCCallNInst (:any) $Reg1, empty: any, false: boolean, empty: any, undefined: undefined, $Reg2, $Reg0
 // CHKRA-NEXT:  $Reg0 = ReturnInst $Reg0
 // CHKRA-NEXT:function_end
 

--- a/test/BCGen/HBC/async-function.js
+++ b/test/BCGen/HBC/async-function.js
@@ -91,49 +91,46 @@ var simpleAsyncFE = async function () {
 // CHECK-NEXT:    PutByIdLoose      r3, r2, 3, "simpleAsyncFE"
 // CHECK-NEXT:    Ret               r1
 
-// CHECK:NCFunction<simpleReturn>(1 params, 18 registers, 0 numbers, 0 non-pointers):
+// CHECK:NCFunction<simpleReturn>(1 params, 17 registers, 0 numbers, 0 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0016, lexical 0x0000
-// CHECK-NEXT:    LoadConstUndefined r5
-// CHECK-NEXT:    Mov               r6, r5
-// CHECK-NEXT:    LoadThisNS        r5
-// CHECK-NEXT:    GetParentEnvironment r4, 0
-// CHECK-NEXT:    CreateEnvironment r4, r4, 0
-// CHECK-NEXT:    CreateClosure     r4, r4, NCFunction<?anon_0_simpleReturn>
+// CHECK-NEXT:    LoadConstUndefined r4
+// CHECK-NEXT:    Mov               r5, r4
+// CHECK-NEXT:    LoadThisNS        r4
+// CHECK-NEXT:    GetParentEnvironment r3, 0
+// CHECK-NEXT:    CreateEnvironment r3, r3, 0
+// CHECK-NEXT:    CreateClosure     r3, r3, NCFunction<?anon_0_simpleReturn>
 // CHECK-NEXT:    GetBuiltinClosure r1, "HermesBuiltin.spawnAsync"
-// CHECK-NEXT:    ReifyArgumentsLoose r6
+// CHECK-NEXT:    ReifyArgumentsLoose r5
 // CHECK-NEXT:    LoadConstUndefined r2
-// CHECK-NEXT:    LoadConstUndefined r3
-// CHECK-NEXT:    Call4             r1, r1, r3, r4, r5, r6
+// CHECK-NEXT:    Call4             r1, r1, r2, r3, r4, r5
 // CHECK-NEXT:    Ret               r1
 
-// CHECK:NCFunction<simpleAwait>(1 params, 18 registers, 0 numbers, 0 non-pointers):
+// CHECK:NCFunction<simpleAwait>(1 params, 17 registers, 0 numbers, 0 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x001d, lexical 0x0000
-// CHECK-NEXT:    LoadConstUndefined r5
-// CHECK-NEXT:    Mov               r6, r5
-// CHECK-NEXT:    LoadThisNS        r5
-// CHECK-NEXT:    GetParentEnvironment r4, 0
-// CHECK-NEXT:    CreateEnvironment r4, r4, 0
-// CHECK-NEXT:    CreateClosure     r4, r4, NCFunction<?anon_0_simpleAwait>
+// CHECK-NEXT:    LoadConstUndefined r4
+// CHECK-NEXT:    Mov               r5, r4
+// CHECK-NEXT:    LoadThisNS        r4
+// CHECK-NEXT:    GetParentEnvironment r3, 0
+// CHECK-NEXT:    CreateEnvironment r3, r3, 0
+// CHECK-NEXT:    CreateClosure     r3, r3, NCFunction<?anon_0_simpleAwait>
 // CHECK-NEXT:    GetBuiltinClosure r1, "HermesBuiltin.spawnAsync"
-// CHECK-NEXT:    ReifyArgumentsLoose r6
+// CHECK-NEXT:    ReifyArgumentsLoose r5
 // CHECK-NEXT:    LoadConstUndefined r2
-// CHECK-NEXT:    LoadConstUndefined r3
-// CHECK-NEXT:    Call4             r1, r1, r3, r4, r5, r6
+// CHECK-NEXT:    Call4             r1, r1, r2, r3, r4, r5
 // CHECK-NEXT:    Ret               r1
 
-// CHECK:NCFunction<simpleAsyncFE>(1 params, 18 registers, 0 numbers, 0 non-pointers):
+// CHECK:NCFunction<simpleAsyncFE>(1 params, 17 registers, 0 numbers, 0 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0024, lexical 0x0000
-// CHECK-NEXT:    LoadConstUndefined r5
-// CHECK-NEXT:    Mov               r6, r5
-// CHECK-NEXT:    LoadThisNS        r5
-// CHECK-NEXT:    GetParentEnvironment r4, 0
-// CHECK-NEXT:    CreateEnvironment r4, r4, 0
-// CHECK-NEXT:    CreateClosure     r4, r4, NCFunction<?anon_0_simpleAsyncFE>
+// CHECK-NEXT:    LoadConstUndefined r4
+// CHECK-NEXT:    Mov               r5, r4
+// CHECK-NEXT:    LoadThisNS        r4
+// CHECK-NEXT:    GetParentEnvironment r3, 0
+// CHECK-NEXT:    CreateEnvironment r3, r3, 0
+// CHECK-NEXT:    CreateClosure     r3, r3, NCFunction<?anon_0_simpleAsyncFE>
 // CHECK-NEXT:    GetBuiltinClosure r1, "HermesBuiltin.spawnAsync"
-// CHECK-NEXT:    ReifyArgumentsLoose r6
+// CHECK-NEXT:    ReifyArgumentsLoose r5
 // CHECK-NEXT:    LoadConstUndefined r2
-// CHECK-NEXT:    LoadConstUndefined r3
-// CHECK-NEXT:    Call4             r1, r1, r3, r4, r5, r6
+// CHECK-NEXT:    Call4             r1, r1, r2, r3, r4, r5
 // CHECK-NEXT:    Ret               r1
 
 // CHECK:NCFunction<?anon_0_simpleReturn>(1 params, 3 registers, 0 numbers, 0 non-pointers):
@@ -484,11 +481,11 @@ var simpleAsyncFE = async function () {
 // CHECK-NEXT:    bc 41: line 10 col 1
 // CHECK-NEXT:    bc 59: line 19 col 19
 // CHECK-NEXT:  0x0016  function idx 1, starts at line 10 col 1
-// CHECK-NEXT:    bc 31: line 10 col 1
+// CHECK-NEXT:    bc 29: line 10 col 1
 // CHECK-NEXT:  0x001d  function idx 2, starts at line 14 col 1
-// CHECK-NEXT:    bc 31: line 14 col 1
+// CHECK-NEXT:    bc 29: line 14 col 1
 // CHECK-NEXT:  0x0024  function idx 3, starts at line 19 col 21
-// CHECK-NEXT:    bc 31: line 19 col 21
+// CHECK-NEXT:    bc 29: line 19 col 21
 // CHECK-NEXT:  0x002b  function idx 8, starts at line 14 col 1
 // CHECK-NEXT:    bc 169: line 15 col 11
 // CHECK-NEXT:    bc 337: line 15 col 11

--- a/test/BCGen/HBC/callbuiltin.js
+++ b/test/BCGen/HBC/callbuiltin.js
@@ -49,10 +49,10 @@ print(foo({a: 10, b: 20, lastKey:30, 5:6}))
 // CHKRA-NEXT:  $Reg3 = HBCAllocObjectFromBufferInst (:object) "a": string, 10: number, "b": string, 20: number, "lastKey": string, 30: number, 5: number, 6: number
 // CHKRA-NEXT:  $Reg5 = ImplicitMovInst (:undefined) $Reg2
 // CHKRA-NEXT:  $Reg4 = ImplicitMovInst (:object) $Reg3
-// CHKRA-NEXT:  $Reg3 = HBCCallNInst (:any) $Reg0, empty: any, false: boolean, empty: any, $Reg2, $Reg2, $Reg3
+// CHKRA-NEXT:  $Reg3 = HBCCallNInst (:any) $Reg0, empty: any, false: boolean, empty: any, undefined: undefined, $Reg2, $Reg3
 // CHKRA-NEXT:  $Reg5 = ImplicitMovInst (:undefined) $Reg2
 // CHKRA-NEXT:  $Reg4 = ImplicitMovInst (:any) $Reg3
-// CHKRA-NEXT:  $Reg3 = HBCCallNInst (:any) $Reg1, empty: any, false: boolean, empty: any, $Reg2, $Reg2, $Reg3
+// CHKRA-NEXT:  $Reg3 = HBCCallNInst (:any) $Reg1, empty: any, false: boolean, empty: any, undefined: undefined, $Reg2, $Reg3
 // CHKRA-NEXT:  $Reg3 = ReturnInst $Reg3
 // CHKRA-NEXT:function_end
 
@@ -67,29 +67,29 @@ print(foo({a: 10, b: 20, lastKey:30, 5:6}))
 // CHKRA:function shadows(): undefined
 // CHKRA-NEXT:%BB0:
 // CHKRA-NEXT:  $Reg0 = HBCAllocObjectFromBufferInst (:object) "keys": string, null: null
-// CHKRA-NEXT:  $Reg3 = HBCGetGlobalObjectInst (:object)
-// CHKRA-NEXT:  $Reg3 = TryLoadGlobalPropertyInst (:any) $Reg3, "print": string
-// CHKRA-NEXT:  $Reg3 = PrStoreInst $Reg3, $Reg0, 0: number, "keys": string, false: boolean
+// CHKRA-NEXT:  $Reg2 = HBCGetGlobalObjectInst (:object)
+// CHKRA-NEXT:  $Reg2 = TryLoadGlobalPropertyInst (:any) $Reg2, "print": string
+// CHKRA-NEXT:  $Reg2 = PrStoreInst $Reg2, $Reg0, 0: number, "keys": string, false: boolean
 // CHKRA-NEXT:  $Reg1 = LoadPropertyInst (:any) $Reg0, "keys": string
-// CHKRA-NEXT:  $Reg3 = HBCLoadConstInst (:undefined) undefined: undefined
 // CHKRA-NEXT:  $Reg2 = HBCLoadConstInst (:string) "evil": string
-// CHKRA-NEXT:  $Reg5 = ImplicitMovInst (:object) $Reg0
-// CHKRA-NEXT:  $Reg4 = ImplicitMovInst (:string) $Reg2
-// CHKRA-NEXT:  $Reg2 = HBCCallNInst (:any) $Reg1, empty: any, false: boolean, empty: any, $Reg3, $Reg0, $Reg2
-// CHKRA-NEXT:  $Reg3 = ReturnInst $Reg3
+// CHKRA-NEXT:  $Reg4 = ImplicitMovInst (:object) $Reg0
+// CHKRA-NEXT:  $Reg3 = ImplicitMovInst (:string) $Reg2
+// CHKRA-NEXT:  $Reg2 = HBCCallNInst (:any) $Reg1, empty: any, false: boolean, empty: any, undefined: undefined, $Reg0, $Reg2
+// CHKRA-NEXT:  $Reg2 = HBCLoadConstInst (:undefined) undefined: undefined
+// CHKRA-NEXT:  $Reg2 = ReturnInst $Reg2
 // CHKRA-NEXT:function_end
 
 // CHKRA:function checkNonStaticBuiltin(): undefined
 // CHKRA-NEXT:%BB0:
-// CHKRA-NEXT:  $Reg3 = HBCGetGlobalObjectInst (:object)
-// CHKRA-NEXT:  $Reg0 = TryLoadGlobalPropertyInst (:any) $Reg3, "HermesInternal": string
+// CHKRA-NEXT:  $Reg2 = HBCGetGlobalObjectInst (:object)
+// CHKRA-NEXT:  $Reg0 = TryLoadGlobalPropertyInst (:any) $Reg2, "HermesInternal": string
 // CHKRA-NEXT:  $Reg1 = LoadPropertyInst (:any) $Reg0, "concat": string
-// CHKRA-NEXT:  $Reg3 = HBCLoadConstInst (:undefined) undefined: undefined
 // CHKRA-NEXT:  $Reg2 = HBCLoadConstInst (:string) "hello": string
-// CHKRA-NEXT:  $Reg5 = ImplicitMovInst (:any) $Reg0
-// CHKRA-NEXT:  $Reg4 = ImplicitMovInst (:string) $Reg2
-// CHKRA-NEXT:  $Reg2 = HBCCallNInst (:any) $Reg1, empty: any, false: boolean, empty: any, $Reg3, $Reg0, $Reg2
-// CHKRA-NEXT:  $Reg3 = ReturnInst $Reg3
+// CHKRA-NEXT:  $Reg4 = ImplicitMovInst (:any) $Reg0
+// CHKRA-NEXT:  $Reg3 = ImplicitMovInst (:string) $Reg2
+// CHKRA-NEXT:  $Reg2 = HBCCallNInst (:any) $Reg1, empty: any, false: boolean, empty: any, undefined: undefined, $Reg0, $Reg2
+// CHKRA-NEXT:  $Reg2 = HBCLoadConstInst (:undefined) undefined: undefined
+// CHKRA-NEXT:  $Reg2 = ReturnInst $Reg2
 // CHKRA-NEXT:function_end
 
 // CHKBC:Bytecode File Information:
@@ -165,27 +165,27 @@ print(foo({a: 10, b: 20, lastKey:30, 5:6}))
 // CHKBC-NEXT:    CallBuiltin       r0, "Object.keys", 2
 // CHKBC-NEXT:    Ret               r0
 
-// CHKBC:Function<shadows>(1 params, 13 registers, 0 numbers, 0 non-pointers):
+// CHKBC:Function<shadows>(1 params, 12 registers, 0 numbers, 0 non-pointers):
 // CHKBC-NEXT:Offset in debug table: source 0x0029, lexical 0x0000
 // CHKBC-NEXT:    NewObjectWithBuffer r0, 1, 17
-// CHKBC-NEXT:    GetGlobalObject   r3
-// CHKBC-NEXT:    TryGetById        r3, r3, 1, "print"
-// CHKBC-NEXT:    PutOwnBySlotIdx   r0, r3, 0
+// CHKBC-NEXT:    GetGlobalObject   r2
+// CHKBC-NEXT:    TryGetById        r2, r2, 1, "print"
+// CHKBC-NEXT:    PutOwnBySlotIdx   r0, r2, 0
 // CHKBC-NEXT:    GetByIdShort      r1, r0, 2, "keys"
-// CHKBC-NEXT:    LoadConstUndefined r3
 // CHKBC-NEXT:    LoadConstString   r2, "evil"
 // CHKBC-NEXT:    Call2             r2, r1, r0, r2
-// CHKBC-NEXT:    Ret               r3
+// CHKBC-NEXT:    LoadConstUndefined r2
+// CHKBC-NEXT:    Ret               r2
 
-// CHKBC:Function<checkNonStaticBuiltin>(1 params, 13 registers, 0 numbers, 0 non-pointers):
+// CHKBC:Function<checkNonStaticBuiltin>(1 params, 12 registers, 0 numbers, 0 non-pointers):
 // CHKBC-NEXT:Offset in debug table: source 0x0036, lexical 0x0000
-// CHKBC-NEXT:    GetGlobalObject   r3
-// CHKBC-NEXT:    TryGetById        r0, r3, 1, "HermesInternal"
+// CHKBC-NEXT:    GetGlobalObject   r2
+// CHKBC-NEXT:    TryGetById        r0, r2, 1, "HermesInternal"
 // CHKBC-NEXT:    GetByIdShort      r1, r0, 2, "concat"
-// CHKBC-NEXT:    LoadConstUndefined r3
 // CHKBC-NEXT:    LoadConstString   r2, "hello"
 // CHKBC-NEXT:    Call2             r2, r1, r0, r2
-// CHKBC-NEXT:    Ret               r3
+// CHKBC-NEXT:    LoadConstUndefined r2
+// CHKBC-NEXT:    Ret               r2
 
 // CHKBC:Debug filename table:
 // CHKBC-NEXT:  0: {{.*}}callbuiltin.js
@@ -210,9 +210,9 @@ print(foo({a: 10, b: 20, lastKey:30, 5:6}))
 // CHKBC-NEXT:  0x0029  function idx 2, starts at line 17 col 1
 // CHKBC-NEXT:    bc 8: line 18 col 25
 // CHKBC-NEXT:    bc 18: line 19 col 16
-// CHKBC-NEXT:    bc 29: line 19 col 16
+// CHKBC-NEXT:    bc 27: line 19 col 16
 // CHKBC-NEXT:  0x0036  function idx 3, starts at line 22 col 1
 // CHKBC-NEXT:    bc 2: line 23 col 3
 // CHKBC-NEXT:    bc 8: line 23 col 24
-// CHKBC-NEXT:    bc 19: line 23 col 24
+// CHKBC-NEXT:    bc 17: line 23 col 24
 // CHKBC-NEXT:  0x0043  end of debug source table

--- a/test/BCGen/HBC/calln.js
+++ b/test/BCGen/HBC/calln.js
@@ -54,7 +54,7 @@ function foo5(f) { f(1, 2, 3, 4); }
 // LRA-NEXT:  $Reg1 = LoadParamInst (:any) %f: any
 // LRA-NEXT:  $Reg0 = HBCLoadConstInst (:undefined) undefined: undefined
 // LRA-NEXT:  $Reg2 = ImplicitMovInst (:undefined) $Reg0
-// LRA-NEXT:  $Reg1 = HBCCallNInst (:any) $Reg1, empty: any, false: boolean, empty: any, $Reg0, $Reg0
+// LRA-NEXT:  $Reg1 = HBCCallNInst (:any) $Reg1, empty: any, false: boolean, empty: any, undefined: undefined, $Reg0
 // LRA-NEXT:  $Reg0 = ReturnInst $Reg0
 // LRA-NEXT:function_end
 
@@ -65,7 +65,7 @@ function foo5(f) { f(1, 2, 3, 4); }
 // LRA-NEXT:  $Reg2 = HBCLoadConstInst (:number) 1: number
 // LRA-NEXT:  $Reg4 = ImplicitMovInst (:undefined) $Reg0
 // LRA-NEXT:  $Reg3 = ImplicitMovInst (:number) $Reg2
-// LRA-NEXT:  $Reg2 = HBCCallNInst (:any) $Reg1, empty: any, false: boolean, empty: any, $Reg0, $Reg0, $Reg2
+// LRA-NEXT:  $Reg2 = HBCCallNInst (:any) $Reg1, empty: any, false: boolean, empty: any, undefined: undefined, $Reg0, $Reg2
 // LRA-NEXT:  $Reg0 = ReturnInst $Reg0
 // LRA-NEXT:function_end
 
@@ -78,7 +78,7 @@ function foo5(f) { f(1, 2, 3, 4); }
 // LRA-NEXT:  $Reg6 = ImplicitMovInst (:undefined) $Reg1
 // LRA-NEXT:  $Reg5 = ImplicitMovInst (:number) $Reg0
 // LRA-NEXT:  $Reg4 = ImplicitMovInst (:number) $Reg3
-// LRA-NEXT:  $Reg3 = HBCCallNInst (:any) $Reg2, empty: any, false: boolean, empty: any, $Reg1, $Reg1, $Reg0, $Reg3
+// LRA-NEXT:  $Reg3 = HBCCallNInst (:any) $Reg2, empty: any, false: boolean, empty: any, undefined: undefined, $Reg1, $Reg0, $Reg3
 // LRA-NEXT:  $Reg1 = ReturnInst $Reg1
 // LRA-NEXT:function_end
 
@@ -93,7 +93,7 @@ function foo5(f) { f(1, 2, 3, 4); }
 // LRA-NEXT:  $Reg7 = ImplicitMovInst (:number) $Reg0
 // LRA-NEXT:  $Reg6 = ImplicitMovInst (:number) $Reg1
 // LRA-NEXT:  $Reg5 = ImplicitMovInst (:number) $Reg4
-// LRA-NEXT:  $Reg4 = HBCCallNInst (:any) $Reg3, empty: any, false: boolean, empty: any, $Reg2, $Reg2, $Reg0, $Reg1, $Reg4
+// LRA-NEXT:  $Reg4 = HBCCallNInst (:any) $Reg3, empty: any, false: boolean, empty: any, undefined: undefined, $Reg2, $Reg0, $Reg1, $Reg4
 // LRA-NEXT:  $Reg2 = ReturnInst $Reg2
 // LRA-NEXT:function_end
 

--- a/test/BCGen/HBC/debuggercheckbreak.js
+++ b/test/BCGen/HBC/debuggercheckbreak.js
@@ -56,45 +56,45 @@ function test1() {
 // CHECK-NEXT:    AsyncBreakCheck
 // CHECK-NEXT:    Ret               r1
 
-// CHECK:Function<test1>(1 params, 18 registers, 4 numbers, 1 non-pointers):
+// CHECK:Function<test1>(1 params, 17 registers, 3 numbers, 0 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0014, lexical 0x0000
-// CHECK-NEXT:    LoadConstUInt8    r2, 1
-// CHECK-NEXT:    GetGlobalObject   r8
-// CHECK-NEXT:    LoadConstUndefined r4
-// CHECK-NEXT:    LoadConstUInt8    r3, 5
-// CHECK-NEXT:    LoadConstUInt8    r1, 3
+// CHECK-NEXT:    LoadConstUInt8    r1, 1
+// CHECK-NEXT:    GetGlobalObject   r7
+// CHECK-NEXT:    LoadConstUInt8    r2, 5
+// CHECK-NEXT:    LoadConstUInt8    r6, 3
 // CHECK-NEXT:    LoadConstZero     r0
 // CHECK-NEXT:    AsyncBreakCheck
 // CHECK-NEXT:L3:
-// CHECK-NEXT:    TryGetById        r6, r8, 1, "Math"
-// CHECK-NEXT:    GetByIdShort      r7, r6, 2, "random"
-// CHECK-NEXT:    Call1             r6, r7, r6
-// CHECK-NEXT:    Mov               r7, r0
+// CHECK-NEXT:    TryGetById        r4, r7, 1, "Math"
+// CHECK-NEXT:    GetByIdShort      r5, r4, 2, "random"
+// CHECK-NEXT:    Call1             r4, r5, r4
+// CHECK-NEXT:    Mov               r5, r0
 // CHECK-NEXT:    AsyncBreakCheck
-// CHECK-NEXT:    JStrictEqual      L1, r6, r1
-// CHECK-NEXT:    TryGetById        r5, r8, 1, "Math"
-// CHECK-NEXT:    GetByIdShort      r6, r5, 2, "random"
-// CHECK-NEXT:    Call1             r6, r6, r5
-// CHECK-NEXT:    JStrictEqual      L2, r6, r3
-// CHECK-NEXT:    AddN              r0, r7, r2
+// CHECK-NEXT:    JStrictEqual      L1, r4, r6
+// CHECK-NEXT:    TryGetById        r3, r7, 1, "Math"
+// CHECK-NEXT:    GetByIdShort      r4, r3, 2, "random"
+// CHECK-NEXT:    Call1             r4, r4, r3
+// CHECK-NEXT:    JStrictEqual      L2, r4, r2
+// CHECK-NEXT:    AddN              r0, r5, r1
 // CHECK-NEXT:    Jmp               L3
 // CHECK-NEXT:L2:
 // CHECK-NEXT:    AsyncBreakCheck
 // CHECK-NEXT:    Jmp               L2
 // CHECK-NEXT:L1:
-// CHECK-NEXT:    LoadConstUInt8    r3, 10
-// CHECK-NEXT:    Mov               r1, r7
-// CHECK-NEXT:    Mov               r7, r1
-// CHECK-NEXT:    JNotGreaterN      L4, r7, r3
+// CHECK-NEXT:    LoadConstUInt8    r2, 10
+// CHECK-NEXT:    Mov               r6, r5
+// CHECK-NEXT:    Mov               r5, r6
+// CHECK-NEXT:    JNotGreaterN      L4, r5, r2
 // CHECK-NEXT:L5:
-// CHECK-NEXT:    SubN              r1, r1, r2
-// CHECK-NEXT:    Mov               r7, r1
+// CHECK-NEXT:    SubN              r6, r6, r1
+// CHECK-NEXT:    Mov               r5, r6
 // CHECK-NEXT:    AsyncBreakCheck
-// CHECK-NEXT:    JGreaterN         L5, r7, r3
+// CHECK-NEXT:    JGreaterN         L5, r5, r2
 // CHECK-NEXT:L4:
-// CHECK-NEXT:    TryGetById        r8, r8, 3, "print"
-// CHECK-NEXT:    Call2             r8, r8, r4, r7
-// CHECK-NEXT:    Ret               r4
+// CHECK-NEXT:    TryGetById        r6, r7, 3, "print"
+// CHECK-NEXT:    LoadConstUndefined r7
+// CHECK-NEXT:    Call2             r6, r6, r7, r5
+// CHECK-NEXT:    Ret               r7
 
 // CHECK:Debug filename table:
 // CHECK-NEXT:  0: {{.*}}debuggercheckbreak.js
@@ -110,19 +110,19 @@ function test1() {
 // CHECK-NEXT:    bc 18: line 10 col 1
 // CHECK-NEXT:    bc 27: line 21 col 1
 // CHECK-NEXT:  0x0014  function idx 1, starts at line 10 col 1
-// CHECK-NEXT:    bc 16: line 13 col 9
-// CHECK-NEXT:    bc 22: line 13 col 20
-// CHECK-NEXT:    bc 27: line 13 col 20
-// CHECK-NEXT:    bc 35: line 13 col 5
-// CHECK-NEXT:    bc 39: line 15 col 9
-// CHECK-NEXT:    bc 45: line 15 col 20
-// CHECK-NEXT:    bc 50: line 15 col 20
-// CHECK-NEXT:    bc 54: line 15 col 5
-// CHECK-NEXT:    bc 62: line 12 col 3
-// CHECK-NEXT:    bc 65: line 16 col 7
-// CHECK-NEXT:    bc 76: line 18 col 3
-// CHECK-NEXT:    bc 88: line 18 col 3
-// CHECK-NEXT:    bc 92: line 20 col 3
+// CHECK-NEXT:    bc 14: line 13 col 9
+// CHECK-NEXT:    bc 20: line 13 col 20
+// CHECK-NEXT:    bc 25: line 13 col 20
+// CHECK-NEXT:    bc 33: line 13 col 5
+// CHECK-NEXT:    bc 37: line 15 col 9
+// CHECK-NEXT:    bc 43: line 15 col 20
+// CHECK-NEXT:    bc 48: line 15 col 20
+// CHECK-NEXT:    bc 52: line 15 col 5
+// CHECK-NEXT:    bc 60: line 12 col 3
+// CHECK-NEXT:    bc 63: line 16 col 7
+// CHECK-NEXT:    bc 74: line 18 col 3
+// CHECK-NEXT:    bc 86: line 18 col 3
+// CHECK-NEXT:    bc 90: line 20 col 3
 // CHECK-NEXT:    bc 98: line 20 col 8
 // CHECK-NEXT:    bc 103: line 21 col 1
 // CHECK-NEXT:  0x0052  end of debug source table

--- a/test/BCGen/HBC/local_var_in_global_function.js
+++ b/test/BCGen/HBC/local_var_in_global_function.js
@@ -46,11 +46,11 @@ print(e);
 // RA-NEXT:  $Reg3 = TryLoadGlobalPropertyInst (:any) $Reg0, "print": string
 // RA-NEXT:  $Reg1 = TryLoadGlobalPropertyInst (:any) $Reg0, "local": string
 // RA-NEXT:  $Reg2 = HBCLoadConstInst (:undefined) undefined: undefined
-// RA-NEXT:  $Reg1 = HBCCallNInst (:any) $Reg1, empty: any, false: boolean, empty: any, $Reg2, $Reg2
-// RA-NEXT:  $Reg1 = HBCCallNInst (:any) $Reg3, empty: any, false: boolean, empty: any, $Reg2, $Reg2, $Reg1
+// RA-NEXT:  $Reg1 = HBCCallNInst (:any) $Reg1, empty: any, false: boolean, empty: any, undefined: undefined, $Reg2
+// RA-NEXT:  $Reg1 = HBCCallNInst (:any) $Reg3, empty: any, false: boolean, empty: any, undefined: undefined, $Reg2, $Reg1
 // RA-NEXT:  $Reg1 = TryLoadGlobalPropertyInst (:any) $Reg0, "print": string
 // RA-NEXT:  $Reg0 = LoadPropertyInst (:any) $Reg0, "e": string
-// RA-NEXT:  $Reg0 = HBCCallNInst (:any) $Reg1, empty: any, false: boolean, empty: any, $Reg2, $Reg2, $Reg0
+// RA-NEXT:  $Reg0 = HBCCallNInst (:any) $Reg1, empty: any, false: boolean, empty: any, undefined: undefined, $Reg2, $Reg0
 // RA-NEXT:  $Reg0 = ReturnInst $Reg0
 // RA-NEXT:%BB2:
 // RA-NEXT:  $Reg2 = HBCLoadConstInst (:string) "local": string

--- a/test/BCGen/HBC/opt-environment-init.js
+++ b/test/BCGen/HBC/opt-environment-init.js
@@ -108,7 +108,7 @@ function foo(o) {
 // CHKLIR-NEXT:       StoreFrameInst %0: environment, %1: number, [%VS1.cnt]: number
 // CHKLIR-NEXT:  %3 = LoadParamInst (:any) %o: any
 // CHKLIR-NEXT:  %4 = HBCLoadConstInst (:undefined) undefined: undefined
-// CHKLIR-NEXT:  %5 = HBCCallNInst (:any) %3: any, empty: any, false: boolean, empty: any, %4: undefined, %4: undefined
+// CHKLIR-NEXT:  %5 = HBCCallNInst (:any) %3: any, empty: any, false: boolean, empty: any, undefined: undefined, %4: undefined
 // CHKLIR-NEXT:       StoreFrameInst %0: environment, %4: undefined, [%VS1.flag2]: undefined|number
 // CHKLIR-NEXT:  %7 = CreateFunctionInst (:object) %0: environment, %""(): functionCode
 // CHKLIR-NEXT:       ReturnInst %7: object

--- a/test/BCGen/HBC/recreate_cheap_values.js
+++ b/test/BCGen/HBC/recreate_cheap_values.js
@@ -43,7 +43,7 @@ function negzero(f) {
 // CHECK-NEXT:  $Reg5 = ImplicitMovInst (:undefined) $Reg0
 // CHECK-NEXT:  $Reg4 = ImplicitMovInst (:number) $Reg2
 // CHECK-NEXT:  $Reg3 = ImplicitMovInst (:number) $Reg2
-// CHECK-NEXT:  $Reg2 = HBCCallNInst (:any) $Reg1, empty: any, false: boolean, empty: any, $Reg0, $Reg0, $Reg2, $Reg2
+// CHECK-NEXT:  $Reg2 = HBCCallNInst (:any) $Reg1, empty: any, false: boolean, empty: any, undefined: undefined, $Reg0, $Reg2, $Reg2
 // CHECK-NEXT:  $Reg2 = ReturnInst $Reg2
 // CHECK-NEXT:function_end
 
@@ -55,6 +55,6 @@ function negzero(f) {
 // CHECK-NEXT:  $Reg5 = ImplicitMovInst (:undefined) $Reg0
 // CHECK-NEXT:  $Reg4 = ImplicitMovInst (:number) $Reg2
 // CHECK-NEXT:  $Reg3 = ImplicitMovInst (:number) $Reg2
-// CHECK-NEXT:  $Reg2 = HBCCallNInst (:any) $Reg1, empty: any, false: boolean, empty: any, $Reg0, $Reg0, $Reg2, $Reg2
+// CHECK-NEXT:  $Reg2 = HBCCallNInst (:any) $Reg1, empty: any, false: boolean, empty: any, undefined: undefined, $Reg0, $Reg2, $Reg2
 // CHECK-NEXT:  $Reg2 = ReturnInst $Reg2
 // CHECK-NEXT:function_end

--- a/test/BCGen/HBC/regress-stringconcat-call-type.js
+++ b/test/BCGen/HBC/regress-stringconcat-call-type.js
@@ -22,13 +22,12 @@
 // CHECK-NEXT:  %0 = HBCLoadConstInst (:string) "": string
 // CHECK-NEXT:  %1 = HBCLoadConstInst (:string) " ": string
 // CHECK-NEXT:  %2 = HBCGetGlobalObjectInst (:object)
-// CHECK-NEXT:  %3 = HBCLoadConstInst (:undefined) undefined: undefined
 // CHECK-NEXT:       BranchInst %BB1
 // CHECK-NEXT:%BB1:
-// CHECK-NEXT:  %5 = PhiInst (:string) %0: string, %BB0, %9: string, %BB1
-// CHECK-NEXT:  %6 = HBCStringConcatInst (:string) %5: string, %1: string
-// CHECK-NEXT:  %7 = TryLoadGlobalPropertyInst (:any) %2: object, "HermesInternal": string
-// CHECK-NEXT:  %8 = LoadPropertyInst (:any) %7: any, "concat": string
-// CHECK-NEXT:  %9 = HBCCallNInst (:string) %8: any, empty: any, false: boolean, empty: any, %3: undefined, %6: string, %6: string, %1: string
-// CHECK-NEXT:        BranchInst %BB1
+// CHECK-NEXT:  %4 = PhiInst (:string) %0: string, %BB0, %8: string, %BB1
+// CHECK-NEXT:  %5 = HBCStringConcatInst (:string) %4: string, %1: string
+// CHECK-NEXT:  %6 = TryLoadGlobalPropertyInst (:any) %2: object, "HermesInternal": string
+// CHECK-NEXT:  %7 = LoadPropertyInst (:any) %6: any, "concat": string
+// CHECK-NEXT:  %8 = HBCCallNInst (:string) %7: any, empty: any, false: boolean, empty: any, undefined: undefined, %5: string, %5: string, %1: string
+// CHECK-NEXT:       BranchInst %BB1
 // CHECK-NEXT:function_end

--- a/test/BCGen/HBC/switch.js
+++ b/test/BCGen/HBC/switch.js
@@ -194,7 +194,7 @@ function switch_neg(x) {
 // CHECK-NEXT:%BB1:
 // CHECK-NEXT:  $Reg0 = PhiInst (:number) $Reg0, %BB0, $Reg0, %BB2, $Reg0, %BB3
 // CHECK-NEXT:  $Reg7 = TryLoadGlobalPropertyInst (:any) $Reg2, "print": string
-// CHECK-NEXT:  $Reg7 = HBCCallNInst (:any) $Reg7, empty: any, false: boolean, empty: any, $Reg1, $Reg1, $Reg0
+// CHECK-NEXT:  $Reg7 = HBCCallNInst (:any) $Reg7, empty: any, false: boolean, empty: any, undefined: undefined, $Reg1, $Reg0
 // CHECK-NEXT:  $Reg7 = BranchInst %BB4
 // CHECK-NEXT:%BB2:
 // CHECK-NEXT:  $Reg0 = MovInst (:number) $Reg4

--- a/test/BCGen/HBC/variables.js
+++ b/test/BCGen/HBC/variables.js
@@ -87,11 +87,10 @@ function daa(a) {
 // CHECK-NEXT:  %7 = LoadPropertyInst (:any) %6: object, "bar": string
 // CHECK-NEXT:  %8 = LoadFrameInst (:any) %1: environment, [%VS2.a]: any
 // CHECK-NEXT:  %9 = HBCLoadConstInst (:undefined) undefined: undefined
-// CHECK-NEXT:  %10 = HBCLoadConstInst (:undefined) undefined: undefined
-// CHECK-NEXT:  %11 = HBCCallNInst (:any) %7: any, empty: any, false: boolean, empty: any, %9: undefined, %10: undefined, %8: any
-// CHECK-NEXT:        StoreFrameInst %1: environment, %11: any, [%VS2.b]: any
-// CHECK-NEXT:  %13 = LoadFrameInst (:any) %1: environment, [%VS2.b]: any
-// CHECK-NEXT:        ReturnInst %13: any
+// CHECK-NEXT:  %10 = HBCCallNInst (:any) %7: any, empty: any, false: boolean, empty: any, undefined: undefined, %9: undefined, %8: any
+// CHECK-NEXT:        StoreFrameInst %1: environment, %10: any, [%VS2.b]: any
+// CHECK-NEXT:  %12 = LoadFrameInst (:any) %1: environment, [%VS2.b]: any
+// CHECK-NEXT:        ReturnInst %12: any
 // CHECK-NEXT:function_end
 
 // CHECK:scope %VS3 [a: any, b: any, daa_capture: any]
@@ -158,7 +157,7 @@ function daa(a) {
 // CHKOPT-NEXT:  %1 = LoadPropertyInst (:any) %0: object, "bar": string
 // CHKOPT-NEXT:  %2 = HBCLoadConstInst (:undefined) undefined: undefined
 // CHKOPT-NEXT:  %3 = LoadParamInst (:any) %a: any
-// CHKOPT-NEXT:  %4 = HBCCallNInst (:any) %1: any, empty: any, false: boolean, empty: any, %2: undefined, %2: undefined, %3: any
+// CHKOPT-NEXT:  %4 = HBCCallNInst (:any) %1: any, empty: any, false: boolean, empty: any, undefined: undefined, %2: undefined, %3: any
 // CHKOPT-NEXT:       ReturnInst %4: any
 // CHKOPT-NEXT:function_end
 

--- a/test/Parser/async-method-newline-error.js
+++ b/test/Parser/async-method-newline-error.js
@@ -17,3 +17,4 @@ var o = {
 // CHECK:{{.*}}async-method-newline-error.js:12:3: error: newline not allowed after 'async' in a method definition
 // CHECK-NEXT:  foo() {}
 // CHECK-NEXT:  ^~~
+// CHECK-NEXT:Emitted 1 errors. exiting.

--- a/test/Parser/await-param-error.js
+++ b/test/Parser/await-param-error.js
@@ -19,3 +19,4 @@ async function f2(x = 1 + await 2) {}
 // CHECK-NEXT:{{.*}}await-param-error.js:12:27: error: 'await' not allowed in a formal parameter
 // CHECK-NEXT:async function f2(x = 1 + await 2) {}
 // CHECK-NEXT:                          ^~~~~~~
+// CHECK-NEXT:Emitted 2 errors. exiting.

--- a/test/Parser/escaped-this.js
+++ b/test/Parser/escaped-this.js
@@ -19,3 +19,4 @@ function f1(v1 = this, \u0074his) {
 // CHECK-NEXT:{{.*}}escaped-this.js:10:24: error: identifier, '{' or '[' expected in binding pattern
 // CHECK-NEXT:function f1(v1 = this, \u0074his) {
 // CHECK-NEXT:                       ^
+// CHECK-NEXT:Emitted 1 errors. exiting.

--- a/test/Parser/private-escape-error.js
+++ b/test/Parser/private-escape-error.js
@@ -24,3 +24,4 @@
 // CHECK-NEXT:{{.*}}private-escape-error.js:11:1: error: Private name can only be used as left-hand side of `in` expression
 // CHECK-NEXT:#do\
 // CHECK-NEXT:^~~~
+// CHECK-NEXT:Emitted 3 errors. exiting.


### PR DESCRIPTION
Summary:
HBCCallN implicitly treats new.target as undefined, so there is no need
to emit a LoadConst for it.

This is causing correctness issues because SpillRegisters assumes that
no instruction uses more than 6 registers, but Call4 ends up using 7
with the extra new.target parameter.

Differential Revision: D63503055
