### PR TITLE
Bump hermes-compiler to 0.16.0

### DIFF
--- a/npm/hermes-compiler/package.json
+++ b/npm/hermes-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-compiler",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "private": false,
   "description": "The hermes compiler CLI used during the React Native build process",
   "license": "MIT",


### PR DESCRIPTION
Follows `0.84-stable` branch cut in React Native.