### PR TITLE
Support @@dispose/@@asyncDispose and fix @@iterator/@@asyncIterator in object/interface types (TS declarations)

### DIFF
--- a/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/class/members/method/dispose/spec.js
+++ b/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/class/members/method/dispose/spec.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+declare class Foo {
+  @@dispose(): void;
+  @@asyncDispose(): Promise<void>;
+}

--- a/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/class/members/method/dispose/translate-result.shot
+++ b/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/class/members/method/dispose/translate-result.shot
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`flowDefToTSDef class/members/method/dispose 1`] = `
+"/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ * @format
+ */
+
+declare class Foo {
+  [Symbol.dispose](): void;
+  [Symbol.asyncDispose](): Promise<void>;
+}
+"
+`;

--- a/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/interface/members/method/dispose/spec.js
+++ b/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/interface/members/method/dispose/spec.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+interface Foo {
+  @@dispose(): void;
+  @@asyncDispose(): Promise<void>;
+}

--- a/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/interface/members/method/dispose/translate-result.shot
+++ b/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/interface/members/method/dispose/translate-result.shot
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`flowDefToTSDef interface/members/method/dispose 1`] = `
+"/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ * @format
+ */
+
+interface Foo {
+  [Symbol.dispose](): void;
+  [Symbol.asyncDispose](): Promise<void>;
+}
+"
+`;

--- a/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/interface/members/method/iterator/spec.js
+++ b/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/interface/members/method/iterator/spec.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+interface Foo {
+  @@iterator(): Iterator<string>;
+  @@asyncIterator(): AsyncIterator<string>;
+}

--- a/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/interface/members/method/iterator/translate-result.shot
+++ b/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/interface/members/method/iterator/translate-result.shot
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`flowDefToTSDef interface/members/method/iterator 1`] = `
+"/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ * @format
+ */
+
+interface Foo {
+  [Symbol.iterator](): Iterator<string>;
+  [Symbol.asyncIterator](): AsyncIterator<string>;
+}
+"
+`;

--- a/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/object/members/method/dispose/spec.js
+++ b/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/object/members/method/dispose/spec.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+type Foo = {
+  @@dispose(): void,
+  @@asyncDispose(): Promise<void>,
+};

--- a/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/object/members/method/dispose/translate-result.shot
+++ b/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/object/members/method/dispose/translate-result.shot
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`flowDefToTSDef object/members/method/dispose 1`] = `
+"/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ * @format
+ */
+
+type Foo = {[Symbol.dispose](): void; [Symbol.asyncDispose](): Promise<void>};
+"
+`;

--- a/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/object/members/method/iterator/spec.js
+++ b/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/object/members/method/iterator/spec.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+type Foo = {
+  @@iterator(): Iterator<string>,
+  @@asyncIterator(): AsyncIterator<string>,
+};

--- a/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/object/members/method/iterator/translate-result.shot
+++ b/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/object/members/method/iterator/translate-result.shot
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`flowDefToTSDef object/members/method/iterator 1`] = `
+"/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ * @format
+ */
+
+type Foo = {
+  [Symbol.iterator](): Iterator<string>;
+  [Symbol.asyncIterator](): AsyncIterator<string>;
+};
+"
+`;

--- a/tools/hermes-parser/js/flow-api-translator/src/flowDefToTSDef.js
+++ b/tools/hermes-parser/js/flow-api-translator/src/flowDefToTSDef.js
@@ -766,6 +766,13 @@ const getTransforms = (
     }
   };
 
