### PR TITLE
Make Math.sumPrecise reject multiple arguments per spec

### DIFF
--- a/lib/InternalJavaScript/20-MathPrototypeSumPrecise.js
+++ b/lib/InternalJavaScript/20-MathPrototypeSumPrecise.js
@@ -41,6 +41,9 @@
 // - Adapted to handle overflow via an additional "biased" partial, representing 2**1024 times its actual value
 
 Math.sumPrecise = function sumPrecise(iterable) {
+  if (arguments.length !== 1) {
+    throw new TypeError('Math.sumPrecise expects exactly one argument');
+  }
   // Type check - ensure iterable has Symbol.iterator
   if (!iterable || typeof iterable[Symbol.iterator] !== 'function') {
     throw new TypeError('Math.sumPrecise requires an iterable');

--- a/test/hermes/math-sumprecise.js
+++ b/test/hermes/math-sumprecise.js
@@ -114,11 +114,12 @@ try {
 // CHECK-NEXT: Non-iterable: TypeError
 
 // Test type checking - multiple arguments
-// Note: test262 expects this to throw TypeError (should only accept 1 arg)
-// Current polyfill implementation accepts multiple args (uses first, ignores rest)
-// TODO: Make Math.sumPrecise reject multiple arguments per spec
-print(Math.sumPrecise([1, 2], [3, 4]));
-// CHECK-NEXT: 3
+try {
+  Math.sumPrecise([1, 2], [3, 4]);
+} catch(e) {
+  print('Multiple args:', e.name);
+}
+// CHECK-NEXT: Multiple args: TypeError
 
 // Test with Set (another iterable type)
 print(Math.sumPrecise(new Set([1, 2, 3])));


### PR DESCRIPTION
## Summary
Make Math.sumPrecise throw a TypeError when called with zero or more than one argument, matching the TC39 proposal and test262 expectations.
