### PR TITLE
Set dependencyResolutionManagement to add repositories to all modules

### DIFF
--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -15,6 +15,13 @@ pluginManagement {
   }
 }
 
+dependencyResolutionManagement {
+  repositories {
+    google()
+    mavenCentral()
+  }
+}
+
 rootProject.name = "hermes-engine"
 
 include(":ios-artifacts", ":hermes", ":cppruntime", ":intltest")


### PR DESCRIPTION
Summary:
The recommended approach is to define repositories in the `settings.gradle.kts`
rather than having to repeat a `repository{}` block in all the subprojects.

Fixes #1893

Differential Revision: D92506849


