### PR TITLE
Fix `hermes-parser-wasm` CMake target

### DIFF
--- a/tools/hermes-parser/CMakeLists.txt
+++ b/tools/hermes-parser/CMakeLists.txt
@@ -7,19 +7,21 @@ if (EMSCRIPTEN)
   add_hermes_tool(hermes-parser-wasm
     hermes-parser-wasm.cpp
     HermesParserJSSerializer.cpp
+    HermesParserDiagHandler.cpp
     ${ALL_HEADER_FILES}
     )
 
   target_link_libraries(hermes-parser-wasm
     hermesAST
     hermesParser
+    hermesSema
     LLVHSupport
   )
 
   target_link_options(hermes-parser-wasm PRIVATE "SHELL: -s NODERAWFS=0 -s WASM=1")
   target_link_options(hermes-parser-wasm PRIVATE "SHELL: -s ALLOW_MEMORY_GROWTH=1")
   target_link_options(hermes-parser-wasm PRIVATE
-    "SHELL: -s EXPORTED_RUNTIME_METHODS=[cwrap,ccall]")
+    "SHELL: -s EXPORTED_RUNTIME_METHODS=[cwrap,ccall,HEAP8,HEAPU8,HEAP16,HEAPU16,HEAP32,HEAPU32,HEAPF32,HEAP64,HEAPU64,HEAPF64]")
   target_link_options(hermes-parser-wasm PRIVATE
     "SHELL: -s EXPORTED_FUNCTIONS=[_malloc,_free]")
   target_link_options(hermes-parser-wasm PRIVATE "SHELL: -s MODULARIZE=1")


### PR DESCRIPTION
- Fixes CMake target for `hermes-parser-warm`
- This change also re-writes some of `build.sh` to be more cross-platform friendly, as the `rename` utility is not part of MacOS standard lib, and the `rename` binary that can be installed has a different API.
- The `--parents` option is also unsupported on MacOS's `cp`, and rather than going down the rabbit-hole of GNU `coreutils` compatibility, I used what I believe to be more cross-platform friendly bash.

## Summary
While working on `flow-api-translator`  I was unable to build `hermes-parser-wasm` as the CMake target no longer built without error.

## Test Plan
It appears that `test-emscripten` job in CircleCI was removed at some point, and there is no job to build this in GitHub workflows. Happy to add a job back in but before I go down that path, it's possible that there was good reason for removing it, so rather than just putting it back, my testing strategy is "I built it successfully" (Which does not exactly instill the most confidence in ensuring it remains working)
