### PR TITLE
Add build flag to support 16KB page size

### DIFF
--- a/android/hermes/build.gradle
+++ b/android/hermes/build.gradle
@@ -19,6 +19,7 @@ android {
 
     externalNativeBuild {
       cmake {
+        arguments "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
         arguments "-DHERMES_IS_ANDROID=True"
         arguments "-DHERMES_FACEBOOK_BUILD=${rootProject.ext.facebookBuild}"
         arguments "-DANDROID_STL=c++_shared"


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/react-native/pull/47042

Add native build flags to support 16KB page size

- https://developer.android.com/guide/practices/page-sizes#compile-r27-higher

Changelog:
[Android][Added] add cmake arguments to support 16KB page size for native libraries

Differential Revision: D64446876


