### PR TITLE
Add with statement support

### DIFF
--- a/include/hermes/Sema/SemContext.h
+++ b/include/hermes/Sema/SemContext.h
@@ -452,6 +452,17 @@ class SemContext {
     return root_->bindingTable_;
   }
 
+  uint32_t getWithLexicalDepth(ESTree::WithStatementNode * node) const {
+    if(auto it = withDepths.find(node); it != withDepths.end())
+      return it->second;
+    assert(false && "with statement must have been processed before attempting to get the depth");
+    return 0;
+  }
+
+  void setWithLexicalDepth(ESTree::WithStatementNode * node, uint32_t depth) {
+    withDepths[node] = depth;
+  }
+
  private:
   /// The parent SemContext of this SemContext.
   /// If null, this SemContext has no parent.
@@ -490,6 +501,8 @@ class SemContext {
   /// "expression decl" are both set and are not the same value.
   llvh::DenseMap<ESTree::IdentifierNode *, Decl *>
       sideIdentifierDeclarationDecl_{};
+
+  llvh::DenseMap<ESTree::WithStatementNode *, uint32_t> withDepths{};
 };
 
 class SemContextDumper {

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -41,6 +41,7 @@ add_hermes_library(hermesFrontend
   IRGen/ESTreeIRGen-func.cpp
   IRGen/ESTreeIRGen-except.cpp
   IRGen/ESTreeIRGen-class.cpp
+  IRGen/ESTreeIRGen-with.cpp
   IR/IR.cpp
   IR/CFG.cpp
   IR/IRBuilder.cpp

--- a/lib/IRGen/ESTreeIRGen-expr.cpp
+++ b/lib/IRGen/ESTreeIRGen-expr.cpp
@@ -522,7 +522,10 @@ Value *ESTreeIRGen::genCallExpr(ESTree::CallExpressionNode *call) {
     // Must call the field init function immediately after.
     fieldInitClassType = curFunction()->typedClassContext.type;
   } else {
-    thisVal = Builder.getLiteralUndefined();
+    thisVal = withAwareEmitLoad(
+        nullptr,
+        call->_callee,
+        ConditionalChainType::OBJECT_ONLY_WITH_UNDEFINED_ALTERNATE);
     callee = genExpression(call->_callee);
   }
 
@@ -588,7 +591,10 @@ Value *ESTreeIRGen::genOptionalCallExpr(
     thisVal = Builder.getLiteralUndefined();
     callee = genOptionalCallExpr(oce, shortCircuitBB);
   } else {
-    thisVal = Builder.getLiteralUndefined();
+    thisVal = withAwareEmitLoad(
+        nullptr,
+        call->_callee,
+        ConditionalChainType::OBJECT_ONLY_WITH_UNDEFINED_ALTERNATE);
     callee = genExpression(getCallee(call));
   }
 
@@ -2036,15 +2042,33 @@ Value *ESTreeIRGen::genUnaryExpression(ESTree::UnaryExpressionNode *U) {
       Identifier name = getNameFieldFromID(iden);
       auto *var = resolveIdentifier(iden);
 
-      if (llvh::isa<GlobalObjectProperty>(var)) {
-        // If the variable doesn't exist or if it is global, we must generate
-        // a delete global property instruction.
-        return Builder.createDeletePropertyInst(
-            Builder.getGlobalObject(), Builder.getLiteralString(name));
+      // With this check we are sure nothing in Hermes breaks
+      if (withScopes.empty()) {
+        if (llvh::isa<GlobalObjectProperty>(var)) {
+          // If the variable doesn't exist or if it is global, we must generate
+          // a delete global property instruction.
+          return Builder.createDeletePropertyInst(
+              Builder.getGlobalObject(), Builder.getLiteralString(name));
+        } else {
+          // Otherwise it is a local variable which can't be deleted and we just
+          // return false.
+          return Builder.getLiteralBool(false);
+        }
       } else {
-        // Otherwise it is a local variable which can't be deleted and we just
-        // return false.
-        return Builder.getLiteralBool(false);
+        auto withObj = withAwareEmitLoad(
+            var,
+            iden,
+            llvh::isa<GlobalObjectProperty>(var)
+                ? ConditionalChainType::OBJECT_ONLY_WITH_GLOBAL_ALTERNATE
+                : ConditionalChainType::OBJECT_ONLY_WITH_UNDEFINED_ALTERNATE);
+
+        return genConditionalExpr(
+            [&]() -> Value * { return withObj; },
+            [&]() -> Value * {
+              return Builder.createDeletePropertyInst(
+                  withObj, Builder.getLiteralString(name));
+            },
+            [&]() -> Value * { return Builder.getLiteralBool(false); });
       }
     }
 
@@ -2305,6 +2329,36 @@ Value *ESTreeIRGen::genLogicalAssignmentExpr(
   return Builder.createPhiInst(std::move(values), std::move(blocks));
 }
 
+Value *ESTreeIRGen::genConditionalExpr(
+    const std::function<Value *()> &conditionGenerator,
+    const std::function<Value *()> &consequentGenerator,
+    const std::function<Value *()> &alternateGenerator) {
+  auto parentFunc = Builder.getInsertionBlock()->getParent();
+
+  PhiInst::ValueListType values;
+  PhiInst::BasicBlockListType blocks;
+
+  auto alternateBlock = Builder.createBasicBlock(parentFunc);
+  auto consequentBlock = Builder.createBasicBlock(parentFunc);
+  auto continueBlock = Builder.createBasicBlock(parentFunc);
+
+  Builder.createCondBranchInst(
+      conditionGenerator(), consequentBlock, alternateBlock);
+
+  Builder.setInsertionBlock(consequentBlock);
+  values.push_back(consequentGenerator());
+  blocks.push_back(Builder.getInsertionBlock());
+  Builder.createBranchInst(continueBlock);
+
+  Builder.setInsertionBlock(alternateBlock);
+  values.push_back(alternateGenerator());
+  blocks.push_back(Builder.getInsertionBlock());
+  Builder.createBranchInst(continueBlock);
+
+  Builder.setInsertionBlock(continueBlock);
+  return Builder.createPhiInst(values, blocks);
+}
+
 Value *ESTreeIRGen::genConditionalExpr(ESTree::ConditionalExpressionNode *C) {
   auto parentFunc = Builder.getInsertionBlock()->getParent();
 
@@ -2357,7 +2411,7 @@ Value *ESTreeIRGen::genIdentifierExpression(
 
   // For uses of undefined/Infinity/NaN as the global property, we make an
   // optimization to always return the constant directly.
-  if (llvh::isa<GlobalObjectProperty>(Var)) {
+  if (llvh::isa<GlobalObjectProperty>(Var) && withScopes.empty()) {
     if (StrName.getUnderlyingPointer() == kw_.identUndefined) {
       return Builder.getLiteralUndefined();
     }
@@ -2374,7 +2428,7 @@ Value *ESTreeIRGen::genIdentifierExpression(
                    << curFunction()->function->getInternalNameStr() << "\"\n");
 
   // Typeof <variable> does not throw.
-  return emitLoad(Var, afterTypeOf);
+  return withAwareEmitLoad(Var, Iden, {}, afterTypeOf);
 }
 
 Value *ESTreeIRGen::genMetaProperty(ESTree::MetaPropertyNode *MP) {

--- a/lib/IRGen/ESTreeIRGen-stmt.cpp
+++ b/lib/IRGen/ESTreeIRGen-stmt.cpp
@@ -219,6 +219,10 @@ void ESTreeIRGen::genStatement(ESTree::Node *stmt) {
     return genClassDeclaration(classDecl);
   }
 
+  if (auto *withDecl = llvh::dyn_cast<ESTree::WithStatementNode>(stmt)) {
+    return genWithStatement(withDecl);
+  }
+
   Builder.getModule()->getContext().getSourceErrorManager().error(
       stmt->getSourceRange(), Twine("invalid statement encountered."));
 }

--- a/lib/IRGen/ESTreeIRGen-with.cpp
+++ b/lib/IRGen/ESTreeIRGen-with.cpp
@@ -1,0 +1,162 @@
+#include "ESTreeIRGen.h"
+
+#include "hermes/IR/Instrs.h"
+#include "llvh/ADT/SmallString.h"
+
+namespace hermes {
+namespace irgen {
+
+void ESTreeIRGen::genWithStatement(ESTree::WithStatementNode *with) {
+  WithScopeInfo withScope{};
+  withScope.depth = semCtx_.getWithLexicalDepth(with);
+
+  withScope.object = Builder.createVariable(
+      curFunction()->curScope->getVariableScope(),
+      Builder
+          .getLiteralString(
+              internal_with.data() + std::to_string(withScope.depth))
+          ->getValue(),
+      Type::createAnyType(),
+      true);
+  withScope.object->setIsConst(true);
+  emitStore(genExpression(with->_object), withScope.object, true);
+
+  withScopes.push_back(withScope);
+  genStatement(with->_body);
+  withScopes.pop_back();
+}
+
+Value *ESTreeIRGen::emitLoadOrStoreWithStatementImpl(
+    Value *value,
+    Value *ptr,
+    bool declInit_,
+    ESTree::IdentifierNode *id,
+    ConditionalChainType conditionalChainType,
+    bool inhibitThrow) {
+  uint32_t identifierDepth = INT_MAX;
+  std::string_view name;
+
+  identifierDepth = getIDDecl(id)->scope->depth;
+  name = id->_name->c_str();
+
+  auto compareDepth = [](uint32_t searching, const WithScopeInfo &scope) {
+    return scope.depth > searching;
+  };
+
+  auto it = std::upper_bound(
+      withScopes.begin(), withScopes.end(), identifierDepth, compareDepth);
+
+  return createConditionalChainImpl(
+      it, withScopes.end(),
+      ptr,
+      value,
+      declInit_,
+      name,
+      conditionalChainType,
+      inhibitThrow);
+}
+
+Value *ESTreeIRGen::createConditionalChainImpl(
+    std::vector<WithScopeInfo>::iterator begin,
+    std::vector<WithScopeInfo>::iterator end,
+    Value *ptr,
+    Value *value,
+    bool declInit_,
+    std::string_view name,
+    ConditionalChainType conditionalChainType,
+    bool inhibitThrow) {
+  if (begin == end) {
+    if (conditionalChainType ==
+        ConditionalChainType::OBJECT_ONLY_WITH_UNDEFINED_ALTERNATE) {
+      return Builder.getLiteralUndefined();
+    } else if (
+        conditionalChainType ==
+        ConditionalChainType::OBJECT_ONLY_WITH_GLOBAL_ALTERNATE) {
+      return Builder.getGlobalObject();
+    } else if (value) {
+      return emitStore(value, ptr, declInit_);
+    } else {
+      return emitLoad(ptr, inhibitThrow);
+    }
+  }
+
+  auto &current = *(end - 1);
+  auto conditionGenerator = [&]() -> Value * {
+    auto *wrapper = Builder.createLoadPropertyInst(
+        Builder.getGlobalObject(), "HermesWithInternal");
+    wrapper = Builder.createLoadPropertyInst(wrapper, "_containsField");
+
+    auto *call = Builder.createCallInst(
+        wrapper,
+        Builder.getLiteralUndefined(),
+        Builder.getLiteralUndefined(),
+        {emitLoad(current.object, false),
+         Builder.getLiteralString(name.data())});
+
+    return call;
+  };
+
+  auto consequentGenerator = [&]() -> Value * {
+    auto loadWithObj = emitLoad(current.object, false);
+
+    if (conditionalChainType == ConditionalChainType::MEMBER_EXPRESSION) {
+      if (value) {
+        return Builder.createStorePropertyInst(value, loadWithObj, name.data());
+      } else {
+        return Builder.createLoadPropertyInst(loadWithObj, name.data());
+      }
+    }
+    return loadWithObj;
+  };
+
+  auto alternateGenerator = [&]() -> Value * {
+    return createConditionalChainImpl(
+        begin, end - 1,
+        ptr,
+        value,
+        declInit_,
+        name,
+        conditionalChainType,
+        inhibitThrow);
+  };
+
+  return genConditionalExpr(
+      conditionGenerator, consequentGenerator, alternateGenerator);
+}
+
+Value *ESTreeIRGen::withAwareEmitLoad(
+    hermes::Value *ptr,
+    ESTree::Node *node,
+    ConditionalChainType conditionalChainType,
+    bool inhibitThrow) {
+  ESTree::IdentifierNode *identifier =
+      node ? llvh::dyn_cast<ESTree::IdentifierNode>(node) : nullptr;
+  if (withScopes.empty() || !identifier) {
+    if (!ptr)
+      return Builder.getLiteralUndefined();
+    return emitLoad(ptr, inhibitThrow);
+  }
+  return emitLoadOrStoreWithStatementImpl(
+      nullptr, ptr, false, identifier, conditionalChainType, inhibitThrow);
+}
+
+Value *ESTreeIRGen::withAwareEmitStore(
+    Value *storedValue,
+    Value *ptr,
+    bool declInit_,
+    ESTree::Node *node) {
+  ESTree::IdentifierNode *identifier =
+      node ? llvh::dyn_cast<ESTree::IdentifierNode>(node) : nullptr;
+  if (withScopes.empty() || !identifier) {
+    return emitStore(storedValue, ptr, declInit_);
+  }
+  return emitLoadOrStoreWithStatementImpl(
+      storedValue,
+      ptr,
+      declInit_,
+      identifier,
+      ConditionalChainType::MEMBER_EXPRESSION);
+}
+
+} // namespace irgen
+} // namespace hermes

--- a/lib/IRGen/ESTreeIRGen.cpp
+++ b/lib/IRGen/ESTreeIRGen.cpp
@@ -54,7 +54,8 @@ Value *LReference::emitLoad() {
               llvh::cast<ESTree::MemberExpressionNode>(ast_), base_, property_)
           .result;
     case Kind::VarOrGlobal:
-      return irgen_->emitLoad(base_, false);
+      return irgen_->withAwareEmitLoad(
+          base_, ast_, ESTreeIRGen::ConditionalChainType::MEMBER_EXPRESSION);
     case Kind::Destructuring:
       assert(false && "destructuring cannot be loaded");
       return builder.getLiteralUndefined();
@@ -76,7 +77,7 @@ void LReference::emitStore(Value *value) {
           base_,
           property_);
     case Kind::VarOrGlobal:
-      irgen_->emitStore(value, base_, declInit_);
+      irgen_->withAwareEmitStore(value, base_, declInit_, ast_);
       return;
     case Kind::Error:
       return;
@@ -393,7 +394,7 @@ LReference ESTreeIRGen::createLRef(ESTree::Node *node, bool declInit) {
         LReference::Kind::VarOrGlobal,
         this,
         declInit,
-        nullptr,
+        iden,
         var,
         nullptr,
         sourceLoc);

--- a/lib/InternalJavaScript/05-With.js
+++ b/lib/InternalJavaScript/05-With.js
@@ -1,0 +1,24 @@
+(function() {
+    function _containsField(obj, field) {
+        // We use __containsField to handle multiple scenarios:
+        // 1. checking for properties in primitive types (e.g. _containsField(1, 'toString') should return true)
+        // 2. checking for properties in objects and functions, including undefined properties (e.g. _containsField({a:undefined}, 'a') should return true)
+        if (obj instanceof Object) {
+            if (obj.hasOwnProperty(Symbol.unscopables)) {
+                const unscopables = obj[Symbol.unscopables];
+                if (unscopables && unscopables[field]) {
+                    return false;
+                }
+            }
+            return obj[field] !== undefined || obj.hasOwnProperty(field);
+        } else {
+            return obj[field] !== undefined;
+        }
+    }
+
+    var HermesWithInternal = {
+        _containsField
+    };
+    Object.freeze(HermesWithInternal);
+    globalThis.HermesWithInternal = HermesWithInternal;
+})();

--- a/lib/Parser/JSParserImpl.h
+++ b/lib/Parser/JSParserImpl.h
@@ -208,6 +208,8 @@ class JSParserImpl {
   /// This is used when checking if `await` is a valid Identifier name.
   bool paramAwait_{false};
 
+  bool insideWithStatement{false};
+
   /// Appended when the parser has seen an directive being visited in the
   /// current function scope (It's intended to be used with
   /// `SaveStrictModeAndSeenDirectives`).

--- a/lib/Sema/SemanticResolver.cpp
+++ b/lib/Sema/SemanticResolver.cpp
@@ -672,17 +672,8 @@ void SemanticResolver::visit(ESTree::ContinueStatementNode *node) {
 }
 
 void SemanticResolver::visit(ESTree::WithStatementNode *node) {
-  if (compile_)
-    sm_.error(node->getStartLoc(), "with statement is not supported");
-
+  semCtx_.setWithLexicalDepth(node, curScope_->depth+1);
   visitESTreeChildren(*this, node);
-
-  uint32_t depth = curScope_->depth;
-  // Run the Unresolver to avoid resolving to variables past the depth of the
-  // `with`.
-  // Pass `depth + 1` because variables declared in this scope also cannot be
-  // trusted.
-  Unresolver::run(semCtx_, depth + 1, node->_body);
 }
 
 void SemanticResolver::visit(ESTree::TryStatementNode *tryStatement) {


### PR DESCRIPTION
This PR introduces support for the with statement via IR 

**Logic:**
- Identifiers within a with statement are transformed with a series of conditional chain. Each condition checks the presence of a key in the object properties, and returns it if present.
- We need to keep track of each `with` statement depth. Hermes also uses a task queue to lazily compile functions, and for this reason, we also need to copy the `with` depths when adding the declaration to the queue. 

**Test262 results:**  92.98%. 
 