### PR TITLE
Set gha-npm-token before publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,7 @@ jobs:
       ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
       ORG_GRADLE_PROJECT_SONATYPE_USERNAME: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_USERNAME }}
       ORG_GRADLE_PROJECT_SONATYPE_PASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_PASSWORD }}
+      GHA_NPM_TOKEN: ${{ secrets.GHA_NPM_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -93,7 +94,17 @@ jobs:
         shell: bash
         run: |
           node ./utils/scripts/hermes/publish-artifacts.js -t ${{ inputs.release-type }} -v ${{ inputs.hermes-version }}
+      - name: Set npm credentials
+        if: ${{ inputs.release-type == 'release' ||
+          inputs.release-type == 'commitly' }}
+        shell: bash
+        run: echo "//registry.npmjs.org/:_authToken=${{ env.GHA_NPM_TOKEN }}" > ~/.npmrc
       - name: Publish to npm
         shell: bash
         run: |
           node ./utils/scripts/hermes/publish-npm.js -t ${{ inputs.release-type }} -v ${{ inputs.hermes-version }}
+      - name: Upload npm logs
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: npm-logs
+          path: ~/.npm/_logs

--- a/utils/scripts/hermes/publish-npm.js
+++ b/utils/scripts/hermes/publish-npm.js
@@ -91,12 +91,10 @@ async function publishNpm(
     }
   }
 
-  const otp = process.env.NPM_CONFIG_OTP;
-  const otpFlag = otp != null ? ` --otp ${otp}` : '';
   const packagePath = path.join(REPO_ROOT, 'npm', 'hermes-compiler');
   const options /*: ExecOptsSync */ = {cwd: packagePath};
 
-  return exec(`npm publish${tagFlag}${otpFlag}${dryRunFlag}`, options);
+  return exec(`npm publish${tagFlag}${dryRunFlag}`, options);
 }
 
 if (require.main === module) {


### PR DESCRIPTION
Summary: Configures `gha-npm-token` auth token in `.npmrc` before the publish npm workflow and uploads npm logs after that. Removes the `otp` flag which is not used in Hermes repo.

Differential Revision: D82440778


