### PR TITLE
fix defineProperty() proxy hook for array length

### DIFF
--- a/lib/VM/JSObject.cpp
+++ b/lib/VM/JSObject.cpp
@@ -1455,10 +1455,11 @@ CallResult<bool> JSObject::putNamedWithReceiver_RJS(
     // object/proxy/internal setter, and the property is writable,
     // just write into the same slot.
 
+    bool isSameObj = *selfHandle == propObj &&
+        selfHandle.getHermesValue().getRaw() == receiver->getRaw();
+
     if (LLVM_LIKELY(
-            *selfHandle == propObj &&
-            selfHandle.getHermesValue().getRaw() == receiver->getRaw() &&
-            !desc.flags.accessor && !desc.flags.internalSetter &&
+            isSameObj && !desc.flags.accessor && !desc.flags.internalSetter &&
             !desc.flags.hostObject && !desc.flags.proxyObject &&
             desc.flags.writable)) {
       auto shv = SmallHermesValue::encodeHermesValue(*valueHandle, runtime);
@@ -1520,7 +1521,7 @@ CallResult<bool> JSObject::putNamedWithReceiver_RJS(
       return false;
     }
 
-    if (*selfHandle == propObj && desc.flags.internalSetter) {
+    if (isSameObj && desc.flags.internalSetter) {
       return internalSetter(
           selfHandle, runtime, name, desc, valueHandle, opFlags);
     }

--- a/test/hermes/regress-array-proxy-length.js
+++ b/test/hermes/regress-array-proxy-length.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -O %s | %FileCheck --match-full-lines %s
+
+print("proxy-length");
+// CHECK: proxy-length
+
+let output = [];
+let arr = new Proxy([], {
+	defineProperty(target, property, attributes) {
+		output.push("def-" + property);
+		return Reflect.defineProperty(target, property, attributes)
+	},
+	deleteProperty(target, property) {
+		output.push("del-" + property);
+		return Reflect.deleteProperty(target, property)
+	},
+});
+
+arr.push('a', 'b', 'c')
+arr.pop()
+arr.shift()
+arr.length = 1
+print(output);
+// CHECK-NEXT: def-0,def-1,def-2,def-length,del-2,def-length,def-0,del-1,def-length,def-length


### PR DESCRIPTION
## Summary

Fixes #1910

`internalSetter()` should be called in `JSObject::putNamedWithReceiver_RJS()` only if target object is the same as receiver. 
The lack of check resulted in the Proxy::defineOwnProperty() call being skipped for the array's internal `length` property. This, in turn, resulted in the Proxy's `defineProperty()` hook being ignored.

Correct flow by spec for push (and one level proxying Proxy -> Array):
...
[Array.prototype.push](https://262.ecma-international.org/16.0/index.html#sec-array.prototype.push)
// item operations
[[[Proxy::Set]]\(length)](https://262.ecma-international.org/16.0/index.html#sec-proxy-object-internal-methods-and-internal-slots-set-p-v-receiver)
// calling proxy `set()` hook or...
[[[Ordinary::Set]]\(length, receiver=Proxy)](https://262.ecma-international.org/16.0/index.html#sec-ordinary-object-internal-methods-and-internal-slots-set-p-v-receiver)
[OrdinarySet\(length, receiver=Proxy)](https://262.ecma-international.org/16.0/index.html#sec-ordinaryset)
[OrdinarySetWithOwnDescriptor\(length, receiver=Proxy)](https://262.ecma-international.org/16.0/index.html#sec-ordinarysetwithowndescriptor)
[[[Proxy::DefineOwnProperty]]\(length)](https://262.ecma-international.org/16.0/index.html#sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc)
// calling proxy `defineProperty()` hook or...
[[[Array::DefineOwnProperty]]\(length)](https://262.ecma-international.org/16.0/index.html#sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc)
[[[Array::ArraySetLength]]](https://262.ecma-international.org/16.0/index.html#sec-arraysetlength)
[OrdinaryDefineOwnProperty\(length)](https://262.ecma-international.org/16.0/index.html#sec-ordinarydefineownproperty)
...

## Test Plan

```js
let log = (...args) => typeof print === 'undefined' ? console.log(JSON.stringify(args)) : print(JSON.stringify(args))

let arr = new Proxy([], {
	defineProperty(target, property, attributes) {
		log('define', target, property, attributes)
		return Reflect.defineProperty(target, property, attributes)
	},
	deleteProperty(target, p) {
		log('del', target, p)
		return Reflect.deleteProperty(target, p)
	},
})

log('push')
arr.push('a')
log('push')
arr.push('b')
log('push')
arr.push('c')
log('pop')
arr.pop()
log('shift')
arr.shift()
log('length=')
arr.length = 1
```

Result before fix:
```js
["push"]
["define",[],"0",{"value":"a","writable":true,"enumerable":true,"configurable":true}]
["push"]
["define",["a"],"1",{"value":"b","writable":true,"enumerable":true,"configurable":true}]
["push"]
["define",["a","b"],"2",{"value":"c","writable":true,"enumerable":true,"configurable":true}]
["pop"]
["del",["a","b","c"],"2"]
["shift"]
["define",["a","b"],"0",{"value":"b"}]
["del",["b","b"],"1"]
["length="]
```

After:
```js
["push"]
["define",[],"0",{"value":"a","writable":true,"enumerable":true,"configurable":true}]
["define",["a"],"length",{"value":1}]
["push"]
["define",["a"],"1",{"value":"b","writable":true,"enumerable":true,"configurable":true}]
["define",["a","b"],"length",{"value":2}]
["push"]
["define",["a","b"],"2",{"value":"c","writable":true,"enumerable":true,"configurable":true}]
["define",["a","b","c"],"length",{"value":3}]
["pop"]
["del",["a","b","c"],"2"]
["define",["a","b",null],"length",{"value":2}]
["shift"]
["define",["a","b"],"0",{"value":"b"}]
["del",["b","b"],"1"]
["define",["b",null],"length",{"value":1}]
["length="]
["define",["b"],"length",{"value":1}]
```
