### PR TITLE
Fix `create-tag` workflow

### DIFF
--- a/.github/workflows/rn-build-hermes.yml
+++ b/.github/workflows/rn-build-hermes.yml
@@ -102,7 +102,11 @@ jobs:
       hermes-version: ${{ needs.set_release_type.outputs.HERMES_VERSION }}
   create-tag:
     uses: ./.github/workflows/create-tag.yml
-    needs: publish
+    needs:
+      [
+        publish,
+        set_release_type,
+      ]
     with:
       release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
       hermes-version: ${{ needs.set_release_type.outputs.HERMES_VERSION }}


### PR DESCRIPTION
Summary: Fixes running `create-tag` by waiting for the `set_release_type` workflow.

Differential Revision: D86103318


