### PR TITLE
- Add conversion of the iterator from Flow to TS

### DIFF
--- a/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/class/members/method/iterator/spec.js
+++ b/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/class/members/method/iterator/spec.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+declare class Foo {
+  @@iterator(): Iterator<string>;
+  @@asyncIterator(): AsyncIterator<string>;
+}

--- a/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/class/members/method/iterator/translate-result.shot
+++ b/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/class/members/method/iterator/translate-result.shot
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`flowDefToTSDef class/members/method/iterator 1`] = `
+"/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ * @format
+ */
+
+declare class Foo {
+  [Symbol.iterator](): Iterator<string>;
+  [Symbol.asyncIterator](): AsyncIterator<string>;
+}
+"
+`;

--- a/tools/hermes-parser/js/flow-api-translator/src/flowDefToTSDef.js
+++ b/tools/hermes-parser/js/flow-api-translator/src/flowDefToTSDef.js
@@ -928,12 +928,44 @@ const getTransforms = (
               cloneJSDocCommentsToNewNode(member, newNode);
               classMembers.push(newNode);
             } else {
+              const [key, computed] = (() => {
+                const _key = member.key;
+                if (_key.type === 'Identifier' && _key.name.startsWith('@@')) {
+                  const name = _key.name.slice(2);
+                  if (['iterator', 'asyncIterator'].includes(name)) {
+                    return [
+                      {
+                        type: 'MemberExpression',
+                        computed: false,
+                        object: {
+                          type: 'Identifier',
+                          name: 'Symbol',
+                          optional: false,
+                          loc: DUMMY_LOC,
+                        },
+                        optional: false,
+                        property: {
+                          type: 'Identifier',
+                          name,
+                          optional: false,
+                          loc: DUMMY_LOC,
+                        },
+                        loc: DUMMY_LOC,
+                      },
+                      true,
+                    ];
+                  }
+                }
+
+                return [member.key, member.computed];
+              })();
+
               const newNode: TSESTree.MethodDefinitionAmbiguous = {
                 type: 'MethodDefinition',
                 loc: DUMMY_LOC,
                 accessibility: member.accessibility,
-                computed: member.computed ?? false,
-                key: member.key,
+                computed: computed ?? false,
+                key,
                 kind: member.kind,
                 optional: member.optional,
                 override: false,


### PR DESCRIPTION
Summary:
`@iterator` and `@asyncIterator` are valid syntaxes for Flow but not for TS which accepts [Symbol.iterator] and [Symbol.asyncIterator]. According to flow lexer these are the only valid syntaxes in this form so checking for other cases prefixed with `@@` should not be required.

Changelog:
[flow-api-translator] - Added conversion of the iterator from Flow to TS

Differential Revision: D68776171


