### PR TITLE
Include empty `index.js` in hermes-compiler package

### DIFF
--- a/npm/hermes-compiler/index.js
+++ b/npm/hermes-compiler/index.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// require.resolve fails if the package does not contain an index.js file.


### PR DESCRIPTION

## Summary
Adds an empty `index.js` into the `hermes-compiler` package to prevent `require.resolve` failing when looking for this package in the `hermes-engine.podspec`.

Reviewed By: cortinico

Differential Revision: D82634987

fbshipit-source-id: 4bd0ef27c09f33fb68d38c96062b8a1a8caa8ce5

## Test Plan
Signals
