### PR TITLE
[Catalyst][main] Fix target triple for multi-arch builds

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,6 +51,7 @@ jobs:
       ANDROID_NDK: /usr/local/lib/android/sdk/ndk/27.1.12297006
       HERMES_WS_DIR: /home/runner/work/hermes
       REACT_NATIVE_OVERRIDE_HERMES_DIR: /home/runner/work/hermes/hermes
+      CMAKE_VERSION: 3.22.1
     steps:
     - name: Install Node
       uses: actions/setup-node@v4.0.2

--- a/.github/workflows/test-apple-runtime.yml
+++ b/.github/workflows/test-apple-runtime.yml
@@ -20,10 +20,10 @@ jobs:
           - destination: platform=iOS Simulator,name=iPhone 16
             scheme: ApplePlatformsIntegrationMobileTests
             name: Test iPhone application
-          - destination: platform=visionOS Simulator,OS=26.0,name=Apple Vision Pro
+          - destination: platform=visionOS Simulator,OS=26.2,name=Apple Vision Pro
             scheme: ApplePlatformsIntegrationVisionOSTests
             name: Test Apple Vision application
-          - destination: platform=tvOS Simulator,name=Apple TV
+          - destination: platform=tvOS Simulator,arch=arm64,OS=26.2,name=Apple TV
             scheme: ApplePlatformsIntegrationTVOSTests
             name: Test Apple TV application
     steps:
@@ -36,40 +36,6 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: brew install ninja
-      # =============================== #
-      # Download visionOS SDK if Needed #
-      # =============================== #
-      - name: Download visionOS SDK
-        id: download-visionos-sdk
-        shell: bash
-        if: ${{ matrix.scheme == 'ApplePlatformsIntegrationVisionOSTests' }}
-        continue-on-error: true
-        run: xcodebuild -downloadPlatform visionOS
-
-      # The download is flaky. Sometimes it fails to connect. So we wait 5 sec and retry once.
-      - name: Try again to download visionOS SDK
-        if: ${{ matrix.scheme == 'ApplePlatformsIntegrationVisionOSTests' && steps.download-visionos-sdk.outcome == 'failure' }}
-        shell: bash
-        run: |
-          sleep 5
-          xcodebuild -downloadPlatform visionOS
-      # =========================== #
-      # Download tvOS SDK if Needed #
-      # =========================== #
-      - name: Download tvOS SDK
-        id: download-tvos-sdk
-        shell: bash
-        if: ${{ matrix.scheme == 'ApplePlatformsIntegrationTVOSTests' }}
-        continue-on-error: true
-        run: xcodebuild -downloadPlatform tvOS
-      # The download is flaky. Sometimes it fails to connect. So we wait 5 sec and retry once.
-      - name: Try again to download visionOS SDK
-        if: ${{ matrix.scheme == 'ApplePlatformsIntegrationTVOSTests' && steps.download-tvos-sdk.outcome == 'failure' }}
-        shell: bash
-        run: |
-          sleep 5
-          xcodebuild -downloadPlatform tvOS
-
       - name: Use built artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary
Fixes: #1883

When both `-target` and `-arch` flags are passed to Apple clang, the `-arch` flag overrides only the architecture portion of the target triple while preserving the OS and environment.

Use a single `-target arm64-apple-ios$VERSION-macabi` flag, and let CMake's multi-arch handling add `-arch x86_64` and `-arch arm64` flags which correctly produce the right target triple for each architecture.

Example:
```
clang -target arm64-apple-ios15.1-macabi -arch x86_64 ...
→ Effective target: x86_64-apple-ios15.1-macabi
```

## Test Plan
Tested via GitHub Actions. The resulting Hermes binary is properly structured and contains all required architectures.