### PR TITLE
Re-enable the Windows hermesc build workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,6 +67,11 @@ jobs:
         with:
           name: hermes-linux-bin
           path: /tmp/hermes/linux64-bin
+      - name: Download windows-bin artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: hermes-win64-bin
+          path: /tmp/hermes/win64-bin
       - name: Show /tmp/hermes directory
         shell: bash
         run: ls -lR /tmp/hermes

--- a/.github/workflows/rn-build-hermes.yml
+++ b/.github/workflows/rn-build-hermes.yml
@@ -64,20 +64,14 @@ jobs:
     needs: build_apple_slices_hermes
   build_hermesc_linux:
     uses: ./.github/workflows/build-hermesc-linux.yml
-  # TODO: Reenable once support for MSVC is added T242502301
-  # build_hermesc_windows:
-  #   uses: ./.github/workflows/build-hermesc-windows.yml
+  build_hermesc_windows:
+    uses: ./.github/workflows/build-hermesc-windows.yml
   build_android:
     uses: ./.github/workflows/build-android.yml
     needs: set_release_type
     secrets: inherit
     with:
       release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
-  test-apple-runtime:
-    needs: build_hermes_macos
-    uses: ./.github/workflows/test-apple-runtime.yml
-  run-tests:
-    uses: ./.github/workflows/run-tests.yml
   publish:
     uses: ./.github/workflows/publish.yml
     secrets: inherit
@@ -86,6 +80,7 @@ jobs:
         set_release_type,
         build_hermes_macos,
         build_hermesc_linux,
+        build_hermesc_windows,
       ]
     with:
       release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}

--- a/utils/scripts/hermes/prepare-artifacts.js
+++ b/utils/scripts/hermes/prepare-artifacts.js
@@ -22,9 +22,7 @@ function copyHermesBinaries() {
   // Create directories for npm/hermes-compiler/hermesc binaries
   mkdir('-p', './npm/hermes-compiler/hermesc/osx-bin');
   mkdir('-p', './npm/hermes-compiler/hermesc/linux64-bin');
-
-  // Once the windows artifacts are available, this can be uncommented.
-  // mkdir('-p', './npm/hermes-compiler/hermesc/win64-bin');
+  mkdir('-p', './npm/hermes-compiler/hermesc/win64-bin');
 
   const osxBinDir = path.join(HERMES_WS_DIR, 'osx-bin');
   const osxReleaseDir = path.join(osxBinDir, 'Release');
@@ -71,13 +69,12 @@ function copyHermesBinaries() {
     fs.renameSync(releaseTarLower, releaseTarUpper);
   }
 
-  // Once the windows artifacts are available, this can be uncommented.
-  // echo('Copying Windows binaries...');
-  // cp(
-  //   '-r',
-  //   path.join(HERMES_WS_DIR, 'win64-bin/*'),
-  //   './npm/hermes-compiler/hermesc/win64-bin/.',
-  // );
+  echo('Copying Windows binaries...');
+  cp(
+    '-r',
+    path.join(HERMES_WS_DIR, 'win64-bin/*'),
+    './npm/hermes-compiler/hermesc/win64-bin/.',
+  );
 
   echo('Copying Linux binaries...');
   cp(


### PR DESCRIPTION
Summary: This diff turns on running hermes-compiler builds for windows after the MSVC support has been added.

Differential Revision: D93610219


