### PR TITLE
Fixes `flow-api-translator` default type parameter generation

### DIFF
--- a/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/type-parameters/default/spec.js
+++ b/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/type-parameters/default/spec.js
@@ -9,3 +9,4 @@
  */
 
 type T1<A = B> = A;
+type T2 = T1<>;

--- a/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/type-parameters/default/translate-result.shot
+++ b/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/type-parameters/default/translate-result.shot
@@ -12,5 +12,6 @@ exports[`flowDefToTSDef type-parameters/default 1`] = `
  */
 
 type T1<A = B> = A;
+type T2 = T1;
 "
 `;

--- a/tools/hermes-parser/js/flow-api-translator/src/flowDefToTSDef.js
+++ b/tools/hermes-parser/js/flow-api-translator/src/flowDefToTSDef.js
@@ -4048,7 +4048,12 @@ const getTransforms = (
       return {
         type: 'TSTypeParameterInstantiation',
         loc: DUMMY_LOC,
-        params: node.params.map(transformTypeAnnotationType),
+        params:
+          // Empty parameters in Flow are valid, but TS requires at least one parameter.
+          // This ensures empty type parameters are not created in TS
+          node.params.length === 0
+            ? null
+            : node.params.map(transformTypeAnnotationType),
       };
     },
     UnionTypeAnnotation(


### PR DESCRIPTION
## Summary
While working on Metro, I noticed that many  of the typescript type definitions were defined with `<void>` as type parameters. This is *incorrect*.

See Discussion Here:
https://github.com/facebook/metro/issues/1491#issuecomment-2824661024

## Test Plan
Added tests to the FlowDef -> TSDef tests to ensure empty type params (which imply default type params) properly omit type parameters when generating TSDef.
