### PR TITLE
tool/node-hermes/third-party/libuv/src/idna: fix OOB read in punycode decoder

### DIFF
--- a/tools/node-hermes/third-party/libuv/src/idna.c
+++ b/tools/node-hermes/third-party/libuv/src/idna.c
@@ -19,6 +19,7 @@
 
 #include "uv.h"
 #include "idna.h"
+#include <assert.h>
 #include <string.h>
 
 static unsigned uv__utf8_decode1_slow(const char** p,
@@ -32,7 +33,7 @@ static unsigned uv__utf8_decode1_slow(const char** p,
   if (a > 0xF7)
     return -1;
 
-  switch (*p - pe) {
+  switch (pe - *p) {
   default:
     if (a > 0xEF) {
       min = 0x10000;
@@ -62,6 +63,8 @@ static unsigned uv__utf8_decode1_slow(const char** p,
       a = 0;
       break;
     }
+    /* Fall through. */
+  case 0:
     return -1;  /* Invalid continuation byte. */
   }
 
@@ -88,6 +91,8 @@ static unsigned uv__utf8_decode1_slow(const char** p,
 unsigned uv__utf8_decode1(const char** p, const char* pe) {
   unsigned a;
 
+  assert(*p < pe);
+
   a = (unsigned char) *(*p)++;
 
   if (a < 128)
@@ -95,9 +100,6 @@ unsigned uv__utf8_decode1(const char** p, const char* pe) {
 
   return uv__utf8_decode1_slow(p, pe, a);
 }
-
-#define foreach_codepoint(c, p, pe) \
-  for (; (void) (*p <= pe && (c = uv__utf8_decode1(p, pe))), *p <= pe;)
 
 static int uv__idna_toascii_label(const char* s, const char* se,
                                   char** d, char* de) {
@@ -121,7 +123,15 @@ static int uv__idna_toascii_label(const char* s, const char* se,
   ss = s;
   todo = 0;
 
-  foreach_codepoint(c, &s, se) {
+  /* Note: after this loop we've visited all UTF-8 characters and know
+   * they're legal so we no longer need to check for decode errors.
+   */
+  while (s < se) {
+    c = uv__utf8_decode1(&s, se);
+
+    if (c == -1u)
+      return UV_EINVAL;
+
     if (c < 128)
       h++;
     else if (c == (unsigned) -1)
@@ -130,6 +140,7 @@ static int uv__idna_toascii_label(const char* s, const char* se,
       todo++;
   }
 
+  /* Only write "xn--" when there are non-ASCII characters. */
   if (todo > 0) {
     if (*d < de) *(*d)++ = 'x';
     if (*d < de) *(*d)++ = 'n';
@@ -137,9 +148,13 @@ static int uv__idna_toascii_label(const char* s, const char* se,
     if (*d < de) *(*d)++ = '-';
   }
 
+  /* Write ASCII characters. */
   x = 0;
   s = ss;
-  foreach_codepoint(c, &s, se) {
+  while (s < se) {
+    c = uv__utf8_decode1(&s, se);
+    assert(c != -1u);
+
     if (c > 127)
       continue;
 
@@ -166,10 +181,15 @@ static int uv__idna_toascii_label(const char* s, const char* se,
   while (todo > 0) {
     m = -1;
     s = ss;
-    foreach_codepoint(c, &s, se)
+
+    while (s < se) {
+      c = uv__utf8_decode1(&s, se);
+      assert(c != -1u);
+
       if (c >= n)
         if (c < m)
           m = c;
+    }
 
     x = m - n;
     y = h + 1;
@@ -181,7 +201,10 @@ static int uv__idna_toascii_label(const char* s, const char* se,
     n = m;
 
     s = ss;
-    foreach_codepoint(c, &s, se) {
+    while (s < se) {
+      c = uv__utf8_decode1(&s, se);
+      assert(c != -1u);
+
       if (c < n)
         if (++delta == 0)
           return UV_E2BIG;  /* Overflow. */
@@ -256,9 +279,13 @@ long uv__idna_toascii(const char* s, const char* se, char* d, char* de) {
 
   ds = d;
 
-  for (si = s; si < se; /* empty */) {
+  si = s;
+  while (si < se) {
     st = si;
     c = uv__utf8_decode1(&si, se);
+
+    if (c == -1u)
+      return UV_EINVAL;
 
     if (c != '.')
       if (c != 0x3002)  /* 。 */

--- a/tools/node-hermes/third-party/libuv/test/test-idna.c
+++ b/tools/node-hermes/third-party/libuv/test/test-idna.c
@@ -96,6 +96,25 @@ TEST_IMPL(utf8_decode1) {
   return 0;
 }
 
+TEST_IMPL(utf8_decode1_overrun) {
+  const char* p;
+  char b[1];
+
+  /* Single byte. */
+  p = b;
+  b[0] = 0x7F;
+  ASSERT_EQ(0x7F, uv__utf8_decode1(&p, b + 1));
+  ASSERT_EQ(p, b + 1);
+
+  /* Multi-byte. */
+  p = b;
+  b[0] = 0xC0;
+  ASSERT_EQ((unsigned) -1, uv__utf8_decode1(&p, b + 1));
+  ASSERT_EQ(p, b + 1);
+
+  return 0;
+}
+
 /* Doesn't work on z/OS because that platform uses EBCDIC, not ASCII. */
 #ifndef __MVS__
 


### PR DESCRIPTION
## Summary
**Description**
This PR fixes a potential vulnerability of an out-of-bounds read in uv__idna_toascii() that was cloned from libuv but did not receive the security patch. The original issue was reported and fixed under https://github.com/libuv/libuv/commit/b7466e31e4bee160d82a68fca11b1f61d46debae.
This PR applies the same patch to eliminate the vulnerability.

**References**
https://nvd.nist.gov/vuln/detail/cve-2021-22918
https://github.com/libuv/libuv/commit/b7466e31e4bee160d82a68fca11b1f61d46debae
