### PR TITLE
Add bound checks to `JSCallSite::getFileName`

### DIFF
--- a/lib/VM/JSCallSite.cpp
+++ b/lib/VM/JSCallSite.cpp
@@ -95,9 +95,12 @@ CallResult<HermesValue> JSCallSite::getFileName(
     if (location) {
       auto debugInfo = runtimeModule->getBytecode()->getDebugInfo();
 
+      auto filenameTable = debugInfo->getFilenameTable();
+      assert(location->filenameId < filenameTable.size() && "Filename ID out of bounds");
+
       std::string utf8Storage;
       llvh::StringRef fileName = hbc::getStringFromEntry(
-          debugInfo->getFilenameTable()[location->filenameId],
+          filenameTable[location->filenameId],
           debugInfo->getFilenameStorage(),
           utf8Storage);
       return StringPrimitive::createEfficient(runtime, makeUTF8Ref(fileName));


### PR DESCRIPTION
## Summary

Seems like a missing bounds check.

Won't sign CLA too much of a hassle, consider it a bug report and fix it yourselves if needed 😄 .

## Test Plan

Previous tests just pass I guess?
