### PR TITLE
[WIP] - Fix Empty Type Parameters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,105 +10,105 @@ jobs:
     env:
       HERMES_WS_DIR: ${{ github.workspace }}
     steps:
-    - name: Set up workspace and install dependencies
-      run: |-
-        yes | sdkmanager "cmake;3.22.1" &
-        sudo apt update && sudo apt install -y libicu-dev
-    - uses: actions/checkout@v4.1.0
-      with:
-        path: hermes
-    - name: Build Hermes Compiler
-      run: |-
-        cmake -S hermes -B build
-        # Build the Hermes compiler so that the cross compiler build can
-        # access it to build the VM
-        cmake --build ./build --target hermesc -j 4
-    - name: Build Hermes for Android
-      run: |-
-        cd hermes/android
-        ./gradlew githubRelease
-    - name: Copy artifacts
-      run: |-
-        mkdir output
-        cp build_android/distributions/hermes-runtime-android-*.tar.gz output
-    - name: Checksum artifacts
-      run: |-
-        cd output
-        for file in *
-        do
-          sha256sum "$file" > "$file.sha256"
-        done
-    - uses: actions/upload-artifact@v4.3.1
-      with:
-        name: android-hermes
-        path: output
+      - name: Set up workspace and install dependencies
+        run: |-
+          yes | sdkmanager "cmake;3.22.1" &
+          sudo apt update && sudo apt install -y libicu-dev
+      - uses: actions/checkout@v4.1.0
+        with:
+          path: hermes
+      - name: Build Hermes Compiler
+        run: |-
+          cmake -S hermes -B build
+          # Build the Hermes compiler so that the cross compiler build can
+          # access it to build the VM
+          cmake --build ./build --target hermesc -j 4
+      - name: Build Hermes for Android
+        run: |-
+          cd hermes/android
+          ./gradlew githubRelease
+      - name: Copy artifacts
+        run: |-
+          mkdir output
+          cp build_android/distributions/hermes-runtime-android-*.tar.gz output
+      - name: Checksum artifacts
+        run: |-
+          cd output
+          for file in *
+          do
+            sha256sum "$file" > "$file.sha256"
+          done
+      - uses: actions/upload-artifact@v4.3.1
+        with:
+          name: android-hermes
+          path: output
   linux:
     runs-on: ubuntu-22.04
     steps:
-    - name: Install dependencies
-      run: |-
-        sudo apt update
-        sudo apt install -y git openssh-client cmake build-essential \
-            libreadline-dev libicu-dev zip python3
-    - uses: actions/checkout@v4.1.0
-      with:
-        path: hermes
-    - name: Build linux CLI
-      run: |-
-        cmake -S hermes -B build_hdb -DHERMES_STATIC_LINK=ON -DCMAKE_BUILD_TYPE=Release \
-          -DCMAKE_CXX_FLAGS=-s -DCMAKE_C_FLAGS=-s \
-          -DCMAKE_EXE_LINKER_FLAGS="-Wl,--whole-archive -lpthread -Wl,--no-whole-archive"
-        cmake -S hermes -B build -DHERMES_STATIC_LINK=ON -DCMAKE_BUILD_TYPE=Release \
-          -DCMAKE_CXX_FLAGS=-s -DCMAKE_C_FLAGS=-s \
-          -DCMAKE_EXE_LINKER_FLAGS="-Wl,--whole-archive -lpthread -Wl,--no-whole-archive" \
-          -DHERMES_ENABLE_DEBUGGER=False
-        cmake --build build_hdb --target hdb
-        cmake --build build --target check-hermes hermes hvm hbcdump hermesc
-    - name: Create CLI tarball
-      run: |-
-        mkdir output staging
-        cp build/bin/hermes build/bin/hvm build/bin/hbcdump \
-          build/bin/hermesc build_hdb/bin/hdb staging
-        tar -C staging -czvf output/${TAR_NAME} .
-        shasum -a 256 output/${TAR_NAME} > output/${TAR_NAME}.sha256
-      env:
-        TAR_NAME: hermes-cli-linux.tar.gz
-    - uses: actions/upload-artifact@v4.3.1
-      with:
-        name: linux-hermes
-        path: output
+      - name: Install dependencies
+        run: |-
+          sudo apt update
+          sudo apt install -y git openssh-client cmake build-essential \
+              libreadline-dev libicu-dev zip python3
+      - uses: actions/checkout@v4.1.0
+        with:
+          path: hermes
+      - name: Build linux CLI
+        run: |-
+          cmake -S hermes -B build_hdb -DHERMES_STATIC_LINK=ON -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_FLAGS=-s -DCMAKE_C_FLAGS=-s \
+            -DCMAKE_EXE_LINKER_FLAGS="-Wl,--whole-archive -lpthread -Wl,--no-whole-archive"
+          cmake -S hermes -B build -DHERMES_STATIC_LINK=ON -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_FLAGS=-s -DCMAKE_C_FLAGS=-s \
+            -DCMAKE_EXE_LINKER_FLAGS="-Wl,--whole-archive -lpthread -Wl,--no-whole-archive" \
+            -DHERMES_ENABLE_DEBUGGER=False
+          cmake --build build_hdb --target hdb
+          cmake --build build --target check-hermes hermes hvm hbcdump hermesc
+      - name: Create CLI tarball
+        run: |-
+          mkdir output staging
+          cp build/bin/hermes build/bin/hvm build/bin/hbcdump \
+            build/bin/hermesc build_hdb/bin/hdb staging
+          tar -C staging -czvf output/${TAR_NAME} .
+          shasum -a 256 output/${TAR_NAME} > output/${TAR_NAME}.sha256
+        env:
+          TAR_NAME: hermes-cli-linux.tar.gz
+      - uses: actions/upload-artifact@v4.3.1
+        with:
+          name: linux-hermes
+          path: output
   macos:
     runs-on: macos-14
     steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: 16.2
