### PR TITLE
Fix setting hermes release version

### DIFF
--- a/.github/workflows/build-apple-slices-hermes.yml
+++ b/.github/workflows/build-apple-slices-hermes.yml
@@ -1,7 +1,16 @@
 name: build-apple-slices-hermes
 
 on:
-  workflow_call
+  workflow_call:
+    inputs:
+      release-type:
+        required: true
+        description: The type of release we are building. It could be commitly, release or dry-run
+        type: string
+      hermes-version:
+        required: true
+        description: The Hermes version to use for this build
+        type: string
 
 jobs:
   build_apple_slices_hermes:
@@ -18,6 +27,16 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+    - name: Setup git safe folders
+      shell: bash
+      run: git config --global --add safe.directory '*'
+    - name: Setup node.js
+      uses: ./.github/actions/setup-node
+    - name: Install node dependencies
+      uses: ./.github/actions/yarn-install
+    - name: Set artifacts version
+      shell: bash
+      run: node ./utils/scripts/hermes/set-artifacts-version.js --build-type ${{ inputs.release-type }} --hermesVersion "${{ inputs.hermes-version }}"
     - name: Setup xcode
       uses: ./.github/actions/setup-xcode
     - name: Restore HermesC Artifact

--- a/.github/workflows/rn-build-hermes.yml
+++ b/.github/workflows/rn-build-hermes.yml
@@ -55,7 +55,14 @@ jobs:
     uses: ./.github/workflows/build-hermesc-apple.yml
   build_apple_slices_hermes:
     uses: ./.github/workflows/build-apple-slices-hermes.yml
-    needs: build_hermesc_apple
+    needs:
+      [
+        set_release_type,
+        build_hermesc_apple,
+      ]
+    with:
+      release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
+      hermes-version: ${{ needs.set_release_type.outputs.HERMES_VERSION }}
   build_hermes_macos:
     uses: ./.github/workflows/build-hermes-macos.yml
     needs: build_apple_slices_hermes


### PR DESCRIPTION
## Summary: 

Fixes setting `HERMES_RELEASE_VERSION` on commitlies. Previously, the version in `npm/hermes-compiler/packager.json` wasn't modified before building apple slices and it read the default version.

## Test Plan:

Run `rn-tester` with prebuilt `hermes-ios-Debug` and logged `global.HermesInternal.getRuntimeProperties()`:

<img width="498" height="170" alt="Screenshot 2025-10-27 at 16 12 25" src="https://github.com/user-attachments/assets/276a8495-4006-4343-9fe1-1077814759c4" />


Differential Revision: D85439475


