### PR TITLE
(DRAFT) Fix JSProxy::ownPropertyKeys index key comparison

### DIFF
--- a/lib/VM/JSProxy.cpp
+++ b/lib/VM/JSProxy.cpp
@@ -1411,6 +1411,23 @@ CallResult<PseudoHandle<JSArray>> JSProxy::ownPropertyKeys(
                         JSMap::insert(lv.map, runtime, valHandle, valHandle) ==
                         ExecutionStatus::EXCEPTION))
                   return ExecutionStatus::EXCEPTION;
+                if (valHandle->isString()) {
+                  Handle<StringPrimitive> str =
+                      Handle<StringPrimitive>::vmcast(valHandle);
+                  OptValue<uint32_t> strAsIndexOpt = toArrayIndex(*str);
+                  // Convert index keys to numbers to match the format
+                  // returned by getOwnPropertyKeys.
+                  if (strAsIndexOpt) {
+                    HermesValue strAsIndexValue =
+                        HermesValue::encodeTrustedNumberValue(
+                            static_cast<double>(strAsIndexOpt.getValue()));
+                    return JSArray::setElementAt(
+                        trapResult,
+                        runtime,
+                        index,
+                        runtime.makeHandle(strAsIndexValue));
+                  }
+                }
                 return JSArray::setElementAt(
                     trapResult, runtime, index, valHandle);
               }) == ExecutionStatus::EXCEPTION)) {

--- a/test/hermes/regress-proxy-ownkeys-index.js
+++ b/test/hermes/regress-proxy-ownkeys-index.js
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -Xes6-proxy -non-strict -O -target=HBC %s | %FileCheck --match-full-lines %s
+
+// Regression test: JSProxy::ownPropertyKeys must convert string-valued
+// array indices (e.g. "0") to numbers before comparing with targetKeys,
+// because getOwnPropertyKeys stores indexed properties as numbers.
+// Without the fix, the isSameValue invariant check fails with a TypeError
+// for non-extensible targets that have indexed properties.
+
+// Case 1: non-extensible plain object with numeric-string keys.
+var obj = {"0": "a", "1": "b"};
+Object.preventExtensions(obj);
+var proxy1 = new Proxy(obj, {
+  ownKeys: function(target) {
+    return ["0", "1"];
+  }
+});
+try {
+  var keys1 = Object.getOwnPropertyNames(proxy1);
+  print("keys1: " + keys1);
+} catch (e) {
+  print("keys1 error: " + e.constructor.name + ": " + e.message);
+}
+// CHECK: keys1: 0,1
+
+// Case 2: non-extensible array (has indexed storage).
+var arr = [10, 20, 30];
+Object.preventExtensions(arr);
+var proxy2 = new Proxy(arr, {
+  ownKeys: function(target) {
+    return ["0", "1", "2", "length"];
+  }
+});
+try {
+  var keys2 = Object.getOwnPropertyNames(proxy2);
+  print("keys2: " + keys2);
+} catch (e) {
+  print("keys2 error: " + e.constructor.name + ": " + e.message);
+}
+// CHECK-NEXT: keys2: 0,1,2,length
+
+// Case 3: sealed array (non-configurable + non-extensible).
+var arr2 = [100, 200];
+Object.seal(arr2);
+var proxy3 = new Proxy(arr2, {
+  ownKeys: function(target) {
+    return ["0", "1", "length"];
+  }
+});
+try {
+  var keys3 = Object.getOwnPropertyNames(proxy3);
+  print("keys3: " + keys3);
+} catch (e) {
+  print("keys3 error: " + e.constructor.name + ": " + e.message);
+}
+// CHECK-NEXT: keys3: 0,1,length
+
+// Case 4: frozen object with numeric keys (non-configurable + non-writable).
+var obj2 = {"0": "x", "1": "y", "foo": "bar"};
+Object.freeze(obj2);
+var proxy4 = new Proxy(obj2, {
+  ownKeys: function(target) {
+    return ["0", "1", "foo"];
+  }
+});
+try {
+  var keys4 = Object.getOwnPropertyNames(proxy4);
+  print("keys4: " + keys4);
+} catch (e) {
+  print("keys4 error: " + e.constructor.name + ": " + e.message);
+}
+// CHECK-NEXT: keys4: 0,1,foo
+
+// Case 5: Reflect.ownKeys on a non-extensible array (uses same code path).
+var arr3 = ["a", "b"];
+Object.preventExtensions(arr3);
+var proxy5 = new Proxy(arr3, {
+  ownKeys: function(target) {
+    return Reflect.ownKeys(target);
+  }
+});
+try {
+  var keys5 = Reflect.ownKeys(proxy5);
+  print("keys5: " + keys5);
+} catch (e) {
+  print("keys5 error: " + e.constructor.name + ": " + e.message);
+}
+// CHECK-NEXT: keys5: 0,1,length


### PR DESCRIPTION
## Summary

`JSProxy::ownPropertyKeys` throws a spurious `TypeError` when the proxy's
`ownKeys` trap returns string-valued array indices (e.g. `"0"`, `"1"`) and
the target object is non-extensible, sealed, or frozen.

## The Bug

`JSObject::getOwnPropertyKeys` stores indexed properties as **numbers** in the
result array (via `HermesValue::encodeTrustedNumberValue`). However, the
`ownKeys` trap result processes values from the trap's return array as-is,
keeping string keys like `"0"` as strings.

Later, the ES spec invariant checks (steps 19 and 21 of
`[[OwnPropertyKeys]]`) compare `targetKeys` entries against `trapResult`
entries using `isSameValue`. Since `isSameValue` checks the HermesValue tag
first, `isSameValue(Number(0), String("0"))` returns `false` — the types
don't match — even though they represent the same property key.

This causes the invariant check to incorrectly throw:
- `"ownKeys target key is non-configurable but not present in trap result"`
  (for sealed/frozen targets)
- `"ownKeys target is non-extensible but key is missing from trap result"`
  (for non-extensible targets)

## The Fix

In `lib/VM/JSProxy.cpp`, inside the `createListFromArrayLike_RJS` callback
in `ownPropertyKeys`, convert string values that are valid array indices to
their numeric representation before storing them in `trapResult`. This uses
`toArrayIndex()` to detect numeric strings and
`HermesValue::encodeTrustedNumberValue()` to convert, matching the format
used by `getOwnPropertyKeys`.

```cpp
if (valHandle->isString()) {
  Handle<StringPrimitive> str =
      Handle<StringPrimitive>::vmcast(valHandle);
  OptValue<uint32_t> strAsIndexOpt = toArrayIndex(*str);
  // Convert index keys to numbers to match the format
  // returned by getOwnPropertyKeys.
  if (strAsIndexOpt) {
    HermesValue strAsIndexValue =
        HermesValue::encodeTrustedNumberValue(
            static_cast<double>(strAsIndexOpt.getValue()));
    return JSArray::setElementAt(
        trapResult,
        runtime,
        index,
        runtime.makeHandle(strAsIndexValue));
  }
}
```

## Reproduction

Any of these patterns trigger the bug without the fix:

```javascript
// Non-extensible object with numeric-string keys
var obj = {"0": "a", "1": "b"};
Object.preventExtensions(obj);
var proxy = new Proxy(obj, {
  ownKeys(target) { return ["0", "1"]; }
});
Object.getOwnPropertyNames(proxy); // TypeError!

// Non-extensible array
var arr = [10, 20, 30];
Object.preventExtensions(arr);
var proxy2 = new Proxy(arr, {
  ownKeys(target) { return ["0", "1", "2", "length"]; }
});
Object.getOwnPropertyNames(proxy2); // TypeError!

// Reflect.ownKeys on a non-extensible array
var arr2 = ["a", "b"];
Object.preventExtensions(arr2);
var proxy3 = new Proxy(arr2, {
  ownKeys(target) { return Reflect.ownKeys(target); }
});
Reflect.ownKeys(proxy3); // TypeError!
```

Note: the bug does **not** manifest for extensible targets because the
`isSameValue` invariant checks (steps 19 and 21) are only reached for
non-extensible targets.

## Test

Added `test/hermes/regress-proxy-ownkeys-index.js` covering five cases:
1. Non-extensible plain object with numeric-string keys
2. Non-extensible array
3. Sealed array (non-configurable + non-extensible)
4. Frozen object with mixed numeric and named keys
5. `Reflect.ownKeys` on a non-extensible array

All five fail with `TypeError` without the fix and pass with it.