-    - uses: actions/checkout@v4.1.0
-      with:
-        path: hermes
-    - name: Install dependencies
-      run: brew install cmake ninja
-    - name: Build macOS CLI
-      run: |-
-        cmake -S hermes -B build -G Ninja ${RELEASE_FLAGS} -DHERMES_ENABLE_DEBUGGER=False
-        cmake --build ./build --target hermes hvm hbcdump hermesc check-hermes
-        cmake -S hermes -B build_hdb -G Ninja ${RELEASE_FLAGS}
-        cmake --build ./build_hdb --target hdb check-hermes
-      env:
-        RELEASE_FLAGS: "-DCMAKE_BUILD_TYPE=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=True -DCMAKE_OSX_ARCHITECTURES=x86_64;arm64 \\ -DBUILD_SHARED_LIBS=OFF -DHERMES_BUILD_SHARED_JSI=OFF"
-    - name: Create CLI tarball
-      run: |-
-        mkdir output staging
-        cp build/bin/hermes build/bin/hvm build/bin/hbcdump \
-          build/bin/hermesc build_hdb/bin/hdb staging
-        tar -C staging -czvf output/${TAR_NAME} .
-        shasum -a 256 output/${TAR_NAME} > output/${TAR_NAME}.sha256
-      env:
-        TAR_NAME: hermes-cli-darwin.tar.gz
-    - uses: actions/upload-artifact@v4.3.1
-      with:
-        name: macos-hermes
-        path: output
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 16.2
+      - uses: actions/checkout@v4.1.0
+        with:
+          path: hermes
+      - name: Install dependencies
+        run: brew install cmake ninja
+      - name: Build macOS CLI
+        run: |-
+          cmake -S hermes -B build -G Ninja ${RELEASE_FLAGS} -DHERMES_ENABLE_DEBUGGER=False
+          cmake --build ./build --target hermes hvm hbcdump hermesc check-hermes
+          cmake -S hermes -B build_hdb -G Ninja ${RELEASE_FLAGS}
+          cmake --build ./build_hdb --target hdb check-hermes
+        env:
+          RELEASE_FLAGS: "-DCMAKE_BUILD_TYPE=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=True -DCMAKE_OSX_ARCHITECTURES=x86_64;arm64 \\ -DBUILD_SHARED_LIBS=OFF -DHERMES_BUILD_SHARED_JSI=OFF"
+      - name: Create CLI tarball
+        run: |-
+          mkdir output staging
+          cp build/bin/hermes build/bin/hvm build/bin/hbcdump \
+            build/bin/hermesc build_hdb/bin/hdb staging
+          tar -C staging -czvf output/${TAR_NAME} .
+          shasum -a 256 output/${TAR_NAME} > output/${TAR_NAME}.sha256
+        env:
+          TAR_NAME: hermes-cli-darwin.tar.gz
+      - uses: actions/upload-artifact@v4.3.1
+        with:
+          name: macos-hermes
+          path: output
   build-apple-runtime:
     runs-on: macos-14
     env:
@@ -116,46 +116,46 @@ jobs:
       HERMES_WS_DIR: "/tmp/hermes"
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: 16.2
-    - uses: actions/checkout@v4.1.0
-    - name: Cache setup
-      uses: actions/cache@v4.0.0
-      with:
-        key: v4-repo-${{ github.sha }}
-        path: |-
-          build_iphoneos
-          build_catalyst
-          build_iphonesimulator
-          build_macosx
-          destroot
-    - name: Set up workspace
-      run: mkdir -p /tmp/hermes/output
-    - name: Install dependencies
-      run: |-
-        brew install cmake ninja
-        sudo gem install cocoapods
-    - name: Build the iOS frameworks
-      run: "./utils/build-ios-framework.sh"
-    - name: Build the Mac frameworks
-      run: "./utils/build-mac-framework.sh"
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 16.2
+      - uses: actions/checkout@v4.1.0
+      - name: Cache setup
+        uses: actions/cache@v4
+        with:
+          key: v4-repo-${{ github.sha }}
+          path: |-
+            build_iphoneos
+            build_catalyst
+            build_iphonesimulator
+            build_macosx
+            destroot
+      - name: Set up workspace
+        run: mkdir -p /tmp/hermes/output
+      - name: Install dependencies
+        run: |-
+          brew install cmake ninja
+          sudo gem install cocoapods
+      - name: Build the iOS frameworks
+        run: "./utils/build-ios-framework.sh"
+      - name: Build the Mac frameworks
+        run: "./utils/build-mac-framework.sh"
   test-macos:
     runs-on: macos-14
     steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: 16.2
-    - uses: actions/checkout@v4.1.0
-      with:
-        path: hermes
-    - name: Install dependencies
-      run: brew install cmake
-    - name: Run MacOS regression tests in debug mode
-      run: |-
-        cmake -S hermes -B build -GXcode
-        cmake --build ./build
-        cmake --build ./build --target check-hermes
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 16.2
+      - uses: actions/checkout@v4.1.0
+        with:
+          path: hermes
+      - name: Install dependencies
+        run: brew install cmake
+      - name: Run MacOS regression tests in debug mode
+        run: |-
+          cmake -S hermes -B build -GXcode
+          cmake --build ./build
+          cmake --build ./build --target check-hermes
   test-apple-runtime:
     runs-on: macos-14
     needs: build-apple-runtime