+  const wellKnownSymbols = new Set([
+    'iterator',
+    'asyncIterator',
+    'dispose',
+    'asyncDispose',
+  ]);
+
   const transform = {
     AnyTypeAnnotation(
       _node: FlowESTree.AnyTypeAnnotation,
@@ -944,7 +951,7 @@ const getTransforms = (
                 const _key = member.key;
                 if (_key.type === 'Identifier' && _key.name.startsWith('@@')) {
                   const name = _key.name.slice(2);
-                  if (['iterator', 'asyncIterator'].includes(name)) {
+                  if (wellKnownSymbols.has(name)) {
                     return [
                       {
                         type: 'MemberExpression',
@@ -3728,16 +3735,47 @@ const getTransforms = (
     ObjectTypeProperty(
       node: FlowESTree.ObjectTypeProperty,
     ): TSESTree.TSPropertySignature | TSESTree.TSMethodSignature {
-      const key =
-        node.key.type === 'Identifier'
-          ? transform.Identifier(node.key)
-          : node.key.literalType === 'string'
-            ? transform.StringLiteral(node.key)
-            : null;
+      const [key, computed] = ((): [TSESTree.PropertyName, boolean] => {
+        if (node.key.type === 'Identifier' && node.key.name.startsWith('@@')) {
+          const name = node.key.name.slice(2);
+          if (wellKnownSymbols.has(name)) {
+            return [
+              {
+                type: 'MemberExpression',
+                computed: false,
+                object: {
+                  type: 'Identifier',
+                  name: 'Symbol',
+                  optional: false,
+                  loc: DUMMY_LOC,
+                },
+                optional: false,
+                property: {
+                  type: 'Identifier',
+                  name,
+                  optional: false,
+                  loc: DUMMY_LOC,
+                },
+                loc: DUMMY_LOC,
+              },
+              true,
+            ];
+          }
+        }
 
-      if (key == null) {
-        throw unexpectedTranslationError(node, 'Unsupported key type');
-      }
+        const key =
+          node.key.type === 'Identifier'
+            ? transform.Identifier(node.key)
+            : node.key.literalType === 'string'
+              ? transform.StringLiteral(node.key)
+              : null;
+
+        if (key == null) {
+          throw unexpectedTranslationError(node, 'Unsupported key type');
+        }
+
+        return [key, false];
+      })();
 
       if (node.method === true) {
         // flow has just one node for all object properties and relies upon the method flag
@@ -3746,7 +3784,7 @@ const getTransforms = (
         return {
           type: 'TSMethodSignature',
           loc: DUMMY_LOC,
-          computed: false,
+          computed,
           key,
           kind: node.kind === 'init' ? 'method' : node.kind,
           optional: node.optional,
@@ -3764,7 +3802,7 @@ const getTransforms = (
         return {
           type: 'TSMethodSignature',
           loc: DUMMY_LOC,
-          computed: false,
+          computed,
           key,
           kind: node.kind,
           optional: false,
@@ -3780,7 +3818,7 @@ const getTransforms = (
       return {
         type: 'TSPropertySignature',
         loc: DUMMY_LOC,
-        computed: false,
+        computed,
         key,
         optional: node.optional,
         readonly: node.variance?.kind === 'plus',

--- a/tools/hermes-parser/js/flow-api-translator/src/flowDefToTSDef.js
+++ b/tools/hermes-parser/js/flow-api-translator/src/flowDefToTSDef.js
@@ -3738,7 +3738,7 @@ const getTransforms = (
       const [key, computed] = ((): [TSESTree.PropertyName, boolean] => {
         if (node.key.type === 'Identifier' && node.key.name.startsWith('@@')) {
           const name = node.key.name.slice(2);
-          if (wellKnownSymbols.has(name)) {
+          if (node.method === true && wellKnownSymbols.has(name)) {
             return [
               {
                 type: 'MemberExpression',


### PR DESCRIPTION
## Summary

The flow-api-translator is not translating `@@iterator` / `@@asyncIterator` in object types and interfaces (only class members are handled). This caused raw `@@iterator` syntax to appear in `react-native` `0.85-rc.0` TypeScript definitions, where an `@@iterator` is present in the generated `Read` TS interface.

This PR extends the `DeclareClass` and `ObjectTypeProperty` transforms to handle all well-known symbols (`@@iterator`, `@@asyncIterator`, `@@dispose`, `@@asyncDispose`), converting them to their `[Symbol.*]` TypeScript equivalents.

## Test Plan

Added snapshot tests for all three contexts (class, interface, object type) covering both iterator and dispose symbols. All tests pass:

```sh
NODE_OPTIONS="--experimental-vm-modules" npx jest flow-api-translator/__tests__/flowDefToTSDef -t "iterator|dispose"
```
