### PR TITLE
Introduce format-agnostic API for JS Sampling

### DIFF
--- a/API/hermes/hermes.cpp
+++ b/API/hermes/hermes.cpp
@@ -1175,6 +1175,27 @@ void HermesRuntime::sampledTraceToStreamInDevToolsFormat(std::ostream &stream) {
 #endif // HERMESVM_SAMPLING_PROFILER_AVAILABLE
 }
 
+sampling_profiler::Profile HermesRuntime::dumpSampledTraceToProfile() {
+#if HERMESVM_SAMPLING_PROFILER_AVAILABLE
+  vm::SamplingProfiler *sp = impl(this)->runtime_.samplingProfiler.get();
+  if (!sp) {
+    throw jsi::JSINativeException("Runtime not registered for profiling");
+  }
+  return sp->dumpAsProfile();
+#else
+  throwHermesNotCompiledWithSamplingProfilerSupport();
+#endif // HERMESVM_SAMPLING_PROFILER_AVAILABLE
+}
+
+std::vector<sampling_profiler::Profile>
+HermesRuntime::dumpSampledTraceToProfilesGlobal() {
+#if HERMESVM_SAMPLING_PROFILER_AVAILABLE
+  return ::hermes::vm::SamplingProfiler::dumpAsProfilesGlobal();
+#else
+  throwHermesNotCompiledWithSamplingProfilerSupport();
+#endif // HERMESVM_SAMPLING_PROFILER_AVAILABLE
+}
+
 /*static*/ std::unordered_map<std::string, std::vector<std::string>>
 HermesRuntime::getExecutedFunctions() {
   std::unordered_map<

--- a/API/hermes/hermes.h
+++ b/API/hermes/hermes.h
@@ -17,6 +17,7 @@
 
 #include <hermes/Public/HermesExport.h>
 #include <hermes/Public/RuntimeConfig.h>
+#include <hermes/Public/SamplingProfiler.h>
 #include <jsi/jsi.h>
 #include <unordered_map>
 
@@ -88,6 +89,15 @@ class HERMES_EXPORT HermesRuntime : public jsi::Runtime {
   /// Serialize the sampled stack to the format expected by DevTools'
   /// Profiler.stop return type.
   void sampledTraceToStreamInDevToolsFormat(std::ostream &stream);
+
+  /// Dump sampled stack trace for a given runtime to a data structure that can
+  /// be used by third parties.
+  sampling_profiler::Profile dumpSampledTraceToProfile();
+
+  /// Dump sampled stack trace for all registered local sampling profiler
+  /// instances to a data structure that can be used by third parties.
+  static std::vector<sampling_profiler::Profile>
+  dumpSampledTraceToProfilesGlobal();
 
   /// Return the executed JavaScript function info.
   /// This information holds the segmentID, Virtualoffset and sourceURL.

--- a/include/hermes/VM/Profiler/SamplingProfiler.h
+++ b/include/hermes/VM/Profiler/SamplingProfiler.h
@@ -12,6 +12,7 @@
 
 #if HERMESVM_SAMPLING_PROFILER_AVAILABLE
 
+#include "hermes/Public/SamplingProfiler.h"
 #include "hermes/VM/Callable.h"
 #include "hermes/VM/JSNativeFunctions.h"
 #include "hermes/VM/Runtime.h"
@@ -267,6 +268,10 @@ class SamplingProfiler {
   /// Dump sampled stack to \p OS in chrome trace format.
   void dumpChromeTrace(llvh::raw_ostream &OS);
 
+  /// Dump sampled stack trace to data structure that can be used by third
+  /// parties.
+  facebook::hermes::sampling_profiler::Profile dumpAsProfile();
+
   /// Dump the sampled stack to \p OS in the format expected by the
   /// Profiler.stop return type. See
   ///
@@ -280,6 +285,11 @@ class SamplingProfiler {
 
   /// Static wrapper for dumpChromeTrace.
   static void dumpChromeTraceGlobal(llvh::raw_ostream &OS);
+
+  /// Static wrapper for dumpAsProfile. Will dump in separate Profile for each
+  /// local sampling profiler instance.
+  static std::vector<facebook::hermes::sampling_profiler::Profile>
+  dumpAsProfilesGlobal();
 
   /// Enable and start profiling.
   static bool enable(double meanHzFreq = 100);

--- a/lib/VM/CMakeLists.txt
+++ b/lib/VM/CMakeLists.txt
@@ -54,6 +54,7 @@ set(source_files
   Profiler/ChromeTraceSerializer.cpp
   Profiler/CodeCoverageProfiler.cpp
   Profiler/InlineCacheProfiler.cpp
+  Profiler/ProfileGenerator.cpp
   Profiler/SamplingProfiler.cpp
   Profiler/SamplingProfilerPosix.cpp
   Profiler/SamplingProfilerWindows.cpp

--- a/lib/VM/Profiler/ProfileGenerator.cpp
+++ b/lib/VM/Profiler/ProfileGenerator.cpp
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ProfileGenerator.h"
+
+#if HERMESVM_SAMPLING_PROFILER_AVAILABLE
+
+namespace fhsp = ::facebook::hermes::sampling_profiler;
+
+namespace hermes {
+namespace vm {
+
+namespace {
+
+/// \return timestamp as time since epoch in microseconds.
+static uint64_t convertTimestampToMicroseconds(
+    SamplingProfiler::TimeStampType timeStamp) {
+  return std::chrono::duration_cast<std::chrono::microseconds>(
+             timeStamp.time_since_epoch())
+      .count();
+}
+
+static std::string getJSFunctionName(
+    hbc::BCProvider *bcProvider,
+    uint32_t funcId) {
+  hbc::RuntimeFunctionHeader functionHeader =
+      bcProvider->getFunctionHeader(funcId);
+  return bcProvider->getStringRefFromID(functionHeader.functionName()).str();
+}
+
+static OptValue<hbc::DebugSourceLocation> getSourceLocation(
+    hbc::BCProvider *bcProvider,
+    uint32_t funcId,
+    uint32_t opcodeOffset) {
+  const hbc::DebugOffsets *debugOffsets = bcProvider->getDebugOffsets(funcId);
+  if (debugOffsets &&
+      debugOffsets->sourceLocations != hbc::DebugOffsets::NO_OFFSET) {
+    return bcProvider->getDebugInfo()->getLocationForAddress(
+        debugOffsets->sourceLocations, opcodeOffset);
+  }
+  return llvh::None;
+}
+
+static fhsp::ProfileSampleCallStackSuspendFrame::SuspendFrameKind
+formatSuspendFrameKind(SamplingProfiler::SuspendFrameInfo::Kind kind) {
+  switch (kind) {
+    case SamplingProfiler::SuspendFrameInfo::Kind::GC:
+      return fhsp::ProfileSampleCallStackSuspendFrame::SuspendFrameKind::GC;
+    case SamplingProfiler::SuspendFrameInfo::Kind::Debugger:
+      return fhsp::ProfileSampleCallStackSuspendFrame::SuspendFrameKind::
+          Debugger;
+    case SamplingProfiler::SuspendFrameInfo::Kind::Multiple:
+      return fhsp::ProfileSampleCallStackSuspendFrame::SuspendFrameKind::
+          Multiple;
+
+    default:
+      llvm_unreachable("Unexpected Suspend Frame kind");
+  }
+}
+
+/// Format VM-level frame to public interface.
+static fhsp::ProfileSampleCallStackFrame *formatCallStackFrame(
+    const SamplingProfiler::StackFrame &frame,
+    const SamplingProfiler &samplingProfiler) {
+  switch (frame.kind) {
+    case SamplingProfiler::StackFrame::FrameKind::SuspendFrame: {
+      return new fhsp::ProfileSampleCallStackSuspendFrame{
+          formatSuspendFrameKind(frame.suspendFrame.kind),
+      };
+    }
+
+    case SamplingProfiler::StackFrame::FrameKind::NativeFunction:
+      return new fhsp::ProfileSampleCallStackNativeFunctionFrame{
+          samplingProfiler.getNativeFunctionName(frame),
+      };
+
+    case SamplingProfiler::StackFrame::FrameKind::FinalizableNativeFunction:
+      return new fhsp::ProfileSampleCallStackHostFunctionFrame{
+          samplingProfiler.getNativeFunctionName(frame),
+      };
+
+    case SamplingProfiler::StackFrame::FrameKind::JSFunction: {
+      RuntimeModule *module = frame.jsFrame.module;
+      hbc::BCProvider *bcProvider = module->getBytecode();
+
+      std::string functionName =
+          getJSFunctionName(bcProvider, frame.jsFrame.functionId);
+      std::optional<uint32_t> scriptId = std::nullopt;
+      std::optional<std::string> url = std::nullopt;
+      std::optional<uint32_t> lineNumber = std::nullopt;
+      std::optional<uint32_t> columnNumber = std::nullopt;
+
+      OptValue<hbc::DebugSourceLocation> sourceLocOpt = getSourceLocation(
+          bcProvider, frame.jsFrame.functionId, frame.jsFrame.offset);
+      if (sourceLocOpt.hasValue()) {
+        // Bundle has debug info.
+        scriptId = sourceLocOpt.getValue().filenameId;
+        url = bcProvider->getDebugInfo()->getFilenameByID(scriptId.value());
+
+        // hbc::DebugSourceLocation is 1-based, but initializes line and column
+        // fields with 0 by default.
+        uint32_t line = sourceLocOpt.getValue().line;
+        uint32_t column = sourceLocOpt.getValue().column;
+        if (line != 0) {
+          lineNumber = line;
+        }
+        if (column != 0) {
+          columnNumber = column;
+        }
+      }
+
+      return new fhsp::ProfileSampleCallStackJSFunctionFrame{
+          functionName,
+          scriptId,
+          url,
+          lineNumber,
+          columnNumber,
+      };
+    }
+
+    default:
+      llvm_unreachable("Unexpected Frame kind");
+  }
+}
+
+} // namespace
+
+/* static */ fhsp::Profile ProfileGenerator::generate(
+    const SamplingProfiler &sp,
+    uint32_t pid,
+    const SamplingProfiler::ThreadNamesMap &threadNames,
+    const std::vector<SamplingProfiler::StackTrace> &sampledStacks) {
+  fhsp::Process process{pid};
+
+  assert(!threadNames.empty() && "Expected at least one Thread recorded");
+  // It is unclear why Hermes keeps map of threads for a local profiler.
+  // See D67453370 for more context, this map is expected to contain a single
+  // entry.
+  auto threadEntry = threadNames.begin();
+  fhsp::Thread thread{threadEntry->first, threadEntry->second};
+
+  std::vector<fhsp::ProfileSample> samples;
+  samples.reserve(sampledStacks.size());
+  for (const SamplingProfiler::StackTrace &sampledStack : sampledStacks) {
+    uint64_t timestamp = convertTimestampToMicroseconds(sampledStack.timeStamp);
+
+    std::vector<fhsp::ProfileSampleCallStackFrame *> callFrames;
+    callFrames.reserve(sampledStack.stack.size());
+    for (const SamplingProfiler::StackFrame &frame : sampledStack.stack) {
+      callFrames.emplace_back(formatCallStackFrame(frame, sp));
+    }
+
+    samples.emplace_back(timestamp, callFrames);
+  }
+
+  return fhsp::Profile{process, thread, samples};
+}
+
+} // namespace vm
+} // namespace hermes
+
+#endif // HERMESVM_SAMPLING_PROFILER_AVAILABLE

--- a/lib/VM/Profiler/ProfileGenerator.h
+++ b/lib/VM/Profiler/ProfileGenerator.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef HERMES_VM_PROFILER_PROFILEGENERATOR_H
+#define HERMES_VM_PROFILER_PROFILEGENERATOR_H
+
+#include "hermes/VM/Profiler/SamplingProfilerDefs.h"
+
+#if HERMESVM_SAMPLING_PROFILER_AVAILABLE
+
+#include "hermes/VM/Profiler/SamplingProfiler.h"
+
+namespace hermes {
+namespace vm {
+
+/// Generate format-agnostic data structure, which should contain relevant
+/// information about the recorded Sampling Profile and may be used by third
+/// parties.
+class ProfileGenerator {
+  ProfileGenerator() = delete;
+
+ public:
+  /// Emit Profile in a single struct.
+  static facebook::hermes::sampling_profiler::Profile generate(
+      const SamplingProfiler &sp,
+      uint32_t pid,
+      const SamplingProfiler::ThreadNamesMap &threadNames,
+      const std::vector<SamplingProfiler::StackTrace> &sampledStacks);
+};
+
+} // namespace vm
+} // namespace hermes
+
+#endif // HERMESVM_SAMPLING_PROFILER_AVAILABLE
+
+#endif // HERMES_VM_PROFILER_PROFILEGENERATOR_H

--- a/public/hermes/Public/SamplingProfiler.h
+++ b/public/hermes/Public/SamplingProfiler.h
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef HERMES_PUBLIC_SAMPLINGPROFILER_H
+#define HERMES_PUBLIC_SAMPLINGPROFILER_H
+
+#include <hermes/Public/HermesExport.h>
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace facebook {
+namespace hermes {
+namespace sampling_profiler {
+
+/// Provides details about the Process where sampling occurred.
+struct HERMES_EXPORT Process {
+ public:
+  explicit Process(uint64_t id) : id_(id) {}
+
+  /// \return id of the OS process, where sampling occurred.
+  uint64_t getId() const {
+    return id_;
+  }
+
+ private:
+  /// OS-level id of the process.
+  uint64_t id_;
+};
+
+/// Provides details about the Thread where sampling occurred.
+struct HERMES_EXPORT Thread {
+ public:
+  Thread(uint64_t id, const std::string &name) : id_(id), name_(name) {}
+
+  /// \return id of the OS thread, where sampling occurred.
+  uint64_t getId() const {
+    return id_;
+  }
+
+  /// \return name of the OS thread, where sampling occurred.
+  const std::string &getName() const {
+    return name_;
+  }
+
+ private:
+  /// OS-level id of the thread.
+  uint64_t id_;
+  /// OS-level name of the thread.
+  std::string name_;
+};
+
+/// Represents a single frame inside the captured sample stack.
+/// Base struct for different kinds of frames.
+struct HERMES_EXPORT ProfileSampleCallStackFrame {
+  /// Represents type of frame inside of recorded call stack.
+  enum class Kind {
+    JSFunction, /// JavaScript function frame.
+    NativeFunction, /// Native built-in functions, like arrayPrototypeMap.
+    HostFunction, /// Native functions, defined by Host, a.k.a. Host functions.
+    Suspend, /// Frame that suspends the execution of the VM: GC or Debugger.
+  };
+
+ public:
+  explicit ProfileSampleCallStackFrame(const Kind kind) : kind_(kind) {}
+
+  /// \return type of the call stack frame.
+  Kind getKind() const {
+    return kind_;
+  }
+
+ private:
+  Kind kind_;
+};
+
+/// Extends ProfileSampleCallStackFrame with an information about JavaScript
+/// function frame: function name, and possibly scriptId, url, line and column
+/// numbers.
+struct HERMES_EXPORT ProfileSampleCallStackJSFunctionFrame
+    : public ProfileSampleCallStackFrame {
+  explicit ProfileSampleCallStackJSFunctionFrame(
+      const std::string &functionName,
+      const std::optional<uint32_t> &scriptId = std::nullopt,
+      const std::optional<std::string> &url = std::nullopt,
+      const std::optional<uint32_t> &lineNumber = std::nullopt,
+      const std::optional<uint32_t> &columnNumber = std::nullopt)
+      : ProfileSampleCallStackFrame(
+            ProfileSampleCallStackFrame::Kind::JSFunction),
+        functionName_(functionName),
+        scriptId_(scriptId),
+        url_(url),
+        lineNumber_(lineNumber),
+        columnNumber_(columnNumber) {}
+
+  /// \return name of the function that represents call frame.
+  const std::string &getFunctionName() const {
+    return functionName_;
+  }
+
+  bool hasScriptId() const {
+    return scriptId_.has_value();
+  }
+
+  /// \return id of the corresponding script in the VM.
+  uint32_t getScriptId() const {
+    return scriptId_.value();
+  }
+
+  bool hasUrl() const {
+    return url_.has_value();
+  }
+
+  /// \return source url of the corresponding script in the VM.
+  const std::string &getUrl() const {
+    return url_.value();
+  }
+
+  bool hasLineNumber() const {
+    return lineNumber_.has_value();
+  }
+
+  /// \return 1-based line number of the corresponding call frame.
+  uint32_t getLineNumber() const {
+    return lineNumber_.value();
+  }
+
+  bool hasColumnNumber() const {
+    return columnNumber_.has_value();
+  }
+
+  /// \return 1-based column number of the corresponding call frame.
+  uint32_t getColumnNumber() const {
+    return columnNumber_.value();
+  }
+
+ private:
+  std::string functionName_;
+  std::optional<uint32_t> scriptId_;
+  std::optional<std::string> url_;
+  std::optional<uint32_t> lineNumber_;
+  std::optional<uint32_t> columnNumber_;
+};
+
+/// Extends ProfileSampleCallStackFrame with a function name.
+struct HERMES_EXPORT ProfileSampleCallStackNativeFunctionFrame
+    : public ProfileSampleCallStackFrame {
+ public:
+  explicit ProfileSampleCallStackNativeFunctionFrame(
+      const std::string &functionName)
+      : ProfileSampleCallStackFrame(
+            ProfileSampleCallStackFrame::Kind::NativeFunction),
+        functionName_(functionName) {}
+
+  /// \return name of the function that represents call frame.
+  const std::string &getFunctionName() const {
+    return functionName_;
+  }
+
+ private:
+  std::string functionName_;
+};
+
+/// Extends ProfileSampleCallStackFrame with a function name.
+struct HERMES_EXPORT ProfileSampleCallStackHostFunctionFrame
+    : public ProfileSampleCallStackFrame {
+ public:
+  explicit ProfileSampleCallStackHostFunctionFrame(
+      const std::string &functionName)
+      : ProfileSampleCallStackFrame(
+            ProfileSampleCallStackFrame::Kind::HostFunction),
+        functionName_(functionName) {}
+
+  /// \return name of the function that represents call frame.
+  const std::string &getFunctionName() const {
+    return functionName_;
+  }
+
+ private:
+  std::string functionName_;
+};
+
+/// Extends ProfileSampleCallStackFrame with a suspend frame information.
+struct HERMES_EXPORT ProfileSampleCallStackSuspendFrame
+    : public ProfileSampleCallStackFrame {
+  /// Subtype of the Suspend frame.
+  enum class SuspendFrameKind {
+    GC, /// Frame that suspends the execution of the VM due to GC.
+    Debugger, /// Frame that suspends the execution of the VM due to debugger.
+    Multiple, /// Multiple suspensions have occurred.
+  };
+
+ public:
+  explicit ProfileSampleCallStackSuspendFrame(
+      const SuspendFrameKind suspendFrameKind)
+      : ProfileSampleCallStackFrame(ProfileSampleCallStackFrame::Kind::Suspend),
+        suspendFrameKind_(suspendFrameKind) {}
+
+  /// \return subtype of the suspend frame.
+  SuspendFrameKind getSuspendFrameKind() const {
+    return suspendFrameKind_;
+  }
+
+ private:
+  SuspendFrameKind suspendFrameKind_;
+};
+
+/// A pair of a timestamp and a snapshot of the call stack at this point in
+/// time.
+struct HERMES_EXPORT ProfileSample {
+ public:
+  ProfileSample(
+      uint64_t timestamp,
+      std::vector<ProfileSampleCallStackFrame *> callStack)
+      : timestamp_(timestamp), callStack_(std::move(callStack)) {}
+
+  /// \return serialized unix timestamp in microseconds granularity. The
+  /// moment when this sample was recorded.
+  uint64_t getTimestamp() const {
+    return timestamp_;
+  }
+
+  /// \return a snapshot of the call stack. The first element of the vector is
+  /// the lowest frame in the stack.
+  const std::vector<ProfileSampleCallStackFrame *> &getCallStack() const {
+    return callStack_;
+  }
+
+ private:
+  /// When the call stack snapshot was taken (μs).
+  uint64_t timestamp_;
+  /// Snapshot of the call stack. The first element of the vector is
+  /// the lowest frame in the stack.
+  std::vector<ProfileSampleCallStackFrame *> callStack_;
+};
+
+/// Contains relevant information about the sampled trace from start to finish.
+struct HERMES_EXPORT Profile {
+ public:
+  Profile(Process process, Thread thread, std::vector<ProfileSample> samples)
+      : process_(process),
+        thread_(std::move(thread)),
+        samples_(std::move(samples)) {}
+
+  /// \return details about the Process where sampling occurred.
+  const Process &getProcess() const {
+    return process_;
+  }
+
+  /// \return details about the Thread where sampling occurred.
+  const Thread &getThread() const {
+    return thread_;
+  }
+
+  /// \return list of recorded samples, should be chronologically sorted.
+  const std::vector<ProfileSample> &getSamples() const {
+    return samples_;
+  }
+
+ private:
+  /// Represents OS process where sampling occurred.
+  Process process_;
+  /// Represents OS thread where sampling occurred.
+  Thread thread_;
+  /// List of recorded samples, should be chronologically sorted.
+  std::vector<ProfileSample> samples_;
+};
+
+} // namespace sampling_profiler
+} // namespace hermes
+} // namespace facebook
+
+#endif


### PR DESCRIPTION
Summary:
This diff adds a new API on `HermesRuntime`, which will emit a `struct` with all necessary information about completed JavaScript Sampling Profile.

This `struct` can later be used by other third parties, such as React Native. The reason for creating a data source, and not just providing a stream to which Hermes will emit serialized information is that on React Native side we own the format in which data should be serialized, together with the data from other potential sources, such as User Timings, Interactions, Network, etc.

HermesRuntime will have 2 new API endpoints:
- `dumpAsProfile`. A method on `HermesRuntime` instance, which returns `Profile` that contains all relevant information about the recorded sampled stack trace.
- `dumpAsProfilesGlobal`. A static method, which returns vector of all recorded Profiles for all registered sampling profiler instances.


The actual conversion to Trace Event Format will hapen on React Native side, Hermes will only emit data structure that is agnostic to format and operates only with JavaScript runtime-level entities and general stuff: call stack frame information, timestamps, information about OS process and thread where sampling occured.

Differential Revision: D67353585


