### PR TITLE
Create tasks for publishing Android only to maven temp local and sonatype

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -45,9 +45,9 @@ jobs:
 
           if [[ "${{ inputs.release-type }}" == "commitly" ]]; then
             export ORG_GRADLE_PROJECT_isSnapshot="true"
-            TASKS=":publishAllToMavenTempLocal :publishToSonatype :build"
+            TASKS="publishAndroidOnlyToMavenTempLocal publishAndroidOnlyToSonatype"
           else
-            TASKS=":publishAllToMavenTempLocal :build"
+            TASKS="publishAndroidOnlyToMavenTempLocal"
           fi
 
           ./gradlew $TASKS -PenableWarningsAsErrors=true

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -324,6 +324,12 @@ tasks.withType<JavaCompile>().configureEach {
   options.compilerArgs.add("-Werror")
 }
 
+tasks.register("publishAndroidOnlyToMavenTempLocal") {
+  dependsOn(":publishAllPublicationsToMavenTempLocalRepository", ":build")
+}
+
+tasks.register("publishAndroidOnlyToSonatype") { dependsOn(":publishToSonatype") }
+
 // We need to override the artifact ID as this project is called `hermes-engine` but
 // the maven coordinates are on `hermes-android`.
 publishing {


### PR DESCRIPTION
Summary: This diff adds tasks (`publishAndroidOnlyToMavenTempLocal` and `publishAndroidOnlyToSonatype`) for publishing Android artifacts to maven temp local and sonatype.

Differential Revision: D80800868


