### PR TITLE
JSError: never fail with invalid getter target"

### DIFF
--- a/include/hermes/VM/JSError.h
+++ b/include/hermes/VM/JSError.h
@@ -205,15 +205,6 @@ class JSError final : public JSObject {
       Handle<JSError> selfHandle,
       size_t index,
       llvh::SmallVectorImpl<char16_t> &str);
-
-  /// Given an object \p targetHandle:
-  /// 1. If its [[CapturedError]] slot has a non-null handle, return it as a
-  ///    JSError.
-  /// 2. Otherwise, return \t targetHandle cast to JSError.
-  /// Throws if any cast or property access fails.
-  static CallResult<Handle<JSError>> getErrorFromStackTarget(
-      Runtime &runtime,
-      Handle<JSObject> targetHandle);
 };
 
 } // namespace vm

--- a/test/hermes/error-capture-stack-trace.js
+++ b/test/hermes/error-capture-stack-trace.js
@@ -161,7 +161,7 @@ print(target.stack);
 var dummy = {};
 Error.captureStackTrace(dummy);
 const stackGetter = Object.getOwnPropertyDescriptor(dummy, 'stack').get;
-try { stackGetter.apply({});   } catch (e) { print(e); }
-//CHECK: TypeError: Error.stack getter called with an invalid receiver
-try { stackGetter.apply(null); } catch (e) { print(e); }
-//CHECK: TypeError: Error.stack getter called with an invalid receiver
+print(stackGetter.apply({}));
+//CHECK: undefined
+print(stackGetter.apply(null));
+//CHECK: undefined

--- a/test/hermes/error-in-proto.js
+++ b/test/hermes/error-in-proto.js
@@ -24,3 +24,16 @@ try {
 }
 // CHECK: Caught Error MyError: 1234
 // CHECK-NEXT:     at global{{.*}}
+
+
+function MyError2() {
+    this.message = "MyError2";
+}
+MyError2.prototype = Object.create(Error.prototype);
+try {
+    throw new MyError2();
+} catch (e) {
+    print("Caught", e, e.stack);
+}
+
+// CHECK-NEXT: Caught Error: MyError2 undefined

--- a/test/hermes/error.js
+++ b/test/hermes/error.js
@@ -90,12 +90,8 @@ print(e);
 // CHECK-NEXT: 12345: 67890
 
 // Check exception case of accessing Error.stack from a different 'this'
-try {
-  new Error().__lookupGetter__("stack").call({});
-} catch (e) {
-  print(e.name);
-}
-//CHECK-NEXT: TypeError
+print(new Error().__lookupGetter__("stack").call({}));
+// CHECK-NEXT: undefined
 
 
 // Regression test: setting the stack while getting the message causes a null dereference.

--- a/test/hermes/regress-proxy-parent.js
+++ b/test/hermes/regress-proxy-parent.js
@@ -15,22 +15,14 @@
 // Install stack trace information on Object.prototype.
 Error.captureStackTrace(Object.prototype);
 
-// Check that lookup on a regular proxy fails.
-try{
-  var p =  new Proxy(new Error(), {});
-  p.stack;
-} catch (e) {
-  print(e);
-}
-// CHECK: TypeError: Error.stack getter called with an invalid receiver
+// Check that lookup on a regular proxy returns undefined.
+var p =  new Proxy(new Error(), {});
+print(p.stack);
+// CHECK: undefined
 
 // Check that lookup on a callable proxy fails.
-try {
-  function foo(){}
-  foo.__proto__ = new Error();
-  var cp = new Proxy(foo, {});
-  cp.stack;
-} catch (e) {
-  print(e);
-}
-// CHECK-NEXT: TypeError: Error.stack getter called with an invalid receiver
+function foo(){}
+foo.__proto__ = new Error();
+var cp = new Proxy(foo, {});
+print(cp.stack);
+// CHECK-NEXT: undefined


### PR DESCRIPTION
Summary:
JS developers expect this to work and print "undefined":
```js
function MyEror() {
    this.message = "MyError";
}
MyError.prototype = Object.create(Error.prototype);
try {
    throw new MyError();
} catch (e) {
    print(e.stack);
}
```

We give it to them by preventing the getter from throwing errors. In V8
this is implemented differently by attaching the getter to the actual
instance.

Arguably, this makes sense.

Add and update tests.

- Grafted path static_h to hermes

Differential Revision: D69757360


