### PR TITLE
Fix Iterator.prototype.reduce callable check order

### DIFF
--- a/lib/InternalJavaScript/15-IteratorPrototypeReduce.js
+++ b/lib/InternalJavaScript/15-IteratorPrototypeReduce.js
@@ -39,16 +39,11 @@ var IteratorPrototypeReduce = function reduce(reducer) {
 		throw new TypeError('`this` value must be an Object'); // step 2
 	}
 
-	var iterated = { '[[Iterator]]': O, '[[NextMethod]]': undefined, '[[Done]]': false }; // step 3
-
 	if (!isCallable(reducer)) {
-		IteratorClose(
-			iterated,
-			ThrowCompletion(new TypeError('`reducer` must be a function'))
-		); // step 4
+		throw new TypeError('`reducer` must be a function'); // step 3
 	}
 
-	iterated = GetIteratorDirect(O); // step 5
+	var iterated = GetIteratorDirect(O); // step 4
 
 	var accumulator;
 	var counter;

--- a/test/hermes/iterator-reduce.js
+++ b/test/hermes/iterator-reduce.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes %s | %FileCheck --match-full-lines %s
+
+print('Iterator.prototype.reduce');
+// CHECK-LABEL: Iterator.prototype.reduce
+
+// Non-callable reducer should throw TypeError before consuming the iterator.
+var iter = (function* () { yield 1; })();
+try {
+  iter.reduce({});
+} catch (e) {
+  print(e instanceof TypeError);
+}
+// CHECK-NEXT: true
+
+// The iterator should not have been consumed by the callable check.
+var result = iter.next();
+print(result.value, result.done);
+// CHECK-NEXT: 1 false
+
+// Basic reduce with initial value.
+var sum = [1, 2, 3].values().reduce(function(acc, v) { return acc + v; }, 0);
+print(sum);
+// CHECK-NEXT: 6
+
+// Reduce without initial value uses first element as accumulator.
+var sum = [1, 2, 3].values().reduce(function(acc, v) { return acc + v; });
+print(sum);
+// CHECK-NEXT: 6
+
+// Reduce of empty iterator with no initial value should throw TypeError.
+try {
+  [].values().reduce(function(acc, v) { return acc + v; });
+} catch (e) {
+  print(e instanceof TypeError);
+}
+// CHECK-NEXT: true


### PR DESCRIPTION
## Summary

The callable check was wrapped in IteratorClose with a fake iterated record created before GetIteratorDirect. This caused .return() to be called on the generator, closing it prematurely. Per the spec, the callable check is a plain throw before GetIteratorDirect, since the iterator hasn't been obtained yet.

## Test Plan

Added test and also ran Test262 test `test262/test/built-ins/Iterator/prototype/reduce/non-callable-reducer.js`
