### PR TITLE
Use == instead of EXPECT_EQ in testlib

### DIFF
--- a/API/jsi/jsi/test/testlib.cpp
+++ b/API/jsi/jsi/test/testlib.cpp
@@ -1877,7 +1877,9 @@ TEST_P(JSITest, CastInterface) {
   auto randomUuid = UUID{0xf2cd96cf, 0x455e, 0x42d9, 0x850a, 0x13e2cde59b8b};
   auto ptr = rd.castInterface(randomUuid);
 
-  EXPECT_EQ(ptr, nullptr);
+  // Use == instead of EXPECT_EQ to avoid ambiguous operator usage due to the
+  // type of 'ptr'.
+  EXPECT_TRUE(ptr == nullptr);
 }
 
 INSTANTIATE_TEST_CASE_P(


### PR DESCRIPTION
Summary:
The `EXPECT_EQ` was leading to potentially ambiguous use of `<<` when
gtest tries to print information.

Differential Revision: D78823354


