### PR TITLE
Add LargeDummyObject and a unit test using it

### DIFF
--- a/include/hermes/VM/AlignedHeapSegment.h
+++ b/include/hermes/VM/AlignedHeapSegment.h
@@ -407,6 +407,17 @@ class AlignedHeapSegment {
     return (cp - base) >> LogHeapAlign;
   }
 
+  /// Return true if objects \p a and \p b live in the same segment. This is
+  /// used to check if a pointer field in an object points to another object in
+  /// the same segment (so that we don't need to dirty the cards -- we only need
+  /// to dirty cards that might contain old-to-young pointers, which must cross
+  /// segments). This also works for large segments, since there is only one
+  /// cell in those segments (i.e., \p a and \p b would be the same).
+  static bool containedInSameSegment(const GCCell *a, const GCCell *b) {
+    return (reinterpret_cast<uintptr_t>(a) ^ reinterpret_cast<uintptr_t>(b)) <
+        kSegmentUnitSize;
+  }
+
   /// Returns the index of the segment containing \p lowLim, which is required
   /// to be the start of its containing segment.  (This can allow extra
   /// efficiency, in cases where the segment start has already been computed.)

--- a/include/hermes/VM/AlignedHeapSegment.h
+++ b/include/hermes/VM/AlignedHeapSegment.h
@@ -610,6 +610,12 @@ class JumboHeapSegment : public AlignedHeapSegment {
     return lowLim() + storageSize();
   }
 
+  /// \return \c true if and only if \p ptr is within the memory range owned by
+  /// this segment.
+  bool contains(const void *ptr) const {
+    return start() <= ptr && ptr < hiLim();
+  }
+
  private:
   JumboHeapSegment(StorageProvider *provider, void *lowLim, size_t segmentSize)
       : AlignedHeapSegment(provider, lowLim, segmentSize),

--- a/include/hermes/VM/AlignedHeapSegment.h
+++ b/include/hermes/VM/AlignedHeapSegment.h
@@ -749,6 +749,16 @@ class FixedSizeHeapSegment : public AlignedHeapSegment {
   static void checkUnwritten(char *start, char *end);
 #endif
 
+#ifdef HERMES_SLOW_DEBUG
+  /// Find the object containing \p loc.
+  static GCCell *findObjectContaining(const void *loc) {
+    auto *lowLim = static_cast<char *>(storageStart(loc));
+    auto *hiLim = lowLim + kSize;
+    return contents(lowLim)->boundaryTable_.findObjectContaining(
+        lowLim, hiLim, loc);
+  }
+#endif
+
  private:
   FixedSizeHeapSegment(StorageProvider *provider, void *lowLim);
 };

--- a/include/hermes/VM/AlignedHeapSegment.h
+++ b/include/hermes/VM/AlignedHeapSegment.h
@@ -641,20 +641,6 @@ class FixedSizeHeapSegment : public AlignedHeapSegment {
         Contents::CardStatus::Dirty, std::memory_order_relaxed);
   }
 
-  /// Make the card table entries for cards that intersect the given address
-  /// range dirty. The range is a closed interval [low, high].
-  /// \pre \p low and \p high are required to be addresses covered by the card
-  /// table.
-  static void dirtyCardsForAddressRange(const void *low, const void *high) {
-    auto *segContents = contents(storageStart(low));
-    high = reinterpret_cast<const char *>(high) + Contents::kCardSize - 1;
-    cleanOrDirtyRange(
-        segContents,
-        addressToCardIndex(segContents, low),
-        addressToCardIndex(segContents, high),
-        Contents::CardStatus::Dirty);
-  }
-
   /// Find the head of the first cell that extends into the card at index
   /// \p cardIdx.
   /// \return A cell such that

--- a/include/hermes/VM/AlignedHeapSegment.h
+++ b/include/hermes/VM/AlignedHeapSegment.h
@@ -254,6 +254,18 @@ class AlignedHeapSegment {
     return lowLim_;
   }
 
+  /// Gets the segment size from SHSegmentInfo. This should only be used when
+  /// we only have a GCCell pointer and don't know its owning segment.
+  static size_t getSegmentSize(const GCCell *cell) {
+    return contents(alignedStorageStart(cell))->getSegmentSize();
+  }
+
+  /// Return the maximum allocation size for the heap segment that contains
+  /// \p cell.
+  static size_t maxSize(const GCCell *cell) {
+    return getSegmentSize(cell) - kOffsetOfAllocRegion;
+  }
+
   /// Returns the address at which the first allocation in this segment would
   /// occur.
   /// Disable UB sanitization because 'this' may be null during the tests.
@@ -593,6 +605,13 @@ class JumboHeapSegment : public AlignedHeapSegment {
   static constexpr size_t computeSegmentSize(uint32_t targetObjSize) {
     return llvh::alignTo<kSegmentUnitSize>(
         targetObjSize + kOffsetOfAllocRegion);
+  }
+
+  /// Compute the actual allocation size for \p targetObjSize. This is
+  /// essentially the `maxSize()` of the JumboHeapSegment with size derived from
+  /// computeSegmentSize().
+  static constexpr size_t computeActualCellSize(uint32_t targetObjSize) {
+    return computeSegmentSize(targetObjSize) - kOffsetOfAllocRegion;
   }
 
   /// The maximum size of allocation region for this segment.

--- a/include/hermes/VM/AlignedHeapSegment.h
+++ b/include/hermes/VM/AlignedHeapSegment.h
@@ -655,15 +655,6 @@ class FixedSizeHeapSegment : public AlignedHeapSegment {
         Contents::CardStatus::Dirty);
   }
 
-  /// Returns whether the card table entry for the given address is dirty.
-  /// \pre \p addr is required to be an address covered by the card table.
-  static bool isCardForAddressDirty(const void *addr) {
-    auto *segContents = contents(storageStart(addr));
-    return segContents->prefixHeader_
-               .cards_[addressToCardIndex(segContents, addr)]
-               .load(std::memory_order_relaxed) == Contents::CardStatus::Dirty;
-  }
-
   /// Find the head of the first cell that extends into the card at index
   /// \p cardIdx.
   /// \return A cell such that

--- a/include/hermes/VM/AllocOptions.h
+++ b/include/hermes/VM/AllocOptions.h
@@ -24,6 +24,11 @@ enum class LongLived { No = 0, Yes };
 /// not the cell being allocated supports large allocation.
 enum class CanBeLarge { No = 0, Yes };
 
+/// Template parameter passed in during allocation, that signifies whether or
+/// not the allocation may fail and return nullptr (MayFail::Yes is only
+/// allowed if CanBeLarge::Yes is provided as well).
+enum class MayFail { No = 0, Yes };
+
 } // namespace vm
 } // namespace hermes
 

--- a/include/hermes/VM/AllocOptions.h
+++ b/include/hermes/VM/AllocOptions.h
@@ -20,6 +20,10 @@ enum class HasFinalizer { No = 0, Yes };
 /// not the cell being allocated should be allocated directly in OG.
 enum class LongLived { No = 0, Yes };
 
+/// Template parameter passed in during allocation, that signifies whether or
+/// not the cell being allocated supports large allocation.
+enum class CanBeLarge { No = 0, Yes };
+
 } // namespace vm
 } // namespace hermes
 

