### PR TITLE
GetByVal and GetByIndex fast paths

### DIFF
--- a/API/hermes/hermes.cpp
+++ b/API/hermes/hermes.cpp
@@ -2699,7 +2699,6 @@ vm::RuntimeConfig hardenedHermesRuntimeConfig() {
   vm::RuntimeConfig::Builder config;
   // Disable optional JS features.
   config.withEnableEval(false);
-  config.withArrayBuffer(false);
   config.withES6Proxy(false);
   config.withEnableHermesInternal(false);
   config.withEnableHermesInternalTestMethods(false);

--- a/include/hermes/Support/Statistic.h
+++ b/include/hermes/Support/Statistic.h
@@ -52,8 +52,10 @@ inline void EnableStatistics() {}
 // HERMES_SLOW_STATISTIC are Statistics which are only enabled if
 // HERMES_SLOW_DEBUG is defined or HERMES_FORCE_SLOW_STATS is defined.
 #if defined(HERMES_SLOW_DEBUG) || defined(HERMES_FORCE_SLOW_STATS)
+#define HERMES_SLOW_STATISTIC_ENABLED 1
 #define HERMES_SLOW_STATISTIC(Name, Desc) STATISTIC(Name, Desc)
 #else
+#define HERMES_SLOW_STATISTIC_ENABLED 0
 #define HERMES_SLOW_STATISTIC(Name, Desc) static hermes::DummyCounter Name;
 #endif
 

--- a/include/hermes/VM/Interpreter.h
+++ b/include/hermes/VM/Interpreter.h
@@ -87,15 +87,6 @@ class Interpreter {
       Runtime &runtime,
       PinnedHermesValue *callTarget);
 
-  /// Fast path to get primitive value \p base's own properties by name \p id
-  /// without boxing.
-  /// Primitive own properties are properties fetching values from primitive
-  /// value itself.
-  /// Currently the only primitive own property is String.prototype.length.
-  /// If the fast path property does not exist, return Empty.
-  static PseudoHandle<>
-  tryGetPrimitiveOwnPropertyById(Runtime &runtime, Handle<> base, SymbolID id);
-
   /// Implement OpCode::GetById/TryGetById when the base is not an object.
   static CallResult<PseudoHandle<>> getByIdTransientWithReceiver_RJS(
       Runtime &runtime,
@@ -106,12 +97,6 @@ class Interpreter {
   getByIdTransient_RJS(Runtime &runtime, Handle<> base, SymbolID id) {
     return getByIdTransientWithReceiver_RJS(runtime, base, id, base);
   }
-
-  /// Fast path for getByValTransient() -- avoid boxing for \p base if it is
-  /// string primitive and \p nameHandle is an array index.
-  /// If the property does not exist, return Empty.
-  static PseudoHandle<>
-  getByValTransientFast(Runtime &runtime, Handle<> base, Handle<> nameHandle);
 
   /// Implement OpCode::GetByVal when the base is not an object.
   static CallResult<PseudoHandle<>> getByValTransientWithReceiver_RJS(

--- a/include/hermes/VM/JSArrayBuffer.h
+++ b/include/hermes/VM/JSArrayBuffer.h
@@ -84,10 +84,6 @@ class JSArrayBuffer final : public JSObject {
   ///   if the ArrayBuffer is empty.
   /// \pre attached() must be true
   uint8_t *getDataBlock(Runtime &runtime) {
-    // This check should never fail, because all ways to illegally access
-    // ArrayBuffer should raise exceptions. It's here as a last line of defense.
-    if (!runtime.hasArrayBuffer())
-      hermes_fatal("Illegal access to ArrayBuffer");
     assert(attached() && "Cannot get a data block from a detached ArrayBuffer");
     return data_;
   }

--- a/include/hermes/VM/JSTypedArray.h
+++ b/include/hermes/VM/JSTypedArray.h
@@ -85,11 +85,11 @@ class JSTypedArrayBase : public JSObject {
     return buffer_.get(runtime);
   }
 
-  uint8_t *begin(Runtime &runtime) {
+  uint8_t *data(Runtime &runtime) {
     return buffer_.getNonNull(runtime)->getDataBlock(runtime) + offset_;
   }
-  uint8_t *end(Runtime &runtime) {
-    return begin(runtime) + getByteLength();
+  uint8_t *dataEnd(Runtime &runtime) {
+    return data(runtime) + getByteLength();
   }
 
   /// \return Whether this JSTypedArrayBase is attached to some buffer.
@@ -215,8 +215,6 @@ class JSTypedArrayBase : public JSObject {
 template <typename T, CellKind C>
 class JSTypedArray final : public JSTypedArrayBase {
  public:
-  using iterator = T *;
-
   static const ObjectVTable vt;
 
   static constexpr CellKind getCellKind() {
@@ -230,10 +228,10 @@ class JSTypedArray final : public JSTypedArrayBase {
       Runtime &runtime,
       Handle<JSObject> prototype);
 
-  iterator begin(Runtime &runtime) {
-    return reinterpret_cast<T *>(JSTypedArrayBase::begin(runtime));
+  T *begin(Runtime &runtime) {
+    return reinterpret_cast<T *>(data(runtime));
   }
-  iterator end(Runtime &runtime) {
+  T *end(Runtime &runtime) {
     return begin(runtime) + length_;
   }
 

--- a/include/hermes/VM/JSTypedArray.h
+++ b/include/hermes/VM/JSTypedArray.h
@@ -92,6 +92,10 @@ class JSTypedArrayBase : public JSObject {
     return data(runtime) + getByteLength();
   }
 
+  /// Polymorphic access to the data in the TypedArray.
+  inline static HermesValue
+  polyReadMayAlloc(JSTypedArrayBase *self, Runtime &runtime, size_type index);
+
   /// \return Whether this JSTypedArrayBase is attached to some buffer.
   bool attached(Runtime &runtime) const {
     return buffer_ && buffer_.getNonNull(runtime)->attached();
@@ -206,6 +210,66 @@ class JSTypedArrayBase : public JSObject {
       const GCCell *cell,
       Metadata::Builder &mb);
 };
+
+#ifdef NDEBUG
+LLVM_ATTRIBUTE_ALWAYS_INLINE
+#endif
+inline HermesValue JSTypedArrayBase::polyReadMayAlloc(
+    JSTypedArrayBase *self,
+    Runtime &runtime,
+    size_type index) {
+  assert(self->attached(runtime) && "at() requires a JSArrayBuffer");
+  assert(
+      index < self->getLength() &&
+      "That index is out of bounds of this TypedArray");
+
+  uint8_t *dataPtr = self->data(runtime);
+  switch (self->getKind()) {
+    case CellKind::Int8ArrayKind:
+      return HermesValue::encodeTrustedNumberValue(
+          reinterpret_cast<int8_t *>(dataPtr)[index]);
+    case CellKind::Uint8ArrayKind:
+      return HermesValue::encodeTrustedNumberValue(
+          reinterpret_cast<uint8_t *>(dataPtr)[index]);
+    case CellKind::Uint8ClampedArrayKind:
+      return HermesValue::encodeTrustedNumberValue(
+          reinterpret_cast<uint8_t *>(dataPtr)[index]);
+    case CellKind::Int16ArrayKind:
+      return HermesValue::encodeTrustedNumberValue(
+          reinterpret_cast<int16_t *>(dataPtr)[index]);
+    case CellKind::Uint16ArrayKind:
+      return HermesValue::encodeTrustedNumberValue(
+          reinterpret_cast<uint16_t *>(dataPtr)[index]);
+    case CellKind::Int32ArrayKind:
+      return HermesValue::encodeTrustedNumberValue(
+          reinterpret_cast<int32_t *>(dataPtr)[index]);
+    case CellKind::Uint32ArrayKind:
+      return HermesValue::encodeTrustedNumberValue(
+          reinterpret_cast<uint32_t *>(dataPtr)[index]);
+    case CellKind::Float32ArrayKind:
+      return HermesValue::encodeUntrustedNumberValue(
+          reinterpret_cast<float *>(dataPtr)[index]);
+    case CellKind::Float64ArrayKind:
+      return HermesValue::encodeUntrustedNumberValue(
+          reinterpret_cast<double *>(dataPtr)[index]);
+    case CellKind::BigInt64ArrayKind: {
+      auto cr = BigIntPrimitive::fromSigned(
+          runtime, reinterpret_cast<int64_t *>(dataPtr)[index]);
+      if (LLVM_UNLIKELY(cr.getStatus() == ExecutionStatus::EXCEPTION))
+        hermes_fatal("Failed to encode BigInt in polyReadMayAlloc");
+      return *cr;
+    }
+    case CellKind::BigUint64ArrayKind: {
+      auto cr = BigIntPrimitive::fromUnsigned(
+          runtime, reinterpret_cast<uint64_t *>(dataPtr)[index]);
+      if (LLVM_UNLIKELY(cr.getStatus() == ExecutionStatus::EXCEPTION))
+        hermes_fatal("Failed to encode BigInt in polyReadMayAlloc");
+      return *cr;
+    }
+    default:
+      llvm_unreachable("Unknown TypedArray kind");
+  }
+}
 
 /// JSTypedArray is a collection with array semantics (random access indexing),
 /// but stores a typed value with a known size, and has a static total size.

--- a/include/hermes/VM/JSTypedArray.h
+++ b/include/hermes/VM/JSTypedArray.h
@@ -235,11 +235,13 @@ class JSTypedArray final : public JSTypedArrayBase {
     return begin(runtime) + length_;
   }
 
+  /// Monomorphic access to the \p i'th element of the buffer. This is
+  /// implemented for each TypedArray subclass.
   /// Retrieve the \p i'th element of the buffer.
   /// \pre
   ///   This cannot be called on a detached TypedArray.
   ///   i must be less than the length of the TypedArray.
-  T &at(Runtime &runtime, size_type i) {
+  T &monoAt(Runtime &runtime, size_type i) {
     assert(attached(runtime) && "at() requires a JSArrayBuffer");
     assert(i < getLength() && "That index is out of bounds of this TypedArray");
     return begin(runtime)[i];

--- a/include/hermes/VM/Runtime.h
+++ b/include/hermes/VM/Runtime.h
@@ -908,10 +908,6 @@ class Runtime : public RuntimeBase, public HandleRootOwner {
     return hasIntl_;
   }
 
-  bool hasArrayBuffer() const {
-    return hasArrayBuffer_;
-  }
-
   bool hasMicrotaskQueue() const {
     return hasMicrotaskQueue_;
   }
@@ -1149,9 +1145,6 @@ class Runtime : public RuntimeBase, public HandleRootOwner {
 
   /// Set to true if we should enable ECMA-402 Intl APIs.
   const bool hasIntl_;
-
-  /// Set to true if we should enable ArrayBuffer, DataView and typed arrays.
-  const bool hasArrayBuffer_;
 
   /// Set to true if we are using microtasks.
   const bool hasMicrotaskQueue_;

--- a/lib/VM/Interpreter-slowpaths.cpp
+++ b/lib/VM/Interpreter-slowpaths.cpp
@@ -622,10 +622,11 @@ ExecutionStatus Interpreter::caseDelByVal(
   return ExecutionStatus::RETURNED;
 }
 
-PseudoHandle<> Interpreter::getByValTransientFast(
-    Runtime &runtime,
-    Handle<> base,
-    Handle<> nameHandle) {
+/// Fast path for getByValTransient() -- avoid boxing for \p base if it is
+/// string primitive and \p nameHandle is an array index.
+/// If the property does not exist, return Empty.
+static inline PseudoHandle<>
+getByValTransientFast(Runtime &runtime, Handle<> base, Handle<> nameHandle) {
   if (base->isString()) {
     // Handle most common fast path -- array index property for string
     // primitive.
@@ -1466,10 +1467,14 @@ ExecutionStatus doGetByIdSlowPath_RJS(
   return ExecutionStatus::RETURNED;
 }
 
-inline PseudoHandle<> Interpreter::tryGetPrimitiveOwnPropertyById(
-    Runtime &runtime,
-    Handle<> base,
-    SymbolID id) {
+/// Fast path to get primitive value \p base's own properties by name \p id
+/// without boxing.
+/// Primitive own properties are properties fetching values from primitive
+/// value itself.
+/// Currently the only primitive own property is String.prototype.length.
+/// If the fast path property does not exist, return Empty.
+static inline PseudoHandle<>
+tryGetPrimitiveOwnPropertyById(Runtime &runtime, Handle<> base, SymbolID id) {
   if (base->isString() && id == Predefined::getSymbolID(Predefined::length)) {
     return createPseudoHandle(HermesValue::encodeTrustedNumberValue(
         base->getString()->getStringLength()));

--- a/lib/VM/Interpreter-slowpaths.cpp
+++ b/lib/VM/Interpreter-slowpaths.cpp
@@ -14,6 +14,8 @@
 #include "hermes/VM/Casting.h"
 #include "hermes/VM/Interpreter.h"
 #include "hermes/VM/JSCallableProxy.h"
+#include "hermes/VM/JSTypedArray.h"
+#include "hermes/VM/PrimitiveBox.h"
 #include "hermes/VM/PropertyAccessor.h"
 #include "hermes/VM/Runtime-inline.h"
 #include "hermes/VM/RuntimeModule-inline.h"
@@ -46,6 +48,10 @@ HERMES_SLOW_STATISTIC(
     "NumGetByIdSlow: Number of property 'read by id' slow path");
 
 HERMES_SLOW_STATISTIC(
+    NumGetByValStr,
+    "NumGetByValStr: Number of GetByVal _,StringPrimitive,_");
+
+HERMES_SLOW_STATISTIC(
     NumPutByIdCacheEvicts,
     "NumPutByIdCacheEvicts: Number of property 'write by id' cache evictions");
 HERMES_SLOW_STATISTIC(
@@ -54,6 +60,8 @@ HERMES_SLOW_STATISTIC(
 HERMES_SLOW_STATISTIC(
     NumPutByIdTransient,
     "NumPutByIdTransient: Number of property 'write by id' to non-objects");
+
+HERMES_SLOW_STATISTIC(NumPutByVal, "NumPutByVal: Number of PutByVal");
 
 namespace hermes {
 namespace vm {
@@ -628,6 +636,8 @@ ExecutionStatus Interpreter::caseDelByVal(
 static inline PseudoHandle<>
 getByValTransientFast(Runtime &runtime, Handle<> base, Handle<> nameHandle) {
   if (base->isString()) {
+    ++NumGetByValStr;
+
     // Handle most common fast path -- array index property for string
     // primitive.
     // Since primitive string cannot have index like property we can
@@ -741,6 +751,7 @@ ExecutionStatus Interpreter::casePutByVal(
     Runtime &runtime,
     PinnedHermesValue *frameRegs,
     const inst::Inst *ip) {
+  ++NumPutByVal;
   bool strictMode = (ip->opCode == inst::OpCode::PutByValStrict);
   if (LLVM_LIKELY(O1REG(PutByValLoose).isObject())) {
     auto defaultPropOpFlags = DEFAULT_PROP_OP_FLAGS(strictMode);

--- a/lib/VM/Interpreter.cpp
+++ b/lib/VM/Interpreter.cpp
@@ -58,6 +58,25 @@ HERMES_SLOW_STATISTIC(
     NumGetByIdDict,
     "NumGetByIdDict: Number of property 'read by id' of dictionaries");
 
+HERMES_SLOW_STATISTIC(NumGetByIndex, "NumGetByIndex: Number of GetByIndex");
+
+HERMES_SLOW_STATISTIC(NumGetByVal, "NumGetByVal: Number of GetByVal");
+HERMES_SLOW_STATISTIC(
+    NumGetByValObj,
+    "NumGetByValObj: Number of GetByVal _,Obj,_");
+HERMES_SLOW_STATISTIC(
+    NumGetByValObjInd,
+    "NumGetByValObjInd: Number of GetByVal _,Obj,Index");
+HERMES_SLOW_STATISTIC(
+    NumGetByValObjIndArr,
+    "NumGetByValObjIndArr: Number of GetByVal _,JSArray,Index");
+HERMES_SLOW_STATISTIC(
+    NumGetByValObjIndArrOK,
+    "NumGetByValObjIndArrOK: Number of GetByVal _,JSArray,[Index] != Empty");
+HERMES_SLOW_STATISTIC(
+    NumGetByValObjIndTA,
+    "NumGetByValObjIndTA: Number of GetByVal _,JSTypedArray,Index");
+
 HERMES_SLOW_STATISTIC(
     NumPutById,
     "NumPutById: Number of property 'write by id' accesses");
@@ -364,6 +383,7 @@ static inline const Inst *nextInstCall(const Inst *ip) {
       ((sizeof(inst::name##Inst) - minSize) \
        << (((uint8_t)OpCode::name - firstCall) * W))
 #include "hermes/BCGen/HBC/BytecodeList.def"
+
       ;
 #undef DEFINE_RET_TARGET
 
@@ -2032,7 +2052,70 @@ tailCall:
       DISPATCH;
     }
 
-      CASE_OUTOFLINE(GetByVal);
+      CASE(GetByVal) {
+        ++NumGetByVal;
+        if constexpr (HERMES_SLOW_STATISTIC_ENABLED) {
+          if (O2REG(GetByVal).isObject())
+            ++NumGetByValObj;
+        }
+        (void)NumGetByValObj;
+
+        // An efficient check whether the value is both a number and a uint32.
+        static_assert(
+            HERMESVALUE_VERSION == 2,
+            "HermesValue must use NaN-encoding for non-numbers");
+        uint32_t index;
+        if (sh_tryfast_f64_to_u32(O3REG(GetByVal).f64, index) &&
+            LLVM_LIKELY(O2REG(GetByVal).isObject())) {
+          ++NumGetByValObjInd;
+          auto *obj = vmcast<JSObject>(O2REG(GetByVal));
+
+          // Check for array with fast index properties and a valid index.
+          if (obj->getKind() == CellKind::JSArrayKind) {
+            if (obj->hasFastIndexProperties() && index != 0xFFFFFFFFu) {
+              ++NumGetByValObjIndArr;
+              auto *jsArray = vmcast<JSArray>(obj);
+              SmallHermesValue shv = jsArray->at(runtime, index);
+              if (!shv.isEmpty()) {
+                ++NumGetByValObjIndArrOK;
+                O1REG(GetByVal) = shv.unboxToHV(runtime);
+                ip = NEXTINST(GetByVal);
+                DISPATCH;
+              }
+            }
+          } else if (vmisa<JSTypedArrayBase>(obj)) {
+            ++NumGetByValObjIndTA;
+            auto *taJSTypedArray = vmcast<JSTypedArrayBase>(obj);
+
+            O1REG(GetByVal) = LLVM_LIKELY(
+                                  index < taJSTypedArray->getLength() &&
+                                  taJSTypedArray->attached(runtime))
+                ? JSTypedArrayBase::polyReadMayAlloc(
+                      taJSTypedArray, runtime, index)
+                : HermesValue::encodeUndefinedValue();
+            ip = NEXTINST(GetByVal);
+            DISPATCH;
+          } else if (obj->hasFastIndexProperties()) {
+            // Fall-back fast path for other objects with fast index properties
+            auto ourValue = createPseudoHandle(JSObject::getOwnIndexed(
+                createPseudoHandle(obj), runtime, index));
+            if (LLVM_LIKELY(!ourValue->isEmpty())) {
+              O1REG(GetByVal) = ourValue.getHermesValue();
+              ip = NEXTINST(GetByVal);
+              DISPATCH;
+            }
+          }
+        }
+
+        CAPTURE_IP_ASSIGN(
+            ExecutionStatus res, caseGetByVal(runtime, frameRegs, ip));
+        if (LLVM_UNLIKELY(res == ExecutionStatus::EXCEPTION))
+          goto exception;
+        gcScope.flushToSmallCount(KEEP_HANDLES);
+        ip = NEXTINST(GetByVal);
+        DISPATCH;
+      }
+
       CASE_OUTOFLINE(GetByValWithReceiver);
 
       CASE(DefineOwnById) {
@@ -2094,15 +2177,39 @@ tailCall:
       }
 
       CASE(GetByIndex) {
+        ++NumGetByIndex;
         if (LLVM_LIKELY(O2REG(GetByIndex).isObject())) {
           auto *obj = vmcast<JSObject>(O2REG(GetByIndex));
-          if (LLVM_LIKELY(obj->hasFastIndexProperties())) {
+          uint32_t index = ip->iGetByIndex.op3;
+
+          if (obj->getKind() == CellKind::JSArrayKind) {
+            if (LLVM_LIKELY(obj->hasFastIndexProperties())) {
+              auto *jsArray = vmcast<JSArray>(obj);
+              SmallHermesValue shv = jsArray->at(runtime, index);
+              if (LLVM_LIKELY(!shv.isEmpty())) {
+                O1REG(GetByIndex) = shv.unboxToHV(runtime);
+                ip = NEXTINST(GetByIndex);
+                DISPATCH;
+              }
+            }
+          } else if (vmisa<JSTypedArrayBase>(obj)) {
+            auto *jsTypedArray = vmcast<JSTypedArrayBase>(obj);
+
+            O1REG(GetByIndex) = LLVM_LIKELY(
+                                    index < jsTypedArray->getLength() &&
+                                    jsTypedArray->attached(runtime))
+                ? JSTypedArrayBase::polyReadMayAlloc(
+                      jsTypedArray, runtime, index)
+                : HermesValue::encodeUndefinedValue();
+            ip = NEXTINST(GetByIndex);
+            DISPATCH;
+          }
+          // Fall-back fast path for other objects with fast index properties
+          else if (obj->hasFastIndexProperties()) {
             CAPTURE_IP_ASSIGN(
                 auto ourValue,
                 createPseudoHandle(JSObject::getOwnIndexed(
-                    PseudoHandle<JSObject>::create(obj),
-                    runtime,
-                    ip->iGetByIndex.op3)));
+                    PseudoHandle<JSObject>::create(obj), runtime, index)));
             if (LLVM_LIKELY(!ourValue->isEmpty())) {
               gcScope.flushToSmallCount(KEEP_HANDLES);
               O1REG(GetByIndex) = ourValue.get();

--- a/lib/VM/JSLib/GlobalObject.cpp
+++ b/lib/VM/JSLib/GlobalObject.cpp
@@ -559,24 +559,19 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
   // Array constructor.
   runtime.arrayConstructor = createArrayConstructor(runtime);
 
-  if (runtime.hasArrayBuffer()) {
-    // ArrayBuffer constructor.
-    runtime.arrayBufferConstructor = createArrayBufferConstructor(runtime);
+  // ArrayBuffer constructor.
+  runtime.arrayBufferConstructor = createArrayBufferConstructor(runtime);
 
-    // DataView constructor.
-    runtime.dataViewConstructor = createDataViewConstructor(runtime);
+  // DataView constructor.
+  runtime.dataViewConstructor = createDataViewConstructor(runtime);
 
-    // TypedArrayBase constructor.
-    runtime.typedArrayBaseConstructor =
-        createTypedArrayBaseConstructor(runtime);
+  // TypedArrayBase constructor.
+  runtime.typedArrayBaseConstructor = createTypedArrayBaseConstructor(runtime);
 
 #define TYPED_ARRAY(name, type)                                             \
   runtime.name##ArrayConstructor = create##name##ArrayConstructor(runtime); \
   gcScope.clearAllHandles();
 #include "hermes/VM/TypedArrays.def"
-  } else {
-    gcScope.clearAllHandles();
-  } // hasArrayBuffer
 
   // Set constructor.
   runtime.setConstructor = createSetConstructor(runtime);

--- a/lib/VM/JSLib/HermesInternal.cpp
+++ b/lib/VM/JSLib/HermesInternal.cpp
@@ -74,7 +74,7 @@ hermesInternalGetEpilogues(void *, Runtime &runtime, NativeArgs args) {
         return ExecutionStatus::EXCEPTION;
       }
       auto ta = result.getValue();
-      std::memcpy(ta->begin(runtime), eps[i].begin(), innerLen);
+      std::memcpy(ta->data(runtime), eps[i].begin(), innerLen);
       const auto shv = SmallHermesValue::encodeObjectValue(*ta, runtime);
       JSArray::unsafeSetExistingElementAt(*outer, runtime, i, shv);
     }

--- a/lib/VM/JSLib/TextEncoder.cpp
+++ b/lib/VM/JSLib/TextEncoder.cpp
@@ -194,7 +194,7 @@ textEncoderPrototypeEncode(void *, Runtime &runtime, NativeArgs args) {
     llvh::ArrayRef<char> strRef = string->getStringRef<char>();
 
     std::memcpy(
-        typedArray->begin(runtime), strRef.data(), string->getStringLength());
+        typedArray->data(runtime), strRef.data(), string->getStringLength());
     return typedArray.getHermesValue();
   } else {
     // Convert UTF-16 to UTF-8
@@ -212,7 +212,7 @@ textEncoderPrototypeEncode(void *, Runtime &runtime, NativeArgs args) {
 
     Handle<JSTypedArrayBase> typedArray = result.getValue();
     std::memcpy(
-        typedArray->begin(runtime), converted.data(), converted.length());
+        typedArray->data(runtime), converted.data(), converted.length());
     return typedArray.getHermesValue();
   }
 }

--- a/lib/VM/JSLib/TypedArray.cpp
+++ b/lib/VM/JSLib/TypedArray.cpp
@@ -831,17 +831,8 @@ typedArrayPrototypeAt(void *, Runtime &runtime, NativeArgs args) {
   if (LLVM_UNLIKELY(!arr->attached(runtime)))
     return runtime.raiseTypeError("Underlying ArrayBuffer detached");
 
-#define TYPED_ARRAY(name, type)                                        \
-  case CellKind::name##ArrayKind:                                      \
-    return HermesValue::encodeUntrustedNumberValue(                    \
-        llvh::cast<JSTypedArray<type, CellKind::name##ArrayKind>>(arr) \
-            ->monoAt(runtime, k));
-
-  switch (O->getKind()) {
-#include "hermes/VM/TypedArrays.def"
-    default:
-      llvm_unreachable("Invalid TypedArray after ValidateTypedArray call");
-  }
+  return JSTypedArrayBase::polyReadMayAlloc(
+      arr, runtime, JSTypedArrayBase::size_type(k));
 }
 
 /// ES6 22.2.3.5

--- a/lib/VM/JSLib/TypedArray.cpp
+++ b/lib/VM/JSLib/TypedArray.cpp
@@ -1048,7 +1048,7 @@ typedArrayPrototypeFill(void *, Runtime &runtime, NativeArgs args) {
     return ExecutionStatus::EXCEPTION;
   }
   auto elementSize = self->getByteWidth();
-  uint8_t *begin = self->begin(runtime);
+  uint8_t *begin = self->data(runtime);
   // Fill with the same raw bytes as the first one.
   switch (elementSize) {
     case 1:

--- a/lib/VM/JSLib/TypedArray.cpp
+++ b/lib/VM/JSLib/TypedArray.cpp
@@ -905,48 +905,22 @@ typedArrayPrototypeCopyWithin(void *, Runtime &runtime, NativeArgs args) {
   // 14. Let count be min(final-from, len-to).
   double count = std::min(fin - from, len - to);
 
-  int direction;
-  if (from < to && to < from + count) {
-    // 15. If from<to and to<from+count
-    // a. Let direction be -1.
-    direction = -1;
-    // b. Let from be from + count -1.
-    from = from + count - 1;
-    // c. Let to be to + count -1.
-    to = to + count - 1;
-  } else {
-    // 16. Else,
-    // a. Let direction = 1.
-    direction = 1;
-  }
-
-  // Need to case on the TypedArray type to avoid encoding using HermesValues.
-  // We need to preserve the bit-level encoding of values, and HermesValues
-  // destroy information, e.g. which NaN is being used.
   auto *baseArr = vmcast<JSTypedArrayBase>(*O);
   if (!baseArr->attached(runtime)) {
     return runtime.raiseTypeError(
         "Underlying ArrayBuffer detached after calling copyWithin");
   }
 
-#define TYPED_ARRAY(name, type)                                             \
-  case CellKind::name##ArrayKind: {                                         \
-    auto *arr =                                                             \
-        llvh::cast<JSTypedArray<type, CellKind::name##ArrayKind>>(baseArr); \
-    while (count > 0) {                                                     \
-      arr->monoAt(runtime, to) = arr->monoAt(runtime, from);                \
-      from += direction;                                                    \
-      to += direction;                                                      \
-      --count;                                                              \
-    }                                                                       \
-    break;                                                                  \
-  }
+  // Get the byte width for this typed array
+  const size_t elemSize = baseArr->getByteWidth();
+  uint8_t *data = baseArr->data(runtime);
 
-  switch (O->getKind()) {
-#include "hermes/VM/TypedArrays.def"
-
-    default:
-      llvm_unreachable("Invalid TypedArray after ValidateTypedArray call");
+  // Use memmove to handle the overlapping regions correctly
+  if (count > 0) {
+    memmove(
+        data + (static_cast<size_t>(to) * elemSize), // destination
+        data + (static_cast<size_t>(from) * elemSize), // source
+        static_cast<size_t>(count) * elemSize); // byte count
   }
 
   return O.getHermesValue();

--- a/lib/VM/JSLib/TypedArray.cpp
+++ b/lib/VM/JSLib/TypedArray.cpp
@@ -827,14 +827,16 @@ typedArrayPrototypeAt(void *, Runtime &runtime, NativeArgs args) {
   // 8. Return ? Get(O, ! ToString(𝔽(k))).
   // Since we know we have a TypedArray, we can directly call JSTypedArray::at
   // rather than getComputed_RJS like the spec mandates.
-#define TYPED_ARRAY(name, type)                                            \
-  case CellKind::name##ArrayKind: {                                        \
-    auto *arr = vmcast<JSTypedArray<type, CellKind::name##ArrayKind>>(*O); \
-    if (!arr->attached(runtime)) {                                         \
-      return runtime.raiseTypeError("Underlying ArrayBuffer detached");    \
-    }                                                                      \
-    return HermesValue::encodeUntrustedNumberValue(arr->at(runtime, k));   \
-  }
+  auto *arr = vmcast<JSTypedArrayBase>(*O);
+  if (LLVM_UNLIKELY(!arr->attached(runtime)))
+    return runtime.raiseTypeError("Underlying ArrayBuffer detached");
+
+#define TYPED_ARRAY(name, type)                                        \
+  case CellKind::name##ArrayKind:                                      \
+    return HermesValue::encodeUntrustedNumberValue(                    \
+        llvh::cast<JSTypedArray<type, CellKind::name##ArrayKind>>(arr) \
+            ->monoAt(runtime, k));
+
   switch (O->getKind()) {
 #include "hermes/VM/TypedArrays.def"
     default:
@@ -921,24 +923,28 @@ typedArrayPrototypeCopyWithin(void *, Runtime &runtime, NativeArgs args) {
   // Need to case on the TypedArray type to avoid encoding using HermesValues.
   // We need to preserve the bit-level encoding of values, and HermesValues
   // destroy information, e.g. which NaN is being used.
-#define TYPED_ARRAY(name, type)                                            \
-  case CellKind::name##ArrayKind: {                                        \
-    auto *arr = vmcast<JSTypedArray<type, CellKind::name##ArrayKind>>(*O); \
-    if (!arr->attached(runtime)) {                                         \
-      return runtime.raiseTypeError(                                       \
-          "Underlying ArrayBuffer detached after calling copyWithin");     \
-    }                                                                      \
-    while (count > 0) {                                                    \
-      arr->at(runtime, to) = arr->at(runtime, from);                       \
-      from += direction;                                                   \
-      to += direction;                                                     \
-      --count;                                                             \
-    }                                                                      \
-    break;                                                                 \
+  auto *baseArr = vmcast<JSTypedArrayBase>(*O);
+  if (!baseArr->attached(runtime)) {
+    return runtime.raiseTypeError(
+        "Underlying ArrayBuffer detached after calling copyWithin");
+  }
+
+#define TYPED_ARRAY(name, type)                                             \
+  case CellKind::name##ArrayKind: {                                         \
+    auto *arr =                                                             \
+        llvh::cast<JSTypedArray<type, CellKind::name##ArrayKind>>(baseArr); \
+    while (count > 0) {                                                     \
+      arr->monoAt(runtime, to) = arr->monoAt(runtime, from);                \
+      from += direction;                                                    \
+      to += direction;                                                      \
+      --count;                                                              \
+    }                                                                       \
+    break;                                                                  \
   }
 
   switch (O->getKind()) {
 #include "hermes/VM/TypedArrays.def"
+
     default:
       llvm_unreachable("Invalid TypedArray after ValidateTypedArray call");
   }

--- a/lib/VM/JSTypedArray.cpp
+++ b/lib/VM/JSTypedArray.cpp
@@ -489,7 +489,7 @@ HermesValue JSTypedArray<T, C>::_getOwnIndexedImpl(
     return HermesValue::encodeUndefinedValue();
   }
   if (LLVM_LIKELY(index < self->getLength())) {
-    auto elem = self->at(runtime, index);
+    auto elem = self->monoAt(runtime, index);
     noAllocs.release();
     return _getOwnRetEncoder<T>::encodeMayAlloc(runtime, elem);
   }
@@ -559,7 +559,7 @@ CallResult<bool> JSTypedArray<T, C>::_setOwnIndexedImpl(
     return true;
   }
   if (LLVM_LIKELY(index < typedArrayHandle->getLength())) {
-    typedArrayHandle->at(runtime, index) = destValue;
+    typedArrayHandle->monoAt(runtime, index) = destValue;
   }
   return true;
 }

--- a/lib/VM/Runtime.cpp
+++ b/lib/VM/Runtime.cpp
@@ -285,7 +285,6 @@ Runtime::Runtime(
       hasES6Proxy_(runtimeConfig.getES6Proxy()),
       hasES6BlockScoping_(runtimeConfig.getES6BlockScoping()),
       hasIntl_(runtimeConfig.getIntl()),
-      hasArrayBuffer_(runtimeConfig.getArrayBuffer()),
       hasMicrotaskQueue_(runtimeConfig.getMicrotaskQueue()),
       shouldRandomizeMemoryLayout_(runtimeConfig.getRandomizeMemoryLayout()),
       bytecodeWarmupPercent_(runtimeConfig.getBytecodeWarmupPercent()),

--- a/lib/VM/StaticH.cpp
+++ b/lib/VM/StaticH.cpp
@@ -16,6 +16,7 @@
 #include "hermes/VM/JSGeneratorObject.h"
 #include "hermes/VM/JSObject.h"
 #include "hermes/VM/JSRegExp.h"
+#include "hermes/VM/JSTypedArray.h"
 #include "hermes/VM/ModuleExportsCache-inline.h"
 #include "hermes/VM/PropertyAccessor.h"
 #include "hermes/VM/SerializedLiteralOperations.h"
@@ -270,27 +271,68 @@ extern "C" SHLegacyValue _sh_ljs_get_by_val_with_receiver_rjs(
   Handle<> sourceHandle{toPHV(source)};
   Handle<> keyHandle{toPHV(key)};
   Handle<> receiverHandle{(toPHV(receiver))};
-  if (LLVM_LIKELY(sourceHandle->isObject())) {
-    CallResult<PseudoHandle<>> res{ExecutionStatus::EXCEPTION};
+  CallResult<PseudoHandle<>> res{ExecutionStatus::EXCEPTION};
+
+  if (LLVM_UNLIKELY(!sourceHandle->isObject())) {
+    // Transient object.
     {
       GCScopeMarkerRAII marker{runtime};
-      res = JSObject::getComputedWithReceiver_RJS(
-          Handle<JSObject>::vmcast(sourceHandle),
-          runtime,
-          keyHandle,
-          receiverHandle);
+      res = Interpreter::getByValTransientWithReceiver_RJS(
+          runtime, sourceHandle, keyHandle, receiverHandle);
     }
     if (LLVM_UNLIKELY(res == ExecutionStatus::EXCEPTION))
       _sh_throw_current(shr);
     return res->getHermesValue();
   }
 
-  // This is the "slow path".
-  CallResult<PseudoHandle<>> res{ExecutionStatus::EXCEPTION};
+  // Fast path for arrays and typed arrays with numeric indices
+  static_assert(
+      HERMESVALUE_VERSION == 2,
+      "HermesValue must use NaN-encoding for non-numbers");
+  uint32_t index;
+  if (sh_tryfast_f64_to_u32(key->f64, index)) {
+    auto *obj = vmcast<JSObject>(*toPHV(source));
+
+    // Fast path for JSArray
+    if (obj->getKind() == CellKind::JSArrayKind) {
+      if (obj->hasFastIndexProperties() && index != 0xFFFF'FFFFu) {
+        auto *jsArray = vmcast<JSArray>(obj);
+        SmallHermesValue shv = jsArray->at(runtime, index);
+        if (!shv.isEmpty())
+          return shv.unboxToHV(runtime);
+      }
+    }
+    // Fast path for JSTypedArray
+    else if (vmisa<JSTypedArrayBase>(obj)) {
+      auto *jsTypedArray = vmcast<JSTypedArrayBase>(obj);
+
+      if (LLVM_LIKELY(
+              index < jsTypedArray->getLength() &&
+              jsTypedArray->attached(runtime))) {
+        return JSTypedArrayBase::polyReadMayAlloc(jsTypedArray, runtime, index);
+      }
+      // For out-of-bounds or detached TypedArray, return undefined
+      return HermesValue::encodeUndefinedValue();
+    }
+    // Fall-back fast path for other objects with fast index properties
+    else if (obj->hasFastIndexProperties()) {
+      GCScopeMarkerRAII marker{runtime};
+      auto ourValue = createPseudoHandle(
+          JSObject::getOwnIndexed(createPseudoHandle(obj), runtime, index));
+      if (LLVM_LIKELY(!ourValue->isEmpty())) {
+        return ourValue.getHermesValue();
+      }
+    }
+  }
+
+  // Slow path for regular objects.
   {
     GCScopeMarkerRAII marker{runtime};
-    res = Interpreter::getByValTransientWithReceiver_RJS(
-        runtime, sourceHandle, keyHandle, receiverHandle);
+    res = JSObject::getComputedWithReceiver_RJS(
+        Handle<JSObject>::vmcast(sourceHandle),
+        runtime,
+        keyHandle,
+        receiverHandle);
   }
   if (LLVM_UNLIKELY(res == ExecutionStatus::EXCEPTION))
     _sh_throw_current(shr);
@@ -302,11 +344,30 @@ _sh_ljs_get_by_index_rjs(SHRuntime *shr, SHLegacyValue *source, uint32_t key) {
   Handle<> sourceHandle{toPHV(source)};
   Runtime &runtime = getRuntime(shr);
   if (LLVM_LIKELY(sourceHandle->isObject())) {
-    Handle<JSObject> objHandle = Handle<JSObject>::vmcast(sourceHandle);
-    if (LLVM_LIKELY(objHandle->hasFastIndexProperties())) {
+    auto *obj = vmcast<JSObject>(*sourceHandle);
+
+    if (obj->getKind() == CellKind::JSArrayKind) {
+      if (obj->hasFastIndexProperties() && key != 0xFFFF'FFFFu) {
+        auto *jsArray = vmcast<JSArray>(obj);
+        SmallHermesValue shv = jsArray->at(runtime, key);
+        if (!shv.isEmpty()) {
+          return shv.unboxToHV(runtime);
+        }
+      }
+    } else if (vmisa<JSTypedArrayBase>(obj)) {
+      auto *jsTypedArray = vmcast<JSTypedArrayBase>(obj);
+
+      if (LLVM_LIKELY(
+              key < jsTypedArray->getLength() &&
+              jsTypedArray->attached(runtime))) {
+        return JSTypedArrayBase::polyReadMayAlloc(jsTypedArray, runtime, key);
+      }
+      // For out-of-bounds or detached TypedArray, return undefined directly
+      return HermesValue::encodeUndefinedValue();
+    } else if (LLVM_LIKELY(obj->hasFastIndexProperties())) {
       GCScopeMarkerRAII marker{runtime};
-      auto ourValue = createPseudoHandle(JSObject::getOwnIndexed(
-          createPseudoHandle(*objHandle), runtime, key));
+      auto ourValue = createPseudoHandle(
+          JSObject::getOwnIndexed(createPseudoHandle(obj), runtime, key));
       if (LLVM_LIKELY(!ourValue->isEmpty())) {
         return ourValue.getHermesValue();
       }

--- a/public/hermes/Public/RuntimeConfig.h
+++ b/public/hermes/Public/RuntimeConfig.h
@@ -72,9 +72,6 @@ class PinnedHermesValue;
   /* Support for ECMA-402 Intl APIs. */                                \
   F(constexpr, bool, Intl, true)                                       \
                                                                        \
-  /* Support for ArrayBuffer, DataView and typed arrays. */            \
-  F(constexpr, bool, ArrayBuffer, true)                                \
-                                                                       \
   /* Support for using microtasks. */                                  \
   F(constexpr, bool, MicrotaskQueue, false)                            \
                                                                        \

--- a/test/hermes/bigint64-array.js
+++ b/test/hermes/bigint64-array.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -O %s | %FileCheck --match-full-lines %s
+
+// Test that TypedArray.prototype.at() returns a bigint.
+
+print(typeof new BigUint64Array(1).at(0), typeof new BigInt64Array(1).at(0));
+// CHECK: bigint bigint

--- a/unittests/VMRuntime/JSTypedArrayTest.cpp
+++ b/unittests/VMRuntime/JSTypedArrayTest.cpp
@@ -25,13 +25,13 @@ TEST_F(JSTypedArrayTest, BeginAndEndMatchesOnBaseAndSub) {
     ASSERT_FALSE(isException(result));                                \
     Handle<name##Array> array = Handle<name##Array>::vmcast(*result); \
     EXPECT_EQ(                                                        \
-        reinterpret_cast<uintptr_t>(array->begin(runtime)),           \
+        reinterpret_cast<uintptr_t>(array->data(runtime)),            \
         reinterpret_cast<uintptr_t>(                                  \
-            Handle<JSTypedArrayBase>(array)->begin(runtime)));        \
+            Handle<JSTypedArrayBase>(array)->data(runtime)));         \
     EXPECT_EQ(                                                        \
-        reinterpret_cast<uintptr_t>(array->end(runtime)),             \
+        reinterpret_cast<uintptr_t>(array->dataEnd(runtime)),         \
         reinterpret_cast<uintptr_t>(                                  \
-            Handle<JSTypedArrayBase>(array)->end(runtime)));          \
+            Handle<JSTypedArrayBase>(array)->dataEnd(runtime)));      \
   }
 #include "hermes/VM/TypedArrays.def"
 }


### PR DESCRIPTION
Summary:
Add `GetByVal` and `GetByIndex` fast paths in the interpreter and
StaticH.cpp (to be used by the JIT and the native backend).

This optimization adds direct access to array elements when possible, avoiding the
overhead of property lookups and prototype chain traversal for numeric indices.

Benchmark results (higher is better):
```
┌─────────────────┬─────────┬─────────┬─────────────┬─────────┬─────────┬─────────────┐
│ Benchmark       │ OLD     │ NEW     │ Improvement │ OLD JIT │ NEW JIT │ Improvement │
├─────────────────┼─────────┼─────────┼─────────────┼─────────┼─────────┼─────────────┤
│ zlib.js         │ 1562    │ 1747    │ 11.8%       │ 2012    │ 2272    │ 12.9%       │
│ mandreel.js     │ 809     │ 928     │ 14.7%       │ 983     │ 1093    │ 11.2%       │
│ MandreelLatency │ 5287    │ 5921    │ 12.0%       │ 5407    │ 5992    │ 10.8%       │
│ crypto.js       │ 1001    │ 1158    │ 15.7%       │ 1425    │ 1627    │ 14.2%       │
│ navier-stokes.js│ 1193    │ 1415    │ 18.6%       │ 1496    │ 1807    │ 20.8%       │
│ gameboy.js      │ 4713    │ 4898    │ 3.9%        │ 5532    │ 5812    │ 5.1%        │
│ pdfjs.js        │ 3990    │ 4102    │ 2.8%        │ 4287    │ 4441    │ 3.6%        │
└─────────────────┴─────────┴─────────┴─────────────┴─────────┴─────────┴─────────────┘
```

Differential Revision: D72099912


