### PR TITLE
Setup Hermes publishing to Maven for commitlies and releases on Android and iOS

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -1,7 +1,12 @@
 name: build-android
 
 on:
-  workflow_call
+  workflow_call:
+    inputs:
+      release-type:
+        required: true
+        description: The type of release we are building. It could be commitly, release or dry-run
+        type: string
 
 jobs:
   build-android:
@@ -26,12 +31,26 @@ jobs:
           # Build the Hermes compiler so that the cross compiler build can
           # access it to build the VM
           cmake --build ./build --target hermesc -j 4
+      - name: Setup node.js
+        uses: ./.github/actions/setup-node
+      - name: Install node dependencies
+        uses: ./.github/actions/yarn-install
+      - name: Set React Native Version
+        shell: bash
+        run: node ./utils/scripts/hermes/set-artifacts-version.js --build-type ${{ inputs.release-type }}
       - name: Build android
         shell: bash
         run: |
           cd android
-          TASKS="publishAllToMavenTempLocal :build"
-          ./gradlew $TASKS
+
+          if [[ "${{ inputs.release-type }}" == "commitly" ]]; then
+            export ORG_GRADLE_PROJECT_isSnapshot="true"
+            TASKS="publishAllToMavenTempLocal publishToSonatype :build"
+          else
+            TASKS="publishAllToMavenTempLocal :build"
+          fi
+
+          ./gradlew $TASKS -PenableWarningsAsErrors=true
       - name: Upload Maven Artifacts
         uses: actions/upload-artifact@v4.3.4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,95 @@
+name: publish
+
+on:
+  workflow_call:
+    inputs:
+      release-type:
+        required: true
+        description: The type of release we are building. It could be commitly, release or dry-run
+        type: string
+
+jobs:
+  publish:
+    runs-on: 8-core-ubuntu
+    container:
+      image: reactnativecommunity/react-native-android:latest
+      env:
+        TERM: "dumb"
+        GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+    env:
+      HERMES_WS_DIR: /tmp/hermes
+      ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
+      ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
+      ORG_GRADLE_PROJECT_SONATYPE_USERNAME: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_USERNAME }}
+      ORG_GRADLE_PROJECT_SONATYPE_PASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_PASSWORD }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup git safe folders
+        shell: bash
+        run: git config --global --add safe.directory '*'
+      - name: Create /tmp/hermes/osx-bin directory
+        shell: bash
+        run: mkdir -p /tmp/hermes/osx-bin
+      - name: Download osx-bin release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: hermes-osx-bin-Release
+          path: /tmp/hermes/osx-bin/Release
+      - name: Download osx-bin debug artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: hermes-osx-bin-Debug
+          path: /tmp/hermes/osx-bin/Debug
+      - name: Download darwin-bin release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: hermes-darwin-bin-Release
+          path: /tmp/hermes/hermes-runtime-darwin
+      - name: Download darwin-bin debug artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: hermes-darwin-bin-Debug
+          path: /tmp/hermes/hermes-runtime-darwin
+      - name: Download hermes dSYM debug artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: hermes-dSYM-Debug
+          path: /tmp/hermes/dSYM/Debug
+      - name: Download hermes dSYM release vartifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: hermes-dSYM-Release
+          path: /tmp/hermes/dSYM/Release
+      - name: Download windows-bin artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: hermes-win64-bin
+          path: /tmp/hermes/win64-bin
+      - name: Download linux-bin artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: hermes-linux-bin
+          path: /tmp/hermes/linux64-bin
+      - name: Show /tmp/hermes directory
+        shell: bash
+        run: ls -lR /tmp/hermes
+      - name: Copy Hermes binaries
+        shell: bash
+        run: |
+          mkdir -p ./android/ios-artifacts/artifacts/
+          cp $HERMES_WS_DIR/hermes-runtime-darwin/hermes-ios-Debug.tar.gz ./android/ios-artifacts/artifacts/hermes-ios-debug.tar.gz
+          cp $HERMES_WS_DIR/hermes-runtime-darwin/hermes-ios-Release.tar.gz ./android/ios-artifacts/artifacts/hermes-ios-release.tar.gz
+          cp $HERMES_WS_DIR/dSYM/Debug/hermes.framework.dSYM  ./android/ios-artifacts/artifacts/hermes-framework-dSYM-debug.tar.gz
+          cp $HERMES_WS_DIR/dSYM/Release/hermes.framework.dSYM  ./android/ios-artifacts/artifacts/hermes-framework-dSYM-release.tar.gz
+      - name: Print Artifacts Directory
+        shell: bash
+        run: ls -lR ./android/ios-artifacts/artifacts/
+      - name: Setup node.js
+        uses: ./.github/actions/setup-node
+      - name: Install dependencies
+        uses: ./.github/actions/yarn-install
+      - name: Publish artifacts
+        shell: bash
+        run: |
+          node ./utils/scripts/hermes/publish-artifacts.js -t ${{ inputs.release-type }}

