### PR TITLE
Change release type input to choice on RN Build Hermes workflow

### DIFF
--- a/.github/workflows/rn-build-hermes.yml
+++ b/.github/workflows/rn-build-hermes.yml
@@ -4,9 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       release-type:
-        description: 'Release type (release, commitly, dry-run)'
         required: false
-        default: 'dry-run'
+        description: The type of release we are building. It could be commitly, release or dry-run
+        type: choice
+        options:
+          - release
+          - commitly
+          - dry-run
+        default: dry-run
   pull_request:
   push:
     branches:


### PR DESCRIPTION
Summary: Changes input type on RN Build Hermes workflow to `choice` to be scoped to only acceptable options.

Differential Revision: D85757322


