### PR TITLE
feat: Add `jsi::ArrayBuffer::getMutableBuffer()`

### DIFF
--- a/API/hermes/TracingRuntime.cpp
+++ b/API/hermes/TracingRuntime.cpp
@@ -879,6 +879,11 @@ jsi::ArrayBuffer TracingRuntime::createArrayBuffer(
   throw std::logic_error("Cannot create external ArrayBuffers in trace mode.");
 }
 
+std::shared_ptr<jsi::MutableBuffer> TracingRuntime::getMutableBuffer(
+  const jsi::ArrayBuffer& buffer) {
+  throw std::logic_error("Cannot get external ArrayBuffers in trace mode.");
+}
+
 size_t TracingRuntime::size(const jsi::Array &arr) {
   // Array size inquiries read from the length property, which is
   // non-configurable and thus cannot have side effects.

--- a/API/hermes/TracingRuntime.h
+++ b/API/hermes/TracingRuntime.h
@@ -121,6 +121,8 @@ class TracingRuntime : public jsi::RuntimeDecorator<jsi::Runtime> {
   jsi::Array createArray(size_t length) override;
   jsi::ArrayBuffer createArrayBuffer(
       std::shared_ptr<jsi::MutableBuffer> buffer) override;
+  std::shared_ptr<jsi::MutableBuffer> getMutableBuffer(
+      const jsi::ArrayBuffer& buffer) override;
 
   size_t size(const jsi::Array &arr) override;
   size_t size(const jsi::ArrayBuffer &buf) override;

--- a/API/hermes/hermes.cpp
+++ b/API/hermes/hermes.cpp
@@ -725,6 +725,8 @@ class HermesRuntimeImpl final : public HermesRuntime,
   jsi::Array createArray(size_t length) override;
   jsi::ArrayBuffer createArrayBuffer(
       std::shared_ptr<jsi::MutableBuffer> buffer) override;
+  std::shared_ptr<jsi::MutableBuffer> getMutableBuffer(
+      const jsi::ArrayBuffer& buffer) override;
   size_t size(const jsi::Array &) override;
   size_t size(const jsi::ArrayBuffer &) override;
   uint8_t *data(const jsi::ArrayBuffer &) override;
@@ -2408,6 +2410,23 @@ uint8_t *HermesRuntimeImpl::data(const jsi::ArrayBuffer &arr) {
   if (LLVM_UNLIKELY(!ab->attached()))
     throw jsi::JSINativeException("ArrayBuffer is detached.");
   return ab->getDataBlock(runtime_);
+}
+
+std::shared_ptr<jsi::MutableBuffer> HermesRuntimeImpl::getMutableBuffer(
+    const jsi::ArrayBuffer& arr) {
+  auto buf = arrayBufferHandle(arr);
+  if (LLVM_UNLIKELY(!buf->attached()))
+    throw jsi::JSINativeException("ArrayBuffer is detached.");
+
+  void* context = nullptr;
+  auto res = vm::JSArrayBuffer::getExternalDataBlock(
+      runtime_, buf, &context);
+  if (context == nullptr)
+    return nullptr;
+  auto mutableBuffer = dynamic_cast<std::shared_ptr<jsi::MutableBuffer> *>(context);
+  if (LLVM_UNLIKELY(mutableBuffer == nullptr))
+    throw jsi::JSINativeException("ArrayBuffer's external data block is not a jsi::MutableBuffer!");
+  return mutableBuffer;
 }
 
 jsi::Value HermesRuntimeImpl::getValueAtIndex(const jsi::Array &arr, size_t i) {

--- a/API/hermes_abi/HermesABIRuntimeWrapper.cpp
+++ b/API/hermes_abi/HermesABIRuntimeWrapper.cpp
@@ -944,6 +944,8 @@ class HermesABIRuntimeWrapper : public Runtime {
     return intoJSIArrayBuffer(vtable_->create_arraybuffer_from_external_data(
         abiRt_, new MutableBufferWrapper(std::move(buffer))));
   }
+  std::shared_ptr<MutableBuffer> getMutableBuffer(
+    const ArrayBuffer& buffer) override;
   size_t size(const Array &arr) override {
     return vtable_->get_array_length(abiRt_, toABIArray(arr));
   }

--- a/API/hermes_sandbox/HermesSandboxRuntime.cpp
+++ b/API/hermes_sandbox/HermesSandboxRuntime.cpp
@@ -2051,6 +2051,10 @@ class HermesSandboxRuntimeImpl : public facebook::hermes::HermesSandboxRuntime,
       std::shared_ptr<MutableBuffer> buffer) override {
     THROW_UNIMPLEMENTED();
   }
+  std::shared_ptr<jsi::MutableBuffer> getMutableBuffer(
+    const ArrayBuffer& buffer) override {
+    THROW_UNIMPLEMENTED();
+  }
   size_t size(const Array &arr) override {
     return vt_.get_array_length(this, srt_, toSandboxArray(arr).pointer);
   }

--- a/API/jsi/jsi/decorator.h
+++ b/API/jsi/jsi/decorator.h
@@ -361,6 +361,10 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
       std::shared_ptr<MutableBuffer> buffer) override {
     return plain_.createArrayBuffer(std::move(buffer));
   };
+  std::shared_ptr<jsi::MutableBuffer> getMutableBuffer(
+    const ArrayBuffer& buffer) override {
+    return plain_.getMutableBuffer(buffer);
+  }
   size_t size(const Array& a) override {
     return plain_.size(a);
   };
@@ -894,6 +898,10 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
       std::shared_ptr<MutableBuffer> buffer) override {
     return RD::createArrayBuffer(std::move(buffer));
   };
