### PR TITLE
Fix building the `node-hermes` target

### DIFF
--- a/external/llvh/lib/Support/CMakeLists.txt
+++ b/external/llvh/lib/Support/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(HERMES_ENABLE_EH_RTTI ON)
+
 add_hermes_library(LLVHSupport
     APFloat.cpp
     APInt.cpp

--- a/tools/node-hermes/CMakeLists.txt
+++ b/tools/node-hermes/CMakeLists.txt
@@ -18,7 +18,7 @@ if(HERMES_BUILD_NODE_HERMES)
     InternalBindings/util.cpp InternalBindings/tty_wrap.cpp
     InternalBindings/pipe_wrap.cpp InternalBindings/stream_base.cpp
     ${ALL_HEADER_FILES}
-    LINK_LIBS libhermes hermesNodeBytecode uv_a
+    LINK_LIBS LLVHSupport libhermes hermesNodeBytecode uv_a
     )
   target_include_directories(node-hermes PRIVATE third-party/libuv/include/)
 endif()

--- a/tools/node-hermes/CMakeLists.txt
+++ b/tools/node-hermes/CMakeLists.txt
@@ -18,7 +18,7 @@ if(HERMES_BUILD_NODE_HERMES)
     InternalBindings/util.cpp InternalBindings/tty_wrap.cpp
     InternalBindings/pipe_wrap.cpp InternalBindings/stream_base.cpp
     ${ALL_HEADER_FILES}
-    LINK_LIBS LLVHSupport libhermes hermesNodeBytecode uv_a
+    LINK_LIBS LLVHSupport libhermes hermesSupport hermesNodeBytecode uv_a
     )
   target_include_directories(node-hermes PRIVATE third-party/libuv/include/)
 endif()


### PR DESCRIPTION
## Summary

In its current state, the `node-hermes` tool isn't building.

8c64c415b6dffc03952b0212c2389142fc7a7208  Linking `LLVMSupport` into `node-hermes` fixes

