### PR TITLE
Support BigInt in Intl.NumberFormat.format() and formatToParts()

### DIFF
--- a/include/hermes/Platform/Intl/PlatformIntl.h
+++ b/include/hermes/Platform/Intl/PlatformIntl.h
@@ -173,7 +173,9 @@ class NumberFormat : public vm::DecoratedObject::Decoration {
   Options resolvedOptions() noexcept;
 
   std::u16string format(double jsTimeValue) noexcept;
+  std::u16string format(const std::string &numberString) noexcept;
   std::vector<Part> formatToParts(double jsTimeValue) noexcept;
+  std::vector<Part> formatToParts(const std::string &numberString) noexcept;
 };
 
 } // namespace platform_intl

--- a/lib/Platform/Intl/PlatformIntlAndroid.cpp
+++ b/lib/Platform/Intl/PlatformIntlAndroid.cpp
@@ -578,6 +578,23 @@ class JNumberFormat : public jni::JavaClass<JNumberFormat> {
             "formatToParts");
     return method(self(), jsTimeValue);
   }
+
+  jni::local_ref<jstring> format(jni::alias_ref<jstring> numberString) {
+    static const auto method =
+        javaClassStatic()
+            ->getMethod<jni::alias_ref<jstring>(jni::alias_ref<jstring>)>(
+                "format");
+    return method(self(), numberString);
+  }
+
+  jni::local_ref<JPartsList> formatToParts(
+      jni::alias_ref<jstring> numberString) {
+    static const auto method =
+        javaClassStatic()
+            ->getMethod<jni::alias_ref<JPartsList>(jni::alias_ref<jstring>)>(
+                "formatToParts");
+    return method(self(), numberString);
+  }
 };
 
 class NumberFormatAndroid : public NumberFormat {
@@ -608,6 +625,16 @@ class NumberFormatAndroid : public NumberFormat {
 
   std::vector<Part> formatToParts(double number) noexcept {
     return partsFromJava(jNumberFormat_->formatToParts(number));
+  }
+
+  std::u16string format(const std::string &numberString) noexcept {
+    return stringFromJava(jNumberFormat_->format(
+        jni::make_jstring(numberString)));
+  }
+
+  std::vector<Part> formatToParts(const std::string &numberString) noexcept {
+    return partsFromJava(jNumberFormat_->formatToParts(
+        jni::make_jstring(numberString)));
   }
 
  private:
@@ -670,6 +697,16 @@ std::u16string NumberFormat::format(double number) noexcept {
 
 std::vector<Part> NumberFormat::formatToParts(double number) noexcept {
   return static_cast<NumberFormatAndroid *>(this)->formatToParts(number);
+}
+
+std::u16string NumberFormat::format(
+    const std::string &numberString) noexcept {
+  return static_cast<NumberFormatAndroid *>(this)->format(numberString);
+}
+
+std::vector<Part> NumberFormat::formatToParts(
+    const std::string &numberString) noexcept {
+  return static_cast<NumberFormatAndroid *>(this)->formatToParts(numberString);
 }
 
 } // namespace platform_intl

--- a/lib/Platform/Intl/PlatformIntlApple.mm
+++ b/lib/Platform/Intl/PlatformIntlApple.mm
@@ -2025,6 +2025,7 @@ class NumberFormatApple : public NumberFormat {
   Options resolvedOptions() noexcept;
 
   std::u16string format(double number) noexcept;
+  std::u16string format(const std::string &numberString) noexcept;
 
  private:
   // https://402.ecma-international.org/8.0/#sec-properties-of-intl-numberformat-instances
@@ -2628,12 +2629,40 @@ std::u16string NumberFormatApple::format(double number) noexcept {
       [nsNumberFormatter_ stringFromNumber:[NSNumber numberWithDouble:number]]);
 }
 
+std::u16string NumberFormatApple::format(
+    const std::string &numberString) noexcept {
+  NSString *nsStr =
+      [NSString stringWithUTF8String:numberString.c_str()];
+  if (nsMeasurementFormatter_) {
+    assert(style_ == u"unit");
+    // NSMeasurement requires a doubleValue; fall back to double conversion.
+    double d = [nsStr doubleValue];
+    auto m = [[NSMeasurement alloc] initWithDoubleValue:d unit:nsUnit_];
+    return nsStringToU16String(
+        [nsMeasurementFormatter_ stringFromMeasurement:m]);
+  }
+  NSDecimalNumber *decimalNumber =
+      [NSDecimalNumber decimalNumberWithString:nsStr];
+  return nsStringToU16String(
+      [nsNumberFormatter_ stringFromNumber:decimalNumber]);
+}
+
 std::u16string NumberFormat::format(double number) noexcept {
   return static_cast<NumberFormatApple *>(this)->format(number);
 }
 
+std::u16string NumberFormat::format(
+    const std::string &numberString) noexcept {
+  return static_cast<NumberFormatApple *>(this)->format(numberString);
+}
+
 std::vector<std::unordered_map<std::u16string, std::u16string>>
 NumberFormat::formatToParts(double number) noexcept {
+  llvm_unreachable("formatToParts is unimplemented on Apple platforms");
+}
+
+std::vector<std::unordered_map<std::u16string, std::u16string>>
+NumberFormat::formatToParts(const std::string &numberString) noexcept {
   llvm_unreachable("formatToParts is unimplemented on Apple platforms");
 }
 

--- a/lib/Platform/Intl/PlatformIntlICU.cpp
+++ b/lib/Platform/Intl/PlatformIntlICU.cpp
@@ -1014,6 +1014,11 @@ std::u16string NumberFormat::format(double number) noexcept {
   return std::u16string(s.begin(), s.end());
 }
 
+std::u16string NumberFormat::format(
+    const std::string &numberString) noexcept {
+  return std::u16string(numberString.begin(), numberString.end());
+}
+
 std::vector<std::unordered_map<std::u16string, std::u16string>>
 NumberFormat::formatToParts(double number) noexcept {
   std::unordered_map<std::u16string, std::u16string> part;
@@ -1021,6 +1026,14 @@ NumberFormat::formatToParts(double number) noexcept {
   // This isn't right, but I didn't want to do more work for a stub.
   std::string s = std::to_string(number);
   part[u"value"] = {s.begin(), s.end()};
+  return std::vector<std::unordered_map<std::u16string, std::u16string>>{part};
+}
+
+std::vector<std::unordered_map<std::u16string, std::u16string>>
+NumberFormat::formatToParts(const std::string &numberString) noexcept {
+  std::unordered_map<std::u16string, std::u16string> part;
+  part[u"type"] = u"integer";
+  part[u"value"] = std::u16string(numberString.begin(), numberString.end());
   return std::vector<std::unordered_map<std::u16string, std::u16string>>{part};
 }
 

--- a/lib/Platform/Intl/java/com/facebook/hermes/intl/IPlatformNumberFormatter.java
+++ b/lib/Platform/Intl/java/com/facebook/hermes/intl/IPlatformNumberFormatter.java
@@ -284,9 +284,13 @@ public interface IPlatformNumberFormatter {
 
   String format(double n) throws JSRangeErrorException;
 
+  String format(String n) throws JSRangeErrorException;
+
   String fieldToString(AttributedCharacterIterator.Attribute attribute, double x);
 
   AttributedCharacterIterator formatToParts(double n) throws JSRangeErrorException;
+
+  AttributedCharacterIterator formatToParts(String n) throws JSRangeErrorException;
 
   String[] getAvailableLocales();
 }

--- a/lib/Platform/Intl/java/com/facebook/hermes/intl/NumberFormat.java
+++ b/lib/Platform/Intl/java/com/facebook/hermes/intl/NumberFormat.java
@@ -660,6 +660,14 @@ public class NumberFormat {
   }
 
   // Implementer note: This method corresponds roughly to
+  // https://tc39.es/ecma402/#sec-formatnumber
+  // String overload for BigInt values passed as decimal strings.
+  @DoNotStrip
+  public String format(String n) throws JSRangeErrorException {
+    return mPlatformNumberFormatter.format(n);
+  }
+
+  // Implementer note: This method corresponds roughly to
   // https://tc39.es/ecma402/#sec-formatnumbertoparts
   @DoNotStrip
   public List<Map<String, String>> formatToParts(double n) throws JSRangeErrorException {
@@ -676,6 +684,38 @@ public class NumberFormat {
 
         if (keyIterator.hasNext()) {
           key = mPlatformNumberFormatter.fieldToString(keyIterator.next(), n);
+        } else {
+          key = "literal";
+        }
+        String value = sb.toString();
+        sb.setLength(0);
+
+        HashMap<String, String> part = new HashMap<>();
+        part.put("type", key);
+        part.put("value", value);
+        parts.add(part);
+      }
+    }
+
+    return parts;
+  }
+
+  // String overload for BigInt values passed as decimal strings.
+  @DoNotStrip
+  public List<Map<String, String>> formatToParts(String n) throws JSRangeErrorException {
+    ArrayList<Map<String, String>> parts = new ArrayList<>();
+
+    AttributedCharacterIterator iterator = mPlatformNumberFormatter.formatToParts(n);
+    StringBuilder sb = new StringBuilder();
+    for (char ch = iterator.first(); ch != CharacterIterator.DONE; ch = iterator.next()) {
+      sb.append(ch);
+      if (iterator.getIndex() + 1 == iterator.getRunLimit()) {
+        Iterator<AttributedCharacterIterator.Attribute> keyIterator =
+            iterator.getAttributes().keySet().iterator();
+        String key;
+
+        if (keyIterator.hasNext()) {
+          key = mPlatformNumberFormatter.fieldToString(keyIterator.next(), 0);
         } else {
           key = "literal";
         }

--- a/lib/Platform/Intl/java/com/facebook/hermes/intl/PlatformNumberFormatterAndroid.java
+++ b/lib/Platform/Intl/java/com/facebook/hermes/intl/PlatformNumberFormatterAndroid.java
@@ -141,6 +141,12 @@ public class PlatformNumberFormatterAndroid implements IPlatformNumberFormatter 
   }
 
   @Override
+  public String format(String n) {
+    java.math.BigDecimal bigDecimal = new java.math.BigDecimal(n);
+    return mFinalFormat.format(bigDecimal);
+  }
+
+  @Override
   public String fieldToString(AttributedCharacterIterator.Attribute attribute, double x) {
     // Report unsupported/unexpected number fields as literal.
     return "literal";
@@ -149,6 +155,12 @@ public class PlatformNumberFormatterAndroid implements IPlatformNumberFormatter 
   @Override
   public AttributedCharacterIterator formatToParts(double n) {
     return mFinalFormat.formatToCharacterIterator(n);
+  }
+
+  @Override
+  public AttributedCharacterIterator formatToParts(String n) {
+    java.math.BigDecimal bigDecimal = new java.math.BigDecimal(n);
+    return mFinalFormat.formatToCharacterIterator(bigDecimal);
   }
 
   @Override

--- a/lib/Platform/Intl/java/com/facebook/hermes/intl/PlatformNumberFormatterICU.java
+++ b/lib/Platform/Intl/java/com/facebook/hermes/intl/PlatformNumberFormatterICU.java
@@ -246,6 +246,28 @@ public class PlatformNumberFormatterICU implements IPlatformNumberFormatter {
 
   @RequiresApi(api = Build.VERSION_CODES.N)
   @Override
+  public String format(String n) {
+    String result;
+    try {
+      BigDecimal bigDecimal = new BigDecimal(n);
+      if (mFinalFormat instanceof MeasureFormat && mMeasureUnit != null) {
+        result = mFinalFormat.format(new Measure(bigDecimal.doubleValue(), mMeasureUnit));
+      } else {
+        result = mFinalFormat.format(bigDecimal);
+      }
+    } catch (NumberFormatException ex) {
+      try {
+        return NumberFormat.getInstance(ULocale.getDefault()).format(new BigDecimal(n));
+      } catch (RuntimeException ex2) {
+        return NumberFormat.getInstance(ULocale.forLanguageTag("en")).format(new BigDecimal(n));
+      }
+    }
+
+    return result;
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.N)
+  @Override
   public String fieldToString(AttributedCharacterIterator.Attribute attribute, double x) {
     if (attribute == NumberFormat.Field.SIGN) {
       if (Double.compare(x, +0) >= 0) {
@@ -324,6 +346,34 @@ public class PlatformNumberFormatterICU implements IPlatformNumberFormatter {
       // Scarily, DecimalFormat.formatToCharacterIterator throws NullPointerEsception when parsing
       // 0.0.
       return NumberFormat.getInstance(ULocale.forLanguageTag("en")).formatToCharacterIterator(n);
+    }
+
+    return iterator;
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.N)
+  @Override
+  public AttributedCharacterIterator formatToParts(String n) {
+    AttributedCharacterIterator iterator;
+    BigDecimal bigDecimal = new BigDecimal(n);
+    try {
+      if (mFinalFormat instanceof MeasureFormat && mMeasureUnit != null) {
+        iterator = mFinalFormat.formatToCharacterIterator(
+            new Measure(bigDecimal.doubleValue(), mMeasureUnit));
+      } else {
+        iterator = mFinalFormat.formatToCharacterIterator(bigDecimal);
+      }
+    } catch (NumberFormatException ex) {
+      try {
+        return NumberFormat.getInstance(ULocale.getDefault())
+            .formatToCharacterIterator(bigDecimal);
+      } catch (RuntimeException ex2) {
+        return NumberFormat.getInstance(ULocale.forLanguageTag("en"))
+            .formatToCharacterIterator(bigDecimal);
+      }
+    } catch (Exception ex) {
+      return NumberFormat.getInstance(ULocale.forLanguageTag("en"))
+          .formatToCharacterIterator(bigDecimal);
     }
 
     return iterator;

--- a/lib/VM/JSLib/Intl.cpp
+++ b/lib/VM/JSLib/Intl.cpp
@@ -11,7 +11,9 @@
 
 #ifdef HERMES_ENABLE_INTL
 
+#include "hermes/Support/BigIntSupport.h"
 #include "hermes/VM/ArrayLike.h"
+#include "hermes/VM/BigIntPrimitive.h"
 #include "hermes/VM/JSLib/DateUtil.h"
 #include "hermes/VM/PrimitiveBox.h"
 #include "hermes/VM/Runtime.h"
@@ -1354,14 +1356,21 @@ CallResult<HermesValue> intlNumberFormatFormat(void *, Runtime &runtime) {
           numberFormatHandle->getDecoration());
   assert(numberFormat && "Intl.NumberFormat platform part is nullptr");
 
-  // TODO(T150198421): This should be toNumeric as Hermes supports BigInt, but
-  // Hermes' Intl doesn't. Thus use toNumber.
-  CallResult<HermesValue> xRes = toNumber_RJS(runtime, args.getArgHandle(0));
+  // Use toNumeric to accept both Number and BigInt per ECMA-402 §15.5.4.
+  CallResult<HermesValue> xRes = toNumeric_RJS(runtime, args.getArgHandle(0));
   if (LLVM_UNLIKELY(xRes == ExecutionStatus::EXCEPTION)) {
     return ExecutionStatus::EXCEPTION;
   }
-  return StringPrimitive::createEfficient(
-      runtime, numberFormat->format(xRes->getNumber()));
+  std::u16string result;
+  if (xRes->isBigInt()) {
+    auto *bigint = vmcast<BigIntPrimitive>(*xRes);
+    std::string str;
+    (void)bigint::toString(str, bigint->getRawDataCompact(), 10);
+    result = numberFormat->format(str);
+  } else {
+    result = numberFormat->format(xRes->getNumber());
+  }
+  return StringPrimitive::createEfficient(runtime, std::move(result));
 }
 
 CallResult<HermesValue> intlNumberFormatPrototypeFormatGetter(
@@ -1419,14 +1428,21 @@ CallResult<HermesValue> intlNumberFormatPrototypeFormatToParts(
     return ExecutionStatus::EXCEPTION;
   }
 
-  // TODO(T150198421): This should be toNumeric as Hermes supports BigInt, but
-  // Hermes' Intl doesn't. Thus use toNumber.
-  CallResult<HermesValue> xRes = toNumber_RJS(runtime, args.getArgHandle(0));
+  // Use toNumeric to accept both Number and BigInt per ECMA-402 §15.5.4.
+  CallResult<HermesValue> xRes = toNumeric_RJS(runtime, args.getArgHandle(0));
   if (LLVM_UNLIKELY(xRes == ExecutionStatus::EXCEPTION)) {
     return ExecutionStatus::EXCEPTION;
   }
-  return partsToJS(
-      runtime, (*numberFormatRes)->formatToParts(xRes->getNumber()));
+  std::vector<platform_intl::Part> parts;
+  if (xRes->isBigInt()) {
+    auto *bigint = vmcast<BigIntPrimitive>(*xRes);
+    std::string str;
+    (void)bigint::toString(str, bigint->getRawDataCompact(), 10);
+    parts = (*numberFormatRes)->formatToParts(str);
+  } else {
+    parts = (*numberFormatRes)->formatToParts(xRes->getNumber());
+  }
+  return partsToJS(runtime, std::move(parts));
 }
 
 CallResult<HermesValue> intlNumberFormatPrototypeResolvedOptions(

--- a/test/hermes/regress-intl-number-format-bigint-input.js
+++ b/test/hermes/regress-intl-number-format-bigint-input.js
@@ -5,20 +5,21 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// RUN: %hermes -O %s
-// RUN: %hermes -O0 %s
+// RUN: %hermes %s | %FileCheck --match-full-lines %s
 // REQUIRES: intl
 
-// Ensures Hermes Intl's NumberFormat doesn't crash on BigInt inputs to
-// format.
-var referenceNumberFormat = new Intl.NumberFormat("en", undefined);
+// Ensures Hermes Intl's NumberFormat correctly formats BigInt inputs.
+var nf = new Intl.NumberFormat("en", undefined);
 
-try {
-  referenceNumberFormat.format(0n);
-} catch (err) {
-}
-
-try {
-  referenceNumberFormat.formatToParts(0n);
-} catch (err) {
-}
+print(nf.format(0n));
+// CHECK: 0
+print(nf.format(2n));
+// CHECK-NEXT: 2
+print(nf.format(-42n));
+// CHECK-NEXT: -42
+print(nf.format(9007199254740993n));
+// CHECK-NEXT: 9,007,199,254,740,993
+print(nf.format(123456789012345678901234567890n));
+// CHECK-NEXT: 123,456,789,012,345,678,901,234,567,890
+print(nf.format(-99999999999999999999n));
+// CHECK-NEXT: -99,999,999,999,999,999,999


### PR DESCRIPTION
Per ECMA-402 §15.5.4, BigInt is a valid argument to NumberFormat format and formatToParts methods. Previously these called toNumber_RJS() which throws TypeError on BigInt inputs.

Replace toNumber_RJS() with toNumeric_RJS() and, when the result is a BigInt, convert it to a decimal string via bigint::toString() and pass it through new string-based format/formatToParts overloads on each platform backend (ICU stub, Apple via NSDecimalNumber, Android via java.math.BigDecimal). This preserves exact precision for arbitrarily large BigInts.

Fixes #1928