### PR TITLE
Fix android build workflow

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -30,7 +30,7 @@ jobs:
         shell: bash
         run: |
           cd android
-          TASKS="publishAllToMavenTempLocal build"
+          TASKS="publishAllToMavenTempLocal :build"
           ./gradlew $TASKS
       - name: Upload Maven Artifacts
         uses: actions/upload-artifact@v4.3.4

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -1,2 +1,3 @@
 .gradle
 .externalNativeBuild
+.cxx

--- a/android/cppruntime/build.gradle
+++ b/android/cppruntime/build.gradle
@@ -15,11 +15,11 @@ buildDir.mkdirs()
 
 android {
   namespace = "com.facebook.hermes.cppruntime"
-  compileSdkVersion = hermesUtils.compileSdk
+  compileSdk = hermesUtils.compileSdk
   ndkVersion = hermesUtils.ndkVersion
 
   defaultConfig {
-    minSdkVersion = hermesUtils.minSdk
+    minSdk = hermesUtils.minSdk
     externalNativeBuild {
       cmake {
         arguments "-DANDROID_STL=c++_shared"

--- a/android/hermes/build.gradle
+++ b/android/hermes/build.gradle
@@ -14,11 +14,11 @@ buildDir = "${hermesUtils.hermesWs}/build_android/hermes"
 buildDir.mkdirs()
 
 android {
-  compileSdkVersion = hermesUtils.compileSdk
+  compileSdk = hermesUtils.compileSdk
   ndkVersion = hermesUtils.ndkVersion
 
   defaultConfig {
-    minSdkVersion hermesUtils.minSdk
+    minSdk = hermesUtils.minSdk
     namespace "com.facebook.hermes"
 
     externalNativeBuild {

--- a/android/intltest/build.gradle
+++ b/android/intltest/build.gradle
@@ -58,11 +58,11 @@ task prepareTests() {
 // TODO: Figure out how to deduplicate this file and intl/build.gradle
 android {
   namespace "com.facebook.hermes.intltest"
-  compileSdkVersion = hermesUtils.compileSdk
+  compileSdk = hermesUtils.compileSdk
   ndkVersion = hermesUtils.ndkVersion
 
   defaultConfig {
-    minSdkVersion = hermesUtils.minSdk
+    minSdk = hermesUtils.minSdk
     ndk {
       abiFilters (*hermesUtils.abis)
     }


### PR DESCRIPTION
## Summary

The `build-android` workflow currently fails, as it tries to execute `build` tasks on all subprojects, while only the root one should be run. This PR fixes that, alongside two minor things:
- add `.cxx` to the gitignore
- use non-deprecated syntax for setting `compileSdk` and `minSdk`

## Test Plan

The workflow should succeed.
