### PR TITLE
[HermesV1] Sync JSI from Aug 29th to Jan 14th

### DIFF
--- a/API/jsi/jsi/jsi.cpp
+++ b/API/jsi/jsi/jsi.cpp
@@ -284,6 +284,10 @@ HostObject::~HostObject() {}
 
 NativeState::~NativeState() {}
 
+#ifdef JSI_UNSTABLE
+Serialized::~Serialized() {}
+#endif
+
 Runtime::~Runtime() {}
 
 ICast* Runtime::castInterface(const UUID& /*interfaceUUID*/) {


### PR DESCRIPTION
## Summary
This PR syncs JSI with the latest commits that landed on static_h:
* [Add JSI_UNSTABLE flag](https://github.com/facebook/hermes/commit/662bfd249e1ff99388efbe7e09c9871c9fe485c7)
* [include <cstdint>](https://github.com/facebook/hermes/commit/e595577844507abb72cbfde4467fdb4a66bf2e10)
* [Add ISerialization interface](https://github.com/facebook/hermes/commit/47f5649def0ef2cbf48d27e7cebddcb7175f62e0)

## Test Plan
GHA
