### PR TITLE
[Hermes][CI] Bump Macos runners to 15

### DIFF
--- a/.github/actions/setup-xcode/action.yml
+++ b/.github/actions/setup-xcode/action.yml
@@ -4,7 +4,7 @@ inputs:
   xcode-version:
     description: 'The xcode version to use'
     required: false
-    default: '16.2.0'
+    default: '16.4.0'
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/build-apple-slices-hermes.yml
+++ b/.github/workflows/build-apple-slices-hermes.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build_apple_slices_hermes:
-    runs-on: macos-14
+    runs-on: macos-15
     env:
       IOS_DEPLOYMENT_TARGET: "15.1"
       XROS_DEPLOYMENT_TARGET: "1.0"

--- a/.github/workflows/build-hermes-macos.yml
+++ b/.github/workflows/build-hermes-macos.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build-hermes-macos:
-    runs-on: macos-14
+    runs-on: macos-15
     continue-on-error: true
     env:
       HERMES_TARBALL_ARTIFACTS_DIR: /tmp/hermes/hermes-runtime-darwin

--- a/.github/workflows/build-hermesc-apple.yml
+++ b/.github/workflows/build-hermesc-apple.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build-hermesc-apple:
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   test-macos:
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
@@ -123,7 +123,7 @@ jobs:
         name: emulator.log
         path: emulator.log
   test-macos-test262:
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:

--- a/.github/workflows/test-apple-runtime.yml
+++ b/.github/workflows/test-apple-runtime.yml
@@ -5,12 +5,13 @@ on:
 
 jobs:
   test-apple-runtime:
-    runs-on: macos-14
+    runs-on: macos-15
     env:
       TERM: dumb
       HERMES_WS_DIR: "/tmp/hermes"
       HOMEBREW_NO_AUTO_UPDATE: 1
     strategy:
+      fail-fast: false
       matrix:
         include:
           - destination: platform=macOS
@@ -19,7 +20,7 @@ jobs:
           - destination: platform=iOS Simulator,name=iPhone 16
             scheme: ApplePlatformsIntegrationMobileTests
             name: Test iPhone application
-          - destination: platform=visionOS Simulator,name=Apple Vision Pro
+          - destination: platform=visionOS Simulator,OS=26.0,name=Apple Vision Pro
             scheme: ApplePlatformsIntegrationVisionOSTests
             name: Test Apple Vision application
           - destination: platform=tvOS Simulator,name=Apple TV

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,8 +41,6 @@ set(CMAKE_OSX_SYSROOT ${HERMES_APPLE_TARGET_PLATFORM})
 
 if(HERMES_APPLE_TARGET_PLATFORM MATCHES "catalyst")
   set(CMAKE_OSX_SYSROOT "macosx")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -target x86_64-arm64-apple-ios14.0-macabi -isystem ${CMAKE_OSX_SYSROOT}/System/iOSSupport/usr/include")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -target x86_64-arm64-apple-ios14.0-macabi -isystem ${CMAKE_OSX_SYSROOT}/System/iOSSupport/usr/include")
   set(CMAKE_THREAD_LIBS_INIT "-lpthread")
   set(CMAKE_HAVE_THREADS_LIBRARY 1)
   set(CMAKE_USE_WIN32_THREADS_INIT 0)

