### PR TITLE
Decrease jobs in linux CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,5 +68,5 @@ jobs:
           name: Run Hermes regression tests
           command: |
             cmake -S hermes -B build
-            cmake --build build -j 4
+            cmake --build build -j 2
             cmake --build build --target check-hermes -j 4


### PR DESCRIPTION
Summary:
Decrease the parallelism in CMake for linux CI by reducing the number of
jobs used from 4 to 2. This is because we are seeing flaky failures on
this test.

Differential Revision: D64490156


