### PR TITLE
Fix SynthTraceSerializationTest for Windows

### DIFF
--- a/unittests/API/SynthTraceSerializationTest.cpp
+++ b/unittests/API/SynthTraceSerializationTest.cpp
@@ -396,23 +396,31 @@ TEST_F(SynthTraceSerializationTest, Utf8Record) {
 }
 
 TEST_F(SynthTraceSerializationTest, Utf16Record) {
+  auto serialized =
+      R"({"type":"Utf16Record","time":0,"objID":"string:123","retval":"hi\ud83d\udc4b"})";
   EXPECT_EQ(
-      R"({"type":"Utf16Record","time":0,"objID":"string:123","retval":"hi\ud83d\udc4b"})",
+      serialized,
       to_string(SynthTrace::Utf16Record(
           dummyTime, SynthTrace::encodeString(123), u"hi👋")));
+  serialized =
+      R"({"type":"Utf16Record","time":0,"objID":"string:111","retval":"\ud83d"})";
   EXPECT_EQ(
-      R"({"type":"Utf16Record","time":0,"objID":"string:111","retval":"\ud83d"})",
+      serialized,
       to_string(SynthTrace::Utf16Record(
           dummyTime, SynthTrace::encodeString(111), u"\xd83d")));
 }
 
 TEST_F(SynthTraceSerializationTest, GetStringDataRecord) {
+  auto serialized =
+      R"({"type":"GetStringDataRecord","time":0,"objID":"string:123","strData":"\nhello\ud83d\udc4b\\"})";
   EXPECT_EQ(
-      R"({"type":"GetStringDataRecord","time":0,"objID":"string:123","strData":"\nhello\ud83d\udc4b\\"})",
+      serialized,
       to_string(SynthTrace::GetStringDataRecord(
           dummyTime, SynthTrace::encodeString(123), u"\nhello👋\\")));
+  serialized =
+      R"({"type":"GetStringDataRecord","time":0,"objID":"propNameID:111","strData":"\ud83d"})";
   EXPECT_EQ(
-      R"({"type":"GetStringDataRecord","time":0,"objID":"propNameID:111","strData":"\ud83d"})",
+      serialized,
       to_string(SynthTrace::GetStringDataRecord(
           dummyTime, SynthTrace::encodePropNameID(111), u"\xd83d")));
 }


### PR DESCRIPTION
Summary:
MSVC has stringizing bug where it doesn't process code units in raw
string literals. See example: https://godbolt.org/z/osjYj95rq

Temporary fix is to move the string literal out of the `EXPECT_EQ` macro
until this gets fixed.

Reviewed By: neildhar

Differential Revision: D66914808