+  std::shared_ptr<jsi::MutableBuffer> getMutableBuffer(
+    const ArrayBuffer& buffer) override {
+    return RD::getMutableBuffer(buffer);
+  }
   size_t size(const Array& a) override {
     Around around{with_};
     return RD::size(a);

--- a/API/jsi/jsi/jsi.h
+++ b/API/jsi/jsi/jsi.h
@@ -499,6 +499,8 @@ class JSI_EXPORT Runtime : public ICast {
   virtual Array createArray(size_t length) = 0;
   virtual ArrayBuffer createArrayBuffer(
       std::shared_ptr<MutableBuffer> buffer) = 0;
+  virtual std::shared_ptr<MutableBuffer> getMutableBuffer(
+    const ArrayBuffer& buffer) = 0;
   virtual size_t size(const Array&) = 0;
   virtual size_t size(const ArrayBuffer&) = 0;
   virtual uint8_t* data(const ArrayBuffer&) = 0;
@@ -1232,6 +1234,13 @@ class JSI_EXPORT ArrayBuffer : public Object {
 
   uint8_t* data(Runtime& runtime) const {
     return runtime.data(*this);
+  }
+
+  /// \return the underlying MutableBuffer if this ArrayBuffer
+  /// was created with one.
+  /// This returns nullptr if it does not carry a MutableBuffer.
+  std::shared_ptr<MutableBuffer> getMutableBuffer() const {
+    return runtime.getMutableBuffer(*this);
   }
 
  private:

--- a/include/hermes/VM/JSArrayBuffer.h
+++ b/include/hermes/VM/JSArrayBuffer.h
@@ -79,6 +79,13 @@ class JSArrayBuffer final : public JSObject {
       void *context,
       FinalizeNativeStatePtr finalizePtr);
 
+  /// Gets the external data block that this JSArrayBuffer holds if there is any.
+  /// If this JSArrayBuffer does not hold external data, this returns an error.
+  static ExecutionStatus getExternalDataBlock(
+    Runtime &runtime,
+    Handle<JSArrayBuffer> self,
+    void **context);
+
   /// Retrieves a pointer to the held buffer.
   /// \return A pointer to the buffer owned by this object. This can be null
   ///   if the ArrayBuffer is empty.

--- a/lib/VM/JSArrayBuffer.cpp
+++ b/lib/VM/JSArrayBuffer.cpp
@@ -274,5 +274,31 @@ ExecutionStatus JSArrayBuffer::setExternalDataBlock(
   return ExecutionStatus::RETURNED;
 }
 
+ExecutionStatus JSArrayBuffer::setExternalDataBlock(
+    Runtime &runtime,
+    Handle<JSArrayBuffer> self,
+    void **context
+) {
+  NamedPropertyDescriptor desc;
+  bool exists = JSObject::getOwnNamedDescriptor(
+      self,
+      runtime,
+      Predefined::getSymbolID(Predefined::InternalPropertyArrayBufferExternalFinalizer),
+      desc);
+  (void)exists;
+  if (!exists) {
+    // JSArrayBuffer does not hold an external data block
+    return ExecutionStatus::ExecutionFailed;
+  }
+  assert(exists && "JSArrayBuffer");
+  // Raw pointers below.
+  NoAllocScope scope(runtime_);
+  NativeState *ns = vmcast<NativeState>(
+      JSObject::getNamedSlotValueUnsafe(*h, runtime_, desc)
+          .getObject(runtime_));
+  context = ns->context();
+  return ExecutionStatus::RETURNED;
+}
+
 } // namespace vm
 } // namespace hermes


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `main`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/HEAD/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.

  Note: We kindly request that pull requests address more than just a single typo.
  While we sincerely appreciate your attention to detail, we would be most grateful
  if typo fixes were batched together to include several corrections. This helps our
  maintainers focus on substantive contributions to the codebase. Thank you for your
  understanding and cooperation!
-->

## Summary

Adds a new API to `jsi::ArrayBuffer`: `getMutableBuffer()` - which returns a `std::shared_ptr<MutableBuffer>` if it carries one (external buffer, held in `InternalPropertyArrayBufferExternalFinalizer`), or `nullptr` otherwise.

I needed this in Nitro to efficiently pass native buffers between JS and native, and back. 

Before this API, I lost all native buffer information if it was passed native -> JS -> native again.

- Fixes https://github.com/facebook/hermes/issues/1578

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
-->

## Test Plan

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes the user interface.
-->
