### PR TITLE
Use checkout@v4 in github workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
         xcode-version: 16.2
     - uses: actions/checkout@v4.1.0
     - name: Cache setup
-      uses: actions/cache@v4.0.0
+      uses: actions/cache@v4
       with:
         key: v4-repo-${{ github.sha }}
         path: |-
@@ -169,7 +169,7 @@ jobs:
         xcode-version: 16.2
     - uses: actions/checkout@v4.1.0
     - name: Cache setup
-      uses: actions/cache@v4.0.0
+      uses: actions/cache@v4
       with:
         key: v4-repo-${{ github.sha }}
         path: |-
@@ -233,7 +233,7 @@ jobs:
         xcode-version: 16.2
     - uses: actions/checkout@v4.1.0
     - name: Cache setup
-      uses: actions/cache@v4.0.0
+      uses: actions/cache@v4
       with:
         key: v4-repo-${{ github.sha }}
         path: |-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -342,7 +342,7 @@ jobs:
         name: windows-hermes
         path: c:\tmp\hermes\output
   npm:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
     - android
     - linux
@@ -392,7 +392,7 @@ jobs:
         name: npm-hermes
         path: /tmp/hermes/output
   emscripten:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: emscripten/emsdk:2.0.9
     steps:
@@ -434,7 +434,7 @@ jobs:
         name: emscripten-hermes
         path: output
   sandbox:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: emscripten/emsdk:3.1.39
     env:
@@ -484,7 +484,7 @@ jobs:
         cmake --build build_opt -j 4
         cmake --build build_opt --target check-hermes -j 4
   test-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Install dependencies
       run: |-
@@ -589,7 +589,7 @@ jobs:
         cmake --build ./build --target check-hermes
         python3 hermes/utils/testsuite/run_testsuite.py --test-intl test262/test -b build/bin
   test-linux-test262:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4.1.0
       with:


### PR DESCRIPTION
Summary:
Some versions of checkout are being deprecated, use a less specific
version.

Differential Revision: D73128981


