### PR TITLE
Add create tag workflow

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -2,35 +2,47 @@ name: Publish Tag
 on:
   workflow_dispatch:
     inputs:
-      rnVersion:
-        description: "The React Native version that will use this tag"
+      release-type:
         required: true
-      targetSha:
-        description: "The SHA you want to tag. If not specified it will tag the HEAD of the selected branch"
-        required: false
+        description: The type of release we are building. It could be commitly, release or dry-run
+        type: choice
+        options:
+          - release
+          - commitly
+          - dry-run
+      hermes-version:
+        required: true
+        description: The Hermes version to use for this tag
+        type: string
+  workflow_call:
+    inputs:
+      release-type:
+        required: true
+        description: The type of release we are building. It could be commitly, release or dry-run
+        type: string
+      hermes-version:
+        required: true
+        description: The Hermes version to use for this tag
+        type: string
 
 jobs:
   publish:
     runs-on: [ubuntu-latest]
-
     steps:
-      - name: Get current date
-        id: date
-        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-
-      - name: Get the target SHA
-        id: targetSha
-        run: echo "targetSha=$(if [ -z "$TARGET_SHA" ]; then echo $GITHUB_SHA; else echo $TARGET_SHA; fi)" >> $GITHUB_OUTPUT
-        env:
-          TARGET_SHA: ${{ github.event.inputs.targetSha }}
-
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Print the target SHA and hermes version
+        run: |
+          echo "targetSha=${{ github.sha }}"
+          echo "hermes-version=${{ inputs.hermes-version }}"
       - name: Create tag
+        if: ${{ inputs.release-type == 'release' }}
         uses: actions/github-script@v5
         with:
           script: |
             github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: 'refs/tags/hermes-${{ steps.date.outputs.date }}-RNv${{ github.event.inputs.rnVersion }}-${{ steps.targetSha.outputs.targetSha }}',
-              sha: '${{ steps.targetSha.outputs.targetSha }}'
+              ref: 'refs/tags/hermes-v${{ inputs.hermes-version }}',
+              sha: '${{ github.sha }}',
             })

--- a/.github/workflows/rn-build-hermes.yml
+++ b/.github/workflows/rn-build-hermes.yml
@@ -11,8 +11,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - "v0.*.*" # This should match v0.X.Y
 
 jobs:
   set_release_type:
@@ -87,6 +85,12 @@ jobs:
         build_hermesc_linux,
         build_hermesc_windows,
       ]
+    with:
+      release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
+      hermes-version: ${{ needs.set_release_type.outputs.HERMES_VERSION }}
+  create-tag:
+    uses: ./.github/workflows/create-tag.yml
+    needs: publish
     with:
       release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
       hermes-version: ${{ needs.set_release_type.outputs.HERMES_VERSION }}


### PR DESCRIPTION
Differential Revision: D85248448

Adds `create-tag` workflow that will tag latest commit on releases. It is also possible to invoke this from GH UI for whatever reason with `release` type. 


