### PR TITLE
Remove HERMES_BUILD_APPLE_DSYM

### DIFF
--- a/API/hermes/CMakeLists.txt
+++ b/API/hermes/CMakeLists.txt
@@ -174,32 +174,3 @@ install(TARGETS libhermes
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/API/hermes" DESTINATION include
   FILES_MATCHING PATTERN "*.h"
   PATTERN "synthtest" EXCLUDE)
-
-# Create debug symbols (dSYM) bundle for Apple platform dylibs/frameworks
-# Largely inspired by https://github.com/llvm/llvm-project/blob/6701993027f8af172d7ba697884459261b00e3c6/llvm/cmake/modules/AddLLVM.cmake#L1934-L1986
-if(HERMES_BUILD_APPLE_DSYM)
-  if(CMAKE_CXX_FLAGS MATCHES "-flto")
-    set(lto_object ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/libhermes-lto.o)
-    set_property(TARGET libhermes APPEND_STRING PROPERTY LINK_FLAGS " -Wl,-object_path_lto,${lto_object}")
-  endif()
-
-  get_target_property(DSYM_PATH libhermes LOCATION)
-  if(HERMES_BUILD_APPLE_FRAMEWORK)
-    get_filename_component(DSYM_PATH ${DSYM_PATH} DIRECTORY)
-  endif()
-  set(DSYM_PATH "${DSYM_PATH}.dSYM")
-
-  if(NOT CMAKE_DSYMUTIL)
-    set(CMAKE_DSYMUTIL xcrun dsymutil)
-  endif()
-  add_custom_command(TARGET libhermes POST_BUILD
-    COMMAND ${CMAKE_DSYMUTIL} $<TARGET_FILE:libhermes> --out ${DSYM_PATH}
-    BYPRODUCTS ${DSYM_PATH}
-  )
-
-  if(HERMES_BUILD_APPLE_FRAMEWORK)
-    install(DIRECTORY ${DSYM_PATH} DESTINATION Library/Frameworks/${HERMES_APPLE_TARGET_PLATFORM})
-  else()
-    install(DIRECTORY ${DSYM_PATH} DESTINATION lib)
-  endif()
-endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,13 +35,6 @@ if(POLICY CMP0022)
   cmake_policy(SET CMP0022 NEW)
 endif()
 
-# Allow reading the LOCATION property of a target to determine the eventual
-# location of build targets. This is needed when building the debugging symbols
-# bundles for Apple platforms.
-if (POLICY CMP0026)
-  cmake_policy(SET CMP0026 OLD)
-endif()
-
 # Has to be set before `project` as per documentation
 # https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_SYSROOT.html
 set(CMAKE_OSX_SYSROOT ${HERMES_APPLE_TARGET_PLATFORM})
@@ -284,9 +277,6 @@ set(HERMES_ENABLE_TEST_SUITE ON CACHE BOOL
 set(HERMES_BUILD_APPLE_FRAMEWORK ON CACHE BOOL
   "Whether to build the libhermes target as a framework bundle or dylib on Apple platforms")
 
-set(HERMES_BUILD_APPLE_DSYM OFF CACHE BOOL
-  "Whether to build a DWARF debugging symbols bundle")
-
 set(IMPORT_HERMESC "" CACHE FILEPATH
   "Import the hermesc compiler from another build using the given CMake file.")
 
@@ -317,10 +307,6 @@ if(HERMES_CHECK_NATIVE_STACK)
     )
   endif()
   add_definitions(-DHERMES_CHECK_NATIVE_STACK)
-endif()
-
-if(HERMES_BUILD_APPLE_DSYM)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -gdwarf")
 endif()
 
 if (HERMES_IS_MOBILE_BUILD)

--- a/utils/build-apple-framework.sh
+++ b/utils/build-apple-framework.sh
@@ -78,7 +78,6 @@ function configure_apple_framework {
     -DHERMES_ENABLE_BITCODE:BOOLEAN="$enable_bitcode" \
     -DHERMES_BUILD_APPLE_FRAMEWORK:BOOLEAN=true \
     -DHERMES_BUILD_SHARED_JSI:BOOLEAN=false \
-    -DHERMES_BUILD_APPLE_DSYM:BOOLEAN=true \
     -DHERMES_ENABLE_TOOLS:BOOLEAN="$build_cli_tools" \
     -DIMPORT_HERMESC:PATH="$PWD/build_host_hermesc/ImportHermesc.cmake" \
     -DCMAKE_INSTALL_PREFIX:PATH=../destroot \


### PR DESCRIPTION
Summary:
The implementation depends on a deprecated CMake feature. While it can
probably be fixed, we have removed usage of this flag, so just delete
it.

Differential Revision: D73054512


