### PR TITLE
Try using 4-core-ubuntu for more disk space on GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm]
+        os: [4-core-ubuntu, ubuntu-24.04-arm]
         cmake_flags: [""]
         lit_flags: [""]
         test_runner_flags: [""]


### PR DESCRIPTION
Summary:
The linux builds were failing because the default `ubuntu` runner
doesn't have much disk space. Supposedly the runner with more cores
allows more disk space.

Differential Revision: D89296524


