### PR TITLE
Set hermes release version

### DIFF
--- a/android/build-logic/src/main/kotlin/com/facebook/hermes/helpers/internal/SerializeHermesCompilerPackageJson.kt
+++ b/android/build-logic/src/main/kotlin/com/facebook/hermes/helpers/internal/SerializeHermesCompilerPackageJson.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.hermes.helpers.internal
+
+import groovy.json.JsonSlurper
+import java.io.File
+import org.gradle.api.Project
+
+data class PackageJson(val version: String)
+
+class SerializeHermesCompilerPackageJson(project: Project) {
+  private val serializedPackageJson = run {
+    val packageJsonFile = File(project.rootDir.parentFile, "npm/hermes-compiler/package.json")
+    if (!packageJsonFile.exists()) {
+      throw IllegalStateException("package.json file not found at $packageJsonFile")
+    }
+
+    val jsonSlurper = JsonSlurper().parseText(packageJsonFile.readText()) as Map<String, Any>
+    val version =
+        jsonSlurper["version"] as? String
+            ?: throw IllegalStateException(
+                "Expected version to be a string in package.json, but got ${jsonSlurper["version"]}"
+            )
+    PackageJson(version)
+  }
+
+  val hermesReleaseVersion = serializedPackageJson.version
+}

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import com.facebook.hermes.helpers.internal.SerializeHermesCompilerPackageJson
 import com.facebook.hermes.tasks.internal.CustomExecTask
 import org.apache.tools.ant.taskdefs.condition.Os
 
@@ -20,6 +21,8 @@ plugins {
 group = "com.facebook.hermes"
 
 version = project.findProperty("VERSION_NAME")?.toString()!!
+
+val hermesReleaseVersion = SerializeHermesCompilerPackageJson(project).hermesReleaseVersion
 
 val cmakeVersion = System.getenv("CMAKE_VERSION") ?: libs.versions.cmake.get()
 val cmakePath = "${getSDKPath()}/cmake/$cmakeVersion"
@@ -222,7 +225,7 @@ android {
             "-DIMPORT_HOST_COMPILERS=${File(hermesBuildDir, "ImportHostCompilers.cmake").toString()}",
             "-DJSI_DIR=${jsiDir}",
             "-DHERMES_BUILD_SHARED_JSI=True",
-            "-DHERMES_RELEASE_VERSION=for RN ${version}",
+            "-DHERMES_RELEASE_VERSION=${hermesReleaseVersion}",
             "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=True",
             // We intentionally build Hermes with Intl support only. This is to simplify
             // the build setup and to avoid overcomplicating the build-type matrix.

--- a/utils/scripts/hermes/publish-artifacts.js
+++ b/utils/scripts/hermes/publish-artifacts.js
@@ -17,6 +17,7 @@ import type {BuildType} from './version-utils';
 const {
   getVersion,
   updateGradlePropertiesFile,
+  updatePackageJsonVersion,
   validateBuildType,
 } = require('./version-utils');
 const {echo, exec, exit, popd, pushd} = require('shelljs');
@@ -63,6 +64,7 @@ async function publishArtifacts(
     version = await getVersion(buildType);
   }
   await updateGradlePropertiesFile(version);
+  await updatePackageJsonVersion(version);
 
   pushd('android');
   await publishAndroidArtifactsToMaven(version, buildType);

--- a/utils/scripts/hermes/set-artifacts-version.js
+++ b/utils/scripts/hermes/set-artifacts-version.js
@@ -17,6 +17,7 @@ const {
   getVersion,
   validateBuildType,
   updateGradlePropertiesFile,
+  updatePackageJsonVersion,
 } = require('./version-utils');
 const {promises: fs} = require('fs');
 const path = require('path');
@@ -66,6 +67,7 @@ async function main() {
   }
 
   await updateGradlePropertiesFile(version);
+  await updatePackageJsonVersion(version);
 }
 
 if (require.main === module) {


### PR DESCRIPTION
Summary: Configures build to pass `-DHERMES_RELEASE_VERSION=for RN ${hermesReleaseVersion}` where `hermesReleaseVersion` is a version read from the `hermes-compiler/package.json`.

Differential Revision: D82733502


