### PR TITLE
Update rn-build-hermes.yml triggers

### DIFF
--- a/.github/workflows/rn-build-hermes.yml
+++ b/.github/workflows/rn-build-hermes.yml
@@ -38,7 +38,11 @@ jobs:
         uses: ./.github/actions/yarn-install
       - id: set_release_type
         run: |
-          if [[ $EVENT_NAME == "workflow_dispatch" ]]; then
+          # Guard: never allow release mode on static_h branch
+          if [[ $REF == "refs/heads/static_h" ]]; then
+            echo "Branch is static_h, forcing dry-run mode"
+            echo "RELEASE_TYPE=dry-run" >> $GITHUB_OUTPUT
+          elif [[ $EVENT_NAME == "workflow_dispatch" ]]; then
             echo "Setting release type to ${{ github.event.inputs.release-type }}"
             echo "RELEASE_TYPE=${{ github.event.inputs.release-type }}" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
## Summary
Ensure that we build Hermes V1 for React Native also in the static_h branch and on PRs, to make sure that we don't break it.

## Test plan
Trigger will only execute after the PR is merged in main.