### PR TITLE
Fix publish workflow and optimize `build_android`

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -25,12 +25,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Build Hermes Compiler
-        run: |-
-          cmake -S . -B build
-          # Build the Hermes compiler so that the cross compiler build can
-          # access it to build the VM
-          cmake --build ./build --target hermesc -j 4
       - name: Setup node.js
         uses: ./.github/actions/setup-node
       - name: Install node dependencies

--- a/android/build-logic/src/main/kotlin/com/facebook/hermes/plugins/internal/TestUtilsPlugin.kt
+++ b/android/build-logic/src/main/kotlin/com/facebook/hermes/plugins/internal/TestUtilsPlugin.kt
@@ -43,8 +43,13 @@ class HermesUtils(private val project: Project) {
               "$hermesWs/build_release/ImportHostCompilers.cmake",
           )
 
-      return candidateHermesCPaths.lastOrNull { File(it).exists() }
-          ?: throw InvalidUserDataException("Hermes host build not found")
+      val hermesCPath = candidateHermesCPaths.lastOrNull { File(it).exists() }
+      if (hermesCPath == null) {
+        project.logger.warn("Could not find hermesC path. Using default path.")
+        return "$hermesWs/build/ImportHermesc.cmake"
+      }
+
+      return hermesCPath
     }
 
   // For Facebook internal use:

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -64,9 +64,12 @@ fun getSDKManagerPath(): String {
   }
 }
 
-val buildDir = project.layout.buildDirectory.get().asFile
 val hermesDir = project.projectDir.parentFile
-val hermesBuildDir = File("$buildDir/hermes")
+val hermesBuildDir = File("$hermesDir/build")
+
+project.layout.buildDirectory.set(hermesBuildDir)
+
+val buildDir = project.layout.buildDirectory.get().asFile
 val hermesCOutputBinary = File("$buildDir/hermes/bin/hermesc")
 
 // This filetree represents the file of the Hermes build that we want as input/output


### PR DESCRIPTION
Summary:

This diff fixes publish workflow and optimizes `build_android` by building hermesc once in the main `build.gradle.kts` and linking `TestUtilsPlugin` with built `ImportHermesc` instead of relying on a separate step that prepared hermesc before the gradle build.

Differential Revision: D80538437