--- a/include/hermes/VM/ArrayStorage.h
+++ b/include/hermes/VM/ArrayStorage.h
@@ -23,11 +23,11 @@ namespace vm {
 /// resizing on both ends which is necessary for the simplest implementation of
 /// JavaScript arrays (using a base offset and length).
 template <typename HVType>
-class ArrayStorageBase final : public VariableSizeRuntimeCell,
-                               private llvh::TrailingObjects<
-                                   ArrayStorageBase<HVType>,
-                                   GCHermesValueBaseImpl<HVType>> {
-  using GCHVType = GCHermesValueBaseImpl<HVType>;
+class ArrayStorageBase final
+    : public VariableSizeRuntimeCell,
+      private llvh::
+          TrailingObjects<ArrayStorageBase<HVType>, GCHermesValueImpl<HVType>> {
+  using GCHVType = GCHermesValueImpl<HVType>;
   friend llvh::TrailingObjects<ArrayStorageBase<HVType>, GCHVType>;
   friend void ArrayStorageBuildMeta(const GCCell *cell, Metadata::Builder &mb);
   friend void ArrayStorageSmallBuildMeta(

--- a/include/hermes/VM/ArrayStorage.h
+++ b/include/hermes/VM/ArrayStorage.h
@@ -245,7 +245,7 @@ class ArrayStorageBase final
     auto *fromStart = other->data();
     auto *fromEnd = fromStart + otherSz;
     GCHVType::uninitialized_copy(
-        fromStart, fromEnd, data() + sz, runtime.getHeap());
+        fromStart, fromEnd, data() + sz, this, runtime.getHeap());
     size_.store(sz + otherSz, std::memory_order_release);
   }
 

--- a/include/hermes/VM/ArrayStorage.h
+++ b/include/hermes/VM/ArrayStorage.h
@@ -23,11 +23,11 @@ namespace vm {
 /// resizing on both ends which is necessary for the simplest implementation of
 /// JavaScript arrays (using a base offset and length).
 template <typename HVType>
-class ArrayStorageBase final
-    : public VariableSizeRuntimeCell,
-      private llvh::
-          TrailingObjects<ArrayStorageBase<HVType>, GCHermesValueBase<HVType>> {
-  using GCHVType = GCHermesValueBase<HVType>;
+class ArrayStorageBase final : public VariableSizeRuntimeCell,
+                               private llvh::TrailingObjects<
+                                   ArrayStorageBase<HVType>,
+                                   GCHermesValueBaseImpl<HVType>> {
+  using GCHVType = GCHermesValueBaseImpl<HVType>;
   friend llvh::TrailingObjects<ArrayStorageBase<HVType>, GCHVType>;
   friend void ArrayStorageBuildMeta(const GCCell *cell, Metadata::Builder &mb);
   friend void ArrayStorageSmallBuildMeta(

--- a/include/hermes/VM/Callable.h
+++ b/include/hermes/VM/Callable.h
@@ -445,7 +445,7 @@ class BoundFunction final : public Callable {
  private:
   /// Return a pointer to the stored arguments, including \c this. \c this is
   /// at index 0, followed by the rest.
-  GCHermesValue *getArgsWithThis(PointerBase &runtime) {
+  ArrayStorage::iterator getArgsWithThis(PointerBase &runtime) {
     return argStorage_.getNonNull(runtime)->begin();
   }
 

--- a/include/hermes/VM/CardBoundaryTable.h
+++ b/include/hermes/VM/CardBoundaryTable.h
@@ -109,6 +109,12 @@ class CardBoundaryTable {
   ///
   /// \pre start is card-aligned.
   void verifyBoundaries(char *start, char *level) const;
+
+  /// Find the object that owns the memory at \p loc.
+  GCCell *findObjectContaining(
+      const char *lowLim,
+      const char *hiLim,
+      const void *loc) const;
 #endif // HERMES_SLOW_DEBUG
 
 #ifndef UNIT_TEST

--- a/include/hermes/VM/CellKinds.def
+++ b/include/hermes/VM/CellKinds.def
@@ -56,8 +56,9 @@ CELL_KIND(BoxedDouble)
 CELL_KIND(NativeState)
 CELL_KIND(BigIntPrimitive)
 
-// Dummy object used only in tests.
+// DummyObject/LargeDummyObject used only in tests.
 CELL_KIND(DummyObject)
+CELL_KIND(LargeDummyObject)
 
 CELL_CLASS(JSObject, "Object")
 CELL_CLASS(DecoratedObject, "DecoratedObject")

--- a/include/hermes/VM/GCBase-inline.h
+++ b/include/hermes/VM/GCBase-inline.h
@@ -36,16 +36,32 @@ template <
     typename T,
     HasFinalizer hasFinalizer,
     LongLived longLived,
+    CanBeLarge canBeLarge,
+    MayFail mayFail,
     class... Args>
 T *GCBase::makeAVariable(uint32_t size, Args &&...args) {
+  // For now, when mayFail == MayFail::Yes, we must have canBeLarge ==
+  // CanBeLarge::Yes.
+  static_assert(
+      (mayFail == MayFail::No) || (canBeLarge == CanBeLarge::Yes),
+      "Only large allocation can actually fail");
+  assert(
+      ((canBeLarge == CanBeLarge::No) ||
+       VTable::getVTable(T::getCellKind())->allowLargeAlloc) &&
+      "T must support large allocation when canBeLarge is Yes");
   // If size is greater than the max, we should OOM.
   assert(
       size >= GC::minAllocationSize() && "Cell size is smaller than minimum");
   assert(
       !VTable::getVTable(T::getCellKind())->size &&
       "Cell is not variable size.");
-  return makeA<T, false /* fixedSize */, hasFinalizer, longLived>(
-      heapAlignSize(size), std::forward<Args>(args)...);
+  return makeA<
+      T,
+      false /* fixedSize */,
+      hasFinalizer,
+      longLived,
+      canBeLarge,
+      mayFail>(heapAlignSize(size), std::forward<Args>(args)...);
 }
 
 template <
@@ -53,8 +69,19 @@ template <
     bool fixedSize,
     HasFinalizer hasFinalizer,
     LongLived longLived,
+    CanBeLarge canBeLarge,
+    MayFail mayFail,
     class... Args>
 T *GCBase::makeA(uint32_t size, Args &&...args) {
+  // For now, when mayFail == MayFail::Yes, we must have canBeLarge ==
+  // CanBeLarge::Yes.
+  static_assert(
+      (mayFail == MayFail::No) || (canBeLarge == CanBeLarge::Yes),
+      "Only large allocation can actually fail");
+  assert(
+      ((canBeLarge == CanBeLarge::No) ||
+       VTable::getVTable(T::getCellKind())->allowLargeAlloc) &&
+      "T must support large allocation when canBeLarge is Yes");
   assert(
       isSizeHeapAligned(size) && "Size must be aligned before reaching here");
   assert(
@@ -63,19 +90,32 @@ T *GCBase::makeA(uint32_t size, Args &&...args) {
       "hasFinalizer should be set iff the cell has a finalizer.");
 #ifdef HERMESVM_GC_RUNTIME
   T *ptr = runtimeGCDispatch([&](auto *gc) {
-    return gc->template makeA<T, fixedSize, hasFinalizer, longLived>(
-        size, std::forward<Args>(args)...);
+    return gc->template makeA<
+        T,
+        fixedSize,
+        hasFinalizer,
+        longLived,
+        canBeLarge,
+        mayFail>(size, std::forward<Args>(args)...);
   });
 #else
   T *ptr =
-      static_cast<GC *>(this)->makeA<T, fixedSize, hasFinalizer, longLived>(
-          size, std::forward<Args>(args)...);
+      static_cast<GC *>(this)
+          ->makeA<T, fixedSize, hasFinalizer, longLived, canBeLarge, mayFail>(
+              size, std::forward<Args>(args)...);
+#endif
+#if !defined(NDEBUG) || defined(HERMES_MEMORY_INSTRUMENTATION)
+  if constexpr (mayFail == MayFail::Yes) {
+    // If it fails, a nullptr is allowed and simply return it to the caller.
+    if (LLVM_UNLIKELY(!ptr))
+      return nullptr;
+  }
 #endif
 #ifndef NDEBUG
   ptr->setDebugAllocationIdInGC(nextObjectID());
 #endif
 #ifdef HERMES_MEMORY_INSTRUMENTATION
-  newAlloc(ptr, size);
+  newAlloc(ptr, ptr->getAllocatedSize());
 #endif
   return ptr;
 }

--- a/include/hermes/VM/GCBase.h
+++ b/include/hermes/VM/GCBase.h
@@ -1161,9 +1161,11 @@ class GCBase {
   void writeBarrierRange(const GCHermesValue *start, uint32_t numHVs);
   void writeBarrierRange(const GCSmallHermesValue *start, uint32_t numHVs);
   void constructorWriteBarrierRange(
+      const GCCell *owningObj,
       const GCHermesValue *start,
       uint32_t numHVs);
   void constructorWriteBarrierRange(
+      const GCCell *owningObj,
       const GCSmallHermesValue *start,
       uint32_t numHVs);
   void snapshotWriteBarrier(const GCHermesValue *loc);

--- a/include/hermes/VM/GCBase.h
+++ b/include/hermes/VM/GCBase.h
@@ -204,6 +204,14 @@ enum XorPtrKeyID {
 ///         const GCSmallHermesValue *start,
 ///         uint32_t numHVs);
 ///
+///   The above barriers may have a variant with "ForLargeObj" suffix, which is
+///   used when the heap location may be from a GCCell of a kind that supports
+///   large allocation. This variant is less efficient since it has to load the
+///   cards array through pointer in SHSegmentInfo, instead of the inline array
+///   field in CardTable structure. Because of this, these variant write
+///   barriers need a pointer to the start of the object in order to locate the
+///   card table for an object that is larger than the unit segment size.
+///
 ///   In debug builds: is a write barrier necessary for a write of the given
 ///   GC pointer \p value to the given \p loc?
 ///      bool needsWriteBarrier(void *loc, void *value);
@@ -1152,12 +1160,36 @@ class GCBase {
   /// Default implementations for read and write barriers: do nothing.
   void writeBarrier(const GCHermesValue *loc, HermesValue value);
   void writeBarrier(const GCSmallHermesValue *loc, SmallHermesValue value);
+  void writeBarrierForLargeObj(
+      const GCCell *owningObj,
+      const GCHermesValue *loc,
+      HermesValue value);
+  void writeBarrierForLargeObj(
+      const GCCell *owningObj,
+      const GCSmallHermesValue *loc,
+      SmallHermesValue value);
   void writeBarrier(const GCPointerBase *loc, const GCCell *value);
+  void writeBarrierForLargeObj(
+      const GCCell *owningObj,
+      const GCPointerBase *loc,
+      const GCCell *value);
   void constructorWriteBarrier(const GCHermesValue *loc, HermesValue value);
   void constructorWriteBarrier(
       const GCSmallHermesValue *loc,
       SmallHermesValue value);
+  void constructorWriteBarrierForLargeObj(
+      const GCCell *owningObj,
+      const GCHermesValue *loc,
+      HermesValue value);
+  void constructorWriteBarrierForLargeObj(
+      const GCCell *owningObj,
+      const GCSmallHermesValue *loc,
+      SmallHermesValue value);
   void constructorWriteBarrier(const GCPointerBase *loc, const GCCell *value);
+  void constructorWriteBarrierForLargeObj(
+      const GCCell *owningObj,
+      const GCPointerBase *loc,
+      const GCCell *value);
   void writeBarrierRange(const GCHermesValue *start, uint32_t numHVs);
   void writeBarrierRange(const GCSmallHermesValue *start, uint32_t numHVs);
   void constructorWriteBarrierRange(

--- a/include/hermes/VM/GCBase.h
+++ b/include/hermes/VM/GCBase.h
@@ -185,23 +185,23 @@ enum XorPtrKeyID {
 ///         const GCSmallHermesValue *start, uint32_t
 ///         numHVs);
 ///     void constructorWriteBarrierRange(
-///         const GCHermesValue *start,
+///         const GCHermesValueBase *start,
 ///         uint32_t numHVs);
 ///     void constructorWriteBarrierRange(
-///         const GCSmallHermesValue *start,
+///         const GCSmallHermesValueBase *start,
 ///         uint32_t numHVs);
 ///
 ///   The given loc or region is about to be overwritten, but the new value is
 ///   not important. Perform any necessary barriers.
-///     void snapshotWriteBarrier(const GCHermesValue *loc);
-///     void snapshotWriteBarrier(const GCSmallHermesValue *loc);
+///     void snapshotWriteBarrier(const GCHermesValueBase *loc);
+///     void snapshotWriteBarrier(const GCSmallHermesValueBase *loc);
 ///     void snapshotWriteBarrier(const GCPointerBase *loc);
 ///     void snapshotWriteBarrier(const GCSymboldID *symbol);
 ///     void snapshotWriteBarrierRange(
-///         const GCHermesValue *start,
+///         const GCHermesValueBase *start,
 ///         uint32_t numHVs);
 ///     void snapshotWriteBarrierRange(
-///         const GCSmallHermesValue *start,
+///         const GCSmallHermesValueBase *start,
 ///         uint32_t numHVs);
 ///
 ///   The above barriers may have a variant with "ForLargeObj" suffix, which is
@@ -1079,18 +1079,19 @@ class GCBase {
   }
   virtual bool dbgContains(const void *ptr) const = 0;
   virtual void trackReachable(CellKind kind, unsigned sz) {}
-  virtual bool needsWriteBarrier(const GCHermesValue *loc, HermesValue value)
-      const = 0;
   virtual bool needsWriteBarrier(
-      const GCSmallHermesValue *loc,
+      const GCHermesValueBase *loc,
+      HermesValue value) const = 0;
+  virtual bool needsWriteBarrier(
+      const GCSmallHermesValueBase *loc,
       SmallHermesValue value) const = 0;
   virtual bool needsWriteBarrier(const GCPointerBase *loc, GCCell *value)
       const = 0;
   virtual bool needsWriteBarrierInCtor(
-      const GCHermesValue *loc,
+      const GCHermesValueBase *loc,
       HermesValue value) const = 0;
   virtual bool needsWriteBarrierInCtor(
-      const GCSmallHermesValue *loc,
+      const GCSmallHermesValueBase *loc,
       SmallHermesValue value) const = 0;
   /// \}
 #endif
@@ -1168,11 +1169,11 @@ class GCBase {
   void writeBarrier(const GCSmallHermesValue *loc, SmallHermesValue value);
   void writeBarrierForLargeObj(
       const GCCell *owningObj,
-      const GCHermesValue *loc,
+      const GCHermesValueInLargeObj *loc,
       HermesValue value);
   void writeBarrierForLargeObj(
       const GCCell *owningObj,
-      const GCSmallHermesValue *loc,
+      const GCSmallHermesValueInLargeObj *loc,
       SmallHermesValue value);
   void writeBarrier(const GCPointerBase *loc, const GCCell *value);
   void writeBarrierForLargeObj(
@@ -1185,11 +1186,11 @@ class GCBase {
       SmallHermesValue value);
   void constructorWriteBarrierForLargeObj(
       const GCCell *owningObj,
-      const GCHermesValue *loc,
+      const GCHermesValueInLargeObj *loc,
       HermesValue value);
   void constructorWriteBarrierForLargeObj(
       const GCCell *owningObj,
-      const GCSmallHermesValue *loc,
+      const GCSmallHermesValueInLargeObj *loc,
       SmallHermesValue value);
   void constructorWriteBarrier(const GCPointerBase *loc, const GCCell *value);
   void constructorWriteBarrierForLargeObj(
@@ -1200,19 +1201,21 @@ class GCBase {
   void writeBarrierRange(const GCSmallHermesValue *start, uint32_t numHVs);
   void constructorWriteBarrierRange(
       const GCCell *owningObj,
-      const GCHermesValue *start,
+      const GCHermesValueBase *start,
       uint32_t numHVs);
   void constructorWriteBarrierRange(
       const GCCell *owningObj,
-      const GCSmallHermesValue *start,
+      const GCSmallHermesValueBase *start,
       uint32_t numHVs);
-  void snapshotWriteBarrier(const GCHermesValue *loc);
-  void snapshotWriteBarrier(const GCSmallHermesValue *loc);
+  void snapshotWriteBarrier(const GCHermesValueBase *loc);
+  void snapshotWriteBarrier(const GCSmallHermesValueBase *loc);
   void snapshotWriteBarrier(const GCPointerBase *loc);
   void snapshotWriteBarrier(const GCSymbolID *symbol);
-  void snapshotWriteBarrierRange(const GCHermesValue *start, uint32_t numHVs);
   void snapshotWriteBarrierRange(
-      const GCSmallHermesValue *start,
+      const GCHermesValueBase *start,
+      uint32_t numHVs);
+  void snapshotWriteBarrierRange(
+      const GCSmallHermesValueBase *start,
       uint32_t numHVs);
   void weakRefReadBarrier(HermesValue value);
   void weakRefReadBarrier(GCCell *value);

--- a/include/hermes/VM/GCBase.h
+++ b/include/hermes/VM/GCBase.h
@@ -1086,6 +1086,12 @@ class GCBase {
       SmallHermesValue value) const = 0;
   virtual bool needsWriteBarrier(const GCPointerBase *loc, GCCell *value)
       const = 0;
+  virtual bool needsWriteBarrierInCtor(
+      const GCHermesValue *loc,
+      HermesValue value) const = 0;
+  virtual bool needsWriteBarrierInCtor(
+      const GCSmallHermesValue *loc,
+      SmallHermesValue value) const = 0;
   /// \}
 #endif
 

--- a/include/hermes/VM/GCPointer.h
+++ b/include/hermes/VM/GCPointer.h
@@ -24,8 +24,9 @@ class GCPointerBase : public CompressedPointer {
  protected:
   explicit GCPointerBase(std::nullptr_t) : CompressedPointer(nullptr) {}
 
-  template <typename NeedsBarriers>
-  inline GCPointerBase(PointerBase &base, GCCell *ptr, GC &gc, NeedsBarriers);
+  /// Construct a GCPointer from a compressed pointer. This assumes that
+  /// subclass constructor has alredy performed necessary write barriers.
+  explicit GCPointerBase(CompressedPointer ptr) : CompressedPointer(ptr) {}
 
  public:
   // These classes are used as arguments to GCPointer constructors, to
@@ -34,21 +35,14 @@ class GCPointerBase : public CompressedPointer {
   class NoBarriers : public std::false_type {};
   class YesBarriers : public std::true_type {};
 
-  /// This must be used to assign a new value to this GCPointer.
-  /// \param ptr The memory being pointed to.
-  /// \param base The base of ptr.
-  /// \param gc Used for write barriers.
-  inline void set(PointerBase &base, GCCell *ptr, GC &gc);
-  inline void set(PointerBase &base, CompressedPointer ptr, GC &gc);
-  inline void setNonNull(PointerBase &base, GCCell *ptr, GC &gc);
-
   /// Set this pointer to null. This needs a write barrier in some types of
   /// garbage collectors.
   inline void setNull(GC &gc);
 };
 
 /// A class to represent "raw" pointers to heap objects.  Disallows assignment,
-/// requiring a method that takes a GC* to perform a write barrier.
+/// requiring a method that takes a GC* to perform a write barrier. This must
+/// not be used if it lives in an object that supports large allocation.
 template <typename T>
 class GCPointer : public GCPointerBase {
  public:
@@ -62,13 +56,16 @@ class GCPointer : public GCPointerBase {
   /// this argument is unused, but its type's boolean value constant indicates
   /// whether barriers are required.)
   template <typename NeedsBarriers>
-  GCPointer(PointerBase &base, T *ptr, GC &gc, NeedsBarriers needsBarriers)
-      : GCPointerBase(base, ptr, gc, needsBarriers) {}
+  inline GCPointer(
+      PointerBase &base,
+      T *ptr,
+      GC &gc,
+      NeedsBarriers needsBarriers);
 
   /// Same as the constructor above, with the default for
   /// NeedsBarriers as "YesBarriers".  (We can't use default template
   /// arguments with the idiom used above.)
-  inline GCPointer(PointerBase &base, T *ptr, GC &gc)
+  GCPointer(PointerBase &base, T *ptr, GC &gc)
       : GCPointer<T>(base, ptr, gc, YesBarriers()) {}
 
   /// We are not allowed to copy-construct or assign GCPointers.
@@ -90,17 +87,56 @@ class GCPointer : public GCPointerBase {
   /// \param base The base of ptr.
   /// \param ptr The memory being pointed to.
   /// \param gc Used for write barriers.
-  void set(PointerBase &base, T *ptr, GC &gc) {
-    GCPointerBase::set(base, ptr, gc);
-  }
-  void setNonNull(PointerBase &base, T *ptr, GC &gc) {
-    GCPointerBase::setNonNull(base, ptr, gc);
-  }
+  inline void set(PointerBase &base, T *ptr, GC &gc);
+  inline void setNonNull(PointerBase &base, T *ptr, GC &gc);
 
   /// Convenience overload of GCPointer::set for other GCPointers.
-  void set(PointerBase &base, const GCPointer<T> &ptr, GC &gc) {
-    GCPointerBase::set(base, ptr, gc);
+  inline void set(PointerBase &base, const GCPointer<T> &ptr, GC &gc);
+};
+
+/// A class to represent "raw" pointers to heap objects that support large
+/// allocation. Disallows assignment, requiring a method that takes a GC* to
+/// perform a write barrier.
+template <typename T>
+class GCPointerInLargeObj : public GCPointerBase {
+ public:
+  /// Default method stores nullptr.  No barrier necessary.
+  GCPointerInLargeObj() : GCPointerBase(nullptr) {}
+  /// Explicit construct for the nullptr type.  No barrier necessary.
+  GCPointerInLargeObj(std::nullptr_t) : GCPointerBase(nullptr) {}
+
+  /// Pass the owning object pointer to perform barriers.
+  inline GCPointerInLargeObj(
+      PointerBase &base,
+      GC &gc,
+      T *ptr,
+      const GCCell *owningObj);
+
+  /// We are not allowed to copy-construct or assign GCPointers.
+  GCPointerInLargeObj(const GCPointerBase &) = delete;
+  GCPointerInLargeObj &operator=(const GCPointerBase &) = delete;
+  GCPointerInLargeObj(const GCPointerInLargeObj<T> &) = delete;
+  GCPointerInLargeObj &operator=(const GCPointerInLargeObj<T> &) = delete;
+
+  /// Get the raw pointer value.
+  /// \param base The base of the address space that the GCPointer points into.
+  T *get(PointerBase &base) const {
+    return vmcast_or_null<T>(GCPointerBase::get(base));
   }
+  T *getNonNull(PointerBase &base) const {
+    return vmcast<T>(GCPointerBase::getNonNull(base));
+  }
+
+  /// Assign a new value to this GCPointer, which lives in an object of kind
+  /// that supports large allocation.
+  /// \param base The PointerBase for compressed pointer translations.
+  /// \param ptr The memory being pointed to.
+  /// \param gc Used for write barriers.
+  /// \param owningObj The object that contains this GCPointer, used by the
+  /// write barriers.
+  inline void set(PointerBase &base, GC &gc, T *ptr, const GCCell *owningObj);
+  inline void
+  setNonNull(PointerBase &base, GC &gc, T *ptr, const GCCell *owningObj);
 };
 
 } // namespace vm

--- a/include/hermes/VM/HadesGC.h
+++ b/include/hermes/VM/HadesGC.h
@@ -169,7 +169,7 @@ class HadesGC final : public GCBase {
   void writeBarrierSlow(const GCHermesValue *loc, HermesValue value);
   void writeBarrierForLargeObj(
       const GCCell *owningObj,
-      const GCHermesValue *loc,
+      const GCHermesValueInLargeObj *loc,
       HermesValue value) {
     assert(
         !calledByBackgroundThread() &&
@@ -184,7 +184,7 @@ class HadesGC final : public GCBase {
   }
   void writeBarrierSlowForLargeObj(
       const GCCell *owningObj,
-      const GCHermesValue *loc,
+      const GCHermesValueInLargeObj *loc,
       HermesValue value);
 
   void writeBarrier(const GCSmallHermesValue *loc, SmallHermesValue value) {
@@ -202,7 +202,7 @@ class HadesGC final : public GCBase {
   void writeBarrierSlow(const GCSmallHermesValue *loc, SmallHermesValue value);
   void writeBarrierForLargeObj(
       const GCCell *owningObj,
-      const GCSmallHermesValue *loc,
+      const GCSmallHermesValueInLargeObj *loc,
       SmallHermesValue value) {
     assert(
         !calledByBackgroundThread() &&
@@ -217,7 +217,7 @@ class HadesGC final : public GCBase {
   }
   void writeBarrierSlowForLargeObj(
       const GCCell *owningObj,
-      const GCSmallHermesValue *loc,
+      const GCSmallHermesValueInLargeObj *loc,
       SmallHermesValue value);
 
   /// The given pointer value is being written at the given loc (required to
@@ -274,7 +274,7 @@ class HadesGC final : public GCBase {
   void constructorWriteBarrierSlow(const GCHermesValue *loc, HermesValue value);
   void constructorWriteBarrierForLargeObj(
       const GCCell *owningObj,
-      const GCHermesValue *loc,
+      const GCHermesValueInLargeObj *loc,
       HermesValue value) {
     assert(
         !calledByBackgroundThread() &&
@@ -289,7 +289,7 @@ class HadesGC final : public GCBase {
   }
   void constructorWriteBarrierSlowForLargeObj(
       const GCCell *owningObj,
-      const GCHermesValue *loc,
+      const GCHermesValueInLargeObj *loc,
       HermesValue value);
 
   void constructorWriteBarrier(
@@ -311,7 +311,7 @@ class HadesGC final : public GCBase {
       SmallHermesValue value);
   void constructorWriteBarrierForLargeObj(
       const GCCell *owningObj,
-      const GCSmallHermesValue *loc,
+      const GCSmallHermesValueInLargeObj *loc,
       SmallHermesValue value) {
     assert(
         !calledByBackgroundThread() &&
@@ -326,7 +326,7 @@ class HadesGC final : public GCBase {
   }
   void constructorWriteBarrierSlowForLargeObj(
       const GCCell *owningObj,
-      const GCSmallHermesValue *loc,
+      const GCSmallHermesValueInLargeObj *loc,
       SmallHermesValue value);
 
   void constructorWriteBarrier(const GCPointerBase *loc, const GCCell *value) {
@@ -359,7 +359,7 @@ class HadesGC final : public GCBase {
 
   void constructorWriteBarrierRange(
       const GCCell *owningObj,
-      const GCHermesValue *start,
+      const GCHermesValueBase *start,
       uint32_t numHVs) {
     // A pointer that lives in YG never needs any write barriers.
     if (LLVM_UNLIKELY(!inYoungGen(start)))
@@ -367,12 +367,12 @@ class HadesGC final : public GCBase {
   }
   void constructorWriteBarrierRangeSlow(
       const GCCell *owningObj,
-      const GCHermesValue *start,
+      const GCHermesValueBase *start,
       uint32_t numHVs);
 
   void constructorWriteBarrierRange(
       const GCCell *owningObj,
-      const GCSmallHermesValue *start,
+      const GCSmallHermesValueBase *start,
       uint32_t numHVs) {
     // A pointer that lives in YG never needs any write barriers.
     if (LLVM_UNLIKELY(!inYoungGen(start)))
@@ -380,14 +380,14 @@ class HadesGC final : public GCBase {
   }
   void constructorWriteBarrierRangeSlow(
       const GCCell *owningObj,
-      const GCSmallHermesValue *start,
+      const GCSmallHermesValueBase *start,
       uint32_t numHVs);
 
-  void snapshotWriteBarrier(const GCHermesValue *loc) {
+  void snapshotWriteBarrier(const GCHermesValueBase *loc) {
     if (LLVM_UNLIKELY(!inYoungGen(loc) && ogMarkingBarriers_))
       snapshotWriteBarrierInternal(*loc);
   }
-  void snapshotWriteBarrier(const GCSmallHermesValue *loc) {
+  void snapshotWriteBarrier(const GCSmallHermesValueBase *loc) {
     if (LLVM_UNLIKELY(!inYoungGen(loc) && ogMarkingBarriers_))
       snapshotWriteBarrierInternal(*loc);
   }
@@ -401,22 +401,24 @@ class HadesGC final : public GCBase {
       snapshotWriteBarrierInternal(*loc);
   }
 
-  void snapshotWriteBarrierRange(const GCHermesValue *start, uint32_t numHVs) {
-    if (LLVM_UNLIKELY(!inYoungGen(start) && ogMarkingBarriers_))
-      snapshotWriteBarrierRangeSlow(start, numHVs);
-  }
-  void snapshotWriteBarrierRangeSlow(
-      const GCHermesValue *start,
-      uint32_t numHVs);
-
   void snapshotWriteBarrierRange(
-      const GCSmallHermesValue *start,
+      const GCHermesValueBase *start,
       uint32_t numHVs) {
     if (LLVM_UNLIKELY(!inYoungGen(start) && ogMarkingBarriers_))
       snapshotWriteBarrierRangeSlow(start, numHVs);
   }
   void snapshotWriteBarrierRangeSlow(
-      const GCSmallHermesValue *start,
+      const GCHermesValueBase *start,
+      uint32_t numHVs);
+
+  void snapshotWriteBarrierRange(
+      const GCSmallHermesValueBase *start,
+      uint32_t numHVs) {
+    if (LLVM_UNLIKELY(!inYoungGen(start) && ogMarkingBarriers_))
+      snapshotWriteBarrierRangeSlow(start, numHVs);
+  }
+  void snapshotWriteBarrierRangeSlow(
+      const GCSmallHermesValueBase *start,
       uint32_t numHVs);
 
   /// Add read barrier for \p value. This is only used when reading entry
@@ -508,16 +510,17 @@ class HadesGC final : public GCBase {
   /// found reachable in a full GC.
   void trackReachable(CellKind kind, unsigned sz) override;
 
-  bool needsWriteBarrier(const GCHermesValue *loc, HermesValue value)
+  bool needsWriteBarrier(const GCHermesValueBase *loc, HermesValue value)
       const override;
-  bool needsWriteBarrier(const GCSmallHermesValue *loc, SmallHermesValue value)
-      const override;
+  bool needsWriteBarrier(
+      const GCSmallHermesValueBase *loc,
+      SmallHermesValue value) const override;
   bool needsWriteBarrier(const GCPointerBase *loc, GCCell *value)
       const override;
-  bool needsWriteBarrierInCtor(const GCHermesValue *loc, HermesValue value)
+  bool needsWriteBarrierInCtor(const GCHermesValueBase *loc, HermesValue value)
       const override;
   bool needsWriteBarrierInCtor(
-      const GCSmallHermesValue *loc,
+      const GCSmallHermesValueBase *loc,
       SmallHermesValue value) const override;
   /// \}
 #endif

--- a/include/hermes/VM/HadesGC.h
+++ b/include/hermes/VM/HadesGC.h
@@ -214,24 +214,28 @@ class HadesGC final : public GCBase {
   }
 
   void constructorWriteBarrierRange(
+      const GCCell *owningObj,
       const GCHermesValue *start,
       uint32_t numHVs) {
     // A pointer that lives in YG never needs any write barriers.
     if (LLVM_UNLIKELY(!inYoungGen(start)))
-      constructorWriteBarrierRangeSlow(start, numHVs);
+      constructorWriteBarrierRangeSlow(owningObj, start, numHVs);
   }
   void constructorWriteBarrierRangeSlow(
+      const GCCell *owningObj,
       const GCHermesValue *start,
       uint32_t numHVs);
 
   void constructorWriteBarrierRange(
+      const GCCell *owningObj,
       const GCSmallHermesValue *start,
       uint32_t numHVs) {
     // A pointer that lives in YG never needs any write barriers.
     if (LLVM_UNLIKELY(!inYoungGen(start)))
-      constructorWriteBarrierRangeSlow(start, numHVs);
+      constructorWriteBarrierRangeSlow(owningObj, start, numHVs);
   }
   void constructorWriteBarrierRangeSlow(
+      const GCCell *owningObj,
       const GCSmallHermesValue *start,
       uint32_t numHVs);
 

--- a/include/hermes/VM/HadesGC.h
+++ b/include/hermes/VM/HadesGC.h
@@ -908,7 +908,8 @@ class HadesGC final : public GCBase {
   };
 
   /// The maximum number of bytes that the heap can hold. Once this amount has
-  /// been filled up, OOM will occur.
+  /// been filled up, OOM will occur. When creating new segment, we allow an
+  /// extra buffer with size AlignedHeapSegment::kSegmentUnitSize.
   const uint64_t maxHeapSize_;
 
   /// This needs to be placed before youngGen_ and oldGen_, because those
@@ -1355,6 +1356,17 @@ class HadesGC final : public GCBase {
 
   /// Create a new segment (to be used by either YG or OG).
   llvh::ErrorOr<FixedSizeHeapSegment> createSegment();
+
+  /// Create a jumbo segment (for large allocation).
+  llvh::ErrorOr<JumboHeapSegment> createJumboSegment(size_t segmentSize);
+
+  /// Actual implementation for creating a heap segment.
+  /// \tparam createSegFunc takes StorageProvider pointer, segment name and size
+  /// to create a segment and return it.
+  template <typename T, typename CreateSegFunc>
+  llvh::ErrorOr<T> createSegmentImpl(
+      size_t segmentSize,
+      CreateSegFunc createSegFunc);
 
   /// Set a given segment as the YG segment.
   /// \return the previous YG segment.

--- a/include/hermes/VM/HadesGC.h
+++ b/include/hermes/VM/HadesGC.h
@@ -555,14 +555,15 @@ class HadesGC final : public GCBase {
    public:
     explicit OldGen(HadesGC &gc);
 
-    std::deque<FixedSizeHeapSegment>::iterator begin();
-    std::deque<FixedSizeHeapSegment>::iterator end();
-    std::deque<FixedSizeHeapSegment>::const_iterator begin() const;
-    std::deque<FixedSizeHeapSegment>::const_iterator end() const;
-
     size_t numSegments() const;
 
-    FixedSizeHeapSegment &operator[](size_t i);
+    /// \return The deque of AlignedHeapSegments in the OG.
+    std::deque<FixedSizeHeapSegment> &getSegments() {
+      return segments_;
+    }
+    const std::deque<FixedSizeHeapSegment> &getSegments() const {
+      return segments_;
+    }
 
     /// Take ownership of the given segment.
     void addSegment(FixedSizeHeapSegment seg);

--- a/include/hermes/VM/HadesGC.h
+++ b/include/hermes/VM/HadesGC.h
@@ -756,6 +756,13 @@ class HadesGC final : public GCBase {
   /// Protected by gcMutex_.
   OldGen oldGen_;
 
+#ifndef NDEBUG
+  /// Map an address aligned to AlignedHeapSegment::kSegmentUnitSize to the
+  /// start and end address of its owning segment.
+  llvh::DenseMap<const char *, std::pair<const char *, const char *>>
+      unitSegmentAddrMap_;
+#endif
+
   /// Whoever holds this lock is permitted to modify data structures around the
   /// GC. This includes mark bits, free lists, etc.
   Mutex gcMutex_;
@@ -1179,6 +1186,9 @@ class HadesGC final : public GCBase {
   void removeSegmentExtentFromCrashManager(const std::string &extraName);
 
 #ifdef HERMES_SLOW_DEBUG
+  /// Return the start/end address of the segment that contains \p addr.
+  std::pair<const char *, const char *> getSegmentAddrRange(const void *addr);
+
   /// Checks the heap to make sure all cells are valid.
   void checkWellFormed();
 

--- a/include/hermes/VM/HadesGC.h
+++ b/include/hermes/VM/HadesGC.h
@@ -514,6 +514,11 @@ class HadesGC final : public GCBase {
       const override;
   bool needsWriteBarrier(const GCPointerBase *loc, GCCell *value)
       const override;
+  bool needsWriteBarrierInCtor(const GCHermesValue *loc, HermesValue value)
+      const override;
+  bool needsWriteBarrierInCtor(
+      const GCSmallHermesValue *loc,
+      SmallHermesValue value) const override;
   /// \}
 #endif
 

--- a/include/hermes/VM/HermesValue-inline.h
+++ b/include/hermes/VM/HermesValue-inline.h
@@ -182,6 +182,7 @@ inline GCHermesValueBase<HVType> *GCHermesValueBase<HVType>::uninitialized_copy(
     GCHermesValueBase<HVType> *first,
     GCHermesValueBase<HVType> *last,
     GCHermesValueBase<HVType> *result,
+    const GCCell *owningObj,
     GC &gc) {
 #ifndef NDEBUG
   uintptr_t fromFirst = reinterpret_cast<uintptr_t>(first),
@@ -194,7 +195,7 @@ inline GCHermesValueBase<HVType> *GCHermesValueBase<HVType>::uninitialized_copy(
       "Uninitialized range cannot overlap with an initialized one.");
 #endif
 
-  gc.constructorWriteBarrierRange(result, last - first);
+  gc.constructorWriteBarrierRange(owningObj, result, last - first);
   // memcpy is fine for an uninitialized copy.
   std::memcpy(
       reinterpret_cast<void *>(result), first, (last - first) * sizeof(HVType));

--- a/include/hermes/VM/HermesValue.h
+++ b/include/hermes/VM/HermesValue.h
@@ -602,6 +602,7 @@ class GCHermesValueBase final : public HVType {
       GCHermesValueBase<HVType> *first,
       GCHermesValueBase<HVType> *last,
       GCHermesValueBase<HVType> *result,
+      const GCCell *owningObj,
       GC &gc);
 
   /// Copies a range of values and performs a write barrier on each.

--- a/include/hermes/VM/HermesValueTraits.h
+++ b/include/hermes/VM/HermesValueTraits.h
@@ -76,9 +76,12 @@ HERMES_VM_GCOBJECT(StringPrimitive);
 
 namespace testhelpers {
 struct DummyObject;
-}
+struct LargeDummyObject;
+} // namespace testhelpers
 template <>
 struct IsGCObject<testhelpers::DummyObject> : public std::true_type {};
+template <>
+struct IsGCObject<testhelpers::LargeDummyObject> : public std::true_type {};
 
 // Typed arrays use templates and cannot use the macro above
 template <typename T, CellKind C>

--- a/include/hermes/VM/JSObject.h
+++ b/include/hermes/VM/JSObject.h
@@ -1734,23 +1734,23 @@ inline T *JSObject::initDirectPropStorage(Runtime &runtime, T *self) {
   // (including calls to memset) so we manually unroll it with a switch.
   switch (numOverlapSlots<T>()) {
     case 0:
-      new (&self->directProps()[0]) GCHermesValueBase(
+      new (&self->directProps()[0]) GCSmallHermesValue(
           SmallHermesValue::encodeUndefinedValue(), runtime.getHeap(), nullptr);
       [[fallthrough]];
     case 1:
-      new (&self->directProps()[1]) GCHermesValueBase(
+      new (&self->directProps()[1]) GCSmallHermesValue(
           SmallHermesValue::encodeUndefinedValue(), runtime.getHeap(), nullptr);
       [[fallthrough]];
     case 2:
-      new (&self->directProps()[2]) GCHermesValueBase(
+      new (&self->directProps()[2]) GCSmallHermesValue(
           SmallHermesValue::encodeUndefinedValue(), runtime.getHeap(), nullptr);
       [[fallthrough]];
     case 3:
-      new (&self->directProps()[3]) GCHermesValueBase(
+      new (&self->directProps()[3]) GCSmallHermesValue(
           SmallHermesValue::encodeUndefinedValue(), runtime.getHeap(), nullptr);
       [[fallthrough]];
     case 4:
-      new (&self->directProps()[4]) GCHermesValueBase(
+      new (&self->directProps()[4]) GCSmallHermesValue(
           SmallHermesValue::encodeUndefinedValue(), runtime.getHeap(), nullptr);
       [[fallthrough]];
     case 5:

--- a/include/hermes/VM/LargeDummyObject.h
+++ b/include/hermes/VM/LargeDummyObject.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "hermes/VM/DummyObject.h"
+#include "hermes/VM/GCCell.h"
+#include "hermes/VM/GCPointer.h"
+#include "hermes/VM/HermesValue.h"
+
+namespace hermes::vm::testhelpers {
+
+/// A GCCell type supports large allocation. Used in test only.
+struct LargeDummyObject final : public VariableSizeRuntimeCell {
+  static const VTable vt;
+
+  GCSmallHermesValueInLargeObj hv;
+  GCPointerInLargeObj<DummyObject> ptrToNormalObj;
+
+  static constexpr CellKind getCellKind() {
+    return CellKind::LargeDummyObjectKind;
+  }
+  static bool classof(const GCCell *cell) {
+    return cell->getKind() == CellKind::LargeDummyObjectKind;
+  }
+
+  LargeDummyObject() = default;
+
+  static LargeDummyObject *create(uint32_t size, GC &gc);
+};
+} // namespace hermes::vm::testhelpers

--- a/include/hermes/VM/MallocGC.h
+++ b/include/hermes/VM/MallocGC.h
@@ -235,10 +235,32 @@ class MallocGC final : public GCBase {
 
   void writeBarrier(const GCHermesValue *, HermesValue) {}
   void writeBarrier(const GCSmallHermesValue *, SmallHermesValue) {}
+  void
+  writeBarrierForLargeObj(const GCCell *, const GCHermesValue *, HermesValue) {}
+  void writeBarrierForLargeObj(
+      const GCCell *,
+      const GCSmallHermesValue *,
+      SmallHermesValue) {}
   void writeBarrier(const GCPointerBase *, const GCCell *) {}
+  void writeBarrierForLargeObj(
+      const GCCell *,
+      const GCPointerBase *,
+      const GCCell *) {}
   void constructorWriteBarrier(const GCHermesValue *, HermesValue) {}
   void constructorWriteBarrier(const GCSmallHermesValue *, SmallHermesValue) {}
+  void constructorWriteBarrierForLargeObj(
+      const GCCell *,
+      const GCSmallHermesValue *,
+      SmallHermesValue) {}
+  void constructorWriteBarrierForLargeObj(
+      const GCCell *,
+      const GCHermesValue *,
+      HermesValue) {}
   void constructorWriteBarrier(const GCPointerBase *, const GCCell *) {}
+  void constructorWriteBarrierForLargeObj(
+      const GCCell *,
+      const GCPointerBase *,
+      const GCCell *) {}
   void writeBarrierRange(const GCHermesValue *, uint32_t) {}
   void writeBarrierRange(const GCSmallHermesValue *, uint32_t) {}
   void constructorWriteBarrierRange(

--- a/include/hermes/VM/MallocGC.h
+++ b/include/hermes/VM/MallocGC.h
@@ -241,8 +241,14 @@ class MallocGC final : public GCBase {
   void constructorWriteBarrier(const GCPointerBase *, const GCCell *) {}
   void writeBarrierRange(const GCHermesValue *, uint32_t) {}
   void writeBarrierRange(const GCSmallHermesValue *, uint32_t) {}
-  void constructorWriteBarrierRange(const GCHermesValue *, uint32_t) {}
-  void constructorWriteBarrierRange(const GCSmallHermesValue *, uint32_t) {}
+  void constructorWriteBarrierRange(
+      const GCCell *,
+      const GCHermesValue *,
+      uint32_t) {}
+  void constructorWriteBarrierRange(
+      const GCCell *,
+      const GCSmallHermesValue *,
+      uint32_t) {}
   void snapshotWriteBarrier(const GCHermesValue *) {}
   void snapshotWriteBarrier(const GCSmallHermesValue *) {}
   void snapshotWriteBarrier(const GCPointerBase *) {}

--- a/include/hermes/VM/MallocGC.h
+++ b/include/hermes/VM/MallocGC.h
@@ -222,6 +222,11 @@ class MallocGC final : public GCBase {
       const override;
   bool needsWriteBarrier(const GCPointerBase *loc, GCCell *value)
       const override;
+  bool needsWriteBarrierInCtor(const GCHermesValue *loc, HermesValue value)
+      const override;
+  bool needsWriteBarrierInCtor(
+      const GCSmallHermesValue *loc,
+      SmallHermesValue value) const override;
 #endif
 
 #ifdef HERMES_MEMORY_INSTRUMENTATION

--- a/include/hermes/VM/MallocGC.h
+++ b/include/hermes/VM/MallocGC.h
@@ -216,16 +216,17 @@ class MallocGC final : public GCBase {
   bool validPointer(const void *p) const override;
   bool dbgContains(const void *p) const override;
 
-  bool needsWriteBarrier(const GCHermesValue *loc, HermesValue value)
+  bool needsWriteBarrier(const GCHermesValueBase *loc, HermesValue value)
       const override;
-  bool needsWriteBarrier(const GCSmallHermesValue *loc, SmallHermesValue value)
-      const override;
+  bool needsWriteBarrier(
+      const GCSmallHermesValueBase *loc,
+      SmallHermesValue value) const override;
   bool needsWriteBarrier(const GCPointerBase *loc, GCCell *value)
       const override;
-  bool needsWriteBarrierInCtor(const GCHermesValue *loc, HermesValue value)
+  bool needsWriteBarrierInCtor(const GCHermesValueBase *loc, HermesValue value)
       const override;
   bool needsWriteBarrierInCtor(
-      const GCSmallHermesValue *loc,
+      const GCSmallHermesValueBase *loc,
       SmallHermesValue value) const override;
 #endif
 
@@ -240,11 +241,13 @@ class MallocGC final : public GCBase {
 
   void writeBarrier(const GCHermesValue *, HermesValue) {}
   void writeBarrier(const GCSmallHermesValue *, SmallHermesValue) {}
-  void
-  writeBarrierForLargeObj(const GCCell *, const GCHermesValue *, HermesValue) {}
   void writeBarrierForLargeObj(
       const GCCell *,
-      const GCSmallHermesValue *,
+      const GCHermesValueInLargeObj *,
+      HermesValue) {}
+  void writeBarrierForLargeObj(
+      const GCCell *,
+      const GCSmallHermesValueInLargeObj *,
       SmallHermesValue) {}
   void writeBarrier(const GCPointerBase *, const GCCell *) {}
   void writeBarrierForLargeObj(
@@ -255,11 +258,11 @@ class MallocGC final : public GCBase {
   void constructorWriteBarrier(const GCSmallHermesValue *, SmallHermesValue) {}
   void constructorWriteBarrierForLargeObj(
       const GCCell *,
-      const GCSmallHermesValue *,
+      const GCSmallHermesValueInLargeObj *,
       SmallHermesValue) {}
   void constructorWriteBarrierForLargeObj(
       const GCCell *,
-      const GCHermesValue *,
+      const GCHermesValueInLargeObj *,
       HermesValue) {}
   void constructorWriteBarrier(const GCPointerBase *, const GCCell *) {}
   void constructorWriteBarrierForLargeObj(
@@ -270,18 +273,18 @@ class MallocGC final : public GCBase {
   void writeBarrierRange(const GCSmallHermesValue *, uint32_t) {}
   void constructorWriteBarrierRange(
       const GCCell *,
-      const GCHermesValue *,
+      const GCHermesValueBase *,
       uint32_t) {}
   void constructorWriteBarrierRange(
       const GCCell *,
-      const GCSmallHermesValue *,
+      const GCSmallHermesValueBase *,
       uint32_t) {}
-  void snapshotWriteBarrier(const GCHermesValue *) {}
-  void snapshotWriteBarrier(const GCSmallHermesValue *) {}
+  void snapshotWriteBarrier(const GCHermesValueBase *) {}
+  void snapshotWriteBarrier(const GCSmallHermesValueBase *) {}
   void snapshotWriteBarrier(const GCPointerBase *) {}
   void snapshotWriteBarrier(const GCSymbolID *) {}
-  void snapshotWriteBarrierRange(const GCHermesValue *, uint32_t) {}
-  void snapshotWriteBarrierRange(const GCSmallHermesValue *, uint32_t) {}
+  void snapshotWriteBarrierRange(const GCHermesValueBase *, uint32_t) {}
+  void snapshotWriteBarrierRange(const GCSmallHermesValueBase *, uint32_t) {}
   void weakRefReadBarrier(HermesValue) {}
   void weakRefReadBarrier(GCCell *) {}
   void weakRefReadBarrier(SymbolID) {}

--- a/include/hermes/VM/MallocGC.h
+++ b/include/hermes/VM/MallocGC.h
@@ -172,6 +172,8 @@ class MallocGC final : public GCBase {
       bool fixedSize = true,
       HasFinalizer hasFinalizer = HasFinalizer::No,
       LongLived longLived = LongLived::Yes,
+      CanBeLarge canBeLarge = CanBeLarge::No,
+      MayFail mayFail = MayFail::No,
       class... Args>
   inline T *makeA(uint32_t size, Args &&...args);
 
@@ -389,6 +391,8 @@ template <
     bool fixedSize,
     HasFinalizer hasFinalizer,
     LongLived longLived,
+    CanBeLarge canBeLarge,
+    MayFail mayFail,
     class... Args>
 inline T *MallocGC::makeA(uint32_t size, Args &&...args) {
   assert(

--- a/include/hermes/VM/RootAndSlotAcceptorDefault.h
+++ b/include/hermes/VM/RootAndSlotAcceptorDefault.h
@@ -38,13 +38,13 @@ class RootAndSlotAcceptorDefault : public RootAndSlotAcceptor {
     acceptHV(hv);
   }
 
-  void accept(GCHermesValue &hv) final {
+  void accept(GCHermesValueBase &hv) final {
     acceptHV(hv);
   }
 
   virtual void acceptHV(HermesValue &hv) = 0;
 
-  void accept(GCSmallHermesValue &shv) final {
+  void accept(GCSmallHermesValueBase &shv) final {
     acceptSHV(shv);
   }
 
@@ -93,13 +93,13 @@ class RootAndSlotAcceptorWithNamesDefault
     acceptHV(hv, name);
   }
 
-  void accept(GCHermesValue &hv, const char *name) final {
+  void accept(GCHermesValueBase &hv, const char *name) final {
     acceptHV(hv, name);
   }
 
   virtual void acceptHV(HermesValue &hv, const char *name) = 0;
 
-  void accept(GCSmallHermesValue &shv, const char *name) final {
+  void accept(GCSmallHermesValueBase &shv, const char *name) final {
     acceptSHV(shv, name);
   }
 

--- a/include/hermes/VM/Runtime.h
+++ b/include/hermes/VM/Runtime.h
@@ -336,6 +336,8 @@ class Runtime : public RuntimeBase, public HandleRootOwner {
       typename T,
       HasFinalizer hasFinalizer = HasFinalizer::No,
       LongLived longLived = LongLived::No,
+      CanBeLarge canBeLarge = CanBeLarge::No,
+      MayFail mayFail = MayFail::No,
       class... Args>
   T *makeAVariable(uint32_t size, Args &&...args);
 
@@ -2049,6 +2051,8 @@ template <
     typename T,
     HasFinalizer hasFinalizer,
     LongLived longLived,
+    CanBeLarge canBeLarge,
+    MayFail mayFail,
     class... Args>
 T *Runtime::makeAVariable(uint32_t size, Args &&...args) {
 #ifndef NDEBUG
@@ -2058,8 +2062,9 @@ T *Runtime::makeAVariable(uint32_t size, Args &&...args) {
   // CAPTURE_IP* macros in the interpreter loop.
   (void)getCurrentIP();
 #endif
-  return getHeap().makeAVariable<T, hasFinalizer, longLived>(
-      size, std::forward<Args>(args)...);
+  return getHeap()
+      .makeAVariable<T, hasFinalizer, longLived, canBeLarge, mayFail>(
+          size, std::forward<Args>(args)...);
 }
 
 template <typename T>

--- a/include/hermes/VM/SegmentedArray.h
+++ b/include/hermes/VM/SegmentedArray.h
@@ -45,8 +45,8 @@ template <typename HVType>
 class SegmentedArrayBase final : public VariableSizeRuntimeCell,
                                  private llvh::TrailingObjects<
                                      SegmentedArrayBase<HVType>,
-                                     GCHermesValueBase<HVType>> {
-  using GCHVType = GCHermesValueBase<HVType>;
+                                     GCHermesValueBaseImpl<HVType>> {
+  using GCHVType = GCHermesValueBaseImpl<HVType>;
 
  public:
   /// A segment is just a blob of raw memory with a fixed size.
@@ -401,8 +401,7 @@ class SegmentedArrayBase final : public VariableSizeRuntimeCell,
  private:
   static const VTable vt;
 
-  friend llvh::
-      TrailingObjects<SegmentedArrayBase<HVType>, GCHermesValueBase<HVType>>;
+  friend llvh::TrailingObjects<SegmentedArrayBase<HVType>, GCHVType>;
   friend void SegmentBuildMeta(const GCCell *cell, Metadata::Builder &mb);
   friend void SegmentedArrayBuildMeta(
       const GCCell *cell,

--- a/include/hermes/VM/SegmentedArray.h
+++ b/include/hermes/VM/SegmentedArray.h
@@ -45,8 +45,8 @@ template <typename HVType>
 class SegmentedArrayBase final : public VariableSizeRuntimeCell,
                                  private llvh::TrailingObjects<
                                      SegmentedArrayBase<HVType>,
-                                     GCHermesValueBaseImpl<HVType>> {
-  using GCHVType = GCHermesValueBaseImpl<HVType>;
+                                     GCHermesValueImpl<HVType>> {
+  using GCHVType = GCHermesValueImpl<HVType>;
 
  public:
   /// A segment is just a blob of raw memory with a fixed size.

--- a/include/hermes/VM/SingleObject.h
+++ b/include/hermes/VM/SingleObject.h
@@ -53,7 +53,7 @@ struct IsGCObject<SingleObject<kind>> {
 
 template <CellKind kind>
 const ObjectVTable SingleObject<kind>::vt = {
-    VTable(kind, cellSize<SingleObject<kind>>(), nullptr, nullptr),
+    VTable(kind, cellSize<SingleObject<kind>>()),
     SingleObject::_getOwnIndexedRangeImpl,
     SingleObject::_haveOwnIndexedImpl,
     SingleObject::_getOwnIndexedPropertyFlagsImpl,

--- a/include/hermes/VM/SlotAcceptor.h
+++ b/include/hermes/VM/SlotAcceptor.h
@@ -34,8 +34,8 @@ class GCCell;
 struct SlotAcceptor {
   virtual ~SlotAcceptor() = default;
   virtual void accept(GCPointerBase &ptr) = 0;
-  virtual void accept(GCHermesValue &hv) = 0;
-  virtual void accept(GCSmallHermesValue &hv) = 0;
+  virtual void accept(GCHermesValueBase &hv) = 0;
+  virtual void accept(GCSmallHermesValueBase &hv) = 0;
   virtual void accept(const GCSymbolID &sym) = 0;
 };
 
@@ -111,15 +111,15 @@ struct RootAndSlotAcceptorWithNames : public RootAndSlotAcceptor {
   }
   virtual void accept(GCPointerBase &ptr, const char *name) = 0;
 
-  void accept(GCHermesValue &hv) final {
+  void accept(GCHermesValueBase &hv) final {
     accept(hv, nullptr);
   }
-  virtual void accept(GCHermesValue &hv, const char *name) = 0;
+  virtual void accept(GCHermesValueBase &hv, const char *name) = 0;
 
-  void accept(GCSmallHermesValue &hv) final {
+  void accept(GCSmallHermesValueBase &hv) final {
     accept(hv, nullptr);
   }
-  virtual void accept(GCSmallHermesValue &hv, const char *name) = 0;
+  virtual void accept(GCSmallHermesValueBase &hv, const char *name) = 0;
 
   void accept(const GCSymbolID &sym) final {
     accept(sym, nullptr);
@@ -167,11 +167,11 @@ struct DroppingAcceptor final : public RootAndSlotAcceptorWithNames {
     acceptor.acceptNullable(hv);
   }
 
-  void accept(GCHermesValue &hv, const char *) override {
+  void accept(GCHermesValueBase &hv, const char *) override {
     acceptor.accept(hv);
   }
 
-  void accept(GCSmallHermesValue &hv, const char *) override {
+  void accept(GCSmallHermesValueBase &hv, const char *) override {
     acceptor.accept(hv);
   }
 

--- a/include/hermes/VM/SlotKinds.def
+++ b/include/hermes/VM/SlotKinds.def
@@ -8,6 +8,6 @@
 // This file lists the types of slots that the GC needs to visit.
 
 SLOT_TYPE(GCPointerBase)
-SLOT_TYPE(GCHermesValue)
-SLOT_TYPE(GCSmallHermesValue)
+SLOT_TYPE(GCHermesValueBase)
+SLOT_TYPE(GCSmallHermesValueBase)
 SLOT_TYPE(GCSymbolID)

--- a/include/hermes/VM/SmallHermesValue.h
+++ b/include/hermes/VM/SmallHermesValue.h
@@ -466,7 +466,15 @@ static_assert(
     std::is_trivial<SmallHermesValue>::value,
     "SmallHermesValue must be trivial");
 
-using GCSmallHermesValue = GCHermesValueBase<SmallHermesValue>;
+/// Base type for GC aware SmallHermesValues. This should only be used when we
+/// don't need to handle large allocation specially.
+using GCSmallHermesValueBase = GCHermesValueBaseImpl<SmallHermesValue>;
+
+/// GCSmallHermesValue stored in a normal object.
+using GCSmallHermesValue = GCSmallHermesValueBase;
+
+/// GCSmallHermesValue stored in an object that supports large allocation.
+using GCSmallHermesValueInLargeObj = GCSmallHermesValueBase;
 
 } // end namespace vm
 } // end namespace hermes

--- a/include/hermes/VM/SmallHermesValue.h
+++ b/include/hermes/VM/SmallHermesValue.h
@@ -471,10 +471,11 @@ static_assert(
 using GCSmallHermesValueBase = GCHermesValueBaseImpl<SmallHermesValue>;
 
 /// GCSmallHermesValue stored in a normal object.
-using GCSmallHermesValue = GCSmallHermesValueBase;
+using GCSmallHermesValue = GCHermesValueImpl<SmallHermesValue>;
 
 /// GCSmallHermesValue stored in an object that supports large allocation.
-using GCSmallHermesValueInLargeObj = GCSmallHermesValueBase;
+using GCSmallHermesValueInLargeObj =
+    GCHermesValueInLargeObjImpl<SmallHermesValue>;
 
 } // end namespace vm
 } // end namespace hermes

--- a/include/hermes/VM/StringPrimitive.h
+++ b/include/hermes/VM/StringPrimitive.h
@@ -838,6 +838,7 @@ template <typename T, bool Uniqued>
 const VTable DynamicStringPrimitive<T, Uniqued>::vt = VTable(
     DynamicStringPrimitive<T, Uniqued>::getCellKind(),
     0,
+    /* allowLargeAlloc */ false,
     nullptr,
     nullptr,
     nullptr
@@ -865,6 +866,7 @@ template <typename T>
 const VTable ExternalStringPrimitive<T>::vt = VTable(
     ExternalStringPrimitive<T>::getCellKind(),
     0,
+    /* allowLargeAlloc */ false,
     ExternalStringPrimitive<T>::_finalizeImpl,
     ExternalStringPrimitive<T>::_mallocSizeImpl,
     nullptr
@@ -886,6 +888,7 @@ template <typename T>
 const VTable BufferedStringPrimitive<T>::vt = VTable(
     BufferedStringPrimitive<T>::getCellKind(),
     0,
+    /* allowLargeAlloc */ false,
     nullptr, // finalize.
     nullptr, // mallocSize
     nullptr

--- a/include/hermes/VM/VTable.h
+++ b/include/hermes/VM/VTable.h
@@ -106,6 +106,8 @@ struct VTable {
   /// If it is variable sized, it should inherit from \see
   /// VariableSizeRuntimeCell.
   const uint32_t size;
+  /// Whether the cell supports large allocation.
+  bool allowLargeAlloc;
   /// Called during GC when an object becomes unreachable. Must not perform any
   /// allocations or access any garbage-collectable objects.  Unless an
   /// operation is documented to be safe to call from a finalizer, it probably
@@ -137,6 +139,7 @@ struct VTable {
   constexpr explicit VTable(
       CellKind kind,
       uint32_t size,
+      bool allowLargeAlloc = false,
       FinalizeCallback *finalize = nullptr,
       MallocSizeCallback *mallocSize = nullptr,
       TrimSizeCallback *trimSize = nullptr
@@ -153,6 +156,7 @@ struct VTable {
       )
       : kind(kind),
         size(heapAlignSize(size)),
+        allowLargeAlloc(allowLargeAlloc),
         finalize_(finalize),
         mallocSize_(mallocSize),
         trimSize_(trimSize)

--- a/lib/VM/ArrayStorage.cpp
+++ b/lib/VM/ArrayStorage.cpp
@@ -19,6 +19,7 @@ template <typename HVType>
 const VTable ArrayStorageBase<HVType>::vt(
     ArrayStorageBase<HVType>::getCellKind(),
     0,
+    /* allowLargeAlloc */ false,
     nullptr,
     nullptr,
     _trimSizeCallback

--- a/lib/VM/ArrayStorage.cpp
+++ b/lib/VM/ArrayStorage.cpp
@@ -104,7 +104,8 @@ ExecutionStatus ArrayStorageBase<HVType>::reallocateToLarger(
   {
     GCHVType *from = self->data() + fromFirst;
     GCHVType *to = newSelf->data() + toFirst;
-    GCHVType::uninitialized_copy(from, from + copySize, to, runtime.getHeap());
+    GCHVType::uninitialized_copy(
+        from, from + copySize, to, newSelf, runtime.getHeap());
   }
 
   // Initialize the elements before the first copied element.

--- a/lib/VM/CMakeLists.txt
+++ b/lib/VM/CMakeLists.txt
@@ -16,6 +16,7 @@ set(source_files
   DictPropertyMap.cpp
   Domain.cpp
   DummyObject.cpp
+  LargeDummyObject.cpp
   FastArray.cpp
   GCBase.cpp
   OrderedHashMap.cpp

--- a/lib/VM/Callable.cpp
+++ b/lib/VM/Callable.cpp
@@ -609,6 +609,7 @@ const CallableVTable BoundFunction::vt{
         VTable(
             CellKind::BoundFunctionKind,
             cellSize<BoundFunction>(),
+            /* allowLargeAlloc */ false,
             nullptr,
             nullptr,
             nullptr
@@ -925,6 +926,7 @@ const CallableVTable NativeJSFunction::vt{
         VTable(
             CellKind::NativeJSFunctionKind,
             cellSize<NativeJSFunction>(),
+            /* allowLargeAlloc */ false,
             nullptr,
             nullptr,
             nullptr
@@ -1051,6 +1053,7 @@ const CallableVTable NativeJSDerivedClass::vt{
         VTable(
             CellKind::NativeJSDerivedClassKind,
             cellSize<NativeJSDerivedClass>(),
+            /*allowLargeAlloc*/ false,
             nullptr,
             nullptr,
             nullptr
@@ -1108,6 +1111,7 @@ const CallableVTable NativeFunction::vt{
         VTable(
             CellKind::NativeFunctionKind,
             cellSize<NativeFunction>(),
+            /* allowLargeAlloc */ false,
             nullptr,
             nullptr,
             nullptr
@@ -1287,6 +1291,7 @@ const CallableVTable NativeConstructor::vt{
         VTable(
             CellKind::NativeConstructorKind,
             cellSize<NativeConstructor>(),
+            /* allowLargeAlloc */ false,
             nullptr,
             nullptr,
             nullptr
@@ -1344,6 +1349,7 @@ const CallableVTable JSFunction::vt{
         VTable(
             CellKind::JSFunctionKind,
             cellSize<JSFunction>(),
+            /* allowLargeAlloc */ false,
             nullptr,
             nullptr,
             nullptr
@@ -1486,6 +1492,7 @@ const CallableVTable JSDerivedClass::vt{
         VTable(
             CellKind::JSDerivedClassKind,
             cellSize<JSDerivedClass>(),
+            /*allowLargeAlloc*/ false,
             nullptr,
             nullptr,
             nullptr

--- a/lib/VM/DecoratedObject.cpp
+++ b/lib/VM/DecoratedObject.cpp
@@ -22,6 +22,7 @@ const ObjectVTable DecoratedObject::vt{
     VTable(
         CellKind::DecoratedObjectKind,
         cellSize<DecoratedObject>(),
+        /* allowLargeAlloc */ false,
         DecoratedObject::_finalizeImpl,
         DecoratedObject::_mallocSizeImpl),
     DecoratedObject::_getOwnIndexedRangeImpl,

--- a/lib/VM/Domain.cpp
+++ b/lib/VM/Domain.cpp
@@ -18,6 +18,7 @@ namespace vm {
 const VTable Domain::vt{
     CellKind::DomainKind,
     cellSize<Domain>(),
+    /* allowLargeAlloc */ false,
     _finalizeImpl,
     _mallocSizeImpl,
     nullptr

--- a/lib/VM/DummyObject.cpp
+++ b/lib/VM/DummyObject.cpp
@@ -19,6 +19,7 @@ namespace testhelpers {
 const VTable DummyObject::vt{
     CellKind::DummyObjectKind,
     cellSize<DummyObject>(),
+    /* allowLargeAlloc */ false,
     _finalizeImpl,
     _mallocSizeImpl,
     nullptr

--- a/lib/VM/FastArray.cpp
+++ b/lib/VM/FastArray.cpp
@@ -28,6 +28,7 @@ const ObjectVTable FastArray::vt{
     VTable(
         CellKind::FastArrayKind,
         cellSize<FastArray>(),
+        /* allowLargeAlloc */ false,
         nullptr,
         nullptr,
         nullptr

--- a/lib/VM/GCBase.cpp
+++ b/lib/VM/GCBase.cpp
@@ -967,13 +967,13 @@ GCBASE_BARRIER_2(writeBarrier, const GCHermesValue *, HermesValue);
 GCBASE_BARRIER_3(
     writeBarrierForLargeObj,
     const GCCell *,
-    const GCHermesValue *,
+    const GCHermesValueInLargeObj *,
     HermesValue);
 GCBASE_BARRIER_2(writeBarrier, const GCSmallHermesValue *, SmallHermesValue);
 GCBASE_BARRIER_3(
     writeBarrierForLargeObj,
     const GCCell *,
-    const GCSmallHermesValue *,
+    const GCSmallHermesValueInLargeObj *,
     SmallHermesValue);
 GCBASE_BARRIER_2(writeBarrier, const GCPointerBase *, const GCCell *);
 GCBASE_BARRIER_3(
@@ -985,7 +985,7 @@ GCBASE_BARRIER_2(constructorWriteBarrier, const GCHermesValue *, HermesValue);
 GCBASE_BARRIER_3(
     constructorWriteBarrierForLargeObj,
     const GCCell *,
-    const GCHermesValue *,
+    const GCHermesValueInLargeObj *,
     HermesValue);
 GCBASE_BARRIER_2(
     constructorWriteBarrier,
@@ -994,7 +994,7 @@ GCBASE_BARRIER_2(
 GCBASE_BARRIER_3(
     constructorWriteBarrierForLargeObj,
     const GCCell *,
-    const GCSmallHermesValue *,
+    const GCSmallHermesValueInLargeObj *,
     SmallHermesValue);
 GCBASE_BARRIER_2(
     constructorWriteBarrier,
@@ -1010,21 +1010,24 @@ GCBASE_BARRIER_2(writeBarrierRange, const GCSmallHermesValue *, uint32_t);
 GCBASE_BARRIER_3(
     constructorWriteBarrierRange,
     const GCCell *,
-    const GCHermesValue *,
+    const GCHermesValueBase *,
     uint32_t);
 GCBASE_BARRIER_3(
     constructorWriteBarrierRange,
     const GCCell *,
-    const GCSmallHermesValue *,
+    const GCSmallHermesValueBase *,
     uint32_t);
-GCBASE_BARRIER_1(snapshotWriteBarrier, const GCHermesValue *);
-GCBASE_BARRIER_1(snapshotWriteBarrier, const GCSmallHermesValue *);
+GCBASE_BARRIER_1(snapshotWriteBarrier, const GCHermesValueBase *);
+GCBASE_BARRIER_1(snapshotWriteBarrier, const GCSmallHermesValueBase *);
 GCBASE_BARRIER_1(snapshotWriteBarrier, const GCPointerBase *);
 GCBASE_BARRIER_1(snapshotWriteBarrier, const GCSymbolID *);
-GCBASE_BARRIER_2(snapshotWriteBarrierRange, const GCHermesValue *, uint32_t);
 GCBASE_BARRIER_2(
     snapshotWriteBarrierRange,
-    const GCSmallHermesValue *,
+    const GCHermesValueBase *,
+    uint32_t);
+GCBASE_BARRIER_2(
+    snapshotWriteBarrierRange,
+    const GCSmallHermesValueBase *,
     uint32_t);
 GCBASE_BARRIER_1(weakRefReadBarrier, HermesValue);
 GCBASE_BARRIER_1(weakRefReadBarrier, GCCell *);
@@ -1810,11 +1813,11 @@ void GCBase::sizeDiagnosticCensus(size_t allocatedBytes) {
           diagnostic.stats.breakdown["HermesValue"],
           sizeof(PinnedHermesValue));
     }
-    void accept(GCHermesValue &hv) override {
+    void accept(GCHermesValueBase &hv) override {
       acceptHV(
           hv, diagnostic.stats.breakdown["HermesValue"], sizeof(GCHermesValue));
     }
-    void accept(GCSmallHermesValue &shv) override {
+    void accept(GCSmallHermesValueBase &shv) override {
       acceptHV(
           shv.toHV(pointerBase_),
           diagnostic.stats.breakdown["SmallHermesValue"],

--- a/lib/VM/GCBase.cpp
+++ b/lib/VM/GCBase.cpp
@@ -964,15 +964,45 @@ bool GCBase::shouldSanitizeHandles() {
   }
 
 GCBASE_BARRIER_2(writeBarrier, const GCHermesValue *, HermesValue);
+GCBASE_BARRIER_3(
+    writeBarrierForLargeObj,
+    const GCCell *,
+    const GCHermesValue *,
+    HermesValue);
 GCBASE_BARRIER_2(writeBarrier, const GCSmallHermesValue *, SmallHermesValue);
+GCBASE_BARRIER_3(
+    writeBarrierForLargeObj,
+    const GCCell *,
+    const GCSmallHermesValue *,
+    SmallHermesValue);
 GCBASE_BARRIER_2(writeBarrier, const GCPointerBase *, const GCCell *);
+GCBASE_BARRIER_3(
+    writeBarrierForLargeObj,
+    const GCCell *,
+    const GCPointerBase *,
+    const GCCell *);
 GCBASE_BARRIER_2(constructorWriteBarrier, const GCHermesValue *, HermesValue);
+GCBASE_BARRIER_3(
+    constructorWriteBarrierForLargeObj,
+    const GCCell *,
+    const GCHermesValue *,
+    HermesValue);
 GCBASE_BARRIER_2(
     constructorWriteBarrier,
     const GCSmallHermesValue *,
     SmallHermesValue);
+GCBASE_BARRIER_3(
+    constructorWriteBarrierForLargeObj,
+    const GCCell *,
+    const GCSmallHermesValue *,
+    SmallHermesValue);
 GCBASE_BARRIER_2(
     constructorWriteBarrier,
+    const GCPointerBase *,
+    const GCCell *);
+GCBASE_BARRIER_3(
+    constructorWriteBarrierForLargeObj,
+    const GCCell *,
     const GCPointerBase *,
     const GCCell *);
 GCBASE_BARRIER_2(writeBarrierRange, const GCHermesValue *, uint32_t);

--- a/lib/VM/GCBase.cpp
+++ b/lib/VM/GCBase.cpp
@@ -958,6 +958,11 @@ bool GCBase::shouldSanitizeHandles() {
     runtimeGCDispatch([&](auto *gc) { gc->name(arg1, arg2); }); \
   }
 
+#define GCBASE_BARRIER_3(name, type1, type2, type3)                   \
+  void GCBase::name(type1 arg1, type2 arg2, type3 arg3) {             \
+    runtimeGCDispatch([&](auto *gc) { gc->name(arg1, arg2, arg3); }); \
+  }
+
 GCBASE_BARRIER_2(writeBarrier, const GCHermesValue *, HermesValue);
 GCBASE_BARRIER_2(writeBarrier, const GCSmallHermesValue *, SmallHermesValue);
 GCBASE_BARRIER_2(writeBarrier, const GCPointerBase *, const GCCell *);
@@ -972,9 +977,14 @@ GCBASE_BARRIER_2(
     const GCCell *);
 GCBASE_BARRIER_2(writeBarrierRange, const GCHermesValue *, uint32_t);
 GCBASE_BARRIER_2(writeBarrierRange, const GCSmallHermesValue *, uint32_t);
-GCBASE_BARRIER_2(constructorWriteBarrierRange, const GCHermesValue *, uint32_t);
-GCBASE_BARRIER_2(
+GCBASE_BARRIER_3(
     constructorWriteBarrierRange,
+    const GCCell *,
+    const GCHermesValue *,
+    uint32_t);
+GCBASE_BARRIER_3(
+    constructorWriteBarrierRange,
+    const GCCell *,
     const GCSmallHermesValue *,
     uint32_t);
 GCBASE_BARRIER_1(snapshotWriteBarrier, const GCHermesValue *);

--- a/lib/VM/HiddenClass.cpp
+++ b/lib/VM/HiddenClass.cpp
@@ -95,6 +95,7 @@ void TransitionMap::uncleanMakeLarge(Runtime &runtime) {
 const VTable HiddenClass::vt{
     CellKind::HiddenClassKind,
     cellSize<HiddenClass>(),
+    /* allowLargeAlloc */ false,
     _finalizeImpl,
     _mallocSizeImpl,
     nullptr

--- a/lib/VM/HostModel.cpp
+++ b/lib/VM/HostModel.cpp
@@ -20,6 +20,7 @@ const CallableVTable FinalizableNativeFunction::vt{
         VTable(
             CellKind::FinalizableNativeFunctionKind,
             cellSize<FinalizableNativeFunction>(),
+            /* allowLargeAlloc */ false,
             FinalizableNativeFunction::_finalizeImpl),
         FinalizableNativeFunction::_getOwnIndexedRangeImpl,
         FinalizableNativeFunction::_haveOwnIndexedImpl,
@@ -81,6 +82,7 @@ const ObjectVTable HostObject::vt{
     VTable(
         CellKind::HostObjectKind,
         cellSize<HostObject>(),
+        /* allowLargeAlloc */ false,
         HostObject::_finalizeImpl),
     HostObject::_getOwnIndexedRangeImpl,
     HostObject::_haveOwnIndexedImpl,

--- a/lib/VM/JSArray.cpp
+++ b/lib/VM/JSArray.cpp
@@ -372,6 +372,7 @@ const ObjectVTable Arguments::vt{
     VTable(
         CellKind::ArgumentsKind,
         cellSize<Arguments>(),
+        /* allowLargeAlloc */ false,
         nullptr,
         nullptr,
         nullptr
@@ -493,6 +494,7 @@ const ObjectVTable JSArray::vt{
     VTable(
         CellKind::JSArrayKind,
         cellSize<JSArray>(),
+        /* allowLargeAlloc */ false,
         nullptr,
         nullptr,
         nullptr

--- a/lib/VM/JSArrayBuffer.cpp
+++ b/lib/VM/JSArrayBuffer.cpp
@@ -20,6 +20,7 @@ const ObjectVTable JSArrayBuffer::vt{
     VTable(
         CellKind::JSArrayBufferKind,
         cellSize<JSArrayBuffer>(),
+        /* allowLargeAlloc */ false,
         _finalizeImpl,
         _mallocSizeImpl,
         nullptr

--- a/lib/VM/JSCallSite.cpp
+++ b/lib/VM/JSCallSite.cpp
@@ -15,7 +15,7 @@
 namespace hermes {
 namespace vm {
 const ObjectVTable JSCallSite::vt{
-    VTable(CellKind::JSCallSiteKind, cellSize<JSCallSite>(), nullptr, nullptr),
+    VTable(CellKind::JSCallSiteKind, cellSize<JSCallSite>()),
     JSCallSite::_getOwnIndexedRangeImpl,
     JSCallSite::_haveOwnIndexedImpl,
     JSCallSite::_getOwnIndexedPropertyFlagsImpl,

--- a/lib/VM/JSError.cpp
+++ b/lib/VM/JSError.cpp
@@ -31,6 +31,7 @@ const ObjectVTable JSError::vt{
     VTable(
         CellKind::JSErrorKind,
         cellSize<JSError>(),
+        /* allowLargeAlloc */ false,
         JSError::_finalizeImpl,
         JSError::_mallocSizeImpl),
     JSError::_getOwnIndexedRangeImpl,

--- a/lib/VM/JSObject.cpp
+++ b/lib/VM/JSObject.cpp
@@ -26,6 +26,7 @@ const ObjectVTable JSObject::vt{
     VTable(
         CellKind::JSObjectKind,
         cellSize<JSObject>(),
+        /* allowLargeAlloc */ false,
         nullptr,
         nullptr,
         nullptr

--- a/lib/VM/JSRegExp.cpp
+++ b/lib/VM/JSRegExp.cpp
@@ -27,6 +27,7 @@ const ObjectVTable JSRegExp::vt{
     VTable(
         CellKind::JSRegExpKind,
         cellSize<JSRegExp>(),
+        /* allowLargeAlloc */ false,
         JSRegExp::_finalizeImpl,
         JSRegExp::_mallocSizeImpl,
         nullptr

--- a/lib/VM/JSWeakMapImpl.cpp
+++ b/lib/VM/JSWeakMapImpl.cpp
@@ -206,6 +206,7 @@ const ObjectVTable JSWeakMapImpl<C>::vt{
     VTable(
         C,
         cellSize<JSWeakMapImpl>(),
+        /* allowLargeAlloc */ false,
         JSWeakMapImpl::_finalizeImpl,
         JSWeakMapImpl::_mallocSizeImpl,
         nullptr

--- a/lib/VM/JSWeakRef.cpp
+++ b/lib/VM/JSWeakRef.cpp
@@ -17,6 +17,7 @@ const ObjectVTable JSWeakRef::vt{
     VTable(
         CellKind::JSWeakRefKind,
         cellSize<JSWeakRef>(),
+        /* allowLargeAlloc */ false,
         JSWeakRef::_finalizeImpl,
         nullptr,
         nullptr

--- a/lib/VM/LargeDummyObject.cpp
+++ b/lib/VM/LargeDummyObject.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "hermes/VM/LargeDummyObject.h"
+
+namespace hermes::vm {
+namespace testhelpers {
+const VTable LargeDummyObject::vt{
+    CellKind::LargeDummyObjectKind,
+    0,
+    /*allowLargeAlloc=*/true};
+
+/* static */ LargeDummyObject *LargeDummyObject::create(uint32_t size, GC &gc) {
+  return gc.makeAVariable<
+      LargeDummyObject,
+      HasFinalizer::No,
+      LongLived::No,
+      CanBeLarge::Yes,
+      MayFail::Yes>(size);
+}
+} // namespace testhelpers
+
+void LargeDummyObjectBuildMeta(const GCCell *cell, Metadata::Builder &mb) {
+  mb.setVTable(&testhelpers::LargeDummyObject::vt);
+  const auto *self = static_cast<const testhelpers::LargeDummyObject *>(cell);
+  mb.addField("HermesValue", &self->hv);
+  mb.addField("ptrToNormalObj", &self->ptrToNormalObj);
+}
+
+} // namespace hermes::vm

--- a/lib/VM/NativeState.cpp
+++ b/lib/VM/NativeState.cpp
@@ -15,6 +15,7 @@ namespace vm {
 const VTable NativeState::vt{
     CellKind::NativeStateKind,
     cellSize<NativeState>(),
+    /* allowLargeAlloc */ false,
     _finalizeImpl,
 };
 

--- a/lib/VM/SegmentedArray.cpp
+++ b/lib/VM/SegmentedArray.cpp
@@ -294,6 +294,7 @@ ExecutionStatus SegmentedArrayBase<HVType>::growRight(
       self->inlineStorage(),
       self->inlineStorage() + numSlotsUsed,
       newSegmentedArray->inlineStorage(),
+      newSegmentedArray.get(),
       runtime.getHeap());
   // Set the size of the new array to be the same as the old array's size.
   newSegmentedArray->numSlotsUsed_.store(

--- a/lib/VM/SegmentedArray.cpp
+++ b/lib/VM/SegmentedArray.cpp
@@ -17,6 +17,7 @@ template <typename HVType>
 const VTable SegmentedArrayBase<HVType>::Segment::vt(
     getCellKind(),
     cellSize<SegmentedArrayBase::Segment>(),
+    /* allowLargeAlloc */ false,
     nullptr,
     nullptr,
     nullptr
@@ -76,6 +77,7 @@ template <typename HVType>
 const VTable SegmentedArrayBase<HVType>::vt(
     getCellKind(),
     /*variableSize*/ 0,
+    /* allowLargeAlloc */ false,
     nullptr,
     nullptr,
     _trimSizeCallback

--- a/lib/VM/gcs/AlignedHeapSegment.cpp
+++ b/lib/VM/gcs/AlignedHeapSegment.cpp
@@ -95,6 +95,22 @@ AlignedHeapSegment::~AlignedHeapSegment() {
   }
 }
 
+/* static */
+llvh::ErrorOr<JumboHeapSegment> JumboHeapSegment::create(
+    StorageProvider *provider,
+    const char *name,
+    size_t segmentSize) {
+  assert(
+      segmentSize > kSegmentUnitSize &&
+      "JumboHeapSegment size must be larger than kSegmentUnitSize");
+  auto result = provider->newStorage(segmentSize, name);
+  if (!result) {
+    return result.getError();
+  }
+  assert(*result && "Heap segment storage allocation failure");
+  return JumboHeapSegment{provider, *result, segmentSize};
+}
+
 llvh::ErrorOr<FixedSizeHeapSegment> FixedSizeHeapSegment::create(
     StorageProvider *provider,
     const char *name) {

--- a/lib/VM/gcs/CardBoundaryTable.cpp
+++ b/lib/VM/gcs/CardBoundaryTable.cpp
@@ -110,6 +110,16 @@ void CardBoundaryTable::verifyBoundaries(char *start, char *level) const {
         "Card object boundary is broken: first obj doesn't extend into card");
   }
 }
+
+GCCell *CardBoundaryTable::findObjectContaining(
+    const char *lowLim,
+    const char *hiLim,
+    const void *loc) const {
+  GCCell *obj = firstObjForCard(lowLim, hiLim, addressToIndex(loc));
+  while (obj->nextCell() < loc)
+    obj = obj->nextCell();
+  return obj;
+}
 #endif // HERMES_SLOW_DEBUG
 
 } // namespace vm

--- a/lib/VM/gcs/HadesGC.cpp
+++ b/lib/VM/gcs/HadesGC.cpp
@@ -2167,6 +2167,17 @@ bool HadesGC::needsWriteBarrier(const GCHermesValue *loc, HermesValue value)
     return true;
   return false;
 }
+bool HadesGC::needsWriteBarrierInCtor(
+    const GCHermesValue *loc,
+    HermesValue value) const {
+  // Values in the YG never need a barrier.
+  if (inYoungGen(loc))
+    return false;
+  // If the new value is a pointer, a relocation barrier is needed.
+  if (value.isPointer())
+    return true;
+  return false;
+}
 bool HadesGC::needsWriteBarrier(
     const GCSmallHermesValue *loc,
     SmallHermesValue value) const {
@@ -2176,6 +2187,17 @@ bool HadesGC::needsWriteBarrier(
   // If the old value is a pointer or a symbol, a snapshot barrier is needed.
   if (loc->isPointer() || loc->isSymbol())
     return true;
+  // If the new value is a pointer, a relocation barrier is needed.
+  if (value.isPointer())
+    return true;
+  return false;
+}
+bool HadesGC::needsWriteBarrierInCtor(
+    const GCSmallHermesValue *loc,
+    SmallHermesValue value) const {
+  // Values in the YG never need a barrier.
+  if (inYoungGen(loc))
+    return false;
   // If the new value is a pointer, a relocation barrier is needed.
   if (value.isPointer())
     return true;

--- a/lib/VM/gcs/HadesGC.cpp
+++ b/lib/VM/gcs/HadesGC.cpp
@@ -1885,27 +1885,40 @@ void HadesGC::constructorWriteBarrierSlow(
 }
 
 void HadesGC::constructorWriteBarrierRangeSlow(
+    const GCCell *owningObj,
     const GCHermesValue *start,
     uint32_t numHVs) {
   assert(
-      FixedSizeHeapSegment::containedInSame(start, start + numHVs) &&
-      "Range must start and end within a heap segment.");
+      reinterpret_cast<const char *>(owningObj) <=
+          reinterpret_cast<const char *>(start) &&
+      reinterpret_cast<const char *>(start + numHVs) <=
+          (reinterpret_cast<const char *>(owningObj) +
+           owningObj->getAllocatedSize()) &&
+      "Range must start and end within the owning object.");
 
   // Most constructors should be running in the YG, so in the common case, we
   // can avoid doing anything for the whole range. If the range is in the OG,
   // then just dirty all the cards corresponding to it, and we can scan them for
   // pointers later. This is less precise but makes the write barrier faster.
 
-  FixedSizeHeapSegment::dirtyCardsForAddressRange(start, start + numHVs);
+  AlignedHeapSegment::dirtyCardsForAddressRange(
+      owningObj, start, start + numHVs);
 }
 
 void HadesGC::constructorWriteBarrierRangeSlow(
+    const GCCell *owningObj,
     const GCSmallHermesValue *start,
     uint32_t numHVs) {
   assert(
-      FixedSizeHeapSegment::containedInSame(start, start + numHVs) &&
-      "Range must start and end within a heap segment.");
-  FixedSizeHeapSegment::dirtyCardsForAddressRange(start, start + numHVs);
+      reinterpret_cast<const char *>(owningObj) <=
+          reinterpret_cast<const char *>(start) &&
+      reinterpret_cast<const char *>(start + numHVs) <=
+          (reinterpret_cast<const char *>(owningObj) +
+           owningObj->getAllocatedSize()) &&
+      "Range must start and end within the owning object.");
+
+  AlignedHeapSegment::dirtyCardsForAddressRange(
+      owningObj, start, start + numHVs);
 }
 
 void HadesGC::snapshotWriteBarrierRangeSlow(

--- a/lib/VM/gcs/HadesGC.cpp
+++ b/lib/VM/gcs/HadesGC.cpp
@@ -1628,6 +1628,9 @@ void HadesGC::finalizeCompactee() {
   // allocated in the compactee.
   oldGen_.incrementAllocatedBytes(-preAllocated);
 
+#ifndef NDEBUG
+  unitSegmentAddrMap_.erase(compactee_.segment->lowLim());
+#endif
   const size_t segIdx = AlignedHeapSegment::getSegmentIndexFromStart(
       compactee_.segment->lowLim());
   segmentIndices_.push_back(segIdx);
@@ -2861,6 +2864,13 @@ llvh::ErrorOr<FixedSizeHeapSegment> HadesGC::createSegment() {
   }
   gcCallbacks_.registerHeapSegment(segIdx, seg.lowLim());
   addSegmentExtentToCrashManager(seg, std::to_string(segIdx));
+#ifndef NDEBUG
+  auto inserted =
+      unitSegmentAddrMap_.try_emplace(seg.lowLim(), seg.lowLim(), seg.hiLim());
+  assert(
+      inserted.second &&
+      "One segment with the same start address exists in unitSegmentAddrMap_");
+#endif
   seg.markBitArray().set();
   return llvh::ErrorOr<FixedSizeHeapSegment>(std::move(seg));
 }
@@ -3004,6 +3014,16 @@ void HadesGC::removeSegmentExtentFromCrashManager(
 }
 
 #ifdef HERMES_SLOW_DEBUG
+std::pair<const char *, const char *> HadesGC::getSegmentAddrRange(
+    const void *addr) {
+  auto *alignedAddr = reinterpret_cast<const char *>(llvh::alignDown(
+      reinterpret_cast<uintptr_t>(addr), AlignedHeapSegment::kSegmentUnitSize));
+  auto iter = unitSegmentAddrMap_.find(alignedAddr);
+  assert(
+      iter != unitSegmentAddrMap_.end() &&
+      "Given addr is not in any valid segment.");
+  return iter->getSecond();
+}
 
 void HadesGC::checkWellFormed() {
   CheckHeapWellFormedAcceptor acceptor(*this);

--- a/lib/VM/gcs/HadesGC.cpp
+++ b/lib/VM/gcs/HadesGC.cpp
@@ -13,6 +13,7 @@
 #include "hermes/VM/CheckHeapWellFormedAcceptor.h"
 #include "hermes/VM/FillerCell.h"
 #include "hermes/VM/GCBase-inline.h"
+#include "hermes/VM/GCCell.h"
 #include "hermes/VM/GCPointer.h"
 #include "hermes/VM/HermesValue-inline.h"
 #include "hermes/VM/RootAndSlotAcceptorDefault.h"
@@ -1845,6 +1846,20 @@ void HadesGC::writeBarrierSlow(const GCHermesValue *loc, HermesValue value) {
   relocationWriteBarrier(loc, value.getPointer());
 }
 
+void HadesGC::writeBarrierSlowForLargeObj(
+    const GCCell *owningObj,
+    const GCHermesValue *loc,
+    HermesValue value) {
+  if (ogMarkingBarriers_) {
+    snapshotWriteBarrierInternal(*loc);
+  }
+  if (!value.isPointer()) {
+    return;
+  }
+  relocationWriteBarrierForLargeObj(
+      owningObj, loc, static_cast<GCCell *>(value.getPointer()));
+}
+
 void HadesGC::writeBarrierSlow(
     const GCSmallHermesValue *loc,
     SmallHermesValue value) {
@@ -1857,12 +1872,37 @@ void HadesGC::writeBarrierSlow(
   relocationWriteBarrier(loc, value.getPointer(getPointerBase()));
 }
 
+void HadesGC::writeBarrierSlowForLargeObj(
+    const GCCell *owningObj,
+    const GCSmallHermesValue *loc,
+    SmallHermesValue value) {
+  if (ogMarkingBarriers_) {
+    snapshotWriteBarrierInternal(*loc);
+  }
+  if (!value.isPointer()) {
+    return;
+  }
+  relocationWriteBarrierForLargeObj(
+      owningObj, loc, value.getPointer(getPointerBase()));
+}
+
 void HadesGC::writeBarrierSlow(const GCPointerBase *loc, const GCCell *value) {
   if (*loc && ogMarkingBarriers_)
     snapshotWriteBarrierInternal(*loc);
   // Always do the non-snapshot write barrier in order for YG to be able to
   // scan cards.
   relocationWriteBarrier(loc, value);
+}
+
+void HadesGC::writeBarrierSlowForLargeObj(
+    const GCCell *owningObj,
+    const GCPointerBase *loc,
+    const GCCell *value) {
+  if (*loc && ogMarkingBarriers_)
+    snapshotWriteBarrierInternal(*loc);
+  // Always do the non-snapshot write barrier in order for YG to be able to
+  // scan cards.
+  relocationWriteBarrierForLargeObj(owningObj, loc, value);
 }
 
 void HadesGC::constructorWriteBarrierSlow(
@@ -1876,6 +1916,19 @@ void HadesGC::constructorWriteBarrierSlow(
   relocationWriteBarrier(loc, value.getPointer());
 }
 
+void HadesGC::constructorWriteBarrierSlowForLargeObj(
+    const GCCell *owningObj,
+    const GCHermesValue *loc,
+    HermesValue value) {
+  // A constructor never needs to execute a SATB write barrier, since its
+  // previous value was definitely not live.
+  if (!value.isPointer()) {
+    return;
+  }
+  relocationWriteBarrierForLargeObj(
+      owningObj, loc, static_cast<GCCell *>(value.getPointer()));
+}
+
 void HadesGC::constructorWriteBarrierSlow(
     const GCSmallHermesValue *loc,
     SmallHermesValue value) {
@@ -1885,6 +1938,19 @@ void HadesGC::constructorWriteBarrierSlow(
     return;
   }
   relocationWriteBarrier(loc, value.getPointer(getPointerBase()));
+}
+
+void HadesGC::constructorWriteBarrierSlowForLargeObj(
+    const GCCell *owningObj,
+    const GCSmallHermesValue *loc,
+    SmallHermesValue value) {
+  // A constructor never needs to execute a SATB write barrier, since its
+  // previous value was definitely not live.
+  if (!value.isPointer()) {
+    return;
+  }
+  relocationWriteBarrierForLargeObj(
+      owningObj, loc, value.getPointer(getPointerBase()));
 }
 
 void HadesGC::constructorWriteBarrierRangeSlow(
@@ -2009,6 +2075,27 @@ void HadesGC::relocationWriteBarrier(const void *loc, const void *value) {
     // Note that this *only* applies since the boundaries are updated separately
     // from the card table being marked itself.
     FixedSizeHeapSegment::dirtyCardForAddress(loc);
+  }
+}
+
+void HadesGC::relocationWriteBarrierForLargeObj(
+    const GCCell *owningObj,
+    const void *loc,
+    const GCCell *value) {
+  assert(!inYoungGen(loc) && "Pre-condition from other callers");
+  // Do not dirty cards for compactee->compactee, yg->yg, or yg->compactee
+  // pointers. But do dirty cards for compactee->yg pointers, since compaction
+  // may not happen in the next YG.
+  if (AlignedHeapSegment::containedInSameSegment(owningObj, value)) {
+    return;
+  }
+  if (inYoungGen(value) || compactee_.contains(value)) {
+    // Only dirty a card if it's an old-to-young or old-to-compactee pointer.
+    // This is fine to do since the GC never modifies card tables outside of
+    // allocation.
+    // Note that this *only* applies since the boundaries are updated separately
+    // from the card table being marked itself.
+    AlignedHeapSegment::dirtyCardForAddressInLargeObj(owningObj, loc);
   }
 }
 
@@ -3023,6 +3110,63 @@ std::pair<const char *, const char *> HadesGC::getSegmentAddrRange(
       iter != unitSegmentAddrMap_.end() &&
       "Given addr is not in any valid segment.");
   return iter->getSecond();
+}
+
+void HadesGC::assertWriteBarrierForNormalObj(const void *loc) {
+  if (currentCellKindAndSize_) {
+    // If currentCellKindAndSize_ is set, the owning object is still being
+    // constructed, use currentCellKindAndSize_ instead of trying to find its
+    // owning object.
+    assert(
+        !VTable::getVTable(currentCellKindAndSize_->first)->allowLargeAlloc &&
+        "This write barrier should not be called on GCCells that support large allocation");
+  } else {
+    // Normal objects should always be allocated in a FixedSizeHeapSegment.
+    auto [start, end] = getSegmentAddrRange(loc);
+    assert(
+        ((end - start) == FixedSizeHeapSegment::kSize) &&
+        "This write barrier does not work for GCCells larger than the size of FixedSizeHeapSegment");
+
+    // Don't run the check with concurrent GC. Because when the background
+    // thread is sweeping, it may merge freed cells and poison memory outside of
+    // FreeListCell, which may be accessed by findObjectContaining() when
+    // visiting next cell.
+    if constexpr (!kConcurrentGC) {
+      // The above check ensures that this loc must be within a
+      // FixedSizeHeapSegment, so it's safe to access its card table.
+      auto *obj = FixedSizeHeapSegment::findObjectContaining(loc);
+      assert(
+          !VTable::getVTable(obj->getKind())->allowLargeAlloc &&
+          "This write barrier only works for GCCells that do not support large allocation");
+    }
+  }
+}
+
+void HadesGC::assertWriteBarrierForLargeObj(
+    const GCCell *owningObj,
+    const void *loc) {
+  if (currentCellKindAndSize_) {
+    // If currentCellKindAndSize_ is set, the owning object is still being
+    // constructed, use currentCellKindAndSize_ instead of the kind and size of
+    // owningObj.
+    assert(
+        VTable::getVTable(currentCellKindAndSize_->first)->allowLargeAlloc &&
+        "This write barrier should only be called on GCCells that support large allocation");
+    assert(
+        owningObj <= loc &&
+        loc < (reinterpret_cast<const char *>(owningObj) +
+               currentCellKindAndSize_->second) &&
+        "The owning object must contain the given heap location");
+  } else {
+    assert(
+        VTable::getVTable(owningObj->getKind())->allowLargeAlloc &&
+        "This write barrier should only be called on GCCells that support large allocation");
+    assert(
+        owningObj <= loc &&
+        loc < (reinterpret_cast<const char *>(owningObj) +
+               owningObj->getAllocatedSize()) &&
+        "The owning object must contain the given heap location");
+  }
 }
 
 void HadesGC::checkWellFormed() {

--- a/lib/VM/gcs/MallocGC.cpp
+++ b/lib/VM/gcs/MallocGC.cpp
@@ -542,7 +542,17 @@ bool MallocGC::needsWriteBarrier(const GCHermesValue *loc, HermesValue value)
     const {
   return false;
 }
+bool MallocGC::needsWriteBarrierInCtor(
+    const GCHermesValue *loc,
+    HermesValue value) const {
+  return false;
+}
 bool MallocGC::needsWriteBarrier(
+    const GCSmallHermesValue *loc,
+    SmallHermesValue value) const {
+  return false;
+}
+bool MallocGC::needsWriteBarrierInCtor(
     const GCSmallHermesValue *loc,
     SmallHermesValue value) const {
   return false;

--- a/lib/VM/gcs/MallocGC.cpp
+++ b/lib/VM/gcs/MallocGC.cpp
@@ -538,22 +538,23 @@ bool MallocGC::dbgContains(const void *p) const {
   return isValid;
 }
 
-bool MallocGC::needsWriteBarrier(const GCHermesValue *loc, HermesValue value)
-    const {
+bool MallocGC::needsWriteBarrier(
+    const GCHermesValueBase *loc,
+    HermesValue value) const {
   return false;
 }
 bool MallocGC::needsWriteBarrierInCtor(
-    const GCHermesValue *loc,
+    const GCHermesValueBase *loc,
     HermesValue value) const {
   return false;
 }
 bool MallocGC::needsWriteBarrier(
-    const GCSmallHermesValue *loc,
+    const GCSmallHermesValueBase *loc,
     SmallHermesValue value) const {
   return false;
 }
 bool MallocGC::needsWriteBarrierInCtor(
-    const GCSmallHermesValue *loc,
+    const GCSmallHermesValueBase *loc,
     SmallHermesValue value) const {
   return false;
 }

--- a/lib/VM/gcs/MallocGC.cpp
+++ b/lib/VM/gcs/MallocGC.cpp
@@ -498,6 +498,7 @@ void MallocGC::resetStats() {
 void MallocGC::getHeapInfo(HeapInfo &info) {
   GCBase::getHeapInfo(info);
   info.allocatedBytes = allocatedBytes_;
+  info.totalAllocatedBytes = totalAllocatedBytes_;
   // MallocGC does not have a heap size.
   info.heapSize = 0;
   info.externalBytes = externalBytes_;

--- a/unittests/VMRuntime/MetadataTest.cpp
+++ b/unittests/VMRuntime/MetadataTest.cpp
@@ -78,8 +78,8 @@ TEST(MetadataTest, TestNormalFields) {
   EXPECT_EQ(meta.offsets.fields[1], offsetof(DummyCell, y_));
   EXPECT_EQ(meta.offsets.fields[2], offsetof(DummyCell, z_));
 
-  EXPECT_EQ(meta.offsets.endGCHermesValue, 3u);
-  EXPECT_EQ(meta.offsets.endGCSmallHermesValue, 3u);
+  EXPECT_EQ(meta.offsets.endGCHermesValueBase, 3u);
+  EXPECT_EQ(meta.offsets.endGCSmallHermesValueBase, 3u);
 
   EXPECT_EQ(meta.offsets.endGCSymbolID, 4u);
   EXPECT_STREQ(meta.names[3], "sym");

--- a/unittests/VMRuntime/VMRuntimeTestHelpers.h
+++ b/unittests/VMRuntime/VMRuntimeTestHelpers.h
@@ -300,10 +300,13 @@ class DummyRuntime final : public RuntimeBase, public HandleRootOwner {
       typename T,
       HasFinalizer hasFinalizer = HasFinalizer::No,
       LongLived longLived = LongLived::No,
+      CanBeLarge canBeLarge = CanBeLarge::No,
+      MayFail mayFail = MayFail::No,
       class... Args>
   T *makeAVariable(uint32_t size, Args &&...args) {
-    return getHeap().makeAVariable<T, hasFinalizer, longLived>(
-        size, std::forward<Args>(args)...);
+    return getHeap()
+        .makeAVariable<T, hasFinalizer, longLived, canBeLarge, mayFail>(
+            size, std::forward<Args>(args)...);
   }
 
   GC &getHeap() {


### PR DESCRIPTION
Summary:
We don't have any GCCell type supporting large allocation yet. This
diff adds a LargeDummyObject type (similar to DummyObject, but
supports large allocation). And add a unit test using it to test basic
operations to ensure it works as expected.

Reviewed By: neildhar

Differential Revision: D71712580
