### PR TITLE
Cherry-pick: Change value of HERMESVM_HEAP_HV_MODE on Android

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -227,6 +227,7 @@ android {
             "-DHERMES_BUILD_SHARED_JSI=True",
             "-DHERMES_RELEASE_VERSION=${hermesReleaseVersion}",
             "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=True",
+            "-DHERMESVM_HEAP_HV_MODE=HEAP_HV_PREFER32",
             // We intentionally build Hermes with Intl support only. This is to simplify
             // the build setup and to avoid overcomplicating the build-type matrix.
             "-DHERMES_ENABLE_INTL=True",


### PR DESCRIPTION
This is a cherry-pick of https://github.com/facebook/hermes/commit/83767e3e425965e32ec9247cfd93b3532375578a

Summary:
X-link: https://github.com/facebook/react-native/pull/54240

Changelog: [Android][Changed] Changed value of `HERMESVM_HEAP_HV_MODE` to `HEAP_HV_PREFER32` for Hermes V1

Reviewed By: cipolleschi

Differential Revision: D85329156

fbshipit-source-id: c7d0a948b1262d081cf0b2c9972f89a8efcf3808