--- a/.github/workflows/rn-build-hermes.yml
+++ b/.github/workflows/rn-build-hermes.yml
@@ -1,12 +1,44 @@
 name: RN Build Hermes
 
 on:
+  workflow_dispatch:
+    inputs:
+      release-type:
+        description: 'Release type (release, commitly, dry-run)'
+        required: false
+        default: 'dry-run'
   pull_request:
   push:
     branches:
       - main
+    tags:
+      - "v0.*.*" # This should match v0.X.Y
 
 jobs:
+  set_release_type:
+    runs-on: ubuntu-latest
+    if: github.repository == 'facebook/hermes'
+    outputs:
+      RELEASE_TYPE: ${{ steps.set_release_type.outputs.RELEASE_TYPE }}
+    env:
+      EVENT_NAME: ${{ github.event_name }}
+      REF: ${{ github.ref }}
+    steps:
+      - id: set_release_type
+        run: |
+          if [[ $EVENT_NAME == "push" && $REF == refs/tags/v* ]]; then
+            echo "Setting release type to release"
+            echo "RELEASE_TYPE=release" >> $GITHUB_OUTPUT
+          elif [[ $EVENT_NAME == "push" && $REF == refs/heads/main ]]; then
+            echo "Setting release type to commitly"
+            echo "RELEASE_TYPE=commitly" >> $GITHUB_OUTPUT
+          elif [[ $EVENT_NAME == "workflow_dispatch" ]]; then
+            echo "Setting release type to ${{ github.event.inputs.release-type }}"
+            echo "RELEASE_TYPE=${{ github.event.inputs.release-type }}" >> $GITHUB_OUTPUT
+          else
+            echo "Setting release type to dry-run"
+            echo "RELEASE_TYPE=dry-run" >> $GITHUB_OUTPUT
+          fi
   build_hermesc_apple:
     uses: ./.github/workflows/build-hermesc-apple.yml
   build_apple_slices_hermes:
@@ -21,7 +53,10 @@ jobs:
     uses: ./.github/workflows/build-hermesc-windows.yml
   build_android:
     uses: ./.github/workflows/build-android.yml
+    needs: set_release_type
     secrets: inherit
+    with:
+      release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
   build_emscripten:
     uses: ./.github/workflows/build-emscripten.yml
   test-apple-runtime:
@@ -29,3 +64,15 @@ jobs:
     uses: ./.github/workflows/test-apple-runtime.yml
   run-tests:
     uses: ./.github/workflows/run-tests.yml
+  publish:
+    uses: ./.github/workflows/publish.yml
+    needs:
+      [
+        set_release_type,
+        build_hermes_macos,
+        build_hermesc_linux,
+        build_hermesc_windows,
+        build_android,
+      ]
+    with:
+      release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}

--- a/android/build-logic/src/main/kotlin/publish.gradle.kts
+++ b/android/build-logic/src/main/kotlin/publish.gradle.kts
@@ -10,6 +10,7 @@ plugins {
   id("signing")
 }
 
+val isSnapshot: Boolean = findProperty("isSnapshot")?.toString()?.toBoolean() ?: false
 val signingKey: String? = findProperty("SIGNING_KEY")?.toString()
 val signingPwd: String? = findProperty("SIGNING_PWD")?.toString()
 
