### PR TITLE
fix: Fix iOS build CI (`.xcframework` missing)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,11 +78,8 @@ jobs:
         name: linux-hermes
         path: output
   macos:
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: 15.4
     - uses: actions/checkout@v4.1.0
       with:
         path: hermes
@@ -110,15 +107,12 @@ jobs:
         name: macos-hermes
         path: output
   build-apple-runtime:
-    runs-on: macos-latest
+    runs-on: macos-15
     env:
       TERM: dumb
       HERMES_WS_DIR: "/tmp/hermes"
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: 15.4
     - uses: actions/checkout@v4.1.0
     - name: Cache setup
       uses: actions/cache@v4.0.0
@@ -141,11 +135,8 @@ jobs:
     - name: Build the Mac frameworks
       run: "./utils/build-mac-framework.sh"
   test-macos:
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: 15.4
     - uses: actions/checkout@v4.1.0
       with:
         path: hermes
@@ -157,16 +148,13 @@ jobs:
         cmake --build ./build
         cmake --build ./build --target check-hermes
   test-apple-runtime:
-    runs-on: macos-latest
+    runs-on: macos-15
     needs: build-apple-runtime
     env:
       TERM: dumb
       HERMES_WS_DIR: "/tmp/hermes"
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: 15.4
     - uses: actions/checkout@v4.1.0
     - name: Cache setup
       uses: actions/cache@v4.0.0
@@ -218,7 +206,7 @@ jobs:
           -scheme ApplePlatformsIntegrationTVOSTests
       working-directory: test/ApplePlatformsIntegrationTestApp
   package-apple-runtime:
-    runs-on: macos-latest
+    runs-on: macos-15
     needs:
     - test-macos
     - test-apple-runtime
@@ -227,9 +215,6 @@ jobs:
       HERMES_WS_DIR: "/tmp/hermes"
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: 15.4
     - uses: actions/checkout@v4.1.0
     - name: Cache setup
       uses: actions/cache@v4.0.0
@@ -566,11 +551,8 @@ jobs:
         emulator-options: -timezone Europe/Paris -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         script: cd android && ./gradlew :intltest:prepareTests && ./gradlew -Pabis=x86 :intltest:connectedAndroidTest
   test-macos-test262:
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: 15.4
     - uses: actions/checkout@v4.1.0
       with:
         path: hermes


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `main`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/HEAD/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.
-->

## Summary

Fixes the build CI which previously failed silently.

See [the last actions run](https://github.com/facebook/hermes/actions/runs/13322712332/job/37210108771), in the end of the logs it fails silently:

```
-- Up-to-date: /Users/runner/work/hermes/hermes/build_appletvsimulator/../destroot/include/jsi/decorator.h
-- Up-to-date: /Users/runner/work/hermes/hermes/build_appletvsimulator/../destroot/include/jsi/threadsafe.h
-- Up-to-date: /Users/runner/work/hermes/hermes/build_appletvsimulator/../destroot/include/jsi/jsilib.h
Creating universal framework for platforms: iphoneos iphonesimulator catalyst xros xrsimulator appletvos appletvsimulator
error: the path does not point to a valid framework: /Users/runner/work/hermes/hermes/destroot/Library/Frameworks/iphoneos/hermes.framework
rm: iphoneos: No such file or directory
rm: appletvos: No such file or directory
/Users/runner/work/hermes/hermes
```

This is fixed by upgrading macOS 14 to macOS 15, or more precise; upgrading Xcode 15.4 to Xcode 16 (which is always installed on a macos-15 runner, hence the removal of that unneeded extra action)

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
-->

## Test Plan

Run the CI and check logs
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes the user interface.
-->
