### PR TITLE
Fixed Array.prototype.toSpliced()

### DIFF
--- a/lib/VM/JSLib/Array.cpp
+++ b/lib/VM/JSLib/Array.cpp
@@ -3650,6 +3650,7 @@ static inline CallResult<double> arrayCopyHelper(
   while (i < count) {
     gcScope.flushToMarker(marker);
     auto fromIndex = fromStartIndex + i;
+    fromValueHandle = MutableHandle<>{runtime, HermesValue::encodeUndefinedValue()};
 
     if (LLVM_LIKELY(fromArr)) {
       const SmallHermesValue elem = fromArr->at(runtime, fromIndex);


### PR DESCRIPTION
## Bug
Sparse arrays calling `Array.prototype.toSpliced` incorrectly fill empty slots with the last non-empty element. This issue arises because `arrayCopyHelper` does not reset the `fromValueHandle` when looping.
#### example:
```js
[1, , , , 5].toSpliced()    // output: [1, 1, 1, 1, 5]
                            // expected: [1, undefined, undefined, undefined, 5]
```

## Fix
Reseting `fromValueHandle` to `undefined` as per [MDN Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSpliced#description)