@@ -20,9 +21,16 @@ publishing {
     create<MavenPublication>("release") {
       afterEvaluate {
         from(components["default"])
-        version = project.version.toString()
-        groupId = project.group.toString()
+
+        version =
+            if (isSnapshot) {
+              "${project.version}-SNAPSHOT"
+            } else {
+              project.version.toString()
+            }
+
         artifactId = "hermes-android"
+        groupId = project.group.toString()
       }
 
       pom {

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -11,6 +11,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 plugins {
   id("maven-publish")
   id("signing")
+  alias(libs.plugins.nexus.publish)
   alias(libs.plugins.android.library)
   alias(libs.plugins.download)
   id("publish")
@@ -23,6 +24,19 @@ version = project.findProperty("VERSION_NAME")?.toString()!!
 val cmakeVersion = System.getenv("CMAKE_VERSION") ?: libs.versions.cmake.get()
 val cmakePath = "${getSDKPath()}/cmake/$cmakeVersion"
 val cmakeBinaryPath = "${cmakePath}/bin/cmake"
+val sonatypeUsername = findProperty("SONATYPE_USERNAME")?.toString()
+val sonatypePassword = findProperty("SONATYPE_PASSWORD")?.toString()
+
+nexusPublishing {
+  repositories {
+    sonatype {
+      username.set(sonatypeUsername)
+      password.set(sonatypePassword)
+      nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+      snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+    }
+  }
+}
 
 fun getSDKPath(): String {
   val androidSdkRoot = System.getenv("ANDROID_SDK_ROOT")

--- a/android/cppruntime/build.gradle
+++ b/android/cppruntime/build.gradle
@@ -34,7 +34,7 @@ android {
 
   externalNativeBuild {
     cmake {
-      version hermesUtils.cmakeVersion
+      version = hermesUtils.cmakeVersion
       path "src/main/cpp/CMakeLists.txt"
       buildStagingDirectory = "${hermesUtils.hermesWs}/staging/cppruntime"
       buildStagingDirectory.mkdirs()

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ download = "5.4.0"
 fbjni = "0.7.0"
 kotlin = "2.1.20"
 ktfmt = "0.22.0"
+nexus-publish = "2.0.0"
 yoga-proguard-annotations = "1.19.0"
 
 [libraries]
@@ -25,4 +26,5 @@ yoga-proguard-annotations = { module = "com.facebook.yoga:proguard-annotations",
 android-library = { id = "com.android.library", version.ref = "agp" }
 download = { id = "de.undercouch.download", version.ref = "download" }
 ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt" }
+nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexus-publish" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/android/intltest/build.gradle
+++ b/android/intltest/build.gradle
@@ -57,7 +57,7 @@ task prepareTests() {
 
 // TODO: Figure out how to deduplicate this file and intl/build.gradle
 android {
-  namespace "com.facebook.hermes.intltest"
+  namespace = "com.facebook.hermes.intltest"
   compileSdk = hermesUtils.compileSdk
   ndkVersion = hermesUtils.ndkVersion
 

--- a/android/ios-artifacts/build.gradle.kts
+++ b/android/ios-artifacts/build.gradle.kts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+plugins {
+  id("maven-publish")
+  id("publish")
+}
+
+group = "com.facebook.hermes"
+
+version = project.findProperty("VERSION_NAME")?.toString()!!
+
+configurations.maybeCreate("iosArtifacts")
+
+// Those artifacts should be placed inside the `artifacts/hermes-ios-*.tar.gz` location.
+val hermesiOSDebugArtifactFile: RegularFile =
+    layout.projectDirectory.file("artifacts/hermes-ios-debug.tar.gz")
+val hermesiOSDebugArtifact: PublishArtifact =
+    artifacts.add("iosArtifacts", hermesiOSDebugArtifactFile) {
+      type = "tgz"
+      extension = "tar.gz"
+      classifier = "hermes-ios-debug"
+    }
+val hermesiOSReleaseArtifactFile: RegularFile =
+    layout.projectDirectory.file("artifacts/hermes-ios-release.tar.gz")
+val hermesiOSReleaseArtifact: PublishArtifact =
+    artifacts.add("iosArtifacts", hermesiOSReleaseArtifactFile) {
+      type = "tgz"
+      extension = "tar.gz"
+      classifier = "hermes-ios-release"
+    }
+
+// Those artifacts should be placed inside the `artifacts/hermes-*.framework.dSYM` location
+val hermesDSYMDebugArtifactFile: RegularFile =
+    layout.projectDirectory.file("artifacts/hermes-framework-dSYM-debug.tar.gz")
+val hermesDSYMDebugArtifact: PublishArtifact =
+    artifacts.add("iosArtifacts", hermesDSYMDebugArtifactFile) {
+      type = "tgz"
+      extension = "tar.gz"
+      classifier = "hermes-framework-dSYM-debug"
+    }
+val hermesDSYMReleaseArtifactFile: RegularFile =
+    layout.projectDirectory.file("artifacts/hermes-framework-dSYM-release.tar.gz")
+val hermesDSYMReleaseArtifact: PublishArtifact =
+    artifacts.add("iosArtifacts", hermesDSYMReleaseArtifactFile) {
+      type = "tgz"
+      extension = "tar.gz"
+      classifier = "hermes-framework-dSYM-release"
+    }
+
+publishing {
+  publications {
+    getByName("release", MavenPublication::class) {
+      artifactId = "hermes-ios"
+      artifact(hermesiOSDebugArtifact)
+      artifact(hermesiOSReleaseArtifact)
+      artifact(hermesDSYMDebugArtifact)
+      artifact(hermesDSYMReleaseArtifact)
+    }
+  }
+}

--- a/utils/scripts/hermes/consts.js
+++ b/utils/scripts/hermes/consts.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+const path = require('path');
+
+/**
+ * The absolute path to the repo root.
+ */
+const REPO_ROOT /*: string */ = path.resolve(__dirname, '../../..');
+
+/**
+ * The absolute path to the android directory.
+ */
+const ANDROID_DIR /*: string */ = path.join(REPO_ROOT, 'android');
+
+module.exports = {
+  REPO_ROOT,
+  ANDROID_DIR,
+};

--- a/utils/scripts/hermes/package.json
+++ b/utils/scripts/hermes/package.json
@@ -1,5 +1,6 @@
 {
     "devDependencies": {
-        "yargs": "^17.6.2"
+        "yargs": "^17.6.2",
+        "shelljs": "^0.8.5"
     }
 }

--- a/utils/scripts/hermes/publish-artifacts.js
+++ b/utils/scripts/hermes/publish-artifacts.js
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+'use strict';
+
+/*::
+import type {BuildType} from './version-utils';
+*/
+
+const {
+  getVersion,
+  validateBuildType,
+  updateGradlePropertiesFile,
+} = require('./version-utils');
+const {echo, exec, exit} = require('shelljs');
+const yargs = require('yargs');
+
+async function main() {
+  const argv = yargs
+    .option('t', {
+      alias: 'builtType',
+      describe: 'The type of build you want to perform.',
+      choices: ['dry-run', 'commitly', 'release'],
+      default: 'dry-run',
+    })
+    .strict().argv;
+
+  // $FlowFixMe[prop-missing]
+  const buildType = argv.builtType;
+
+  if (!validateBuildType(buildType)) {
+    throw new Error(`Unsupported build type: ${buildType}`);
+  }
+
+  await publishArtifacts(buildType);
+}
+
+async function publishArtifacts(buildType /*: BuildType */) {
+  if (buildType === 'dry-run') {
+    console.log('Skipping publishing artifacts because --dry-run is set.');
+    return;
+  }
+
+  const version = getVersion(buildType);
+
+  updateGradlePropertiesFile(version);
+  await publishAndroidArtifactsToMaven(version, buildType);
+  await publishExternalArtifactsToMaven(version, buildType);
+}
+
+function publishAndroidArtifactsToMaven(
+  releaseVersion /*: string */,
+  buildType /*: BuildType */,
+) {
+  // We want to gate ourselves against accidentally publishing a 1.x or a 1000.x on
+  // maven central which will break the semver for our artifacts.
+  if (
+    buildType === 'release' &&
+    releaseVersion.startsWith('0.') &&
+    !releaseVersion.startsWith('0.0.0')
+  ) {
+    // -------- For stable releases, we also need to close and release the staging repository.
+    if (
+      exec(
+        './android/gradlew publishAndroidToSonatype closeSonatypeStagingRepository',
+      ).code
+    ) {
+      echo(
+        'Failed to close and release the staging repository on Sonatype (Maven Central) for Android artifacts',
+      );
+      exit(1);
+    }
+  } else {
+    echo(
+      'Nothing to do as this is not a stable release - Nightlies Android artifacts are published by build_android',
+    );
+  }
+
+  echo('Finished publishing Android artifacts to Maven Central');
+}
+
+function publishExternalArtifactsToMaven(
+  releaseVersion /*: string */,
+  buildType /*: BuildType */,
+) {
+  // We want to gate ourselves against accidentally publishing a 1.x or a 1000.x on
+  // maven central which will break the semver for our artifacts.
+  if (
+    buildType === 'release' &&
+    releaseVersion.startsWith('0.') &&
+    !releaseVersion.startsWith('0.0.0')
+  ) {
+    // -------- For stable releases, we do the publishing and close the staging repository.
+    // This can't be done earlier in build_android because this artifact are partially built by the iOS jobs.
+    if (
+      exec(
+        './android/gradlew :ios-artifacts:publishToSonatype closeSonatypeStagingRepository',
+      ).code
+    ) {
+      echo(
+        'Failed to close and release the staging repository on Sonatype (Maven Central) for external artifacts',
+      );
+      exit(1);
+    }
+  } else {
+    const isSnapshot = buildType === 'commitly';
+    // -------- For nightly releases, we only need to publish the snapshot to Sonatype snapshot repo.
+    if (
+      exec(
+        './android/gradlew :ios-artifacts:publishToSonatype -PisSnapshot=' +
+          isSnapshot.toString(),
+      ).code
+    ) {
+      echo('Failed to publish external artifacts to Sonatype (Maven Central)');
+      exit(1);
+    }
+  }
+
+  echo('Finished publishing external artifacts to Maven Central');
+}
+
+if (require.main === module) {
+  void main();
+}

--- a/utils/scripts/hermes/scm-utils.js
+++ b/utils/scripts/hermes/scm-utils.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+const {echo, exec} = require('shelljs');
+
+function getCurrentCommit() /*: string */ {
+  return isGitRepo()
+    ? exec('git rev-parse HEAD', {
+        silent: true,
+      }).stdout.trim()
+    : 'TEMP';
+}
+
+function isGitRepo() /*: boolean */ {
+  try {
+    return (
+      exec('git rev-parse --is-inside-work-tree', {
+        silent: true,
+      }).stdout.trim() === 'true'
+    );
+  } catch (error) {
+    echo(
+      `It wasn't possible to check if we are in a git repository. Details: ${error}`,
+    );
+  }
+  return false;
+}
+
+module.exports = {
+  getCurrentCommit,
+  isGitRepo,
+};

--- a/utils/scripts/hermes/set-artifacts-version.js
+++ b/utils/scripts/hermes/set-artifacts-version.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+/*::
+import type {BuildType, Version} from './version-utils';
+*/
+
+const {ANDROID_DIR} = require('./consts');
+const {
+  getVersion,
+  validateBuildType,
+  updateGradlePropertiesFile,
+} = require('./version-utils');
+const {promises: fs} = require('fs');
+const path = require('path');
+const {parseArgs} = require('util');
+
+const config = {
+  options: {
+    'build-type': {
+      type: 'string',
+      short: 'b',
+    },
+    help: {type: 'boolean'},
+  },
+};
+
+async function main() {
+  const {
+    values: {'build-type': buildType, help},
+    /* $FlowFixMe[incompatible-call] Natural Inference rollout. See
+     * https://fburl.com/workplace/6291gfvu */
+  } = parseArgs(config);
+
+  if (help) {
+    console.log(`
+  Usage: node ./utils/scripts/hermes/set-artifacts-version.js [OPTIONS]
+
+  Updates version in gradle.proparties file.
+
+  Options:
+    --build-type       One of ['dry-run', 'commitly', 'release'].
+    `);
+    return;
+  }
+
+  if (!validateBuildType(buildType)) {
+    throw new Error(`Unsupported build type: ${buildType}`);
+  }
+
+  const version = await getVersion(buildType);
+  await updateGradlePropertiesFile(version);
+}
+
+if (require.main === module) {
+  void main();
+}

--- a/utils/scripts/hermes/yarn.lock
+++ b/utils/scripts/hermes/yarn.lock
@@ -14,6 +14,19 @@ ansi-styles@^4.0.0:
   dependencies:
     color-convert "^2.0.1"
 
+balanced-match@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+brace-expansion@^1.1.7:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.12.tgz#ab9b454466e5a8cc3a187beaad580412a9c5b843"
+  integrity sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
+
 cliui@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
@@ -35,6 +48,11 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+concat-map@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
@@ -45,20 +63,123 @@ escalade@^3.1.1:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
   integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
 
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+function-bind@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
+  integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+
 get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
+glob@^7.0.0:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+hasown@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
+  integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
+  dependencies:
+    function-bind "^1.1.2"
+
+inflight@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  integrity sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==
+  dependencies:
+    once "^1.3.0"
+    wrappy "1"
+
+inherits@2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+interpret@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
+  integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
+
+is-core-module@^2.16.0:
+  version "2.16.1"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.1.tgz#2a98801a849f43e2add644fbb6bc6229b19a4ef4"
+  integrity sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==
+  dependencies:
+    hasown "^2.0.2"
 
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
+minimatch@^3.1.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+once@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
+  dependencies:
+    wrappy "1"
+
+path-is-absolute@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
+
+path-parse@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  integrity sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==
+  dependencies:
+    resolve "^1.1.6"
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
+
+resolve@^1.1.6:
+  version "1.22.10"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.10.tgz#b663e83ffb09bbf2386944736baae803029b8b39"
+  integrity sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==
+  dependencies:
+    is-core-module "^2.16.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
+shelljs@^0.8.5:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
+  integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
 
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
@@ -76,6 +197,11 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
+supports-preserve-symlinks-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
 wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
@@ -84,6 +210,11 @@ wrap-ansi@^7.0.0:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
+
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
Summary:
This setups publishing Android and iOS artifacts on commits and releases to be used by React Native.

## Motivation
Reduce CI time by decreasing the number of Hermes builds currently running on the React Native repo by moving them to the Hermes repo with less traffic.

Reviewed By: cortinico

Differential Revision: D79163000


