### PR TITLE
[LOCAL] Bump hermes-compiler to prepare for 0.83 release

### DIFF
--- a/npm/hermes-compiler/package.json
+++ b/npm/hermes-compiler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hermes-compiler",
-    "version": "250829098.0.1",
+    "version": "250829098.0.2",
     "private": false,
     "description": "The hermes compiler CLI used during the React Native build process",
     "license": "MIT",


### PR DESCRIPTION
## Summary
The hermes-compiler's version for HermesV1 should always point to the next version we want to release.

This PR prepares hermes for the branch cut of next monday.

## Test Plan
GHA
