### PR TITLE
Add a compiler stage for AST transformation

### DIFF
--- a/include/hermes/AST/TransformAST.h
+++ b/include/hermes/AST/TransformAST.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "hermes/AST/Context.h"
+#include "hermes/AST/ESTree.h"
+
+namespace hermes {
+
+/// General purpose AST transformation which will be applied before running
+/// semantic resolution in the compiler pipeline.
+/// Allows adding functionality/transforms in a general way directly to the AST
+/// in a way that works for lazy compilation, debugger eval, etc.
+///
+/// \return the transformed node, which should be used for the remainder of
+///   compilation. On failure, report an error and return nullptr.
+///   The returned Node must be the same kind as the original \p root.
+ESTree::Node *transformASTForCompilation(Context &context, ESTree::Node *root);
+
+} // namespace hermes

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -10,6 +10,7 @@ add_hermes_library(hermesAST
     ESTreeJSONDumper.cpp
     CommonJS.cpp
     TS2Flow.cpp
+    TransformAST.cpp
     Context.cpp
     NativeContext.cpp
     LINK_OBJLIBS

--- a/lib/AST/TransformAST.cpp
+++ b/lib/AST/TransformAST.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "hermes/AST/TransformAST.h"
+
+namespace hermes {
+
+ESTree::Node *transformASTForCompilation(Context &context, ESTree::Node *root) {
+  return root;
+}
+
+} // namespace hermes

--- a/lib/BCGen/HBC/BCProviderFromSrc.cpp
+++ b/lib/BCGen/HBC/BCProviderFromSrc.cpp
@@ -7,6 +7,7 @@
 
 #include "hermes/BCGen/HBC/BCProviderFromSrc.h"
 
+#include "hermes/AST/TransformAST.h"
 #include "hermes/BCGen/HBC/HBC.h"
 #include "hermes/IR/IR.h"
 #include "hermes/IRGen/IRGen.h"
@@ -206,6 +207,12 @@ BCProviderFromSrc::create(
     useStaticBuiltinDetected = parser.getUseStaticBuiltin();
     parser.registerMagicURLs();
   }
+
+  if (!parsed)
+    return {nullptr, getErrorString()};
+
+  parsed = llvh::cast<ESTree::ProgramNode>(
+      hermes::transformASTForCompilation(*context, *parsed));
 
   if (!parsed ||
       !hermes::sema::resolveAST(*context, *semCtx, *parsed, declFileList)) {

--- a/lib/BCGen/HBC/HBC.cpp
+++ b/lib/BCGen/HBC/HBC.cpp
@@ -8,6 +8,7 @@
 #include "hermes/BCGen/HBC/HBC.h"
 
 #include "BytecodeGenerator.h"
+#include "hermes/AST/TransformAST.h"
 #include "hermes/BCGen/HBC/BCProviderFromSrc.h"
 #include "hermes/IRGen/IRGen.h"
 #include "hermes/Optimizer/PassManager/Pipeline.h"
@@ -163,6 +164,14 @@ static void compileLazyFunctionWorker(void *argPtr) {
   sema::SemContext *semCtx = provider->getSemCtx();
   assert(semCtx && "missing semantic data to compile");
 
+  if (!optParsed) {
+    data->success = false;
+    data->error = outputManager.getErrorString();
+    return;
+  }
+
+  optParsed = hermes::transformASTForCompilation(context, *optParsed);
+
   // A non-null home object means the parent function context could reference
   // super.
   bool parentHadSuperBinding = lazyDataInst->getHomeObject();
@@ -307,6 +316,11 @@ static void compileEvalWorker(void *argPtr) {
   parser.setStrictMode(data->compileFlags.strict);
 
   auto optParsed = parser.parse();
+  if (!optParsed) {
+    data->success = false;
+    data->error = outputManager.getErrorString();
+    return;
+  }
 
   if (optParsed && parserMode != parser::LazyParse) {
     parser.registerMagicURLs();
@@ -317,6 +331,9 @@ static void compileEvalWorker(void *argPtr) {
   // BCProviderFromSrc is destroyed.
   std::shared_ptr<sema::SemContext> semCtx = std::make_shared<sema::SemContext>(
       context, provider->shareSemCtx(), lexScope);
+
+  optParsed = llvh::cast<ESTree::ProgramNode>(
+      hermes::transformASTForCompilation(context, *optParsed));
 
   // A non-null home object means the parent function context could reference
   // super.

--- a/lib/CompilerDriver/CompilerDriver.cpp
+++ b/lib/CompilerDriver/CompilerDriver.cpp
@@ -12,6 +12,7 @@
 #include "hermes/AST/Context.h"
 #include "hermes/AST/ESTreeJSONDumper.h"
 #include "hermes/AST/TS2Flow.h"
+#include "hermes/AST/TransformAST.h"
 #include "hermes/AST2JS/AST2JS.h"
 #include "hermes/BCGen/HBC/BytecodeDisassembler.h"
 #include "hermes/BCGen/HBC/HBC.h"
@@ -887,6 +888,10 @@ ESTree::NodePtr parseJS(
     }
   }
 #endif
+
+  parsedAST = hermes::transformASTForCompilation(*context, parsedAST);
+  if (!parsedAST)
+    return nullptr;
 
   // If we are executing in typed mode and not script, then wrap the program.
   if (shouldWrapInIIFE) {

--- a/tools/shermes/shermes.cpp
+++ b/tools/shermes/shermes.cpp
@@ -13,6 +13,7 @@
 #include "hermes/AST/ESTreeJSONDumper.h"
 #include "hermes/AST/NativeContext.h"
 #include "hermes/AST/TS2Flow.h"
+#include "hermes/AST/TransformAST.h"
 #include "hermes/IR/IRVerifier.h"
 #include "hermes/IRGen/IRGen.h"
 #include "hermes/Optimizer/PassManager/PassManager.h"
@@ -813,6 +814,11 @@ ESTree::NodePtr parseJS(
     }
   }
 #endif
+
+  parsedAST = llvh::cast<ESTree::ProgramNode>(
+      hermes::transformASTForCompilation(*context, parsedAST));
+  if (!parsedAST)
+    return nullptr;
 
   // If we are executing in typed mode and not script, then wrap the program.
   if (shouldWrapInIIFE) {


### PR DESCRIPTION
Summary:
This is a compiler stage that is invoked from every place we compile JS,
allowing arbitrary AST transformations between parsing and semantic
resolution.
It's currently only set up for `ProgramNode` and
`FunctionLikeNode`, but can be extended as needed in the future.

Differential Revision: D72414034


