### PR TITLE
Fix proxy defineProperty descriptors to omit absent fields

### DIFF
--- a/lib/VM/Operations.cpp
+++ b/lib/VM/Operations.cpp
@@ -2316,42 +2316,46 @@ CallResult<HermesValue> objectFromPropertyDescriptor(
     // Accessor
     auto *accessor = vmcast<PropertyAccessor>(valueOrAccessor.get());
 
-    auto getter = runtime.makeHandle(
-        accessor->getter ? HermesValue::encodeObjectValue(
-                               accessor->getter.getNonNull(runtime))
-                         : HermesValue::encodeUndefinedValue());
+    if (dpFlags.setGetter) {
+      auto getter = runtime.makeHandle(
+          accessor->getter ? HermesValue::encodeObjectValue(
+                                 accessor->getter.getNonNull(runtime))
+                           : HermesValue::encodeUndefinedValue());
 
-    auto setter = runtime.makeHandle(
-        accessor->setter ? HermesValue::encodeObjectValue(
-                               accessor->setter.getNonNull(runtime))
-                         : HermesValue::encodeUndefinedValue());
-
-    auto result = JSObject::defineOwnProperty(
-        obj,
-        runtime,
-        Predefined::getSymbolID(Predefined::get),
-        dpf,
-        getter,
-        PropOpFlags().plusThrowOnError());
-    assert(
-        result != ExecutionStatus::EXCEPTION &&
-        "defineOwnProperty() failed on a new object");
-    if (result == ExecutionStatus::EXCEPTION) {
-      return ExecutionStatus::EXCEPTION;
+      auto result = JSObject::defineOwnProperty(
+          obj,
+          runtime,
+          Predefined::getSymbolID(Predefined::get),
+          dpf,
+          getter,
+          PropOpFlags().plusThrowOnError());
+      assert(
+          result != ExecutionStatus::EXCEPTION &&
+          "defineOwnProperty() failed on a new object");
+      if (result == ExecutionStatus::EXCEPTION) {
+        return ExecutionStatus::EXCEPTION;
+      }
     }
 
-    result = JSObject::defineOwnProperty(
-        obj,
-        runtime,
-        Predefined::getSymbolID(Predefined::set),
-        dpf,
-        setter,
-        PropOpFlags().plusThrowOnError());
-    assert(
-        result != ExecutionStatus::EXCEPTION &&
-        "defineOwnProperty() failed on a new object");
-    if (result == ExecutionStatus::EXCEPTION) {
-      return ExecutionStatus::EXCEPTION;
+    if (dpFlags.setSetter) {
+      auto setter = runtime.makeHandle(
+          accessor->setter ? HermesValue::encodeObjectValue(
+                                 accessor->setter.getNonNull(runtime))
+                           : HermesValue::encodeUndefinedValue());
+
+      auto result = JSObject::defineOwnProperty(
+          obj,
+          runtime,
+          Predefined::getSymbolID(Predefined::set),
+          dpf,
+          setter,
+          PropOpFlags().plusThrowOnError());
+      assert(
+          result != ExecutionStatus::EXCEPTION &&
+          "defineOwnProperty() failed on a new object");
+      if (result == ExecutionStatus::EXCEPTION) {
+        return ExecutionStatus::EXCEPTION;
+      }
     }
   }
 

--- a/lib/VM/Operations.cpp
+++ b/lib/VM/Operations.cpp
@@ -2283,22 +2283,24 @@ CallResult<HermesValue> objectFromPropertyDescriptor(
 
   if (!dpFlags.isAccessor()) {
     // Data Descriptor
-    auto result = JSObject::defineOwnProperty(
-        obj,
-        runtime,
-        Predefined::getSymbolID(Predefined::value),
-        dpf,
-        valueOrAccessor,
-        PropOpFlags().plusThrowOnError());
-    assert(
-        result != ExecutionStatus::EXCEPTION &&
-        "defineOwnProperty() failed on a new object");
-    if (result == ExecutionStatus::EXCEPTION) {
-      return ExecutionStatus::EXCEPTION;
+    if (dpFlags.setValue) {
+      auto result = JSObject::defineOwnProperty(
+          obj,
+          runtime,
+          Predefined::getSymbolID(Predefined::value),
+          dpf,
+          valueOrAccessor,
+          PropOpFlags().plusThrowOnError());
+      assert(
+          result != ExecutionStatus::EXCEPTION &&
+          "defineOwnProperty() failed on a new object");
+      if (result == ExecutionStatus::EXCEPTION) {
+        return ExecutionStatus::EXCEPTION;
+      }
     }
 
     if (dpFlags.setWritable) {
-      result = JSObject::defineOwnProperty(
+      auto result = JSObject::defineOwnProperty(
           obj,
           runtime,
           Predefined::getSymbolID(Predefined::writable),

--- a/test/hermes/regress-proxy-accessor-descriptor.js
+++ b/test/hermes/regress-proxy-accessor-descriptor.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -Xes6-proxy -non-strict -O -target=HBC %s | %FileCheck --match-full-lines %s
+
+var setterCalled = false;
+var target = {};
+
+Object.defineProperty(target, 'x', {
+  get: function() {
+    return 42;
+  },
+  set: function(v) {
+    setterCalled = true;
+    print('setter called:', v);
+  },
+  configurable: true,
+});
+
+var proxy = new Proxy(target, {
+  defineProperty: function(obj, prop, desc) {
+    print('has get:', Object.prototype.hasOwnProperty.call(desc, 'get'));
+    print('has set:', Object.prototype.hasOwnProperty.call(desc, 'set'));
+    print('configurable:', desc.configurable);
+    return Reflect.defineProperty(obj, prop, desc);
+  },
+});
+
+Object.defineProperty(proxy, 'x', {
+  get: function() {
+    return 99;
+  },
+  configurable: true,
+});
+
+target.x = 5;
+
+print('setter intact:', setterCalled);
+
+// CHECK: has get: true
+// CHECK-NEXT: has set: false
+// CHECK-NEXT: configurable: true
+// CHECK-NEXT: setter called: 5
+// CHECK-NEXT: setter intact: true

--- a/test/hermes/regress-proxy-defineproperty-value.js
+++ b/test/hermes/regress-proxy-defineproperty-value.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -Xes6-proxy -non-strict -O -target=HBC %s | %FileCheck --match-full-lines %s
+
+var target = {x: 42};
+
+var proxy = new Proxy(target, {
+  defineProperty: function(obj, prop, desc) {
+    print('has value:', Object.prototype.hasOwnProperty.call(desc, 'value'));
+    print(
+        'has writable:',
+        Object.prototype.hasOwnProperty.call(desc, 'writable'));
+    return Reflect.defineProperty(obj, prop, desc);
+  },
+});
+
+Object.defineProperty(proxy, 'x', {writable: false});
+
+print('target.x:', target.x);
+print(
+    'descriptor.writable:',
+    Object.getOwnPropertyDescriptor(target, 'x').writable);
+
+// CHECK: has value: false
+// CHECK-NEXT: has writable: true
+// CHECK-NEXT: target.x: 42
+// CHECK-NEXT: descriptor.writable: false


### PR DESCRIPTION
## Summary

Fix proxy `defineProperty` descriptor conversion to omit absent fields.

Before this change, `objectFromPropertyDescriptor()` in `lib/VM/Operations.cpp` would materialize some descriptor fields unconditionally based on descriptor kind, instead of only emitting fields that were actually present in the input
property descriptor.

For data descriptors, it always emitted `value`, even when `[[Value]]` was not present:

```cpp
if (!dpFlags.isAccessor()) {
  // Data Descriptor
  auto result = JSObject::defineOwnProperty(
      obj,
      runtime,
      Predefined::getSymbolID(Predefined::value),
      dpf,
      valueOrAccessor,
      PropOpFlags().plusThrowOnError());
  ...
}
```

For accessor descriptors, it always emitted both `get` and `set`, even when one side was absent:

```cpp
auto result = JSObject::defineOwnProperty(
    obj,
    runtime,
    Predefined::getSymbolID(Predefined::get),
    dpf,
    getter,
    PropOpFlags().plusThrowOnError());
...

result = JSObject::defineOwnProperty(
    obj,
    runtime,
    Predefined::getSymbolID(Predefined::set),
    dpf,
    setter,
    PropOpFlags().plusThrowOnError());
```

That is incorrect for forwarding proxies. When a proxy `defineProperty` trap receives a descriptor object, absent fields must stay absent. Emitting them unconditionally changes semantics:

- Accessor-only updates could inject `set: undefined` and silently remove an existing setter.
- Attribute-only data updates could inject `value: undefined` and silently clobber an existing property value.

This change fixes both cases by only emitting `value`, `get`, and `set` when their corresponding `DefinePropertyFlags` bits are set.

[accessor-poc.js](https://github.com/user-attachments/files/25939578/accessor-poc.js)

Original accessor PoC reproduction:

```bash
./build/bin/hermes ./accessor-poc.js
```

Original accessor output before the fix:

```text
BUG CONFIRMED: setter was silently removed (spurious 'set: undefined' injected into descriptor)
```

[value-poc.js](https://github.com/user-attachments/files/25939588/value-poc.js)


Original value PoC reproduction:

```bash
./build/bin/hermes ./value-poc.js
```

Original value output before the fix:

```text
target.x = undefined
```

## Test Plan

```bash
cmake -S ./hermes -B ./hermes/build -G Ninja -DCMAKE_BUILD_TYPE=Debug
cmake --build ./hermes/build --target hermes -j4

./hermes/build/bin/hermes -Xes6-proxy -non-strict -O -target=HBC \
  ./hermes/test/hermes/regress-proxy-accessor-descriptor.js

./hermes/build/bin/hermes ./accessor-poc.js

./hermes/build/bin/hermes -Xes6-proxy -non-strict -O -target=HBC \
  ./hermes/test/hermes/regress-proxy-defineproperty-value.js

./hermes/build-static_h/bin/hermes ./value-poc.js
```

Observed results:

```text
$ hermes -Xes6-proxy -non-strict -O -target=HBC test/hermes/regress-proxy-accessor-descriptor.js
has get: true
has set: false
configurable: true
setter called: 5
setter intact: true

$ hermes ./accessor-poc.js
setter called: 5
No bug: setter still intact

$ hermes -Xes6-proxy -non-strict -O -target=HBC test/hermes/regress-proxy-defineproperty-value.js
has value: false
has writable: true
target.x: 42
descriptor.writable: false

$ hermes ./value-poc.js
target.x = 42
```