@@ -164,108 +164,108 @@ jobs:
       HERMES_WS_DIR: "/tmp/hermes"
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: 16.2
-    - uses: actions/checkout@v4.1.0
-    - name: Cache setup
-      uses: actions/cache@v4.0.0
-      with:
-        key: v4-repo-${{ github.sha }}
-        path: |-
-          build_iphoneos
-          build_catalyst
-          build_iphonesimulator
-          build_macosx
-          destroot
-    - name: Install dependencies
-      run: brew install cmake ninja && xcodebuild -downloadPlatform visionOS && xcodebuild -downloadPlatform tvOS
-    - name: Build the test application
-      run: pod install
-      working-directory: test/ApplePlatformsIntegrationTestApp
-    - name: Test MacOS application
-      run: |-
-        xcodebuild test \
-          -workspace ApplePlatformsIntegrationTests.xcworkspace \
-          -configuration Debug \
-          -destination 'platform=macOS' \
-          -scheme ApplePlatformsIntegrationMacTests
-      working-directory: test/ApplePlatformsIntegrationTestApp
-    - name: Test iPhone application
-      run: |-
-        # macos-14 installs simulators for iPhone 15/16, so use the oldest model
-        # here:
-        # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
-        xcodebuild test \
-          -workspace ApplePlatformsIntegrationTests.xcworkspace \
-          -configuration Debug \
-          -destination 'platform=iOS Simulator,name=iPhone 15' \
-          -scheme ApplePlatformsIntegrationMobileTests
-      working-directory: test/ApplePlatformsIntegrationTestApp
-    - name: Test Apple Vision application
-      run: |-
-        xcodebuild test \
-          -workspace ApplePlatformsIntegrationTests.xcworkspace \
-          -configuration Debug \
-          -destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
-          -scheme ApplePlatformsIntegrationVisionOSTests
-      working-directory: test/ApplePlatformsIntegrationTestApp
-    - name: Test Apple TV application
-      run: |-
-        xcodebuild test \
-          -workspace ApplePlatformsIntegrationTests.xcworkspace \
-          -configuration Debug \
-          -destination 'platform=tvOS Simulator,name=Apple TV' \
-          -scheme ApplePlatformsIntegrationTVOSTests
-      working-directory: test/ApplePlatformsIntegrationTestApp
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 16.2
+      - uses: actions/checkout@v4.1.0
+      - name: Cache setup
+        uses: actions/cache@v4
+        with:
+          key: v4-repo-${{ github.sha }}
+          path: |-
+            build_iphoneos
+            build_catalyst
+            build_iphonesimulator
+            build_macosx
+            destroot
+      - name: Install dependencies
+        run: brew install cmake ninja && xcodebuild -downloadPlatform visionOS && xcodebuild -downloadPlatform tvOS
+      - name: Build the test application
+        run: pod install
+        working-directory: test/ApplePlatformsIntegrationTestApp
+      - name: Test MacOS application
+        run: |-
+          xcodebuild test \
+            -workspace ApplePlatformsIntegrationTests.xcworkspace \
+            -configuration Debug \
+            -destination 'platform=macOS' \
+            -scheme ApplePlatformsIntegrationMacTests
+        working-directory: test/ApplePlatformsIntegrationTestApp
+      - name: Test iPhone application
+        run: |-
+          # macos-14 installs simulators for iPhone 15/16, so use the oldest model
+          # here:
+          # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
+          xcodebuild test \
+            -workspace ApplePlatformsIntegrationTests.xcworkspace \
+            -configuration Debug \
+            -destination 'platform=iOS Simulator,name=iPhone 15' \
+            -scheme ApplePlatformsIntegrationMobileTests
+        working-directory: test/ApplePlatformsIntegrationTestApp
+      - name: Test Apple Vision application
+        run: |-
+          xcodebuild test \
+            -workspace ApplePlatformsIntegrationTests.xcworkspace \
+            -configuration Debug \
+            -destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
+            -scheme ApplePlatformsIntegrationVisionOSTests
+        working-directory: test/ApplePlatformsIntegrationTestApp
+      - name: Test Apple TV application
+        run: |-
+          xcodebuild test \
+            -workspace ApplePlatformsIntegrationTests.xcworkspace \
+            -configuration Debug \
+            -destination 'platform=tvOS Simulator,name=Apple TV' \
+            -scheme ApplePlatformsIntegrationTVOSTests
+        working-directory: test/ApplePlatformsIntegrationTestApp
   package-apple-runtime:
     runs-on: macos-14
     needs:
-    - test-macos
-    - test-apple-runtime
+      - test-macos
+      - test-apple-runtime
     env:
       TERM: dumb
       HERMES_WS_DIR: "/tmp/hermes"
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: 16.2
-    - uses: actions/checkout@v4.1.0
-    - name: Cache setup
-      uses: actions/cache@v4.0.0
-      with:
-        key: v4-repo-${{ github.sha }}
-        path: |-
-          build_iphoneos
-          build_catalyst
-          build_iphonesimulator
-          build_macosx
-          destroot
-    - name: Set up workspace
-      run: mkdir -p /tmp/hermes/output
-    - name: Install dependencies
-      run: |-
-        brew install cmake ninja
-        sudo gem install cocoapods
-    - name: Package the framework
-      run: |-
-        . ./utils/build-apple-framework.sh
-        mkdir -p /tmp/cocoapods-package-root/destroot
-        cp -R ./destroot /tmp/cocoapods-package-root
-        cp hermes-engine.podspec LICENSE /tmp/cocoapods-package-root
-        tar -C /tmp/cocoapods-package-root/ -czvf /tmp/hermes/output/hermes-runtime-darwin-v$(get_release_version).tar.gz .
-    - name: Checksum artifacts
-      run: |-
-        cd /tmp/hermes/output
-        for file in *
-        do
-          shasum -a 256 "$file" > "$file.sha256"
-        done
-    - uses: actions/upload-artifact@v4.3.1
-      with:
-        name: apple-runtime
-        path: /tmp/hermes/output/
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 16.2
+      - uses: actions/checkout@v4.1.0
+      - name: Cache setup
+        uses: actions/cache@v4
+        with:
+          key: v4-repo-${{ github.sha }}
+          path: |-
+            build_iphoneos
+            build_catalyst
+            build_iphonesimulator
+            build_macosx
+            destroot
+      - name: Set up workspace
+        run: mkdir -p /tmp/hermes/output
+      - name: Install dependencies
+        run: |-
+          brew install cmake ninja
+          sudo gem install cocoapods
+      - name: Package the framework
+        run: |-
+          . ./utils/build-apple-framework.sh
+          mkdir -p /tmp/cocoapods-package-root/destroot
+          cp -R ./destroot /tmp/cocoapods-package-root
+          cp hermes-engine.podspec LICENSE /tmp/cocoapods-package-root
+          tar -C /tmp/cocoapods-package-root/ -czvf /tmp/hermes/output/hermes-runtime-darwin-v$(get_release_version).tar.gz .
+      - name: Checksum artifacts
+        run: |-
+          cd /tmp/hermes/output
+          for file in *
+          do
+            shasum -a 256 "$file" > "$file.sha256"
+          done
+      - uses: actions/upload-artifact@v4.3.1
+        with:
+          name: apple-runtime
+          path: /tmp/hermes/output/
   windows:
     runs-on: windows-2019
     env:
@@ -276,238 +276,238 @@ jobs:
       RELEASE_FLAGS: "-DCMAKE_BUILD_TYPE=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=True -DHERMES_ENABLE_WIN10_ICU_FALLBACK=OFF"
       TAR_NAME: hermes-cli-windows.tar.gz
     steps:
