### PR TITLE
Expose parseFlowMatch in Rust parser FFI

### DIFF
--- a/lib/Parser/rust-api.cpp
+++ b/lib/Parser/rust-api.cpp
@@ -501,6 +501,8 @@ struct ParserFlags {
   bool strictMode = false;
   /// Enable JSX parsing.
   bool enableJSX = false;
+  /// Enable Flow match parsing.
+  bool parseFlowMatch = false;
   /// Dialect control.
   ParserDialect dialect = ParserDialect::JavaScript;
   /// Store doc-comment block at the top of the file.
@@ -660,6 +662,7 @@ hermes_parser_parse(ParserFlags flags, const char *source, size_t len) {
 
   parserCtx->context_.setStrictMode(flags.strictMode);
   parserCtx->context_.setParseJSX(flags.enableJSX);
+  parserCtx->context_.setParseFlowMatch(flags.parseFlowMatch);
 
   if (len == 0 || source[len - 1] != 0) {
     parserCtx->addError("Input is not zero terminated");

--- a/unsupported/juno/crates/hermes/src/parser/hermes_parser.rs
+++ b/unsupported/juno/crates/hermes/src/parser/hermes_parser.rs
@@ -52,6 +52,8 @@ pub struct ParserFlags {
     pub strict_mode: bool,
     /// Enable JSX parsing.
     pub enable_jsx: bool,
+    /// Enable Flow match parsing.
+    pub parse_flow_match: bool,
     /// Dialect control.
     pub dialect: ParserDialect,
     /// Store doc-comment block at the top of the file.
@@ -65,6 +67,7 @@ impl Default for ParserFlags {
         ParserFlags {
             strict_mode: false,
             enable_jsx: false,
+            parse_flow_match: false,
             dialect: ParserDialect::JavaScript,
             store_doc_block: false,
             store_comments: false,
@@ -427,6 +430,7 @@ var foo; // Comment 2
             ParserFlags {
                 strict_mode: false,
                 enable_jsx: false,
+                parse_flow_match: false,
                 dialect: ParserDialect::JavaScript,
                 store_doc_block: false,
                 store_comments: true,


### PR DESCRIPTION
## Summary

Expose `parseFlowMatch` through Hermes' Rust parser FFI so `ParserFlags` stays ABI-compatible with the C++ bridge and Rust consumers get parity with existing Hermes parser entry points.

## Test Plan

- Formatted the change with `utils/format.sh -f`
- Verified the Rust FFI bridge with `cargo check -p hermes --tests` in `unsupported/juno`
- Verified the C++ bridge by building `hermesParser`
