### PR TITLE
Speed up Object.freeze()

### DIFF
--- a/include/hermes/VM/InternalProperties.def
+++ b/include/hermes/VM/InternalProperties.def
@@ -33,5 +33,8 @@ NAMED_PROP(ArrayBufferExternalFinalizer)
 NAMED_PROP(ExternalMemoryPressure)
 NAMED_PROP(TextEncoderType)
 
+/// A reserved symbol ID to use for the HC transition to the frozen state.
+NAMED_PROP(FreezeTransition)
+
 #undef PROP
 #undef NAMED_PROP


### PR DESCRIPTION
Summary:
`Object.freeze()` relies on `HiddenClass::makeAllReadOnly()`, which
iterates through all properties and updates their flags, either creating
 a new `HiddenClass` (HC) for each, or locating the previously created
one. Best case, the performance is
O(number-of-properties)*O(hash-table-lookup).

We can speed this up significantly by caching the transition to the
final HC in the HC where `makeAllReadOnly()` is invoked. For that we
simply define a new "internal property name" `FreezeTransition`. The
rest is trivial.

Benchmark:
```js
function make(i) {
    return {a: 10, b: 20, c: 30, d: 40, e: 50, f: 60, g: 70, h: 80, i};
}

const N = 1_000_000;
let t1 = Date.now();
for(let i = 0; i < N; ++i)
    Object.freeze(make(i));
let t2 = Date.now();
console.log(t2 - t1, "ms");
```

- Time before: 277 ms
- Time after: 66 ms

Differential Revision: D70845213