-    - uses: actions/checkout@v4.1.0
-    - name: Set up workspace
-      run: |-
-        New-Item -ItemType Directory $Env:HERMES_WS_DIR
-        New-Item -ItemType Directory $Env:HERMES_WS_DIR\icu
-        New-Item -ItemType Directory $Env:HERMES_WS_DIR\staging
-        New-Item -ItemType Directory $Env:HERMES_WS_DIR\output
-        New-Item -ItemType SymbolicLink -Target $Env:GITHUB_WORKSPACE -Path $Env:HERMES_WS_DIR -Name hermes
-    - name: Download ICU
-      run: |-
-        cd $Env:HERMES_WS_DIR\icu
-        # If Invoke-WebRequest shows a progress bar, it will fail with
-        #   Win32 internal error "Access is denied" 0x5 occurred [...]
-        $progressPreference = 'silentlyContinue'
-        Invoke-WebRequest -Uri "$Env:ICU_URL" -OutFile "icu.zip"
-        Expand-Archive -Path "icu.zip" -DestinationPath "."
-    - name: Setup cmake
-      uses: jwlawson/actions-setup-cmake@v2.0.0
-      with:
-        cmake-version: 3.14.7
-    - name: Setup python
-      uses: actions/setup-python@v5.0.0
-      with:
-        python-version: 3.12.1
-    - name: Assemble Windows runtime dependencies
-      run: |-
-        cd $Env:HERMES_WS_DIR
-        Copy-Item -Path "icu\bin64\icu*.dll" -Destination "staging"
-        # Include MSVC++ 2015 redistributables
-        Copy-Item -Path "c:\windows\system32\msvcp140.dll" -Destination "staging"
-        Copy-Item -Path "c:\windows\system32\vcruntime140.dll" -Destination "staging"
-        Copy-Item -Path "c:\windows\system32\vcruntime140_1.dll" -Destination "staging"
-    - name: Build Windows CLI
-      run: |-
-        $Env:PATH += ";$Env:MSBUILD_DIR"
-        $Env:ICU_ROOT = "$Env:HERMES_WS_DIR\icu"
-        cd $Env:HERMES_WS_DIR
-        cmake -S hermes -B build -G 'Visual Studio 16 2019' -Ax64 -DHERMES_ENABLE_DEBUGGER=False $Env:RELEASE_FLAGS
-        if (-not $?) { throw "Failed to configure Hermes" }
-        cmake -S hermes -B build_hdb -G 'Visual Studio 16 2019' -Ax64 $Env:RELEASE_FLAGS
-        if (-not $?) { throw "Failed to configure Hermes" }
-        cmake --build ./build --config Release -- -m /p:UseMultiToolTask=true -m /p:EnforceProcessCountAcrossBuilds=true
-        if (-not $?) { throw "Failed to build Hermes" }
-        cmake --build ./build_hdb --config Release --target hdb -- -m /p:UseMultiToolTask=true -m /p:EnforceProcessCountAcrossBuilds=true
-        if (-not $?) { throw "Failed to build Hermes" }
-    - name: Create CLI tarball
-      run: |-
-        cd $Env:HERMES_WS_DIR
-        Copy-Item -Path "build\bin\Release\hermes.exe" -Destination "staging"
-        Copy-Item -Path "build\bin\Release\hvm.exe" -Destination "staging"
-        Copy-Item -Path "build\bin\Release\hbcdump.exe" -Destination "staging"
-        Copy-Item -Path "build\bin\Release\hermesc.exe" -Destination "staging"
-        Copy-Item -Path "build_hdb\bin\Release\hdb.exe" -Destination "staging"
-        cd staging
-        cmake -E tar zcf ..\output\$Env:TAR_NAME .
-    - name: Checksum artifacts
-      run: |-
-        cd $Env:HERMES_WS_DIR\output
-        $hash = Get-FileHash -Path $Env:TAR_NAME -Algorithm SHA256
-        Write-Output ($hash.Hash + "  " + $Env:TAR_NAME) |
-              Out-File -Encoding ASCII -FilePath ($Env:TAR_NAME +".sha256")
-    - uses: actions/upload-artifact@v4.3.1
-      with:
-        name: windows-hermes
-        path: c:\tmp\hermes\output
+      - uses: actions/checkout@v4.1.0
+      - name: Set up workspace
+        run: |-
+          New-Item -ItemType Directory $Env:HERMES_WS_DIR
+          New-Item -ItemType Directory $Env:HERMES_WS_DIR\icu
+          New-Item -ItemType Directory $Env:HERMES_WS_DIR\staging
+          New-Item -ItemType Directory $Env:HERMES_WS_DIR\output
+          New-Item -ItemType SymbolicLink -Target $Env:GITHUB_WORKSPACE -Path $Env:HERMES_WS_DIR -Name hermes
+      - name: Download ICU
+        run: |-
+          cd $Env:HERMES_WS_DIR\icu
+          # If Invoke-WebRequest shows a progress bar, it will fail with
+          #   Win32 internal error "Access is denied" 0x5 occurred [...]
+          $progressPreference = 'silentlyContinue'
+          Invoke-WebRequest -Uri "$Env:ICU_URL" -OutFile "icu.zip"
+          Expand-Archive -Path "icu.zip" -DestinationPath "."
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2.0.0
+        with:
+          cmake-version: 3.14.7
+      - name: Setup python
+        uses: actions/setup-python@v5.0.0
+        with:
+          python-version: 3.12.1
+      - name: Assemble Windows runtime dependencies
+        run: |-
+          cd $Env:HERMES_WS_DIR
+          Copy-Item -Path "icu\bin64\icu*.dll" -Destination "staging"
+          # Include MSVC++ 2015 redistributables
+          Copy-Item -Path "c:\windows\system32\msvcp140.dll" -Destination "staging"
+          Copy-Item -Path "c:\windows\system32\vcruntime140.dll" -Destination "staging"
+          Copy-Item -Path "c:\windows\system32\vcruntime140_1.dll" -Destination "staging"
+      - name: Build Windows CLI
+        run: |-
+          $Env:PATH += ";$Env:MSBUILD_DIR"
+          $Env:ICU_ROOT = "$Env:HERMES_WS_DIR\icu"
+          cd $Env:HERMES_WS_DIR
+          cmake -S hermes -B build -G 'Visual Studio 16 2019' -Ax64 -DHERMES_ENABLE_DEBUGGER=False $Env:RELEASE_FLAGS
+          if (-not $?) { throw "Failed to configure Hermes" }
+          cmake -S hermes -B build_hdb -G 'Visual Studio 16 2019' -Ax64 $Env:RELEASE_FLAGS
+          if (-not $?) { throw "Failed to configure Hermes" }
+          cmake --build ./build --config Release -- -m /p:UseMultiToolTask=true -m /p:EnforceProcessCountAcrossBuilds=true
+          if (-not $?) { throw "Failed to build Hermes" }
+          cmake --build ./build_hdb --config Release --target hdb -- -m /p:UseMultiToolTask=true -m /p:EnforceProcessCountAcrossBuilds=true
+          if (-not $?) { throw "Failed to build Hermes" }
+      - name: Create CLI tarball
+        run: |-
+          cd $Env:HERMES_WS_DIR
+          Copy-Item -Path "build\bin\Release\hermes.exe" -Destination "staging"
+          Copy-Item -Path "build\bin\Release\hvm.exe" -Destination "staging"
+          Copy-Item -Path "build\bin\Release\hbcdump.exe" -Destination "staging"
+          Copy-Item -Path "build\bin\Release\hermesc.exe" -Destination "staging"
+          Copy-Item -Path "build_hdb\bin\Release\hdb.exe" -Destination "staging"
+          cd staging
+          cmake -E tar zcf ..\output\$Env:TAR_NAME .
+      - name: Checksum artifacts
+        run: |-
+          cd $Env:HERMES_WS_DIR\output
+          $hash = Get-FileHash -Path $Env:TAR_NAME -Algorithm SHA256
+          Write-Output ($hash.Hash + "  " + $Env:TAR_NAME) |
+                Out-File -Encoding ASCII -FilePath ($Env:TAR_NAME +".sha256")
+      - uses: actions/upload-artifact@v4.3.1
+        with:
+          name: windows-hermes
+          path: c:\tmp\hermes\output
   npm:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
