### PR TITLE
Set gha-npm-token before publish workflow in static_h

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,10 @@ on:
         required: true
         description: The type of release we are building. It could be release or dry-run
         type: string
+      gha-npm-token:
+        required: false
+        description: The GHA npm token, required only to publish to npm
+        default: ''
 
 jobs:
   publish:
@@ -84,7 +88,17 @@ jobs:
         shell: bash
         run: |
           node ./utils/scripts/hermes/publish-artifacts.js -t ${{ inputs.release-type }}
+      - name: Set npm credentials
+        if: ${{ inputs.release-type == 'release' ||
+          inputs.release-type == 'commitly' }}
+        shell: bash
+        run: echo "//registry.npmjs.org/:_authToken=${{ inputs.gha-npm-token }}" > ~/.npmrc
       - name: Publish to npm
         shell: bash
         run: |
           node ./utils/scripts/hermes/publish-npm.js -t ${{ inputs.release-type }}
+      - name: Upload npm logs
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: npm-logs
+          path: ~/.npm/_logs

--- a/.github/workflows/rn-build-hermes.yml
+++ b/.github/workflows/rn-build-hermes.yml
@@ -60,3 +60,4 @@ jobs:
       ]
     with:
       release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
+      gha-npm-token: ${{ secrets.GHA_NPM_TOKEN }}

--- a/utils/scripts/hermes/publish-npm.js
+++ b/utils/scripts/hermes/publish-npm.js
@@ -72,12 +72,10 @@ async function publishNpm(
     dryRunFlag = ` --dry-run`;
   }
 
-  const otp = process.env.NPM_CONFIG_OTP;
-  const otpFlag = otp != null ? ` --otp ${otp}` : '';
   const packagePath = path.join(REPO_ROOT, 'npm', 'hermes-compiler');
   const options /*: ExecOptsSync */ = {cwd: packagePath};
 
-  return exec(`npm publish${otpFlag}${dryRunFlag}`, options);
+  return exec(`npm publish${dryRunFlag}`, options);
 }
 
 if (require.main === module) {


### PR DESCRIPTION
Summary: Configures `gha-npm-token` auth token in `.npmrc` before the publish npm workflow and uploads npm logs after that. Removes the `otp` flag which is not used in Hermes repo.

Differential Revision: D82440861


