### PR TITLE
Add create tag workflow for hermes-v1

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -2,35 +2,47 @@ name: Publish Tag
 on:
   workflow_dispatch:
     inputs:
-      rnVersion:
-        description: "The React Native version that will use this tag"
+      release-type:
         required: true
-      targetSha:
-        description: "The SHA you want to tag. If not specified it will tag the HEAD of the selected branch"
-        required: false
+        description: The type of release we are building. It could be commitly, release or dry-run
+        type: choice
+        options:
+          - release
+          - commitly
+          - dry-run
+      hermes-version:
+        required: true
+        description: The Hermes version to use for this tag
+        type: string
+  workflow_call:
+    inputs:
+      release-type:
+        required: true
+        description: The type of release we are building. It could be commitly, release or dry-run
+        type: string
+      hermes-version:
+        required: true
+        description: The Hermes version to use for this tag
+        type: string
 
 jobs:
   publish:
     runs-on: [ubuntu-latest]
-
     steps:
-      - name: Get current date
-        id: date
-        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-
-      - name: Get the target SHA
-        id: targetSha
-        run: echo "targetSha=$(if [ -z "$TARGET_SHA" ]; then echo $GITHUB_SHA; else echo $TARGET_SHA; fi)" >> $GITHUB_OUTPUT
-        env:
-          TARGET_SHA: ${{ github.event.inputs.targetSha }}
-
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Print the target SHA and hermes version
+        run: |
+          echo "targetSha=${{ github.sha }}"
+          echo "hermes-version=${{ inputs.hermes-version }}"
       - name: Create tag
+        if: ${{ inputs.release-type == 'release' }}
         uses: actions/github-script@v5
         with:
           script: |
             github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: 'refs/tags/hermes-${{ steps.date.outputs.date }}-RNv${{ github.event.inputs.rnVersion }}-${{ steps.targetSha.outputs.targetSha }}',
-              sha: '${{ steps.targetSha.outputs.targetSha }}'
+              ref: 'refs/tags/hermes-v${{ inputs.hermes-version }}',
+              sha: '${{ github.sha }}',
             })

--- a/.github/workflows/rn-build-hermes.yml
+++ b/.github/workflows/rn-build-hermes.yml
@@ -22,6 +22,12 @@ jobs:
       EVENT_NAME: ${{ github.event_name }}
       REF: ${{ github.ref }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup node.js
+        uses: ./.github/actions/setup-node
+      - name: Install node dependencies
+        uses: ./.github/actions/yarn-install
       - id: set_release_type
         run: |
           if [[ $EVENT_NAME == "workflow_dispatch" ]]; then
@@ -31,6 +37,11 @@ jobs:
             echo "Setting release type to dry-run"
             echo "RELEASE_TYPE=dry-run" >> $GITHUB_OUTPUT
           fi
+      - id: generate_version
+        run: |
+          VERSION=$(node ./utils/scripts/hermes/get-hermes-version.js --build-type ${{ steps.set_release_type.outputs.RELEASE_TYPE }})
+          echo "Generated version: $VERSION"
+          echo "HERMES_VERSION=$VERSION" >> $GITHUB_OUTPUT
   build_hermesc_apple:
     uses: ./.github/workflows/build-hermesc-apple.yml
   build_apple_slices_hermes:
@@ -61,3 +72,9 @@ jobs:
       ]
     with:
       release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
+  create-tag:
+    uses: ./.github/workflows/create-tag.yml
+    needs: publish
+    with:
+      release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
+      hermes-version: ${{ needs.set_release_type.outputs.HERMES_VERSION }}

--- a/utils/scripts/hermes/get-hermes-version.js
+++ b/utils/scripts/hermes/get-hermes-version.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+/*::
+import type {BuildType} from './version-utils';
+*/
+
+const {getVersion, validateBuildType} = require('./version-utils');
+const {parseArgs} = require('util');
+
+const config = {
+  options: {
+    'build-type': {
+      type: 'string',
+      short: 'b',
+    },
+    help: {type: 'boolean'},
+  },
+};
+
+async function main() {
+  const {
+    values: {'build-type': buildType, help},
+    /* $FlowFixMe[incompatible-call] Natural Inference rollout. See
+     * https://fburl.com/workplace/6291gfvu */
+  } = parseArgs(config);
+
+  if (help) {
+    console.log(`
+  Usage: node ./utils/scripts/hermes/get-hermes-version.js [OPTIONS]
+
+  Generates and outputs version string for the given build type.
+
+  Options:
+    --build-type       One of ['dry-run', 'release'].
+    `);
+    return;
+  }
+
+  if (!validateBuildType(buildType)) {
+    throw new Error(`Unsupported build type: ${buildType}`);
+  }
+
+  const version = await getVersion(buildType);
+  console.log(version);
+}
+
+if (require.main === module) {
+  void main();
+}


### PR DESCRIPTION
Summary: Adds `create-tag` workflow that will tag latest commit on releases. It is also possible to invoke this from GH UI for whatever reason with `release` type.

Reviewed By: cipolleschi

Differential Revision: D85255055


