### PR TITLE
fix NumberFormat.resolvedOptions on Android

### DIFF
--- a/android/intltest/java/com/facebook/hermes/test/HermesIntlAndroidTest.java
+++ b/android/intltest/java/com/facebook/hermes/test/HermesIntlAndroidTest.java
@@ -49,6 +49,18 @@ public class HermesIntlAndroidTest {
   }
 
   @Test
+  public void testNumberFormatSignificantDigitsFromAsset() throws IOException {
+    AssetManager assets =
+        InstrumentationRegistry.getInstrumentation().getTargetContext().getAssets();
+    InputStream is = assets.open("number-format-significant-digits.js");
+    String script =
+        new BufferedReader(new InputStreamReader(is)).lines().collect(Collectors.joining("\n"));
+    try (JSRuntime rt = JSRuntime.makeHermesRuntime()) {
+      rt.evaluateJavaScript(script);
+    }
+  }
+
+  @Test
   public void testDateTimeFormat() {
     try (JSRuntime rt = JSRuntime.makeHermesRuntime()) {
       rt.evaluateJavaScript(

--- a/lib/Platform/Intl/java/com/facebook/hermes/intl/NumberFormat.java
+++ b/lib/Platform/Intl/java/com/facebook/hermes/intl/NumberFormat.java
@@ -626,10 +626,10 @@ public class NumberFormat {
 
     if (mRoundingType == IPlatformNumberFormatter.RoundingType.SIGNIFICANT_DIGITS) {
       if (mResolvedMaximumSignificantDigits != -1)
-        finalResolvedOptions.put("minimumSignificantDigits", mResolvedMaximumSignificantDigits);
+        finalResolvedOptions.put("maximumSignificantDigits", mResolvedMaximumSignificantDigits);
 
       if (mResolvedMinimumSignificantDigits != -1)
-        finalResolvedOptions.put("maximumSignificantDigits", mResolvedMinimumSignificantDigits);
+        finalResolvedOptions.put("minimumSignificantDigits", mResolvedMinimumSignificantDigits);
 
     } else if (mRoundingType == IPlatformNumberFormatter.RoundingType.FRACTION_DIGITS) {
 

--- a/test/hermes/intl/number-format-significant-digits.js
+++ b/test/hermes/intl/number-format-significant-digits.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes %s
+// REQUIRES: intl
+
+function assert(pred, str) {
+  if (!pred) {
+    throw new Error('assertion failed' + (str === undefined ? '' : (': ' + str)));
+  }
+}
+
+let resolvedOptions;
+
+resolvedOptions = new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD' }).resolvedOptions();
+assert(resolvedOptions.minimumSignificantDigits === undefined);
+assert(resolvedOptions.maximumSignificantDigits === undefined);
+
+//
+// Validate minimumSignificantDigits logic
+//
+try { new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD', minimumSignificantDigits: -1 }) }
+catch (e) { assert(e.message.includes('minimumSignificantDigits value is invalid.')) }
+
+try { new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD', minimumSignificantDigits: 22 }) }
+catch (e) { assert(e.message.includes('minimumSignificantDigits value is invalid.')) }
+
+resolvedOptions = new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD', minimumSignificantDigits: 1 }).resolvedOptions();
+assert(resolvedOptions.minimumSignificantDigits === 1);
+assert(resolvedOptions.maximumSignificantDigits === undefined);
+
+resolvedOptions = new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD', minimumSignificantDigits: 21 }).resolvedOptions();
+assert(resolvedOptions.minimumSignificantDigits === 21);
+assert(resolvedOptions.maximumSignificantDigits === undefined);
+
+//
+// Validate maximumSignificantDigits logic
+//
+try { new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD', maximumSignificantDigits: -1 }) }
+catch (e) { assert(e.message.includes('maximumSignificantDigits value is invalid.')) }
+
+try { new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD', maximumSignificantDigits: 22 }) }
+catch (e) { assert(e.message.includes('maximumSignificantDigits value is invalid.')) }
+
+resolvedOptions = new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD', maximumSignificantDigits: 1 }).resolvedOptions();
+assert(resolvedOptions.minimumSignificantDigits === undefined);
+assert(resolvedOptions.maximumSignificantDigits === 1);
+
+resolvedOptions = new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD', maximumSignificantDigits: 21 }).resolvedOptions();
+assert(resolvedOptions.minimumSignificantDigits === undefined);
+assert(resolvedOptions.maximumSignificantDigits === 21);
+
+//
+// Validate when both are set
+//
+try { new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD', minimumSignificantDigits: 5, maximumSignificantDigits: 2 }) }
+catch (e) { assert(e.message.includes('minimumSignificantDigits is greater than maximumSignificantDigits')) }
+
+resolvedOptions = new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD', minimumSignificantDigits: 3, maximumSignificantDigits: 5 }).resolvedOptions();
+assert(resolvedOptions.minimumSignificantDigits === 3);
+assert(resolvedOptions.maximumSignificantDigits === 5);

--- a/test/hermes/intl/number-format-significant-digits.js
+++ b/test/hermes/intl/number-format-significant-digits.js
@@ -31,11 +31,11 @@ catch (e) { assert(e.message.includes('minimumSignificantDigits value is invalid
 
 resolvedOptions = new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD', minimumSignificantDigits: 1 }).resolvedOptions();
 assert(resolvedOptions.minimumSignificantDigits === 1);
-assert(resolvedOptions.maximumSignificantDigits === undefined);
+assert(resolvedOptions.maximumSignificantDigits === 21);
 
 resolvedOptions = new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD', minimumSignificantDigits: 21 }).resolvedOptions();
 assert(resolvedOptions.minimumSignificantDigits === 21);
-assert(resolvedOptions.maximumSignificantDigits === undefined);
+assert(resolvedOptions.maximumSignificantDigits === 21);
 
 //
 // Validate maximumSignificantDigits logic
@@ -47,11 +47,11 @@ try { new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD', maximu
 catch (e) { assert(e.message.includes('maximumSignificantDigits value is invalid.')) }
 
 resolvedOptions = new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD', maximumSignificantDigits: 1 }).resolvedOptions();
-assert(resolvedOptions.minimumSignificantDigits === undefined);
+assert(resolvedOptions.minimumSignificantDigits === 1);
 assert(resolvedOptions.maximumSignificantDigits === 1);
 
 resolvedOptions = new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD', maximumSignificantDigits: 21 }).resolvedOptions();
-assert(resolvedOptions.minimumSignificantDigits === undefined);
+assert(resolvedOptions.minimumSignificantDigits === 1);
 assert(resolvedOptions.maximumSignificantDigits === 21);
 
 //

--- a/test/hermes/intl/number-format-significant-digits.js
+++ b/test/hermes/intl/number-format-significant-digits.js
@@ -58,7 +58,7 @@ assert(resolvedOptions.maximumSignificantDigits === 21);
 // Validate when both are set
 //
 try { new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD', minimumSignificantDigits: 5, maximumSignificantDigits: 2 }) }
-catch (e) { assert(e.message.includes('minimumSignificantDigits is greater than maximumSignificantDigits')) }
+catch (e) { assert(e.message.includes('maximumSignificantDigits value is invalid.')) }
 
 resolvedOptions = new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD', minimumSignificantDigits: 3, maximumSignificantDigits: 5 }).resolvedOptions();
 assert(resolvedOptions.minimumSignificantDigits === 3);


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `main`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/HEAD/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.
-->

## Summary

A typo currently leads to wrong results for `NumberFormat.resolvedOptions()`: `minimumSignificantDigits` and `maximumSignificantDigits` are interchanged.

This PR fixes that and adds tests.

## Test Plan

Added unit tests.
