### PR TITLE
Set hermes release version in static_h (#1791)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ endif()
 # - npm/package.json
 # - hermes-engine.podspec
 project(Hermes
-        VERSION 0.12.0
+        VERSION 1.0.0
         LANGUAGES C CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/")

--- a/android/build-logic/src/main/kotlin/com/facebook/hermes/helpers/internal/SerializeHermesCompilerPackageJson.kt
+++ b/android/build-logic/src/main/kotlin/com/facebook/hermes/helpers/internal/SerializeHermesCompilerPackageJson.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.hermes.helpers.internal
+
+import groovy.json.JsonSlurper
+import java.io.File
+import org.gradle.api.Project
+
+data class PackageJson(val version: String)
+
+class SerializeHermesCompilerPackageJson(project: Project) {
+  private val serializedPackageJson = run {
+    val packageJsonFile = File(project.rootDir.parentFile, "npm/hermes-compiler/package.json")
+    if (!packageJsonFile.exists()) {
+      throw IllegalStateException("package.json file not found at $packageJsonFile")
+    }
+
+    val jsonSlurper = JsonSlurper().parseText(packageJsonFile.readText()) as Map<String, Any>
+    val version =
+        jsonSlurper["version"] as? String
+            ?: throw IllegalStateException(
+                "Expected version to be a string in package.json, but got ${jsonSlurper["version"]}"
+            )
+    PackageJson(version)
+  }
+
+  val hermesReleaseVersion = serializedPackageJson.version
+}

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import com.facebook.hermes.helpers.internal.SerializeHermesCompilerPackageJson
 import com.facebook.hermes.tasks.internal.CustomExecTask
 import org.apache.tools.ant.taskdefs.condition.Os
 
@@ -20,6 +21,8 @@ plugins {
 group = "com.facebook.hermes"
 
 version = project.findProperty("VERSION_NAME")?.toString()!!
+
+val hermesReleaseVersion = SerializeHermesCompilerPackageJson(project).hermesReleaseVersion
 
 val cmakeVersion = System.getenv("CMAKE_VERSION") ?: libs.versions.cmake.get()
 val cmakePath = "${getSDKPath()}/cmake/$cmakeVersion"
@@ -222,7 +225,7 @@ android {
             "-DIMPORT_HOST_COMPILERS=${File(hermesBuildDir, "ImportHostCompilers.cmake").toString()}",
             "-DJSI_DIR=${jsiDir}",
             "-DHERMES_BUILD_SHARED_JSI=True",
-            // "-DHERMES_RELEASE_VERSION=for RN ${version}",
+            "-DHERMES_RELEASE_VERSION=${hermesReleaseVersion}",
             "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=True",
             // We intentionally build Hermes with Intl support only. This is to simplify
             // the build setup and to avoid overcomplicating the build-type matrix.

--- a/utils/build-apple-framework-rn.sh
+++ b/utils/build-apple-framework-rn.sh
@@ -13,6 +13,7 @@ IMPORT_HERMESC_PATH=${HERMES_OVERRIDE_HERMESC_PATH:-$PWD/build_host_hermesc/Impo
 BUILD_TYPE=${BUILD_TYPE:-Debug}
 
 HERMES_PATH="$CURR_SCRIPT_DIR/.."
+HERMES_COMPILER_PACKAGE_PATH="$HERMES_PATH/npm/hermes-compiler"
 
 NUM_CORES=$(sysctl -n hw.ncpu)
 
@@ -41,6 +42,24 @@ function get_visionos_deployment_target {
 
 function get_mac_deployment_target {
   use_env_var "${MAC_DEPLOYMENT_TARGET}" "MAC_DEPLOYMENT_TARGET"
+}
+
+function get_release_version {
+  local package_json_path="$HERMES_COMPILER_PACKAGE_PATH/package.json"
+  if [[ -f "$package_json_path" ]]; then
+    local version
+    version=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$package_json_path', 'utf8')).version)" 2>/dev/null)
+    if [[ -n "$version" ]]; then
+      echo "$version"
+      return
+    else
+      echo >&2 "Error: Failed to read version from $package_json_path"
+      exit 1
+    fi
+  else
+    echo >&2 "Error: Package file not found at $package_json_path"
+    exit 1
+  fi
 }
 
 # Build host hermes compiler for internal bytecode
@@ -98,6 +117,7 @@ function configure_apple_framework {
       -DCMAKE_C_FLAGS:STRING="-gdwarf" \
       -DIMPORT_HOST_COMPILERS:PATH="$IMPORT_HERMESC_PATH" \
       -DJSI_DIR="$JSI_PATH" \
+      -DHERMES_RELEASE_VERSION="$(get_release_version)" \
       -DCMAKE_BUILD_TYPE="$cmake_build_type" \
       $boost_context_flag
     popd > /dev/null || exit 1


### PR DESCRIPTION

## Summary

This diff sets version in `CMakeLists.txt` to `1.0.0` and configures build to pass `-DHERMES_RELEASE_VERSION=for RN ${hermesReleaseVersion}` where `hermesReleaseVersion` is a version read from the `hermes-compiler/package.json`.

Reviewed By: cortinico

Differential Revision: D82313203

fbshipit-source-id: 4c66368a077e19083d75bd3ae36380c2c5a1ded1

## Test Plan
Signals
