### PR TITLE
[Catalyst][250829098.0.0-stable] Fix target triple for multi-arch builds

### DIFF
--- a/utils/build-apple-framework-rn.sh
+++ b/utils/build-apple-framework-rn.sh
@@ -94,20 +94,15 @@ function configure_apple_framework {
     xcode_15_flags="LINKER:-ld_classic"
   fi
 
+  # For catalyst, we need to set the target triple to use the macabi environment.
+  # The architecture in -target is overridden by CMake's -arch flags, so we can use
+  # any architecture here (arm64). CMake will add -arch x86_64 and -arch arm64 which
+  # correctly override just the architecture portion while preserving ios-macabi.
   boost_context_flag=""
-  # For catalyst, we need to set some additional C and Cxx flags
   shared_clang_flags=""
   if [[ $1 == "catalyst" ]]; then
     boost_context_flag="-DHERMES_ALLOW_BOOST_CONTEXT=0"
-    # return the right target flags for catalyst depending on the architecture
-    if [[ $2 == "x86_64" ]]; then
-      shared_clang_flags="-target x86_64-apple-ios$3-macabi -isystem ${CMAKE_OSX_SYSROOT}/System/iOSSupport/usr/include"
-    elif [[ $2 == "arm64" ]]; then
-      shared_clang_flags="-target arm64-apple-ios$3-macabi -isystem ${CMAKE_OSX_SYSROOT}/System/iOSSupport/usr/include"
-    else
-      echo "Error: unknown architecture passed $1"
-      exit 1
-    fi
+    shared_clang_flags="-target arm64-apple-ios$3-macabi -isystem ${CMAKE_OSX_SYSROOT}/System/iOSSupport/usr/include"
   fi
 
   pushd "$HERMES_PATH" > /dev/null || exit 1


### PR DESCRIPTION
## Summary
Fixes: #1883

When both `-target` and `-arch` flags are passed to Apple clang, the `-arch` flag overrides only the architecture portion of the target triple while preserving the OS and environment.

Use a single `-target arm64-apple-ios$VERSION-macabi` flag, and let CMake's multi-arch handling add `-arch x86_64` and `-arch arm64` flags which correctly produce the right target triple for each architecture.

Example:
```
clang -target arm64-apple-ios15.1-macabi -arch x86_64 ...
→ Effective target: x86_64-apple-ios15.1-macabi
```

## Test Plan
Tested via GitHub Actions. The resulting Hermes binary is properly structured and contains all required architectures.