### PR TITLE
[WIP] Add for await of

### DIFF
--- a/include/hermes/VM/RuntimeModule.h
+++ b/include/hermes/VM/RuntimeModule.h
@@ -51,6 +51,11 @@ union RuntimeModuleFlags {
     /// Whether this runtime module's epilogue should be hidden in
     /// runtime.getEpilogues().
     bool hidesEpilogue : 1;
+
+    /// Whether we want to ignore ES6 promise checks.
+    /// This is used to force compiling modules with ES6 promises even if the
+    /// runtime is not configured to support them.
+    bool ignoreES6PromiseChecks : 1;
   };
   uint8_t flags;
   RuntimeModuleFlags() : flags(0) {}

--- a/lib/IRGen/ESTreeIRGen.h
+++ b/lib/IRGen/ESTreeIRGen.h
@@ -559,6 +559,7 @@ class ESTreeIRGen {
   void genForOfFastArrayStatement(
       ESTree::ForOfStatementNode *forOfStmt,
       flow::ArrayType *type);
+  void genAsyncForOfStatement(ESTree::ForOfStatementNode *forOfStmt);
   void genWhileLoop(ESTree::WhileStatementNode *loop);
   void genDoWhileLoop(ESTree::DoWhileStatementNode *loop);
 
@@ -1210,6 +1211,9 @@ class ESTreeIRGen {
   /// \return the internal value @@iterator
   Value *emitIteratorSymbol();
 
+  /// \return the internal value @@asyncIterator
+  Value *emitAsyncIteratorSymbol();
+
   /// IteratorRecord as defined in ES2018 7.4.1 GetIterator
   struct IteratorRecordSlow {
     Value *iterator;
@@ -1227,6 +1231,15 @@ class ESTreeIRGen {
   ///
   /// \return (iterator, nextMethod)
   IteratorRecordSlow emitGetIteratorSlow(Value *obj);
+
+  /// Call obj[@@asyncIterator], which should return an async iterator,
+  /// and return the iterator itself and its \c next() method.
+  ///
+  /// NOTE: This API is slow and should only be used if it is necessary to
+  /// provide a value to the `next()` method on the iterator.
+  ///
+  /// \return (iterator, nextMethod)
+  IteratorRecordSlow emitGetAsyncIteratorSlow(Value *obj);
 
   /// ES2018 7.4.2 IteratorNext
   /// https://www.ecma-international.org/ecma-262/9.0/index.html#sec-iteratornext

--- a/lib/InternalJavaScript/04-AsyncIterator.js
+++ b/lib/InternalJavaScript/04-AsyncIterator.js
@@ -1,0 +1,38 @@
+var initAsyncIterators = function() {
+    function _makeAsyncIterator(iterable, asyncIterMethod, syncIterMethod) {
+        if (asyncIterMethod) {
+            return asyncIterMethod.call(iterable);
+        }
+
+        let syncIterator = syncIterMethod.call(iterable);
+        async function handleResult(result) {
+            if (result.done) {
+                return result;
+            }
+            const value = result.value;
+            const resolvedValue = value instanceof Promise ? await value : value;
+            return { done: false, value: resolvedValue };
+        }
+
+        return {
+            async next() {
+                const result = syncIterator.next();
+                return handleResult(result);
+            },
+            async return(value) {
+                const result = typeof syncIterator.return === 'function' ? syncIterator.return(value) : { done: true, value };
+                return handleResult(result);
+            },
+            async throw(error) {
+                const result = typeof syncIterator.throw === 'function' ? syncIterator.throw(error) : { done: true, value: error };
+                return handleResult(result);
+            }
+        };
+    }
+
+    var HermesAsyncIteratorsInternal = {
+        _makeAsyncIterator
+    };
+    Object.freeze(HermesAsyncIteratorsInternal);
+    globalThis.HermesAsyncIteratorsInternal = HermesAsyncIteratorsInternal;
+};

--- a/lib/Sema/SemanticResolver.cpp
+++ b/lib/Sema/SemanticResolver.cpp
@@ -479,8 +479,6 @@ void SemanticResolver::visit(ESTree::ForInStatementNode *node) {
 }
 
 void SemanticResolver::visit(ESTree::ForOfStatementNode *node) {
-  if (compile_ && node->_await)
-    sm_.error(node->getStartLoc(), "for await is not supported");
   visitForInOf(node, node, node->_left, node->_right, node->_body);
 }
 

--- a/lib/VM/Runtime.cpp
+++ b/lib/VM/Runtime.cpp
@@ -1047,7 +1047,7 @@ CallResult<HermesValue> Runtime::runBytecode(
     assert(builtinsFrozen_ && "Builtins must be frozen by now.");
   }
 
-  if (bytecode->getBytecodeOptions().hasAsync && !hasES6Promise_) {
+  if (!flags.ignoreES6PromiseChecks && bytecode->getBytecodeOptions().hasAsync && !hasES6Promise_) {
     return raiseTypeError(
         "Cannot execute a bytecode having async functions when Promise is disabled.");
   }
@@ -1191,6 +1191,7 @@ Handle<JSObject> Runtime::runInternalJavaScript() {
   RuntimeModuleFlags flags;
   flags.persistent = true;
   flags.hidesEpilogue = true;
+  flags.ignoreES6PromiseChecks = true;
   auto res = runBytecode(
       std::move(bcResult.first),
       flags,

--- a/test/hermes/for-await-of-async-iterator.js
+++ b/test/hermes/for-await-of-async-iterator.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -Xes6-promise %s | %FileCheck --match-full-lines %s
+// RUN: %hermes -O0 -Xes6-promise %s | %FileCheck --match-full-lines %s
+// RUN: %hermes -lazy -Xes6-promise %s | %FileCheck --match-full-lines %s
+
+// Custom async iterable using Symbol.asyncIterator
+const asyncIterable = {
+    [Symbol.asyncIterator]: function() {
+        let i = 1;
+        const max = 3;
+        return {
+            next: function() {
+                if (i <= max) {
+                    return Promise.resolve({ value: i++, done: false });
+                } else {
+                    return Promise.resolve({ done: true });
+                }
+            }
+        };
+    }
+};
+
+// Test for await of loop with custom async iterable
+(async function testCustomAsyncIterable() {
+    sum = 0;
+    for await (const value of asyncIterable) {
+        sum += value;
+    }
+    print(sum);
+})();
+
+//CHECK: 6

--- a/test/hermes/for-await-of-return.js
+++ b/test/hermes/for-await-of-return.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -Xes6-promise %s | %FileCheck --match-full-lines %s
+// RUN: %hermes -O0 -Xes6-promise %s | %FileCheck --match-full-lines %s
+// RUN: %hermes -lazy -Xes6-promise %s | %FileCheck --match-full-lines %s
+
+// Custom async iterable using Symbol.asyncIterator
+const asyncIterable = {
+    [Symbol.asyncIterator]: function() {
+        return {
+            next: function() {
+                return Promise.resolve({ value:0, done: false });
+            },
+            return: function() {
+                print('Cleanup performed');
+                return Promise.resolve({ done: true });
+            }
+        };
+    }
+};
+
+// Using break and triggering return() in for await...of loop
+(async function testBreakWithReturn() {
+    for await (const value of asyncIterable) {
+        if (value === 0) {
+            break;
+        }
+    }
+})();
+
+//CHECK: Cleanup performed

--- a/test/hermes/for-await-of-sync-iterator.js
+++ b/test/hermes/for-await-of-sync-iterator.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -Xes6-promise %s | %FileCheck --match-full-lines %s
+// RUN: %hermes -O0 -Xes6-promise %s | %FileCheck --match-full-lines %s
+// RUN: %hermes -lazy -Xes6-promise %s | %FileCheck --match-full-lines %s
+
+// For await of loop should work with a sync iterable
+const syncIterable = [1,2,3];
+
+(async function testCustomSyncIterable() {
+    sum = 0;
+    for await (const value of syncIterable) {
+        sum += value;
+    }
+    print(sum);
+})();
+
+//CHECK: 6


### PR DESCRIPTION
## Summary

This PR introduces support for the `for await of` syntax through IR.

In detail:
- The helper function `_makeAsyncIterator` is used to create an async iterator for a given iterable. It checks if an async iterator method is available; if not, it creates an async iterator from a synchronous iterator by wrapping its results in promises.
- Added a `genAsyncForOfStatement` which handles the for await of loop by iterating over the async iterator object. It follows the same rules described [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of)

## Test Plan
- Unit tests
- Test262