```
[build] Undefined symbols for architecture arm64:
[build]   "llvh::raw_ostream::write(char const*, unsigned long)", referenced from:
[build]       llvh::raw_ostream::operator<<(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) in node-hermes.cpp.o
[build]       llvh::raw_ostream::operator<<(llvh::StringRef) in node-hermes.cpp.o
[build]   "llvh::raw_ostream::write(unsigned char)", referenced from:
[build]       llvh::raw_ostream::operator<<(char) in node-hermes.cpp.o
[build]   "llvh::MemoryBuffer::getFileOrSTDIN(llvh::Twine const&, long long, bool)", referenced from:
[build]       FileBuffer::bufferFromFile(llvh::StringRef) in node-hermes.cpp.o
[build]       resolveRequireCall(facebook::jsi::String const&, facebook::RuntimeState&, facebook::jsi::Object&) in node-hermes.cpp.o
[build]   "llvh::llvm_shutdown()", referenced from:
[build]       llvh::llvm_shutdown_obj::~llvm_shutdown_obj() in node-hermes.cpp.o
[build]   "llvh::SmallVectorBase::grow_pod(void*, unsigned long, unsigned long)", referenced from:
[build]       llvh::SmallVectorTemplateCommon<char, void>::grow_pod(unsigned long, unsigned long) in node-hermes.cpp.o
[build]   "llvh::PrettyStackTraceEntry::PrettyStackTraceEntry()", referenced from:
[build]       llvh::PrettyStackTraceProgram::PrettyStackTraceProgram(int, char const* const*) in node-hermes.cpp.o
[build]   "llvh::PrettyStackTraceEntry::~PrettyStackTraceEntry()", referenced from:
[build]       llvh::PrettyStackTraceProgram::PrettyStackTraceProgram(int, char const* const*) in node-hermes.cpp.o
[build]       llvh::PrettyStackTraceProgram::~PrettyStackTraceProgram() in node-hermes.cpp.o
[build]   "llvh::EnablePrettyStackTrace()", referenced from:
[build]       llvh::PrettyStackTraceProgram::PrettyStackTraceProgram(int, char const* const*) in node-hermes.cpp.o
[build]   "llvh::llvm_unreachable_internal(char const*, char const*, unsigned int)", referenced from:
[build]       handleType(uv_handle_type) in util.cpp.o
[build]   "llvh::cl::basic_parser<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>::basic_parser(llvh::cl::Option&)", referenced from:
[build]       llvh::cl::parser<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>::parser(llvh::cl::Option&) in node-hermes.cpp.o
[build]   "llvh::cl::GeneralCategory", referenced from:
[build]       llvh::cl::Option::Option(llvh::cl::NumOccurrencesFlag, llvh::cl::OptionHidden) in node-hermes.cpp.o
[build]   "llvh::cl::GenericOptionValue::anchor()", referenced from:
[build]       vtable for llvh::cl::OptionValueCopy<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>> in node-hermes.cpp.o
[build]   "llvh::cl::ParseCommandLineOptions(int, char const* const*, llvh::StringRef, llvh::raw_ostream*)", referenced from:
[build]       _main in node-hermes.cpp.o
[build]   "llvh::cl::opt<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, false, llvh::cl::parser<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>::setInitialValue(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)", referenced from:
[build]       void llvh::cl::initializer<char [2]>::apply<llvh::cl::opt<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, false, llvh::cl::parser<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>>(llvh::cl::opt<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, false, llvh::cl::parser<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>&) const in node-hermes.cpp.o
[build]   "llvh::cl::opt<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, false, llvh::cl::parser<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>::done()", referenced from:
[build]       llvh::cl::opt<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, false, llvh::cl::parser<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>::opt<char [5], llvh::cl::desc, llvh::cl::value_desc>(char const (&) [5], llvh::cl::desc const&, llvh::cl::value_desc const&) in node-hermes.cpp.o
[build]       llvh::cl::opt<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, false, llvh::cl::parser<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>::opt<llvh::cl::FormattingFlags, llvh::cl::desc, llvh::cl::initializer<char [2]>>(llvh::cl::FormattingFlags const&, llvh::cl::desc const&, llvh::cl::initializer<char [2]> const&) in node-hermes.cpp.o
[build]   "llvh::cl::Option::setArgStr(llvh::StringRef)", referenced from:
[build]       void llvh::cl::applicator<char [5]>::opt<llvh::cl::opt<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, false, llvh::cl::parser<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>>(llvh::StringRef, llvh::cl::opt<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, false, llvh::cl::parser<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>&) in node-hermes.cpp.o
[build]   "llvh::sys::PrintStackTraceOnErrorSignal(llvh::StringRef, bool)", referenced from:
[build]       _main in node-hermes.cpp.o
[build]   "llvh::sys::path::remove_dots(llvh::SmallVectorImpl<char>&, bool, llvh::sys::path::Style)", referenced from:
[build]       facebook::RuntimeState::resolvePath(llvh::StringRef, llvh::StringRef) in RuntimeState.cpp.o
[build]   "llvh::sys::path::remove_filename(llvh::SmallVectorImpl<char>&, llvh::sys::path::Style)", referenced from:
[build]       _main in node-hermes.cpp.o
[build]   "llvh::sys::path::append(llvh::SmallVectorImpl<char>&, llvh::sys::path::Style, llvh::Twine const&, llvh::Twine const&, llvh::Twine const&, llvh::Twine const&)", referenced from:
[build]       facebook::RuntimeState::resolvePath(llvh::StringRef, llvh::StringRef) in RuntimeState.cpp.o
[build]   "llvh::errs()", referenced from:
[build]       _main in node-hermes.cpp.o
[build]       _main in node-hermes.cpp.o
[build]       _main in node-hermes.cpp.o
[build]       initialize(facebook::RuntimeState&, facebook::jsi::Object&, facebook::jsi::Function&)::$_2::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long) const in node-hermes.cpp.o
[build]   "llvh::InitLLVM::InitLLVM(int&, char const**&)", referenced from:
[build]       llvh::InitLLVM::InitLLVM(int&, char**&) in node-hermes.cpp.o
[build]   "llvh::InitLLVM::~InitLLVM()", referenced from:
[build]       _main in node-hermes.cpp.o
[build]       _main in node-hermes.cpp.o
[build]   "vtable for llvh::PrettyStackTraceProgram", referenced from:
[build]       llvh::PrettyStackTraceProgram::PrettyStackTraceProgram(int, char const* const*) in node-hermes.cpp.o
[build]    NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
[build]   "vtable for llvh::cl::OptionValue<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>", referenced from:
[build]       llvh::cl::OptionValue<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>::OptionValue() in node-hermes.cpp.o
[build]    NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
[build]   "vtable for llvh::cl::GenericOptionValue", referenced from:
[build]       llvh::cl::GenericOptionValue::GenericOptionValue() in node-hermes.cpp.o
[build]    NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
[build]   "vtable for llvh::cl::opt<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, false, llvh::cl::parser<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>", referenced from:
[build]       llvh::cl::opt<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, false, llvh::cl::parser<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>::opt<char [5], llvh::cl::desc, llvh::cl::value_desc>(char const (&) [5], llvh::cl::desc const&, llvh::cl::value_desc const&) in node-hermes.cpp.o
[build]       llvh::cl::opt<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, false, llvh::cl::parser<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>::opt<llvh::cl::FormattingFlags, llvh::cl::desc, llvh::cl::initializer<char [2]>>(llvh::cl::FormattingFlags const&, llvh::cl::desc const&, llvh::cl::initializer<char [2]> const&) in node-hermes.cpp.o
[build]    NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
[build]   "vtable for llvh::cl::Option", referenced from:
[build]       llvh::cl::Option::~Option() in node-hermes.cpp.o
[build]       llvh::cl::Option::Option(llvh::cl::NumOccurrencesFlag, llvh::cl::OptionHidden) in node-hermes.cpp.o
[build]    NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
[build]   "vtable for llvh::cl::parser<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>", referenced from:
[build]       llvh::cl::parser<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>::parser(llvh::cl::Option&) in node-hermes.cpp.o
[build]    NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
```

4cfd0e6d2f29b0e430d3640db7e40ea62d06cf16 Linking `hermesSupport` library into `node-hermes` fixes

```
[build] Undefined symbols for architecture arm64:
[build]   "hermes::oscompat::SigAltStackLeakSuppressor::~SigAltStackLeakSuppressor()", referenced from:
[build]       _main in node-hermes.cpp.o
[build]       _main in node-hermes.cpp.o
```

23654d5a638a4e525cf2517db20830ccf7ad2356 Enabling RTTI for the `LLVHSupport` target fixes

```
[build]   "typeinfo for llvh::cl::GenericOptionValue", referenced from:
[build]       typeinfo for llvh::cl::OptionValueCopy<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>> in node-hermes.cpp.o
```

## Test Plan

Configure a build with the `node-hermes` target enabled:

```
cmake -S hermes -B node-hermes-build -G Ninja -DHERMES_BUILD_NODE_HERMES:BOOL=TRUE
```

Build the target

```
cmake --build ./node-hermes-build -- node-hermes
```

Run the tool

```
./node-hermes-build/bin/node-hermes -eval="console.log('hi')"
```