### PR TITLE
Fix publishing release artifacts to sonatype

### DIFF
--- a/utils/scripts/hermes/publish-artifacts.js
+++ b/utils/scripts/hermes/publish-artifacts.js
@@ -64,8 +64,9 @@ function publishAndroidArtifactsToMaven(
   if (buildType === 'release') {
     // -------- For stable releases, we also need to close and release the staging repository.
     if (
-      exec('./gradlew publishAndroidToSonatype closeSonatypeStagingRepository')
-        .code
+      exec(
+        './gradlew publishAndroidOnlyToSonatype closeSonatypeStagingRepository',
+      ).code
     ) {
       echo(
         'Failed to close and release the staging repository on Sonatype (Maven Central) for Android artifacts',


### PR DESCRIPTION
## Summary

Fixes publishing release artifacts to sonatype by invoking correct task `publishAndroidOnlyToSonatype`.

## Test Plan

Signals