### PR TITLE
fix: prevent DCE from removing throwing bigint unary minus

### DIFF
--- a/lib/IR/Instrs.cpp
+++ b/lib/IR/Instrs.cpp
@@ -72,6 +72,11 @@ ValueKind UnaryOperatorInst::parseOperator(llvh::StringRef op) {
 }
 
 SideEffect UnaryOperatorInst::getSideEffectImpl() const {
+  if (getKind() == ValueKind::UnaryMinusInstKind &&
+      getSingleOperand()->getType().canBeBigInt()) {
+    return SideEffect{}.setThrow();
+  }
+
   if (getSingleOperand()->getType().isPrimitive()) {
     return SideEffect{}.setIdempotent();
   }

--- a/test/Optimizer/regress-bigint-unary-minus-dce.js
+++ b/test/Optimizer/regress-bigint-unary-minus-dce.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermesc -dump-ir %s -O | %FileCheck --match-full-lines %s
+
+function f() {
+  let a = BigInt.asUintN(65472, -1n);
+  let b = -a;
+  -b;
+}
+
+// CHECK-LABEL:function f(): undefined
+// CHECK:  %{{[0-9]+}} = UnaryMinusInst {{.*}}
+// CHECK:  %{{[0-9]+}} = UnaryMinusInst {{.*}}
+// CHECK:       ReturnInst undefined: undefined

--- a/test/shermes/regress-bigint-unary-minus-dce.js
+++ b/test/shermes/regress-bigint-unary-minus-dce.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %shermes -exec -O0 %s | %FileCheck --match-full-lines %s
+// RUN: %shermes -exec -O %s | %FileCheck --match-full-lines %s
+
+(function() {
+  let a = BigInt.asUintN(65472, -1n);
+  let b = -a;
+
+  try {
+    -b;
+  } catch (e) {
+    print(e);
+  }
+})();
+
+// CHECK: RangeError: Maximum BigInt size exceeded


### PR DESCRIPTION
## Summary

Fix DCE incorrectly removing throwing unary minus on BigInt values.

Before this change, `UnaryOperatorInst::getSideEffectImpl()` treated any unary operation on a primitive operand as idempotent:

```cpp
SideEffect UnaryOperatorInst::getSideEffectImpl() const {
  if (getSingleOperand()->getType().isPrimitive()) {
    return SideEffect{}.setIdempotent();
  }
  ...
}
```

That is wrong for `UnaryMinusInst` when the operand can be a BigInt. Negating a negative max-size BigInt may need one extra digit in the result, which throws `RangeError: Maximum BigInt size exceeded`. Because the instruction was marked
idempotent, DCE could delete an unused `-bigint` and silently suppress the exception under `-O`.

This change fixes that by marking unary minus as throwing when its operand `canBeBigInt()`:

```cpp
if (getKind() == ValueKind::UnaryMinusInstKind &&
    getSingleOperand()->getType().canBeBigInt()) {
  return SideEffect{}.setThrow();
}
```

[poc.js](https://github.com/user-attachments/files/25931101/poc.js)

Original PoC reproduction:

```bash
./build-static_h/bin/hermes -O ./poc.js
./build-static_h/bin/hermes -O0 ./poc.js
```

Original output before the fix:

```text
$ ./build-static_h/bin/hermes -O poc.js
Bug: RangeError was suppressed by DCE

$ ./build-static_h/bin/hermes -O0 poc.js
Uncaught RangeError: Maximum BigInt size exceeded
```

## Test Plan

```bash
cmake -S ./hermes -B ./hermes/build-static_h -G Ninja -DCMAKE_BUILD_TYPE=Debug
cmake --build ./hermes/build-static_h --target hermes hermesc shermes -j4

./hermes/build-static_h/bin/hermes -O0 \
  ./hermes/test/shermes/regress-bigint-unary-minus-dce.js

./hermes/build-static_h/bin/hermes -O \
  ./hermes/test/shermes/regress-bigint-unary-minus-dce.js

./hermes/build-static_h/bin/hermesc -dump-ir -O \
  ./hermes/test/Optimizer/regress-bigint-unary-minus-dce.js
```

Observed results:

```text
$ hermes -O0 test/shermes/regress-bigint-unary-minus-dce.js
RangeError: Maximum BigInt size exceeded

$ hermes -O test/shermes/regress-bigint-unary-minus-dce.js
RangeError: Maximum BigInt size exceeded

$ hermesc -dump-ir -O test/Optimizer/regress-bigint-unary-minus-dce.js
...
%2 = UnaryMinusInst (:bigint) 1: bigint
%4 = UnaryMinusInst (:number|bigint) %3: any
%5 = UnaryMinusInst (:number|bigint) %4: number|bigint
...
```

Thanks for looking into this and I appreciate any feedback!