### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -24,7 +24,7 @@ jobs:
         ORG_GRADLE_PROJECT_SONATYPE_PASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_PASSWORD }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup git safe folders
         shell: bash
         run: git config --global --add safe.directory '*'
@@ -41,7 +41,7 @@ jobs:
           cd android
           ./gradlew publishAndroidOnlyToMavenTempLocal :build -PenableWarningsAsErrors=true
       - name: Upload Maven Artifacts
-        uses: actions/upload-artifact@v4.3.4
+        uses: actions/upload-artifact@v6
         with:
           name: maven-local
           path: /tmp/maven-local

--- a/.github/workflows/build-apple-slices-hermes.yml
+++ b/.github/workflows/build-apple-slices-hermes.yml
@@ -26,11 +26,11 @@ jobs:
           ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup xcode
         uses: ./.github/actions/setup-xcode
       - name: Restore HermesC Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: hermesc-apple
           path: ./build_host_hermesc
@@ -80,7 +80,7 @@ jobs:
         run: |
           tar -czv -f build_${{ matrix.slice }}_${{ matrix.flavor }}.tar.gz build_${{ matrix.slice }}_${{ matrix.flavor }}
       - name: Upload Artifact for Slice (${{ matrix.slice }}, ${{ matrix.flavor }})
-        uses: actions/upload-artifact@v4.3.4
+        uses: actions/upload-artifact@v6
         with:
           name: slice-${{ matrix.slice }}-${{ matrix.flavor }}
           path: ./build_${{ matrix.slice }}_${{ matrix.flavor }}.tar.gz

--- a/.github/workflows/build-hermes-macos.yml
+++ b/.github/workflows/build-hermes-macos.yml
@@ -14,7 +14,7 @@ jobs:
         flavor: [Debug, Release]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup xcode
         uses: ./.github/actions/setup-xcode
       - name: Setup node.js
@@ -22,7 +22,7 @@ jobs:
       - name: Yarn Install Dependencies
         uses: ./.github/actions/yarn-install
       - name: Download slice artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: slice-*-${{ matrix.flavor }}
           path: .
@@ -119,17 +119,17 @@ jobs:
           mkdir -p "$DEST_DIR"
           mv "hermesvm.framework.dSYM" "$DEST_DIR"
       - name: Upload hermes dSYM artifacts
-        uses: actions/upload-artifact@v4.3.4
+        uses: actions/upload-artifact@v6
         with:
           name: hermes-dSYM-${{ matrix.flavor }}
           path: /tmp/hermes/dSYM/${{ matrix.flavor }}
       - name: Upload hermes Runtime artifacts
-        uses: actions/upload-artifact@v4.3.4
+        uses: actions/upload-artifact@v6
         with:
           name: hermes-darwin-bin-${{ matrix.flavor }}
           path: /tmp/hermes/hermes-runtime-darwin/hermes-ios-${{ matrix.flavor }}.tar.gz
       - name: Upload hermes osx artifacts
-        uses: actions/upload-artifact@v4.3.4
+        uses: actions/upload-artifact@v6
         with:
           name: hermes-osx-bin-${{ matrix.flavor }}
           path: /tmp/hermes/osx-bin/${{ matrix.flavor }}

--- a/.github/workflows/build-hermesc-apple.yml
+++ b/.github/workflows/build-hermesc-apple.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup xcode
         uses: ./.github/actions/setup-xcode
       - name: Build HermesC Apple
@@ -16,7 +16,7 @@ jobs:
           source ./utils/build-apple-framework.sh
           build_host_hermesc_if_needed
       - name: Upload HermesC Artifact
-        uses: actions/upload-artifact@v4.3.4
+        uses: actions/upload-artifact@v6
         with:
           name: hermesc-apple
           path: ./build_host_hermesc

--- a/.github/workflows/build-hermesc-linux.yml
+++ b/.github/workflows/build-hermesc-linux.yml
@@ -9,7 +9,7 @@ jobs:
       HERMES_TARBALL_ARTIFACTS_DIR: /tmp/hermes/hermes-runtime-darwin
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install dependencies
         shell: bash
         run: |
@@ -37,7 +37,7 @@ jobs:
           cmake --build build --target hermesc -j 4
           cp build/bin/hermesc /tmp/hermes/linux64-bin/.
       - name: Upload linux artifacts
-        uses: actions/upload-artifact@v4.3.4
+        uses: actions/upload-artifact@v6
         with:
           name: hermes-linux-bin
           path: /tmp/hermes/linux64-bin