--- a/utils/build-apple-framework.sh
+++ b/utils/build-apple-framework.sh
@@ -94,6 +94,20 @@ function configure_apple_framework {
     xcode_15_flags="LINKER:-ld_classic"
   fi
 
+  # For catalyst, we need to set some additional C and Cxx flags
+  shared_clang_flags=""
+  if [[ $1 == "catalyst" ]]; then
+    # return the right target flags for catalyst depending on the architecture
+    if [[ $2 == "x86_64" ]]; then
+      shared_clang_flags="-target x86_64-apple-ios$3-macabi -isystem ${CMAKE_OSX_SYSROOT}/System/iOSSupport/usr/include"
+    elif [[ $2 == "arm64" ]]; then
+      shared_clang_flags="-target arm64-apple-ios$3-macabi -isystem ${CMAKE_OSX_SYSROOT}/System/iOSSupport/usr/include"
+    else
+      echo "Error: unknown architecture passed $1"
+      exit 1
+    fi
+  fi
+
   pushd "$HERMES_PATH" > /dev/null || exit 1
     cmake -S . -B "build_$1" \
       -DHERMES_EXTRA_LINKER_FLAGS="$xcode_15_flags" \
@@ -108,8 +122,8 @@ function configure_apple_framework {
       -DHERMES_ENABLE_BITCODE:BOOLEAN=false \
       -DHERMES_BUILD_APPLE_FRAMEWORK:BOOLEAN=true \
       -DHERMES_BUILD_SHARED_JSI:BOOLEAN=false \
-      -DCMAKE_CXX_FLAGS:STRING="-gdwarf" \
-      -DCMAKE_C_FLAGS:STRING="-gdwarf" \
+      -DCMAKE_CXX_FLAGS:STRING="-gdwarf $shared_clang_flags" \
+      -DCMAKE_C_FLAGS:STRING="-gdwarf $shared_clang_flags" \
       -DIMPORT_HOST_COMPILERS:PATH="$IMPORT_HOST_COMPILERS_PATH" \
       -DHERMES_RELEASE_VERSION="$(get_release_version)" \
       -DJSI_DIR="$JSI_PATH" \

--- a/utils/build-ios-framework.sh
+++ b/utils/build-ios-framework.sh
@@ -36,10 +36,57 @@ function get_deployment_target {
     fi
 }
 
-# build a single framework
-# $1 is the target to build
+function build_catalyst {
+  # $1 is the deployment_target here
+
+  # get the architectures
+  architectures=$(get_architecture "catalyst")
+
+  # loop over the architectures and build them
+  echo "$architectures" | tr ';' '\n' | while read -r arch; do
+    build_apple_framework "catalyst" "$arch" "$1"
+
+    echo "Finding the hermesvm.framework"
+    find "." -name "hermesvm.framework" -print
+    echo "=============================="
+    ls -lr .
+    echo "=============================="
+
+    mkdir -p "./build_catalyst/lib/$arch/hermesvm.framework"
+    mv "./build_catalyst/lib/hermesvm.framework" "./build_catalyst/lib/$arch/"
+    mv "./build_catalyst/lib/hermesvm.framework.dSYM" "./build_catalyst/lib/$arch/"
+  done
+
+  echo "Create the framework for both Catalyst architectures"
+  cp -R "./build_catalyst/lib/arm64/hermesvm.framework" "./build_catalyst/lib/hermesvm.framework"
+  lipo -create \
+    "./build_catalyst/lib/x86_64/hermesvm.framework/hermesvm" \
+    "./build_catalyst/lib/arm64/hermesvm.framework/hermesvm" \
+    -output "./build_catalyst/lib/hermesvm.framework/hermesvm"
+
+  echo "Create the dSYMs for both Catalyst architectures"
+  cp -R "./build_catalyst/lib/arm64/hermesvm.framework.dSYM" "./build_catalyst/lib/hermesvm.framework.dSYM"
+  lipo -create \
+    "./build_catalyst/lib/x86_64/hermesvm.framework.dSYM/Contents/Resources/DWARF/hermesvm" \
+    "./build_catalyst/lib/arm64/hermesvm.framework.dSYM/Contents/Resources/DWARF/hermesvm" \
+    -output "./build_catalyst/lib/hermesvm.framework.dSYM/Contents/Resources/DWARF/hermesvm"
+
+  echo "Remove the individual architectures folders"
+  echo "$architectures" | tr ';' '\n' | while read -r arch; do
+    rm -rf "./build_catalyst/lib/$arch"
+  done
+}
+
 function build_framework {
   if [ ! -d destroot/Library/Frameworks/universal/hermesvm.xcframework ]; then
+    deployment_target=$(get_deployment_target "$1")
+
+    # If $1 (platform) is catalyst call build catalyst
+    if [[ $1 == "catalyst" ]]; then
+      build_catalyst "$deployment_target"
+      return
+    fi
+
     deployment_target=$(get_deployment_target "$1")
 
     architecture=$(get_architecture "$1")


### PR DESCRIPTION
## Summary
GH asked us to bump the macos runners to 15.

Unfortunately, with macos-15, Apple decided that Apple Clang was not supporting the `x86_64-arm64-apple-ios14.0-macabi` compiler flag anymore.

So we now have to build the two Catalyst architecture separately and then merge them together calling `lipo` manually

## Test Plan
GHA + I tested that the produced slice for Catalyst contains both architectures in both the hermesvm and the dSYMs

<img width="1062" height="88" alt="Screenshot 2025-10-28 at 11 04 41" src="https://github.com/user-attachments/assets/3cddcad4-148a-4509-8b25-f25695b3bffa" />

