### PR TITLE
Add funcsAreBuiltins flag to show [native code] for JS builtins

### DIFF
--- a/API/hermes/hermes.cpp
+++ b/API/hermes/hermes.cpp
@@ -1311,6 +1311,7 @@ static void loadAndInstallExtensions(HermesRuntimeImpl &runtime) {
   vm::RuntimeModuleFlags flags;
   flags.persistent = true;
   flags.hidesEpilogue = true;
+  flags.funcsAreBuiltins = true;
   auto res = runtime.runtime_.runBytecode(
       std::move(bcResult.first),
       flags,

--- a/include/hermes/VM/RuntimeModule.h
+++ b/include/hermes/VM/RuntimeModule.h
@@ -54,6 +54,11 @@ union RuntimeModuleFlags {
     /// Whether this runtime module's epilogue should be hidden in
     /// runtime.getEpilogues().
     bool hidesEpilogue : 1;
+
+    /// Whether functions in this module should be treated as builtins, meaning
+    /// Function.prototype.toString() returns "[native code]" instead of the
+    /// actual source. This is used for InternalJavaScript and extensions.
+    bool funcsAreBuiltins : 1;
   };
   uint8_t flags;
   RuntimeModuleFlags() : flags(0) {}
@@ -347,6 +352,12 @@ class RuntimeModule final : public llvh::ilist_node<RuntimeModule> {
   /// Runtime.getEpilogues().
   bool hidesEpilogue() const {
     return flags_.hidesEpilogue;
+  }
+
+  /// \return whether functions in this module should be treated as builtins,
+  /// i.e., their toString() returns "[native code]".
+  bool funcsAreBuiltins() const {
+    return flags_.funcsAreBuiltins;
   }
 
   /// \return any trailing data after the real bytecode.

--- a/test/hermes/function-tostring-builtins-microtask.js
+++ b/test/hermes/function-tostring-builtins-microtask.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -Xmicrotask-queue=0 %s | %FileCheck --match-full-lines --check-prefix=DISABLED %s
+// RUN: %hermes -Xmicrotask-queue=1 %s | %FileCheck --match-full-lines --check-prefix=ENABLED %s
+
+// Test that Function.prototype.toString() behavior for JS-implemented builtins
+// depends on the microtask queue setting. This is intentional: some React Native
+// versions check Promise.toString().includes("[native code]") to detect whether
+// the engine's microtask queue is in use.
+
+print("Function toString microtask test");
+// DISABLED-LABEL: Function toString microtask test
+// ENABLED-LABEL: Function toString microtask test
+
+// Promise is implemented in InternalJavaScript.
+// With microtask queue disabled, it should NOT show [native code].
+// With microtask queue enabled, it should show [native code].
+print(Promise.toString().includes("[native code]"));
+// DISABLED-NEXT: false
+// ENABLED-NEXT: true
+
+print(Promise.prototype.then.toString().includes("[native code]"));
+// DISABLED-NEXT: false
+// ENABLED-NEXT: true
+
+// TextEncoder is implemented as an extension.
+// Extensions always show [native code] regardless of microtask queue setting.
+print(TextEncoder.toString().includes("[native code]"));
+// DISABLED-NEXT: true
+// ENABLED-NEXT: true
+
+print(TextEncoder.prototype.encode.toString().includes("[native code]"));
+// DISABLED-NEXT: true
+// ENABLED-NEXT: true
+
+// Native builtins always show [native code] regardless of microtask queue.
+print(Array.isArray.toString().includes("[native code]"));
+// DISABLED-NEXT: true
+// ENABLED-NEXT: true
+
+print("Done");
+// DISABLED-NEXT: Done
+// ENABLED-NEXT: Done

--- a/test/hermes/function-tostring-builtins.js
+++ b/test/hermes/function-tostring-builtins.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -O %s | %FileCheck --match-full-lines %s
+
+// Test that JS-implemented builtin functions return "[native code]" from toString().
+// This is required by ECMAScript for all builtin functions.
+
+print("Function toString builtins test");
+// CHECK-LABEL: Function toString builtins test
+
+// Promise is implemented in InternalJavaScript
+print(Promise.toString());
+// CHECK-NEXT: function Promise() { [native code] }
+
+// Promise methods (note: names may be empty due to internal bytecode optimizations)
+print(Promise.prototype.then.toString().includes("[native code]"));
+// CHECK-NEXT: true
+
+print(Promise.prototype.catch.toString().includes("[native code]"));
+// CHECK-NEXT: true
+
+print(Promise.prototype.finally.toString().includes("[native code]"));
+// CHECK-NEXT: true
+
+print(Promise.all.toString().includes("[native code]"));
+// CHECK-NEXT: true
+
+print(Promise.race.toString().includes("[native code]"));
+// CHECK-NEXT: true
+
+print(Promise.resolve.toString().includes("[native code]"));
+// CHECK-NEXT: true
+
+print(Promise.reject.toString().includes("[native code]"));
+// CHECK-NEXT: true
+
+// Native builtins should also show [native code]
+print(Array.isArray.toString());
+// CHECK-NEXT: function isArray() { [native code] }
+
+print(Object.keys.toString());
+// CHECK-NEXT: function keys() { [native code] }
+
+print(Math.abs.toString());
+// CHECK-NEXT: function abs() { [native code] }
+
+// TextEncoder is implemented as an extension
+print(TextEncoder.toString().includes("[native code]"));
+// CHECK-NEXT: true
+
+print(TextEncoder.prototype.encode.toString().includes("[native code]"));
+// CHECK-NEXT: true
+
+print(TextEncoder.prototype.encodeInto.toString().includes("[native code]"));
+// CHECK-NEXT: true
+
+print("Done");
+// CHECK-NEXT: Done


### PR DESCRIPTION
Summary:
ECMAScript requires that builtin functions return "[native code]" from
toString(). Many libraries (e.g., Babel) check for this string to detect
builtins and alter their behavior accordingly.

Previously, JS-implemented builtins from InternalJavaScript and extensions
would return "[bytecode]" (since their source is not available), causing
these library heuristics to fail.

Add a new funcsAreBuiltins flag to RuntimeModuleFlags that causes
Function.prototype.toString() to return "[native code]" for all functions
in the module. Set the flag when loading internal bytecode and extensions
bytecode.

**Subtle logic for InternalJavaScript (Promise):**
The funcsAreBuiltins flag for InternalJavaScript is set conditionally based
on hasMicrotaskQueue(). This is intentional:

Some React Native versions detect whether to use the VM's microtask queue by
checking Promise.toString().includes("[native code]"). When microtask queue
is disabled but Promise still reports as "[native code]", RN incorrectly
assumes the engine queue is enabled and skips its own queue implementation.

By making funcsAreBuiltins conditional:
- Microtask queue enabled: Promise shows "[native code]" (behaves like native)
- Microtask queue disabled: Promise shows "[bytecode]" (RN uses its own queue)

This ensures the RN heuristic produces correct results.

Note: The hermes CLI defaults to microtask queue enabled, so existing tests
continue to pass without modification.

Extensions always have funcsAreBuiltins=true since they don't affect the
microtask queue detection logic.

Differential Revision: D89523668


