### PR TITLE
perf: fast divide shorter by longer bigint

### DIFF
--- a/lib/Support/BigIntSupport.cpp
+++ b/lib/Support/BigIntSupport.cpp
@@ -1755,7 +1755,7 @@ static OperationStatus compute(
     return OperationStatus::DIVISION_BY_ZERO;
   }
 
-  if (lhs.numDigits < rhs.numDigits) {
+  if (lhs.numDigits + 1 < rhs.numDigits) {
     // In this case, divideResultSize returns 0 and mismatches remainderResultSize
 
     if (quoc.digits != nullptr) {
@@ -1878,8 +1878,9 @@ static OperationStatus compute(
 } // namespace
 
 uint32_t divideResultSize(ImmutableBigIntRef lhs, ImmutableBigIntRef rhs) {
-  if (lhs.numDigits < rhs.numDigits) {
+  if (lhs.numDigits + 1 < rhs.numDigits) {
     // Special case: (res = 0, rem = lhs), regardless of rhs sign
+    // Can't use lhs.numDigits < rhs.numDigits here because -(2n**63n)/(2n**63n) is not 0
     return 0;
   }
 
@@ -1901,8 +1902,9 @@ divide(MutableBigIntRef dst, ImmutableBigIntRef lhs, ImmutableBigIntRef rhs) {
 }
 
 uint32_t remainderResultSize(ImmutableBigIntRef lhs, ImmutableBigIntRef rhs) {
-  if (lhs.numDigits < rhs.numDigits) {
+  if (lhs.numDigits + 1 < rhs.numDigits) {
     // Special case: (res = 0, rem = lhs), regardless of rhs sign
+    // Can't use lhs.numDigits < rhs.numDigits here because -(2n**63n)/(2n**63n) is not 0
     return lhs.numDigits;
   }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `main`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/HEAD/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.

  Note: We kindly request that pull requests address more than just a single typo.
  While we sincerely appreciate your attention to detail, we would be most grateful
  if typo fixes were batched together to include several corrections. This helps our
  maintainers focus on substantive contributions to the codebase. Thank you for your
  understanding and cooperation!
-->

## Summary

See #1850 

This assumes that `rhs` is canonical

---

There is another low-hanging fruit after this, which is result size calculation
`+1` is really useless there and results in a lot of unoptimal operations

## Test Plan

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes the user interface.
-->
