### PR TITLE
Fix 'enviroment' -> 'environment' in comments, docs, and display strings

### DIFF
--- a/include/hermes/BCGen/HBC/Passes/OptEnvironmentInit.h
+++ b/include/hermes/BCGen/HBC/Passes/OptEnvironmentInit.h
@@ -14,7 +14,7 @@ namespace hermes {
 namespace hbc {
 
 /// Eliminate (HBCStoreToEnvironment _ undefined _) instructions right after
-/// enviroment creation, since all slots are already initialized to undefined.
+/// environment creation, since all slots are already initialized to undefined.
 class OptEnvironmentInit : public FunctionPass {
  public:
   explicit OptEnvironmentInit() : FunctionPass("OptEnvironmentInit") {}


### PR DESCRIPTION
Summary:
Fix misspelling of "environment" in comments, documentation, JSDoc comments, help text, echo strings, log messages, and description strings across fbcode/ and xplat/. All changes are limited to non-functional text — no identifiers or API-facing strings are affected.

Skipped: generated code (generated), third-party code (TVM, WebRTC, Boost, VS Code extensions), GraphQL schema identifiers, exported type/context names (CosplayEnviromentContext), public method names, Manifold paths, URL paths, icon glyph names, and spelling dictionary entries.

Differential Revision: D92873933


