### PR TITLE
Automate releasing staging repo to Maven Central

### DIFF
--- a/utils/scripts/hermes/publish-artifacts.js
+++ b/utils/scripts/hermes/publish-artifacts.js
@@ -65,7 +65,7 @@ function publishAndroidArtifactsToMaven(
     // -------- For stable releases, we also need to close and release the staging repository.
     if (
       exec(
-        './gradlew publishAndroidOnlyToSonatype closeSonatypeStagingRepository',
+        './gradlew publishAndroidOnlyToSonatype closeAndReleaseSonatypeStagingRepository',
       ).code
     ) {
       echo(
@@ -89,7 +89,7 @@ function publishExternalArtifactsToMaven(
     // This can't be done earlier in build_android because this artifact are partially built by the iOS jobs.
     if (
       exec(
-        './gradlew :ios-artifacts:publishToSonatype closeSonatypeStagingRepository',
+        './gradlew :ios-artifacts:publishToSonatype closeAndReleaseSonatypeStagingRepository',
       ).code
     ) {
       echo(


### PR DESCRIPTION

## Summary
Automates releasing staging repository to Maven Central after publishing Android and iOS aftifacts.

Reviewed By: cortinico

Differential Revision: D82616466

fbshipit-source-id: d8fb12f7a6e404a7e843d4ba9c6b194150864215

## Test Plan

Signals
