### PR TITLE
Fix freeze/seal on lazy function objects

### DIFF
--- a/lib/VM/JSObject.cpp
+++ b/lib/VM/JSObject.cpp
@@ -2735,6 +2735,10 @@ CallResult<bool> JSObject::preventExtensions(
 }
 
 ExecutionStatus JSObject::seal(Handle<JSObject> selfHandle, Runtime &runtime) {
+  if (selfHandle->isLazy()) {
+    initializeLazyObject(runtime, selfHandle);
+  }
+
   CallResult<bool> statusRes = JSObject::preventExtensions(
       selfHandle, runtime, PropOpFlags().plusThrowOnError());
   if (LLVM_UNLIKELY(statusRes == ExecutionStatus::EXCEPTION)) {
@@ -2759,6 +2763,10 @@ ExecutionStatus JSObject::seal(Handle<JSObject> selfHandle, Runtime &runtime) {
 ExecutionStatus JSObject::freeze(
     Handle<JSObject> selfHandle,
     Runtime &runtime) {
+  if (selfHandle->isLazy()) {
+    initializeLazyObject(runtime, selfHandle);
+  }
+
   CallResult<bool> statusRes = JSObject::preventExtensions(
       selfHandle, runtime, PropOpFlags().plusThrowOnError());
   if (LLVM_UNLIKELY(statusRes == ExecutionStatus::EXCEPTION)) {

--- a/test/hermes/regress-lazy-freeze-seal-function.js
+++ b/test/hermes/regress-lazy-freeze-seal-function.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes %s | %FileCheck --match-full-lines %s
+// RUN: %hermes -emit-binary -out %t.hbc %s && %hermes %t.hbc | %FileCheck --match-full-lines %s
+
+'use strict';
+
+print('freeze');
+// CHECK-LABEL: freeze
+(function () {
+  function frozenFn(a, b) {}
+
+  Object.freeze(frozenFn);
+
+  var frozenDesc = Object.getOwnPropertyDescriptor(frozenFn, 'length');
+  print(Object.isFrozen(frozenFn));
+  // CHECK-NEXT: true
+  print(frozenDesc.configurable, frozenDesc.writable);
+  // CHECK-NEXT: false false
+
+  try {
+    delete frozenFn.length;
+  } catch (e) {
+    print(e.name);
+    // CHECK-NEXT: TypeError
+  }
+})();
+
+print('seal');
+// CHECK-LABEL: seal
+(function () {
+  function sealedFn(a, b) {}
+
+  Object.seal(sealedFn);
+
+  var sealedDesc = Object.getOwnPropertyDescriptor(sealedFn, 'length');
+  print(Object.isSealed(sealedFn));
+  // CHECK-NEXT: true
+  print(sealedDesc.configurable, sealedDesc.writable);
+  // CHECK-NEXT: false false
+
+  try {
+    delete sealedFn.length;
+  } catch (e) {
+    print(e.name);
+    // CHECK-NEXT: TypeError
+  }
+})();


### PR DESCRIPTION
## Summary

Fix `Object.freeze()` / `Object.seal()` on lazy function objects.

Before this change, `JSObject::freeze()` and `JSObject::seal()` could mark a lazy function object as frozen/sealed before its lazy properties were materialized. Later, lazy initialization would still add properties like `length` and `name`, leaving them configurable on an object that already reported itself as frozen.

The problematic code path was that `seal()` / `freeze()` did not initialize lazy objects first:

```cpp
ExecutionStatus JSObject::seal(Handle<JSObject> selfHandle, Runtime &runtime) {
  CallResult<bool> statusRes = JSObject::preventExtensions(
      selfHandle, runtime, PropOpFlags().plusThrowOnError());
  ...
}

ExecutionStatus JSObject::freeze(
    Handle<JSObject> selfHandle,
    Runtime &runtime) {
  CallResult<bool> statusRes = JSObject::preventExtensions(
      selfHandle, runtime, PropOpFlags().plusThrowOnError());
  ...
}
```

This change fixes that by forcing lazy initialization before the object is marked non-extensible and before the hidden class flags are updated.

[poc.js](https://github.com/user-attachments/files/25926631/poc.js)

Original PoC reproduction:

```bash
./build/bin/hermes ./poc.js
```

Original output before the fix:

```text
isFrozen: true
length.configurable: true
BUG CONFIRMED: delete foo.length succeeded on a frozen function object.
  foo.length after delete: 0
  Object.isFrozen(foo): true
```

## Test Plan

```bash
cmake --build ./build --target hermes
./build/bin/hermes test/hermes/regress-lazy-freeze-seal-function.js
./build/bin/hermes -emit-binary -out /tmp/regress-lazy-freeze-seal-function.hbc \
  test/hermes/regress-lazy-freeze-seal-function.js
./build/bin/hermes /tmp/regress-lazy-freeze-seal-function.hbc
cmake --build ./build --target check-hermes
```

`check-hermes` result:

```text
Testing Time: 25.44s
  Expected Passes    : 2761
  Expected Failures  : 5
  Unsupported Tests  : 159
```

