### PR TITLE
Fix uint64_t underflow inside Array::arrayPrototypeSplice

### DIFF
--- a/lib/VM/JSLib/Array.cpp
+++ b/lib/VM/JSLib/Array.cpp
@@ -2691,19 +2691,18 @@ CallResult<HermesValue> arrayPrototypeSplice(void *, Runtime &runtime) {
       gcScope.flushToMarker(gcMarker);
     }
 
-    // Use i here to refer to (k-1) in the spec, and reindex the loop.
-    double i = len - 1;
+    // (len - actualDeleteCount + itemCount) >= 0 so k never underflow
+    uint64_t k = len;
 
     // Delete the remaining elements from the right that we didn't copy into.
-    while (i > (len - actualDeleteCount + itemCount - 1)) {
-      lv.i = HermesValue::encodeTrustedNumberValue(i);
+    while (k-- > len - actualDeleteCount + itemCount) {
+      lv.i = HermesValue::encodeTrustedNumberValue(k);
       if (LLVM_UNLIKELY(
               JSObject::deleteComputed(
                   lv.O, runtime, lv.i, PropOpFlags().plusThrowOnError()) ==
               ExecutionStatus::EXCEPTION)) {
         return ExecutionStatus::EXCEPTION;
       }
-      i -= 1;
       gcScope.flushToMarker(gcMarker);
     }
   } else if (itemCount > actualDeleteCount) {

--- a/test/hermes/regress-array-splice.js
+++ b/test/hermes/regress-array-splice.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -O %s | %FileCheck --match-full-lines %s
+
+print("splice");
+// CHECK: splice
+
+let removed = [];
+let arr = new Proxy([], {
+	deleteProperty(target, p) {
+		removed.push(p);
+		return Reflect.deleteProperty(target, p);
+	},
+});
+
+arr.push('a', 'b', 'c');
+arr.splice(0);
+print(removed);
+// CHECK-NEXT: 2,1,0


### PR DESCRIPTION
## Summary

Fixes #1912 

Incorrect handling of unsigned variables causes an undeflow inside `Array::arrayPrototypeSplice` when calling `array.splice(0)`. This leads to a missed call to DeleteProperty on array elements.

https://github.com/facebook/hermes/blob/657380912e05dda0dda49a9e1204f9166442d737/lib/VM/JSLib/Array.cpp#L2698

If `len == actualDeleteCount` (as for `array.splice(0)`) result expression `< 0` for `uint64_t` and the loop never executes.

## Steps To Reproduce

An example with Proxy, which is a symptom:

```js
let log = (...args) => typeof print === 'undefined' ? console.log(JSON.stringify(args)) : print(JSON.stringify(args))

let arr = new Proxy([], {
	deleteProperty(target, p) {
		log('del', target, p)
		return Reflect.deleteProperty(target, p)
	},
})

arr.push('a', 'b', 'c')
arr.splice(0)
```

Hermes
```js
no messages
```

V8
```
["del",["a","b","c"],"2"]
["del",["a","b",null],"1"]
["del",["a",null,null],"0"]
```

## Test Plan

```js
["del",["a","b","c"],"2"]
["del",["a","b",null],"1"]
["del",["a",null,null],"0"]
```