### PR TITLE
Add support for Symbol member expression in class method definition

### DIFF
--- a/tools/hermes-parser/js/flow-api-translator/__tests__/flowToFlowDef-test.js
+++ b/tools/hermes-parser/js/flow-api-translator/__tests__/flowToFlowDef-test.js
@@ -444,6 +444,16 @@ describe('flowToFlowDef', () => {
            static 2(): void;
          }`,
       );
+      await expectTranslate(
+        `export class A {
+           [Symbol.iterator]() {}
+           static get [Symbol.asyncIterator]() {}
+         }`,
+        `declare export class A {
+           @@iterator(): void;
+           static get @@asyncIterator(): void;
+         }`,
+      );
     });
   });
   describe('InterfaceDeclaration', () => {


### PR DESCRIPTION
Summary:
This diff introduces support for [Symbol.<...>] as a method definition. Previously, that type of code wasn't supported and caused an exception:

```js
export default {
  [Symbol.iterator]() {};
}
```

The generated output if the type is not specified should be:

```js
declare export default {
  @iterator(): void;
}
```

There are a few places in react-native source that will benefit from this, like: DOMRectList, URLSeachParams, NodeList and HTMLCollection.

Changelog:
[flow-api-translator] - Added support for Symbol member expression in class method definition

Differential Revision: D68766740


