### PR TITLE
Skip plugin for non-Flow JS code

### DIFF
--- a/tools/hermes-parser/js/babel-plugin-syntax-hermes-parser/src/index.js
+++ b/tools/hermes-parser/js/babel-plugin-syntax-hermes-parser/src/index.js
@@ -14,11 +14,27 @@ import type {ParserOptions} from 'hermes-parser';
 
 import * as HermesParser from 'hermes-parser';
 
+type Options = {
+  /**
+   * When set to 'flow', will check files for a `@flow` annotation to apply
+   * this plugin, otherwise falling back to Babel's parser.
+   *
+   * This is independent of `parserOpts.flow`, which may customise 'detect'
+   * behaviour within hermes-parser (downstream from this plugin).
+   *
+   * Defaults to 'all'.
+   */
+  parseLangTypes?: 'flow' | 'all',
+};
+
 export default function BabelPluginSyntaxHermesParser(
   // $FlowExpectedError[unclear-type] We don't have types for this.
   api: any,
+  options: Options,
 ): $ReadOnly<{...}> {
   api.assertVersion('^7.0.0 || ^8.0.0-alpha.6');
+
+  const {parseLangTypes = 'all'} = options;
 
   let curParserOpts: ParserOptions = {};
   let curFilename: ?string = null;
@@ -42,14 +58,20 @@ export default function BabelPluginSyntaxHermesParser(
       ) {
         return;
       }
-      const opts: ParserOptions = {};
+
+      const parserOpts: ParserOptions = {};
       for (const [key, value] of Object.entries(curParserOpts)) {
         if (HermesParser.ParserOptionsKeys.has(key)) {
           // $FlowExpectedError[incompatible-type]
-          opts[key] = value;
+          parserOpts[key] = value;
         }
       }
-      return HermesParser.parse(code, {...opts, babel: true});
+
+      if (parseLangTypes === 'flow' && !/@flow/.test(code)) {
+        return;
+      }
+
+      return HermesParser.parse(code, {...parserOpts, babel: true});
     },
 
     pre() {


### PR DESCRIPTION
Summary:
This is a mitigation for https://github.com/facebook/hermes/issues/1549.

Updates `babel-plugin-syntax-hermes-parser` to include a new `parseLangTypes` option, which we will configure in React Native's Babel preset to abort when the file contents do not include `@flow`.

**Context: React Native**

Originally changed in https://github.com/facebook/react-native/pull/46696, as our internal Flow support had diverged from `babel/plugin-syntax-flow` (https://github.com/facebook/react-native/issues/46601).

We effectively have three flavours of JavaScript in support:
- Flow@latest for the `react-native` package, shipped as source — uses `hermes-parser`.
- TypeScript for product code (community template, Expo) — uses `babel/plugin-syntax-typescript`.
- Plain JavaScript/JSX in product code, *which may be extended with additional user Babel plugins and needs lenient parsing* — uses base `babel/parser` (**this change**).

I'd love to simplify this 😅.

Differential Revision: D65272155


