### PR TITLE
Fix CMake build for Windows

### DIFF
--- a/lib/VM/CMakeLists.txt
+++ b/lib/VM/CMakeLists.txt
@@ -177,6 +177,10 @@ set(link_libs
   dtoa
 )
 
+if (WIN32)
+  list(APPEND link_libs winmm)
+endif()
+
 if(HERMES_ENABLE_INTL)
   list(APPEND link_libs hermesPlatformIntl)
 endif()


### PR DESCRIPTION
Summary:
We recently added a dependency on `timeBeginPeriod` and `timeEndPeriod` from `winmm.lib` for Windows builds.

This change fixes the CMake build for Windows.

Differential Revision: D69786895
