### PR TITLE
Fix -Wc++11-narrowing error in IdentifierTableTest.cpp

### DIFF
--- a/unittests/VMRuntime/IdentifierTableTest.cpp
+++ b/unittests/VMRuntime/IdentifierTableTest.cpp
@@ -117,7 +117,7 @@ TEST(IdentifierTableDeathTest, LazyExternalSymbolTooBig) {
     GCScope gcScope{runtime};
     auto &idTable = runtime.getIdentifierTable();
 
-    const auto extSize =
+    const size_t extSize =
         (1 << 24) +
         std::max<uint64_t>(
             kTestGCConfig.getMaxHeapSize(),


### PR DESCRIPTION
Summary:
This error appeared in our Github armv7 job. Narrowing in initializer
list is not allowed. There won't be actual value truncation in the
error line (since the max heap size in test config is small), but
the compiler is unable to infer that.

Differential Revision: D91794876


