### PR TITLE
Fix designated initializer warning suppression on GCC

### DIFF
--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -23,9 +23,10 @@
 
 // Disable warnings about missing designated initializers since they occur often
 // when we construct SlowPaths.
-#if defined(__clang__) && \
-    __has_warning("-Wmissing-designated-field-initializers")
+#ifdef __clang__
+#if __has_warning("-Wmissing-designated-field-initializers")
 #pragma clang diagnostic ignored "-Wmissing-designated-field-initializers"
+#endif
 #endif
 
 #if defined(HERMESVM_COMPRESSED_POINTERS) && !defined(HERMESVM_CONTIGUOUS_HEAP)


### PR DESCRIPTION
Summary:
GCC does not have the `__has_warning` macro. Test for the macro itself
instead of testing for clang, and nest the use of `__has_warning`

Differential Revision: D73152843


