### PR TITLE
Bump Macos runners to 15

### DIFF
--- a/.github/actions/setup-xcode/action.yml
+++ b/.github/actions/setup-xcode/action.yml
@@ -4,7 +4,7 @@ inputs:
   xcode-version:
     description: 'The xcode version to use'
     required: false
-    default: '16.2.0'
+    default: '16.4.0'
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/build-apple-slices-hermes.yml
+++ b/.github/workflows/build-apple-slices-hermes.yml
@@ -4,7 +4,7 @@ on: workflow_call
 
 jobs:
   build_apple_slices_hermes:
-    runs-on: macos-14
+    runs-on: macos-15
     env:
       IOS_DEPLOYMENT_TARGET: "15.1"
       XROS_DEPLOYMENT_TARGET: "1.0"

--- a/.github/workflows/build-hermes-macos.yml
+++ b/.github/workflows/build-hermes-macos.yml
@@ -4,7 +4,7 @@ on: workflow_call
 
 jobs:
   build-hermes-macos:
-    runs-on: macos-14
+    runs-on: macos-15
     continue-on-error: true
     env:
       HERMES_TARBALL_ARTIFACTS_DIR: /tmp/hermes/hermes-runtime-darwin

--- a/.github/workflows/build-hermesc-apple.yml
+++ b/.github/workflows/build-hermesc-apple.yml
@@ -4,7 +4,7 @@ on: workflow_call
 
 jobs:
   build-hermesc-apple:
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/rn-build-hermes.yml
+++ b/.github/workflows/rn-build-hermes.yml
@@ -61,6 +61,11 @@ jobs:
     secrets: inherit
     with:
       release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
+  test-apple-runtime:
+    needs: build_hermes_macos
+    uses: ./.github/workflows/test-apple-runtime.yml
+  run-tests:
+    uses: ./.github/workflows/run-tests.yml
   publish:
     uses: ./.github/workflows/publish.yml
     secrets: inherit

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,8 +51,6 @@ set(CMAKE_OSX_SYSROOT ${HERMES_APPLE_TARGET_PLATFORM})
 
 if(HERMES_APPLE_TARGET_PLATFORM MATCHES "catalyst")
   set(CMAKE_OSX_SYSROOT "macosx")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -target x86_64-arm64-apple-ios14.0-macabi -isystem ${CMAKE_OSX_SYSROOT}/System/iOSSupport/usr/include")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -target x86_64-arm64-apple-ios14.0-macabi -isystem ${CMAKE_OSX_SYSROOT}/System/iOSSupport/usr/include")
   set(CMAKE_THREAD_LIBS_INIT "-lpthread")
   set(CMAKE_HAVE_THREADS_LIBRARY 1)
   set(CMAKE_USE_WIN32_THREADS_INIT 0)

