### PR TITLE
Align build script used on Github Actions with `static_h` branch

### DIFF
--- a/.github/workflows/rn-build-hermes.yml
+++ b/.github/workflows/rn-build-hermes.yml
@@ -79,11 +79,7 @@ jobs:
       release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
   create-tag:
     uses: ./.github/workflows/create-tag.yml
-    needs:
-      [
-        publish,
-        set_release_type,
-      ]
+    needs: set_release_type
     with:
       release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
       hermes-version: ${{ needs.set_release_type.outputs.HERMES_VERSION }}


### PR DESCRIPTION
## Summary

Cherry-picks two changes to the stable release branch of Hermes V1:
- disables hermesc builds for Windows, as support for MSVC is currently missing
- creates the tag for releases optimistically, without waiting for the entire build pipeline to pass

## Test Plan

It's a cherry-pick of changes that are already being used.
