### PR TITLE
Fix BigInt string conversion

### DIFF
--- a/tools/hermes-parser/js/hermes-parser/__tests__/Literal-test.js
+++ b/tools/hermes-parser/js/hermes-parser/__tests__/Literal-test.js
@@ -75,19 +75,16 @@ describe('Literal', () => {
             value: new RegExp('foo', 'g'),
           },
         },
-        // we don't yet emit the bigint value
         {
           type: 'ExpressionStatement',
           expression: {
-            // $FlowExpectedError[cannot-resolve-name] - not supported by flow yet
             value: BigInt(4321),
           },
         },
         {
           type: 'ExpressionStatement',
           expression: {
-            // $FlowExpectedError[cannot-resolve-name] - not supported by flow yet
-            value: BigInt(1234),
+            value: 1_2_34n,
           },
         },
       ],

--- a/tools/hermes-parser/js/hermes-parser/__tests__/TypeAnnotations-test.js
+++ b/tools/hermes-parser/js/hermes-parser/__tests__/TypeAnnotations-test.js
@@ -72,7 +72,6 @@ describe('Literal', () => {
           type: 'TypeAlias',
           right: {
             type: 'BigIntLiteralTypeAnnotation',
-            // $FlowExpectedError[cannot-resolve-name] - not supported by flow yet
             value: BigInt(4321),
           },
         },
@@ -80,8 +79,7 @@ describe('Literal', () => {
           type: 'TypeAlias',
           right: {
             type: 'BigIntLiteralTypeAnnotation',
-            // $FlowExpectedError[cannot-resolve-name] - not supported by flow yet
-            value: BigInt(1234),
+            value: 1234n,
           },
         },
       ],

--- a/tools/hermes-parser/js/hermes-parser/src/HermesASTAdapter.js
+++ b/tools/hermes-parser/js/hermes-parser/src/HermesASTAdapter.js
@@ -172,17 +172,14 @@ export default class HermesASTAdapter {
 
   getBigIntLiteralValue(bigintString: string): {
     bigint: string,
-    value: $FlowFixMe /* bigint */,
+    value: bigint | null,
   } {
-    // TODO - once we update flow we can remove this
-    declare var BigInt: ?(value: $FlowFixMe) => mixed;
-
     const bigint = bigintString
       // estree spec is to not have a trailing `n` on this property
       // https://github.com/estree/estree/blob/db962bb417a97effcfe9892f87fbb93c81a68584/es2020.md#bigintliteral
       .replace(/n$/, '')
       // `BigInt` doesn't accept numeric separator and `bigint` property should not include numeric separator
-      .replace(/_/, '');
+      .replaceAll('_', '');
     return {
       bigint,
       // coerce the string to a bigint value if supported by the environment


### PR DESCRIPTION
Summary:
Fix replace function to strip all underscores from big int literals. Also since Flow now fully supports bigint we can strip some comments and improve the tests.

Fixes: https://github.com/facebook/hermes/issues/1708

Differential Revision: D75476963


