### PR TITLE
Alpine aarch64 build questions

### DIFF
--- a/API/hermes/CMakeLists.txt
+++ b/API/hermes/CMakeLists.txt
@@ -84,9 +84,9 @@ if(HERMES_THREAD_SAFETY_ANALYSIS)
     AsyncDebuggerAPI.cpp
     ${CDP_API_SOURCES}
   )
-  if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+  if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang") # warning instead for struggle with std:mutex capabilities annotation
     set_property(SOURCE ${TSA_SOURCES} APPEND_STRING PROPERTY
-      COMPILE_FLAGS "-Wthread-safety -Werror=thread-safety-analysis -Werror=thread-safety-precise -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS")
+      COMPILE_FLAGS "-Wthread-safety -Wthread-safety-analysis -Werror=thread-safety-precise -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS")
   endif()
 endif()
 

--- a/API/hermes/cdp/DomainState.cpp
+++ b/API/hermes/cdp/DomainState.cpp
@@ -5,6 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <string>
+#include <functional>
+#include <iostream>
 #include "DomainState.h"
 
 #include <cassert>

--- a/external/llvh/lib/Support/raw_ostream.cpp
+++ b/external/llvh/lib/Support/raw_ostream.cpp
@@ -736,6 +736,7 @@ uint64_t raw_fd_ostream::seek(uint64_t off) {
   flush();
 #ifdef _WIN32
   pos = ::_lseeki64(FD, off, SEEK_SET);
+# FIXME: https://reviews.llvm.org/D139752?id=484363
 #elif defined(HAVE_LSEEK64)
   pos = ::lseek64(FD, off, SEEK_SET);
 #else

--- a/external/llvh/lib/Support/raw_ostream.cpp
+++ b/external/llvh/lib/Support/raw_ostream.cpp
@@ -737,10 +737,10 @@ uint64_t raw_fd_ostream::seek(uint64_t off) {
 #ifdef _WIN32
   pos = ::_lseeki64(FD, off, SEEK_SET);
 # FIXME: https://reviews.llvm.org/D139752?id=484363
-#elif defined(HAVE_LSEEK64)
+#elif defined(NOT_HAVE_LSEEK64)
   pos = ::lseek64(FD, off, SEEK_SET);
 #else
-  pos = ::lseek(FD, off, SEEK_SET);
+  pos = lseek(FD, off, SEEK_SET);  
 #endif
   if (pos == (uint64_t)-1)
     error_detected(std::error_code(errno, std::generic_category()));


### PR DESCRIPTION
## Summary

Running `cmake --build ./build` on a stock Alpine Linux installation with clang 17 (and clang 18) resulted in two compile errors - I am not clear if there's a simple environment fix or if it just needs more actual code in the Hermes repo.

lseek has lseek64 capabilities, but neither lseek or lseek64 are in the namespace scope. (`raw_ostream.cpp`)
`thread-safety-analysis` is not picking up capability annotations for `std:mutex` and so the analysis fails on the lock.

They're very simple and the patch just shows an inline workaround (e.g. calling `lseek` instead of `lseek64`, and for the sake of compiling, just disabling tsa as that source is already verified by other build environments)

## Test Plan

This code presents the two issues and work-arounds, and is request for clarification as to the correct environment or appropriate workarounds:

lseek64 and sleek are not in the global namespace, and it may be that lseek is desired though the capability is 64.
This may have some clue as to that evolution:
https://reviews.llvm.org/D139752?id=484363

The failure of the TSA attribute is seen here:
```
/tmp/scratch/hermes/API/hermes/cdp/DomainAgent.h:67:39: warning: 'guarded_by' attribute requires arguments whose type is annotated with 'capability' attribute; type here is 'std::mutex' [-Wthread-safety-attributes]
   67 |     std::function<void(Args...)> func TSA_GUARDED_BY(mutex);
      |                                       ^
/tmp/scratch/hermes/API/hermes/../hermes/ThreadSafetyAnalysis.h:26:61: note: expanded from macro 'TSA_GUARDED_BY'
   26 | #define TSA_GUARDED_BY(x) TSA_THREAD_ANNOTATION_ATTRIBUTE__(guarded_by(x))
      |                                                             ^
/tmp/scratch/hermes/API/hermes/cdp/DomainAgent.h:47:25: error: reading variable 'func' requires holding mutex 'funcContainer_->mutex' [-Werror,-Wthread-safety-analysis]
   47 |     if (funcContainer_->func) {
```


While this couple line patch works fine to get things going - it would be nice to understand if there's an appropriate patch or change to the environment.  I've not checked a separate aarch64 Linux distribution with LLVM.  I've not checked for pre-built releases from Hermes for aarch64. React Native 0.76 does not supply aarch64.

With this small patch I believe I'm building just fine end-to-end for RN 0.76 on aarch64. This patch is not intended to be merged upstream, but rather illustrates the only two issues I hit in compiling.