-    - android
-    - linux
-    - package-apple-runtime
-    - windows
-    - macos
+      - android
+      - linux
+      - package-apple-runtime
+      - windows
+      - macos
     env:
       YARN: yarnpkg
       TERM: dumb
       DEBIAN_FRONTEND: noninteractive
     steps:
-    - uses: actions/setup-node@v4.0.2
-    - name: Print versions
-      run: |-
-        node --version
-        yarn --version
-    - name: Install dependencies and set up
-      run: mkdir -p /tmp/hermes/output
-    - uses: actions/checkout@v4.1.0
-    - uses: actions/download-artifact@v4.1.3
-    - name: Build NPM
-      run: |-
-        ls -lR
-        cd npm
-        cp ../macos-hermes/* .
-        cp ../windows-hermes/* .
-        cp ../android-hermes/* .
-        cp ../apple-runtime/* .
-        cp ../emscripten-hermes/* .
-        cp ../linux-hermes/* .
-        yarn install
-        yarn unpack-builds
-        yarn create-npms
-    - name: Copy artifacts
-      run: |-
-        cd npm
-        cp *.tgz /tmp/hermes/output
-    - name: Checksum artifacts
-      run: |-
-        cd /tmp/hermes/output
-        for file in *
-        do
-          sha256sum "$file" > "$file.sha256"
-        done
-    - uses: actions/upload-artifact@v4.3.1
-      with:
-        name: npm-hermes
-        path: /tmp/hermes/output
+      - uses: actions/setup-node@v4.0.2
+      - name: Print versions
+        run: |-
+          node --version
+          yarn --version
+      - name: Install dependencies and set up
+        run: mkdir -p /tmp/hermes/output
+      - uses: actions/checkout@v4.1.0
+      - uses: actions/download-artifact@v4.1.3
+      - name: Build NPM
+        run: |-
+          ls -lR
+          cd npm
+          cp ../macos-hermes/* .
+          cp ../windows-hermes/* .
+          cp ../android-hermes/* .
+          cp ../apple-runtime/* .
+          cp ../emscripten-hermes/* .
+          cp ../linux-hermes/* .
+          yarn install
+          yarn unpack-builds
+          yarn create-npms
+      - name: Copy artifacts
+        run: |-
+          cd npm
+          cp *.tgz /tmp/hermes/output
+      - name: Checksum artifacts
+        run: |-
+          cd /tmp/hermes/output
+          for file in *
+          do
+            sha256sum "$file" > "$file.sha256"
+          done
+      - uses: actions/upload-artifact@v4.3.1
+        with:
+          name: npm-hermes
+          path: /tmp/hermes/output
   emscripten:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: emscripten/emsdk:2.0.9
     steps:
-    - name: Install dependencies
-      run: |-
-        apt update
-        apt install -y libicu-dev
-    - uses: actions/checkout@v4.1.0
-      with:
-        path: hermes
-    - name: Build Hermes Compiler
-      run: |-
-        cmake -S hermes -B build_host_hermesc
-        cmake --build ./build_host_hermesc --target hermesc -j 4
-    - name: Build Hermes with Emscripten for Website Playground
-      run: |-
-        echo LINKER_FLAGS: $LINKER_FLAGS
-        cmake -S hermes -B playground \
-            -DCMAKE_BUILD_TYPE=Release  \
-            -DCMAKE_EXE_LINKER_FLAGS="$LINKER_FLAGS" \
-            -DCMAKE_TOOLCHAIN_FILE="$EMSDK/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake" \
-            -DIMPORT_HERMESC="$PWD/build_host_hermesc/ImportHermesc.cmake"
-        cmake --build ./playground --target hermes -j 4
-        cmake --build ./playground --target hermesc -j 4
-        cmake --build ./playground --target emhermesc -j 4
-        EMHERMESC="$PWD/playground/bin/emhermesc.js" node ./hermes/tools/emhermesc/test.js
-      env:
-        LINKER_FLAGS: "-s WASM=1 \\ -s ALLOW_MEMORY_GROWTH=0 \\ -s TOTAL_MEMORY=33554432 \\ -s MODULARIZE=1 \\ -s EXPORT_NAME=createHermes \\ -s INVOKE_RUN=0 \\ -s EXIT_RUNTIME=1 \\ -s NODERAWFS=0 \\ -s EXTRA_EXPORTED_RUNTIME_METHODS=[callMain,FS]"
-    - name: Create Playground tarball
-      run: |-
-        mkdir output staging
-        cp ./playground/bin/hermes.js ./playground/bin/hermes.wasm staging
-        tar -C staging -czvf output/${TAR_NAME} .
-        shasum -a 256 output/${TAR_NAME} > output/${TAR_NAME}.sha256
-      env:
-        TAR_NAME: hermes-cli-emscripten.tar.gz
-    - uses: actions/upload-artifact@v4.3.1
-      with:
-        name: emscripten-hermes
-        path: output
+      - name: Install dependencies
+        run: |-
+          apt update
+          apt install -y libicu-dev
+      - uses: actions/checkout@v4.1.0
+        with:
+          path: hermes
+      - name: Build Hermes Compiler
+        run: |-
+          cmake -S hermes -B build_host_hermesc
+          cmake --build ./build_host_hermesc --target hermesc -j 4
+      - name: Build Hermes with Emscripten for Website Playground
+        run: |-
+          echo LINKER_FLAGS: $LINKER_FLAGS
+          cmake -S hermes -B playground \
+              -DCMAKE_BUILD_TYPE=Release  \
+              -DCMAKE_EXE_LINKER_FLAGS="$LINKER_FLAGS" \
+              -DCMAKE_TOOLCHAIN_FILE="$EMSDK/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake" \
+              -DIMPORT_HERMESC="$PWD/build_host_hermesc/ImportHermesc.cmake"
+          cmake --build ./playground --target hermes -j 4
+          cmake --build ./playground --target hermesc -j 4
+          cmake --build ./playground --target emhermesc -j 4
+          EMHERMESC="$PWD/playground/bin/emhermesc.js" node ./hermes/tools/emhermesc/test.js
+        env:
+          LINKER_FLAGS: "-s WASM=1 \\ -s ALLOW_MEMORY_GROWTH=0 \\ -s TOTAL_MEMORY=33554432 \\ -s MODULARIZE=1 \\ -s EXPORT_NAME=createHermes \\ -s INVOKE_RUN=0 \\ -s EXIT_RUNTIME=1 \\ -s NODERAWFS=0 \\ -s EXTRA_EXPORTED_RUNTIME_METHODS=[callMain,FS]"
+      - name: Create Playground tarball
+        run: |-
+          mkdir output staging
+          cp ./playground/bin/hermes.js ./playground/bin/hermes.wasm staging
+          tar -C staging -czvf output/${TAR_NAME} .
+          shasum -a 256 output/${TAR_NAME} > output/${TAR_NAME}.sha256
+        env:
+          TAR_NAME: hermes-cli-emscripten.tar.gz
+      - uses: actions/upload-artifact@v4.3.1
+        with:
+          name: emscripten-hermes
+          path: output
   sandbox:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: emscripten/emsdk:3.1.39
     env:
       DEBIAN_FRONTEND: noninteractive
     steps:
-    - name: Install dependencies
-      run: |-
-        apt update
-        apt install -y libicu-dev tzdata
-        wget https://github.com/WebAssembly/wabt/releases/download/1.0.33/wabt-1.0.33-ubuntu.tar.gz
-        tar -xvf ./wabt-1.0.33-ubuntu.tar.gz
-    - uses: actions/checkout@v4.1.0
-      with:
-        path: hermes
-    - name: Build Hermes with Emscripten
-      run: |-
-        # Generate the host compiler.
-        cmake -S hermes -B build_host
-        cmake --build ./build_host --target hermesc -j 4
-        # Generate and build the debug artefact.
-        cmake -S hermes -B build_wasm_dbg \
-          -DCMAKE_TOOLCHAIN_FILE=$EMSDK/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake \
-          -DIMPORT_HERMESC=build_host/ImportHermesc.cmake \
-          -DCMAKE_BUILD_TYPE=Debug -DHERMES_UNICODE_LITE=ON \
-          -DCMAKE_CXX_FLAGS=-O2  -DCMAKE_C_FLAGS=-O2 \
-          -DCMAKE_EXE_LINKER_FLAGS="-sALLOW_MEMORY_GROWTH=1 -sSTACK_SIZE=256KB" \
-          -DHERMES_ENABLE_DEBUGGER=OFF -DHERMES_SLOW_DEBUG=OFF
-        cmake --build build_wasm_dbg --target hermesSandboxImpl -j 4
-        ./wabt-1.0.33/bin/wasm2c build_wasm_dbg/API/hermes_sandbox/hermesSandboxImpl.wasm -n hermes \
-          -o hermes/API/hermes_sandbox/external/hermes_sandbox_impl_dbg_compiled.c --num-outputs 8
-        # Generate and build the release artefact.
-        cmake -S hermes -B build_wasm_opt \
-          -DCMAKE_TOOLCHAIN_FILE=$EMSDK/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake \
-          -DIMPORT_HERMESC=build_host/ImportHermesc.cmake \
-          -DCMAKE_BUILD_TYPE=Release -DHERMES_UNICODE_LITE=ON \
-          -DCMAKE_EXE_LINKER_FLAGS="-sALLOW_MEMORY_GROWTH=1 -sSTACK_SIZE=256KB -g2" \
-          -DHERMES_ENABLE_DEBUGGER=OFF
-        cmake --build build_wasm_opt --target hermesSandboxImpl -j 4
-        ./wabt-1.0.33/bin/wasm2c build_wasm_opt/API/hermes_sandbox/hermesSandboxImpl.wasm -n hermes \
-          -o hermes/API/hermes_sandbox/external/hermes_sandbox_impl_opt_compiled.c --num-outputs 8
-    - name: Build and test with the newly generated sandbox
-      run: |-
-        cmake -S hermes -B build_dbg -DCMAKE_BUILD_TYPE=Debug
-        cmake --build build_dbg -j 4
-        cmake --build build_dbg --target check-hermes -j 4
-        cmake -S hermes -B build_opt -DCMAKE_BUILD_TYPE=Release
-        cmake --build build_opt -j 4
-        cmake --build build_opt --target check-hermes -j 4
+      - name: Install dependencies
+        run: |-
+          apt update
+          apt install -y libicu-dev tzdata
+          wget https://github.com/WebAssembly/wabt/releases/download/1.0.33/wabt-1.0.33-ubuntu.tar.gz
+          tar -xvf ./wabt-1.0.33-ubuntu.tar.gz
+      - uses: actions/checkout@v4.1.0
+        with:
+          path: hermes
+      - name: Build Hermes with Emscripten
+        run: |-
+          # Generate the host compiler.
+          cmake -S hermes -B build_host
+          cmake --build ./build_host --target hermesc -j 4
+          # Generate and build the debug artefact.
+          cmake -S hermes -B build_wasm_dbg \
+            -DCMAKE_TOOLCHAIN_FILE=$EMSDK/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake \
+            -DIMPORT_HERMESC=build_host/ImportHermesc.cmake \
+            -DCMAKE_BUILD_TYPE=Debug -DHERMES_UNICODE_LITE=ON \
+            -DCMAKE_CXX_FLAGS=-O2  -DCMAKE_C_FLAGS=-O2 \
+            -DCMAKE_EXE_LINKER_FLAGS="-sALLOW_MEMORY_GROWTH=1 -sSTACK_SIZE=256KB" \
+            -DHERMES_ENABLE_DEBUGGER=OFF -DHERMES_SLOW_DEBUG=OFF
+          cmake --build build_wasm_dbg --target hermesSandboxImpl -j 4
+          ./wabt-1.0.33/bin/wasm2c build_wasm_dbg/API/hermes_sandbox/hermesSandboxImpl.wasm -n hermes \
+            -o hermes/API/hermes_sandbox/external/hermes_sandbox_impl_dbg_compiled.c --num-outputs 8
+          # Generate and build the release artefact.
+          cmake -S hermes -B build_wasm_opt \
+            -DCMAKE_TOOLCHAIN_FILE=$EMSDK/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake \
+            -DIMPORT_HERMESC=build_host/ImportHermesc.cmake \
+            -DCMAKE_BUILD_TYPE=Release -DHERMES_UNICODE_LITE=ON \
+            -DCMAKE_EXE_LINKER_FLAGS="-sALLOW_MEMORY_GROWTH=1 -sSTACK_SIZE=256KB -g2" \
+            -DHERMES_ENABLE_DEBUGGER=OFF
+          cmake --build build_wasm_opt --target hermesSandboxImpl -j 4
+          ./wabt-1.0.33/bin/wasm2c build_wasm_opt/API/hermes_sandbox/hermesSandboxImpl.wasm -n hermes \
+            -o hermes/API/hermes_sandbox/external/hermes_sandbox_impl_opt_compiled.c --num-outputs 8
+      - name: Build and test with the newly generated sandbox
+        run: |-
+          cmake -S hermes -B build_dbg -DCMAKE_BUILD_TYPE=Debug
+          cmake --build build_dbg -j 4
+          cmake --build build_dbg --target check-hermes -j 4
+          cmake -S hermes -B build_opt -DCMAKE_BUILD_TYPE=Release
+          cmake --build build_opt -j 4
+          cmake --build build_opt --target check-hermes -j 4
   test-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-    - name: Install dependencies
-      run: |-
-        sudo apt update
-        sudo apt install -y git openssh-client cmake build-essential \
-            libicu-dev zip python3
-    - uses: actions/checkout@v4.1.0
-      with:
-        path: hermes
-    - name: Run Hermes regression tests
-      run: |-
-        cmake -S hermes -B build
-        cmake --build build --target check-hermes all -j 4
+      - name: Install dependencies
+        run: |-
+          sudo apt update
+          sudo apt install -y git openssh-client cmake build-essential \
+              libicu-dev zip python3
+      - uses: actions/checkout@v4.1.0
+        with:
+          path: hermes
+      - name: Run Hermes regression tests
+        run: |-
+          cmake -S hermes -B build
+          cmake --build build --target check-hermes all -j 4
   test-windows:
     runs-on: windows-2019
     steps:
-    - uses: actions/checkout@v4.1.0
-      with:
-        path: hermes
-    - name: Run Hermes regression tests
-      run: |-
-        cmake -S hermes -B build -G 'Visual Studio 16 2019'
-        cmake --build build --target check-hermes -- -m /p:UseMultiToolTask=true -m /p:EnforceProcessCountAcrossBuilds=true
+      - uses: actions/checkout@v4.1.0
+        with:
+          path: hermes
+      - name: Run Hermes regression tests
+        run: |-
+          cmake -S hermes -B build -G 'Visual Studio 16 2019'
+          cmake --build build --target check-hermes -- -m /p:UseMultiToolTask=true -m /p:EnforceProcessCountAcrossBuilds=true
   test-e2e:
     runs-on: ubuntu-22.04
     env:
@@ -515,99 +515,99 @@ jobs:
       HERMES_WS_DIR: /home/runner/work/hermes
       REACT_NATIVE_OVERRIDE_HERMES_DIR: /home/runner/work/hermes/hermes
     steps:
-    - name: Install Node
-      uses: actions/setup-node@v4.0.2
-    - name: Install JDK
-      uses: actions/setup-java@v3
-      with:
-        distribution: "temurin"
-        java-version: "17"
-    - name: Checkout Hermes
-      uses: actions/checkout@v4.1.0
-    - name: Checkout React Native
-      run: |-
-        cd "$HERMES_WS_DIR"
-        git clone --depth=1 https://github.com/facebook/react-native
-        cd react-native
-        yarn install
-        echo "console.log('Using Hermes: ' + (global.HermesInternal != null));" >> packages/rn-tester/js/RNTesterApp.android.js
-    - name: Run RNTester
-      uses: ReactiveCircus/android-emulator-runner@v2.30.1
-      with:
-        api-level: 29
-        ndk: 27.1.12297006
-        cmake: 3.22.1
-        script: |
-          cd ../react-native && ./gradlew -PreactNativeArchitectures=x86 :packages:rn-tester:android:app:installHermesRelease
-          adb shell am start com.facebook.react.uiapp/.RNTesterActivity
-          timeout 30s adb logcat -e "Using Hermes: true" -m 1
+      - name: Install Node
+        uses: actions/setup-node@v4.0.2
+      - name: Install JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "17"
+      - name: Checkout Hermes
+        uses: actions/checkout@v4.1.0
+      - name: Checkout React Native
+        run: |-
+          cd "$HERMES_WS_DIR"
+          git clone --depth=1 https://github.com/facebook/react-native
+          cd react-native
+          yarn install
+          echo "console.log('Using Hermes: ' + (global.HermesInternal != null));" >> packages/rn-tester/js/RNTesterApp.android.js
+      - name: Run RNTester
+        uses: ReactiveCircus/android-emulator-runner@v2.30.1
+        with:
+          api-level: 29
+          ndk: 27.1.12297006
+          cmake: 3.22.1
+          script: |
+            cd ../react-native && ./gradlew -PreactNativeArchitectures=x86 :packages:rn-tester:android:app:installHermesRelease
+            adb shell am start com.facebook.react.uiapp/.RNTesterActivity
+            timeout 30s adb logcat -e "Using Hermes: true" -m 1
   test-e2e-intl:
     runs-on: ubuntu-22.04
     env:
       HERMES_WS_DIR: /home/runner/work/hermes
       ANDROID_NDK: /usr/local/lib/android/sdk/ndk/27.1.12297006
     steps:
-    - name: Checkout Hermes
-      uses: actions/checkout@v4.1.0
-    - name: Checkout Test262
-      run: |-
-        cd "$HERMES_WS_DIR"
-        git clone https://github.com/tc39/test262
-        cd test262
-        git checkout 62626e083bd506124aac6c799464d76c2c42851b
-    - name: Build Hermes Compiler
-      run: |-
-        cd "$HERMES_WS_DIR"
-        cmake -S hermes -B ./build -DCMAKE_BUILD_TYPE=Release
-        cmake --build ./build -j 4 --target hermesc
-    - name: Run android tests
-      uses: ReactiveCircus/android-emulator-runner@v2.30.1
-      with:
-        api-level: 29
-        emulator-options: -timezone Europe/Paris -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-        script: cd android && ./gradlew :intltest:prepareTests && ./gradlew -Pabis=x86 :intltest:connectedAndroidTest
+      - name: Checkout Hermes
+        uses: actions/checkout@v4.1.0
+      - name: Checkout Test262
+        run: |-
+          cd "$HERMES_WS_DIR"
+          git clone https://github.com/tc39/test262
+          cd test262
+          git checkout 62626e083bd506124aac6c799464d76c2c42851b
+      - name: Build Hermes Compiler
+        run: |-
+          cd "$HERMES_WS_DIR"
+          cmake -S hermes -B ./build -DCMAKE_BUILD_TYPE=Release
+          cmake --build ./build -j 4 --target hermesc
+      - name: Run android tests
+        uses: ReactiveCircus/android-emulator-runner@v2.30.1
+        with:
+          api-level: 29
+          emulator-options: -timezone Europe/Paris -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          script: cd android && ./gradlew :intltest:prepareTests && ./gradlew -Pabis=x86 :intltest:connectedAndroidTest
   test-macos-test262:
     runs-on: macos-14
     steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: 16.2
-    - uses: actions/checkout@v4.1.0
-      with:
-        path: hermes
-    - name: Setup dependencies
-      run: |-
-        brew install cmake ninja
-        # Check out test262 at a pinned revision to reduce flakiness
-        git clone https://github.com/tc39/test262
-        cd test262
-        git checkout 62626e083bd506124aac6c799464d76c2c42851b
-    - name: Run Hermes tests and test262 with Intl
-      run: |-
-        cmake -S hermes -B build -GNinja -DHERMES_ENABLE_INTL=ON
-        cmake --build ./build
-        cmake --build ./build --target check-hermes
-        python3 hermes/utils/testsuite/run_testsuite.py --test-intl test262/test -b build/bin
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 16.2
+      - uses: actions/checkout@v4.1.0
+        with:
+          path: hermes
+      - name: Setup dependencies
+        run: |-
+          brew install cmake ninja
+          # Check out test262 at a pinned revision to reduce flakiness
+          git clone https://github.com/tc39/test262
+          cd test262
+          git checkout 62626e083bd506124aac6c799464d76c2c42851b
+      - name: Run Hermes tests and test262 with Intl
+        run: |-
+          cmake -S hermes -B build -GNinja -DHERMES_ENABLE_INTL=ON
+          cmake --build ./build
+          cmake --build ./build --target check-hermes
+          python3 hermes/utils/testsuite/run_testsuite.py --test-intl test262/test -b build/bin
   test-linux-test262:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4.1.0
-      with:
-        path: hermes
-    - name: Setup dependencies
-      run: |-
-        sudo apt update
-        sudo apt install -y git openssh-client cmake build-essential \
-            libreadline-dev libicu-dev zip python3
-        # Check out test262 at a pinned revision to reduce flakiness
-        git clone https://github.com/tc39/test262
-        cd test262
-        git checkout 62626e083bd506124aac6c799464d76c2c42851b
-    - name: Run test262 with Intl
-      run: |-
-        cmake -S hermes -B build -DHERMES_ENABLE_INTL=ON -DCMAKE_CXX_FLAGS=-O2 -DCMAKE_C_FLAGS=-O2
-        cmake --build ./build -j 4
-        # Not running Hermes test until more of Intl is built out:
-        # toLocaleLowerCase and toLocaleUpperCase are the two main ones.
-        # cmake --build ./build --target check-hermes -j 4
-        python3 hermes/utils/testsuite/run_testsuite.py --test-intl test262/test -b build/bin
+      - uses: actions/checkout@v4.1.0
+        with:
+          path: hermes
+      - name: Setup dependencies
+        run: |-
+          sudo apt update
+          sudo apt install -y git openssh-client cmake build-essential \
+              libreadline-dev libicu-dev zip python3
+          # Check out test262 at a pinned revision to reduce flakiness
+          git clone https://github.com/tc39/test262
+          cd test262
+          git checkout 62626e083bd506124aac6c799464d76c2c42851b
+      - name: Run test262 with Intl
+        run: |-
+          cmake -S hermes -B build -DHERMES_ENABLE_INTL=ON -DCMAKE_CXX_FLAGS=-O2 -DCMAKE_C_FLAGS=-O2
+          cmake --build ./build -j 4
+          # Not running Hermes test until more of Intl is built out:
+          # toLocaleLowerCase and toLocaleUpperCase are the two main ones.
+          # cmake --build ./build --target check-hermes -j 4
+          python3 hermes/utils/testsuite/run_testsuite.py --test-intl test262/test -b build/bin

--- a/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/type-parameters/default/spec.js
+++ b/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/type-parameters/default/spec.js
@@ -9,3 +9,4 @@
  */
 
 type T1<A = B> = A;
+type T2 = T1<>;

--- a/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/type-parameters/default/translate-result.shot
+++ b/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/type-parameters/default/translate-result.shot
@@ -12,5 +12,6 @@ exports[`flowDefToTSDef type-parameters/default 1`] = `
  */
 
 type T1<A = B> = A;
+type T2 = T1;
 "
 `;


### PR DESCRIPTION
## Summary
While working on a project that utilizes `metro`, I found that some of the type definitions were incorrect:
https://github.com/facebook/metro/issues/1491

## Test Plan
Flow's empty type parameter syntax should properly translate to empty TypeScript type parameters. Currently `flow-api-translator` will happily translate:

`type Foo = Bar<>` to `type Foo= Bar<>` which is invalid TypeScript.