--- a/.github/workflows/build-hermesc-windows.yml
+++ b/.github/workflows/build-hermesc-windows.yml
@@ -14,7 +14,7 @@ jobs:
       CMAKE_DIR: 'C:\Program Files\CMake\bin'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up workspace
         shell: powershell
         run: |
@@ -64,7 +64,7 @@ jobs:
           # Include Windows runtime dependencies
           Copy-Item -Path "$Env:HERMES_WS_DIR\deps\*" -Destination "$Env:HERMES_WS_DIR\win64-bin"
       - name: Upload windows artifacts
-        uses: actions/upload-artifact@v4.3.4
+        uses: actions/upload-artifact@v6
         with:
           name: hermes-win64-bin
           path: C:\tmp\hermes\win64-bin\

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: 16.2
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
       with:
         path: hermes
     - name: Install dependencies
@@ -33,7 +33,7 @@ jobs:
         shasum -a 256 output/${TAR_NAME} > output/${TAR_NAME}.sha256
       env:
         TAR_NAME: hermes-cli-darwin.tar.gz
-    - uses: actions/upload-artifact@v4.3.1
+    - uses: actions/upload-artifact@v6
       with:
         name: macos-hermes
         path: output
@@ -56,7 +56,7 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: 16.2
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
       with:
         path: hermes
     - name: Setup dependencies
@@ -90,7 +90,7 @@ jobs:
             test_runner_flags: "--vm-args='-Xjit=force'"
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
       with:
         path: hermes
     - name: Setup dependencies
@@ -124,7 +124,7 @@ jobs:
     steps:
       # checkout action has problem running on container, currently using v1 can bypass it,
       # see https://github.com/actions/checkout/issues/334.
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v6
       - name: Setup dependencies
         run: |-
             apt update

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -30,14 +30,14 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Print the target SHA and hermes version
         run: |
           echo "targetSha=${{ github.sha }}"
           echo "hermes-version=${{ inputs.hermes-version }}"
       - name: Create tag
         if: ${{ inputs.release-type == 'release' }}
-        uses: actions/github-script@v5
+        uses: actions/github-script@v8
         with:
           script: |
             github.rest.git.createRef({

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       GHA_NPM_TOKEN: ${{ secrets.GHA_NPM_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup git safe folders
         shell: bash
         run: git config --global --add safe.directory '*'
@@ -33,37 +33,37 @@ jobs:
         shell: bash
         run: mkdir -p /tmp/hermes/osx-bin
       - name: Download osx-bin release artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: hermes-osx-bin-Release
           path: /tmp/hermes/osx-bin/Release
       - name: Download osx-bin debug artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: hermes-osx-bin-Debug
           path: /tmp/hermes/osx-bin/Debug
       - name: Download darwin-bin release artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: hermes-darwin-bin-Release
           path: /tmp/hermes/hermes-runtime-darwin
       - name: Download darwin-bin debug artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: hermes-darwin-bin-Debug
           path: /tmp/hermes/hermes-runtime-darwin
       - name: Download hermes dSYM debug artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: hermes-dSYM-Debug
           path: /tmp/hermes/dSYM/Debug
       - name: Download hermes dSYM release vartifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: hermes-dSYM-Release
           path: /tmp/hermes/dSYM/Release
       - name: Download linux-bin artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: hermes-linux-bin
           path: /tmp/hermes/linux64-bin
@@ -95,7 +95,7 @@ jobs:
         run: |
           node ./utils/scripts/hermes/publish-npm.js -t ${{ inputs.release-type }}
       - name: Upload npm logs
-        uses: actions/upload-artifact@v4.3.4
+        uses: actions/upload-artifact@v6
         with:
           name: npm-logs
           path: ~/.npm/_logs

--- a/.github/workflows/rn-build-hermes.yml
+++ b/.github/workflows/rn-build-hermes.yml
@@ -28,7 +28,7 @@ jobs:
       REF: ${{ github.ref }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup node.js
         uses: ./.github/actions/setup-node
       - name: Install node dependencies


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [``](https://github.com/actions/checkout/releases/tag/) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) |  |
| `actions/download-artifact` | [``](https://github.com/actions/download-artifact/releases/tag/) | [`v7`](https://github.com/actions/download-artifact/releases/tag/v7) | [Release](https://github.com/actions/download-artifact/releases/tag/v7) |  |
| `actions/github-script` | [``](https://github.com/actions/github-script/releases/tag/) | [`v8`](https://github.com/actions/github-script/releases/tag/v8) | [Release](https://github.com/actions/github-script/releases/tag/v8) |  |
| `actions/upload-artifact` | [``](https://github.com/actions/upload-artifact/releases/tag/) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) |  |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
