### PR TITLE
[SH}CMake: use PROJECT_SOURCE_DIR instead of CMAKE_SOURCE_DIR

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -240,7 +240,7 @@ endif()
 # Since we use private dependencies above, we need to enumerate all the headers
 # that should be available to consumers of hermesvm. Note that we only expose
 # the headers which produce visible symbols.
-target_include_directories(hermesvm PUBLIC ${CMAKE_SOURCE_DIR}/public ${HERMES_COMMON_DIR}/public ${CMAKE_SOURCE_DIR}/API ${HERMES_JSI_DIR})
+target_include_directories(hermesvm PUBLIC ${PROJECT_SOURCE_DIR}/public ${HERMES_COMMON_DIR}/public ${PROJECT_SOURCE_DIR}/API ${HERMES_JSI_DIR})
 
 # Private dependencies also mean that JSI will not get propagated to libraries
 # that depend on hermesvm. If JSI is built as a shared library, ensure it is

--- a/tools/shermes/CMakeLists.txt
+++ b/tools/shermes/CMakeLists.txt
@@ -17,7 +17,7 @@ set(SHERMES_CC "cc" CACHE STRING "C compiler to invoke")
 set(SHERMES_CC_SYSCFLAGS "" CACHE STRING "C compiler system flags")
 set(SHERMES_CC_SYSLDFLAGS "" CACHE STRING "C compiler system linker flags")
 set(SHERMES_CC_INCLUDE_PATH
-  "${CMAKE_BINARY_DIR}/lib/config:${CMAKE_SOURCE_DIR}/include" CACHE STRING
+  "${CMAKE_BINARY_DIR}/lib/config:${PROJECT_SOURCE_DIR}/include" CACHE STRING
   "Include path when invoking CC")
 set(SHERMES_CC_LIB_PATH "$<TARGET_FILE_DIR:hermesvm>:$<TARGET_FILE_DIR:jsi>:$<TARGET_FILE_DIR:shermes_console>" CACHE STRING
   "Library path when invoking CC")


### PR DESCRIPTION
Summary:
`CMAKE_SOURCE_DIR` contains the directory of the "root" CMakeLists.txt,
but `PROJECT_SOURCE_DIR` contains the directory of the closest
`project()` directive. Using the former is usually the wrong thing to
do, if projects can be nested.

Closes https://github.com/facebook/hermes/issues/1678

Differential Revision: D73482392