--- a/utils/build-apple-framework.sh
+++ b/utils/build-apple-framework.sh
@@ -95,8 +95,19 @@ function configure_apple_framework {
   fi
 
   boost_context_flag=""
+  # For catalyst, we need to set some additional C and Cxx flags
+  shared_clang_flags=""
   if [[ $1 == "catalyst" ]]; then
     boost_context_flag="-DHERMES_ALLOW_BOOST_CONTEXT=0"
+    # return the right target flags for catalyst depending on the architecture
+    if [[ $2 == "x86_64" ]]; then
+      shared_clang_flags="-target x86_64-apple-ios$3-macabi -isystem ${CMAKE_OSX_SYSROOT}/System/iOSSupport/usr/include"
+    elif [[ $2 == "arm64" ]]; then
+      shared_clang_flags="-target arm64-apple-ios$3-macabi -isystem ${CMAKE_OSX_SYSROOT}/System/iOSSupport/usr/include"
+    else
+      echo "Error: unknown architecture passed $1"
+      exit 1
+    fi
   fi
 
   pushd "$HERMES_PATH" > /dev/null || exit 1
@@ -113,8 +124,8 @@ function configure_apple_framework {
       -DHERMES_ENABLE_BITCODE:BOOLEAN=false \
       -DHERMES_BUILD_APPLE_FRAMEWORK:BOOLEAN=true \
       -DHERMES_BUILD_SHARED_JSI:BOOLEAN=false \
-      -DCMAKE_CXX_FLAGS:STRING="-gdwarf" \
-      -DCMAKE_C_FLAGS:STRING="-gdwarf" \
+      -DCMAKE_CXX_FLAGS:STRING="-gdwarf $shared_clang_flags" \
+      -DCMAKE_C_FLAGS:STRING="-gdwarf $shared_clang_flags" \
       -DIMPORT_HOST_COMPILERS:PATH="$IMPORT_HERMESC_PATH" \
       -DJSI_DIR="$JSI_PATH" \
       -DHERMES_RELEASE_VERSION="$(get_release_version)" \

--- a/utils/build-ios-framework.sh
+++ b/utils/build-ios-framework.sh
@@ -36,11 +36,58 @@ function get_deployment_target {
     fi
 }
 
+function build_catalyst {
+  # $1 is the deployment_target here
+
+  # get the architectures
+  architectures=$(get_architecture "catalyst")
+
+  # loop over the architectures and build them
+  echo "$architectures" | tr ';' '\n' | while read -r arch; do
+    build_apple_framework "catalyst" "$arch" "$1"
+
+    echo "Finding the hermesvm.framework"
+    find "." -name "hermesvm.framework" -print
+    echo "=============================="
+    ls -lr .
+    echo "=============================="
+
+    mkdir -p "./build_catalyst/lib/$arch/hermesvm.framework"
+    mv "./build_catalyst/lib/hermesvm.framework" "./build_catalyst/lib/$arch/"
+    mv "./build_catalyst/lib/hermesvm.framework.dSYM" "./build_catalyst/lib/$arch/"
+  done
+
+  echo "Create the framework for both Catalyst architectures"
+  cp -R "./build_catalyst/lib/arm64/hermesvm.framework" "./build_catalyst/lib/hermesvm.framework"
+  lipo -create \
+    "./build_catalyst/lib/x86_64/hermesvm.framework/hermesvm" \
+    "./build_catalyst/lib/arm64/hermesvm.framework/hermesvm" \
+    -output "./build_catalyst/lib/hermesvm.framework/hermesvm"
+
+  echo "Create the dSYMs for both Catalyst architectures"
+  cp -R "./build_catalyst/lib/arm64/hermesvm.framework.dSYM" "./build_catalyst/lib/hermesvm.framework.dSYM"
+  lipo -create \
+    "./build_catalyst/lib/x86_64/hermesvm.framework.dSYM/Contents/Resources/DWARF/hermesvm" \
+    "./build_catalyst/lib/arm64/hermesvm.framework.dSYM/Contents/Resources/DWARF/hermesvm" \
+    -output "./build_catalyst/lib/hermesvm.framework.dSYM/Contents/Resources/DWARF/hermesvm"
+
+  echo "Remove the individual architectures folders"
+  echo "$architectures" | tr ';' '\n' | while read -r arch; do
+    rm -rf "./build_catalyst/lib/$arch"
+  done
+}
+
 # build a single framework
 # $1 is the target to build
 function build_framework {
   if [ ! -d destroot/Library/Frameworks/universal/hermesvm.xcframework ]; then
     deployment_target=$(get_deployment_target "$1")
+
+    # If $1 (platform) is catalyst call build catalyst
+    if [[ $1 == "catalyst" ]]; then
+      build_catalyst "$deployment_target"
+      return
+    fi
 
     architecture=$(get_architecture "$1")
 


### PR DESCRIPTION
Summary:
GH asked us to bump the macos runners to 15.

Unfortunately, with macos-15, Apple decided that Apple Clang was not supporting the `x86_64-arm64-apple-ios14.0-macabi` compiler flag anymore.

So we now have to build the two Catalyst architecture separately and then merge them together calling `lipo` manually

Differential Revision: D85662422


