### PR TITLE
Disable windows builds for static_h

### DIFF
--- a/.github/workflows/rn-build-hermes.yml
+++ b/.github/workflows/rn-build-hermes.yml
@@ -41,8 +41,9 @@ jobs:
     needs: build_apple_slices_hermes
   build_hermesc_linux:
     uses: ./.github/workflows/build-hermesc-linux.yml
-  build_hermesc_windows:
-    uses: ./.github/workflows/build-hermesc-windows.yml
+  # TODO: Reenable once support for MSVC is added T242502301
+  # build_hermesc_windows:
+  #   uses: ./.github/workflows/build-hermesc-windows.yml
   build_android:
     uses: ./.github/workflows/build-android.yml
     needs: set_release_type


### PR DESCRIPTION
Summary: Disables GitHub builds for hermesc on windows for static_h.

Differential Revision: D85331863


