### PR TITLE
Move isCachedUsingEpoch to HiddenClass

### DIFF
--- a/API/hermes/hermes.cpp
+++ b/API/hermes/hermes.cpp
@@ -2413,7 +2413,7 @@ std::shared_ptr<jsi::HostObject> HermesRuntimeImpl::getHostObject(
 bool HermesRuntimeImpl::hasNativeState(const jsi::Object &obj) {
   vm::GCScope gcScope(runtime_);
   auto h = handle(obj);
-  if (h->isProxyObject() || h->isHostObject()) {
+  if (h->isProxyObject(runtime_) || h->isHostObject(runtime_)) {
     return false;
   }
   vm::NamedPropertyDescriptor desc;
@@ -2438,9 +2438,9 @@ void HermesRuntimeImpl::setNativeState(
 
   vm::GCScope gcScope(runtime_);
   auto h = handle(obj);
-  if (h->isProxyObject()) {
+  if (h->isProxyObject(runtime_)) {
     throw jsi::JSINativeException("native state unsupported on Proxy");
-  } else if (h->isHostObject()) {
+  } else if (h->isHostObject(runtime_)) {
     throw jsi::JSINativeException("native state unsupported on HostObject");
   }
   // Allocate a shared_ptr on the C++ heap and use it as context of
@@ -2495,7 +2495,7 @@ void HermesRuntimeImpl::setExternalMemoryPressure(
 
   vm::GCScope gcScope(runtime_);
   auto h = handle(obj);
-  if (h->isProxyObject())
+  if (h->isProxyObject(runtime_))
     throw jsi::JSINativeException("Cannot set external memory on Proxy");
 
   // Check if the internal property is already set. If so, we can update the

--- a/API/hermes_abi/hermes_vtable.cpp
+++ b/API/hermes_abi/hermes_vtable.cpp
@@ -706,7 +706,7 @@ HermesABIVoidOrError set_object_external_memory_pressure(
   auto &rt = *hart->rt;
   vm::GCScope gcScope(rt);
   auto objHandle = toHandle(obj);
-  if (objHandle->isProxyObject()) {
+  if (objHandle->isProxyObject(rt)) {
     hart->nativeExceptionMessage = "Cannot set external memory on Proxy";
     return abi::createVoidOrError(HermesABIErrorCodeNativeException);
   }
@@ -1194,7 +1194,7 @@ HermesABINativeState *get_native_state(
   auto h = toHandle(obj);
 
   // Proxy and HostObject cannot have native state.
-  if (h->isProxyObject() || h->isHostObject())
+  if (h->isProxyObject(runtime) || h->isHostObject(runtime))
     return nullptr;
 
   // Check if the internal property exists, and if so retrieve its descriptor.
@@ -1242,10 +1242,10 @@ HermesABIVoidOrError set_native_state(
   lv.ns = vm::NativeState::create(runtime, abiState, finalize);
 
   auto h = toHandle(obj);
-  if (h->isProxyObject()) {
+  if (h->isProxyObject(runtime)) {
     hart->nativeExceptionMessage = "Native state is unsupported on Proxy";
     return abi::createVoidOrError(HermesABIErrorCodeNativeException);
-  } else if (h->isHostObject()) {
+  } else if (h->isHostObject(runtime)) {
     hart->nativeExceptionMessage = "Native state is unsupported on HostObject";
     return abi::createVoidOrError(HermesABIErrorCodeNativeException);
   }

--- a/include/hermes/BCGen/HBC/BytecodeFileFormat.h
+++ b/include/hermes/BCGen/HBC/BytecodeFileFormat.h
@@ -37,6 +37,9 @@ const static uint64_t DELTA_MAGIC = ~MAGIC;
 static constexpr uint8_t PROPERTY_CACHING_DISABLED =
     std::numeric_limits<uint8_t>::max();
 
+/// Shape table index which indicates no caching.
+static constexpr uint8_t SHAPE_TABLE_CACHING_DISABLED = 0;
+
 /// Alignment of data structures of in file.
 static constexpr size_t BYTECODE_ALIGNMENT = alignof(uint32_t);
 

--- a/include/hermes/BCGen/HBC/BytecodeList.def
+++ b/include/hermes/BCGen/HBC/BytecodeList.def
@@ -123,7 +123,7 @@ DEFINE_OPCODE_1(NewObject, Reg8)
 /// Object.prototype is used. Otherwise the parent itself is used.
 /// Arg1 = the created object
 /// Arg2 = the parent.
-DEFINE_OPCODE_2(NewObjectWithParent, Reg8, Reg8)
+DEFINE_OPCODE_3(NewObjectWithParent, Reg8, Reg8, UInt32)
 
 /// Create an array from a static list of values, as for var=[1,2,3].
 /// Any non-constant elements can be set afterwards with DefineOwnByIndex.

--- a/include/hermes/BCGen/HBC/BytecodeList.def
+++ b/include/hermes/BCGen/HBC/BytecodeList.def
@@ -725,7 +725,8 @@ OPERAND_FUNCTION_ID(CreateClosureLongIndex, 3)
 /// Arg2 is the constructor closure that will be invoked.
 /// Arg3 is a cache index used to speed up fetching the new target prototype
 /// property.
-DEFINE_OPCODE_3(CreateThisForNew, Reg8, Reg8, UInt8)
+/// Arg4 is a shape table entry used for caching the HiddenClass of the object.
+DEFINE_OPCODE_4(CreateThisForNew, Reg8, Reg8, UInt8, UInt16)
 
 /// Allocate an empty, uninitialized object to be used as the `this` parameter
 /// in a `new` expression.
@@ -733,7 +734,8 @@ DEFINE_OPCODE_3(CreateThisForNew, Reg8, Reg8, UInt8)
 /// Arg2 is the constructor closure that will be invoked.
 /// Arg3 is the new.target.
 /// Arg4 is a cache index used to speed up fetching the new target prototype property.
-DEFINE_OPCODE_4(CreateThisForSuper, Reg8, Reg8, Reg8, UInt8)
+/// Arg5 is a shape table entry used for caching the HiddenClass of the object.
+DEFINE_OPCODE_5(CreateThisForSuper, Reg8, Reg8, Reg8, UInt8, UInt16)
 
 /// Choose the result of a constructor: 'this' or a returned object.
 /// Arg1 is the result.

--- a/include/hermes/VM/Callable.h
+++ b/include/hermes/VM/Callable.h
@@ -764,26 +764,50 @@ class NativeFunction : public Callable {
     return createPseudoHandle(*res);
   }
 
+  /// Create an instance of NativeFunction with Function.prototype as the parent
+  /// and the default HiddenClass.
+  ///
+  /// \param context the context to be passed to the function
+  /// \param functionPtr the native function
+  /// \param name the name property of the function.
+  /// \param paramCount number of parameters (excluding `this`)
+  static Handle<NativeFunction> create(
+      Runtime &runtime,
+      void *context,
+      NativeFunctionPtr functionPtr,
+      SymbolID name,
+      unsigned paramCount) {
+    return create(
+        runtime,
+        runtime.functionPrototype,
+        runtime.classNativeFunction,
+        Runtime::makeNullHandle<Environment>(),
+        context,
+        functionPtr,
+        name,
+        paramCount,
+        Runtime::makeNullHandle<JSObject>());
+  }
+
   /// Create an instance of NativeFunction.
   /// \param parentHandle object to use as [[Prototype]].
+  /// \param clazz the HiddenClass for the result object.
   /// \param parentEnvHandle the parent environment
   /// \param context the context to be passed to the function
   /// \param functionPtr the native function
   /// \param name the name property of the function.
   /// \param paramCount number of parameters (excluding `this`)
   /// \param prototypeObjectHandle if non-null, set as prototype property.
-  /// \param additionalSlotCount internal slots to reserve within the
-  /// object (defaults to zero).
   static Handle<NativeFunction> create(
       Runtime &runtime,
       Handle<JSObject> parentHandle,
+      Handle<HiddenClass> clazz,
       Handle<Environment> parentEnvHandle,
       void *context,
       NativeFunctionPtr functionPtr,
       SymbolID name,
       unsigned paramCount,
-      Handle<JSObject> prototypeObjectHandle,
-      unsigned additionalSlotCount = 0);
+      Handle<JSObject> prototypeObjectHandle);
 
   /// \return the value in an additional slot.
   /// \param index must be less than the \c additionalSlotCount passed to
@@ -866,30 +890,8 @@ class NativeConstructor final : public NativeFunction {
         runtime,
         parentHandle,
         runtime.getHiddenClassForPrototype(
-            *parentHandle, numOverlapSlots<NativeConstructor>()),
+            *parentHandle, runtime.classNativeConstructor),
         Runtime::makeNullHandle<Environment>(),
-        context,
-        functionPtr);
-    return JSObjectInit::initToPseudoHandle(runtime, cell);
-  }
-
-  /// Create an instance of NativeConstructor.
-  /// \param parentHandle object to use as [[Prototype]].
-  /// \param parentEnvHandle the parent environment
-  /// \param context the context to be passed to the function
-  /// \param functionPtr the native function
-  static PseudoHandle<NativeConstructor> create(
-      Runtime &runtime,
-      Handle<JSObject> parentHandle,
-      Handle<Environment> parentEnvHandle,
-      void *context,
-      NativeFunctionPtr functionPtr) {
-    auto *cell = runtime.makeAFixed<NativeConstructor>(
-        runtime,
-        parentHandle,
-        runtime.getHiddenClassForPrototype(
-            *parentHandle, numOverlapSlots<NativeConstructor>()),
-        parentEnvHandle,
         context,
         functionPtr);
     return JSObjectInit::initToPseudoHandle(runtime, cell);

--- a/include/hermes/VM/CellKinds.def
+++ b/include/hermes/VM/CellKinds.def
@@ -62,6 +62,7 @@ CELL_KIND(BoxedDouble)
 CELL_KIND(NativeState)
 CELL_KIND(BigIntPrimitive)
 CELL_KIND(FinalizationRecord)
+CELL_KIND(WeakValueObjectMap)
 
 // DummyObject/LargeDummyObject used only in tests.
 CELL_KIND(DummyObject)

--- a/include/hermes/VM/CellKinds.def
+++ b/include/hermes/VM/CellKinds.def
@@ -16,15 +16,29 @@
 #define CELL_JS_NAME(name, jsClassName)
 #endif
 
+#ifndef CELL_JSOBJECT_NAME
+#define CELL_JSOBJECT_NAME(name, vmClassName)
+#endif
+
 #ifndef CELL_RANGE
 #define CELL_RANGE(rangeName, first, last)
 #endif
 
 // Helper macro for defining a CellKind which 1:1 corresponds with a JS Class.
 // Defines both the kind and the JS Class name.
+// Also defines CELL_JSOBJECT_NAME, allowing us to perform operations only on
+// CellKinds that have corresponding VM C++ classes.
 #define CELL_CLASS(name, jsClassName) \
   CELL_KIND(name)                     \
-  CELL_JS_NAME(name, jsClassName)
+  CELL_JS_NAME(name, jsClassName)     \
+  CELL_JSOBJECT_NAME(name, name)
+
+// Helper macro for defining a CellKind which 1:1 corresponds with a VM Class.
+// Defines both the kind and the CELL_JSOBJECT_NAME, allowing us to perform codegen
+// only on CellKinds that have corresponding VM C++ classes.
+#define CELL_KIND_JSOBJECT(name)       \
+  CELL_KIND(name)                \
+  CELL_JSOBJECT_NAME(name, name)
 
 CELL_KIND(Uninitialized)
 CELL_KIND(FillerCell)
@@ -55,7 +69,7 @@ CELL_KIND(LargeDummyObject)
 
 CELL_CLASS(JSObject, "Object")
 CELL_CLASS(DecoratedObject, "DecoratedObject")
-CELL_KIND(HostObject)
+CELL_KIND_JSOBJECT(HostObject)
 
 CELL_CLASS(JSError, "Error")
 CELL_CLASS(JSCallSite, "CallSite")
@@ -99,19 +113,19 @@ CELL_CLASS(FastArray, "FastArray")
 
 // Unknown if these callables make `this`. This is also where we put
 // callables that are not allowed to be called as a constructor.
-CELL_KIND(BoundFunction)
+CELL_KIND_JSOBJECT(BoundFunction)
 // *NativeFunction begin*
-CELL_KIND(NativeFunction)
+CELL_KIND_JSOBJECT(NativeFunction)
 // Makes own `this`.
-CELL_KIND(NativeConstructor)
-CELL_KIND(FinalizableNativeFunction)
+CELL_KIND_JSOBJECT(NativeConstructor)
+CELL_KIND_JSOBJECT(FinalizableNativeFunction)
 // *NativeFunction end*, including JSCallableProxy
 CELL_CLASS(JSCallableProxy, "CallableProxy")
-CELL_KIND(NativeJSClass)
-CELL_KIND(JSClass)
+CELL_KIND_JSOBJECT(NativeJSClass)
+CELL_KIND_JSOBJECT(JSClass)
 // Expects a made `this` parameter.
 CELL_CLASS(JSFunction, "Function")
-CELL_KIND(NativeJSFunction)
+CELL_KIND_JSOBJECT(NativeJSFunction)
 
 // Update AllCells, below, if new CellKinds are added.
 // (AllCells is useful for checking that a CellKind is valid.)
@@ -144,6 +158,8 @@ CELL_RANGE(
     ExternalASCIIStringPrimitive)
 
 #undef CELL_KIND
+#undef CELL_KIND_JSOBJECT
 #undef CELL_JS_NAME
+#undef CELL_JSOBJECT_NAME
 #undef CELL_RANGE
 #undef CELL_CLASS

--- a/include/hermes/VM/DecoratedObject.h
+++ b/include/hermes/VM/DecoratedObject.h
@@ -42,8 +42,8 @@ class DecoratedObject : public JSObject {
   static PseudoHandle<DecoratedObject> create(
       Runtime &runtime,
       Handle<JSObject> parentHandle,
-      std::unique_ptr<Decoration> decoration,
-      unsigned int additionalSlotCount = 0);
+      Handle<HiddenClass> clazz,
+      std::unique_ptr<Decoration> decoration);
 
   /// Access the decoration.
   Decoration *getDecoration() {

--- a/include/hermes/VM/FastArray.h
+++ b/include/hermes/VM/FastArray.h
@@ -153,8 +153,9 @@ class FastArray : public JSObject {
       Handle<HiddenClass> clazz,
       NeedsBarriers needsBarriers)
       : JSObject(runtime, *parent, *clazz, needsBarriers) {
-    flags_.indexedStorage = true;
-    flags_.fastIndexProperties = true;
+    assert(hasIndexedStorage(runtime) && "must have indexed storage");
+    assert(
+        hasFastIndexProperties(runtime) && "must have fast index properties");
   }
 
  private:

--- a/include/hermes/VM/FastArray.h
+++ b/include/hermes/VM/FastArray.h
@@ -135,9 +135,11 @@ class FastArray : public JSObject {
 
   /// Construct an instance of the hidden class describing the layout of JSArray
   /// instances.
+  /// \param rootClazz the starting HiddenClass for the JSArray.
   static Handle<HiddenClass> createClass(
       Runtime &runtime,
-      Handle<JSObject> prototypeHandle);
+      Handle<JSObject> prototypeHandle,
+      Handle<HiddenClass> rootClazz);
 
   /// Create a new FastArray with the given capacity. Note that storage will be
   /// allocated even if the capacity is zero, to maintain indexedStorage_ as

--- a/include/hermes/VM/FastArray.h
+++ b/include/hermes/VM/FastArray.h
@@ -155,8 +155,6 @@ class FastArray : public JSObject {
       : JSObject(runtime, *parent, *clazz, needsBarriers) {
     flags_.indexedStorage = true;
     flags_.fastIndexProperties = true;
-    flags_.noExtend = true;
-    flags_.sealed = true;
   }
 
  private:

--- a/include/hermes/VM/HermesValueTraits.h
+++ b/include/hermes/VM/HermesValueTraits.h
@@ -40,6 +40,7 @@ HERMES_VM_GCOBJECT(Domain);
 HERMES_VM_GCOBJECT(Environment);
 HERMES_VM_GCOBJECT(FastArray);
 HERMES_VM_GCOBJECT(FinalizableNativeFunction);
+HERMES_VM_GCOBJECT(GCCell);
 HERMES_VM_GCOBJECT(HiddenClass);
 HERMES_VM_GCOBJECT(HostObject);
 HERMES_VM_GCOBJECT(JSArray);
@@ -76,6 +77,7 @@ HERMES_VM_GCOBJECT(NativeState);
 HERMES_VM_GCOBJECT(PropertyAccessor);
 HERMES_VM_GCOBJECT(RequireContext);
 HERMES_VM_GCOBJECT(StringPrimitive);
+HERMES_VM_GCOBJECT(WeakValueObjectMapImpl);
 
 namespace testhelpers {
 struct DummyObject;
@@ -106,6 +108,11 @@ template <CellKind C>
 class JSWeakMapImpl;
 template <CellKind C>
 struct IsGCObject<JSWeakMapImpl<C>> : public std::true_type {};
+
+template <class ValueT>
+class WeakValueObjectMap;
+template <class ValueT>
+struct IsGCObject<WeakValueObjectMap<ValueT>> : public std::true_type {};
 
 template <typename T, bool Uniqued>
 class DynamicStringPrimitive;

--- a/include/hermes/VM/HiddenClass-inline.h
+++ b/include/hermes/VM/HiddenClass-inline.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "hermes/VM/HiddenClass.h"
+
+#include "hermes/VM/GCPointer-inline.h"
+#include "hermes/VM/JSObject.h"
+
+namespace hermes::vm {
+
+inline HiddenClass::HiddenClass(
+    Runtime &runtime,
+    ClassFlags flags,
+    Handle<HiddenClass> parent,
+    Handle<JSObject> objectParent,
+    SymbolID symbolID,
+    PropertyFlags propertyFlags,
+    unsigned numProperties)
+    : parent_(runtime, *parent, runtime.getHeap()),
+      objectParent_(runtime, *objectParent, runtime.getHeap()),
+      symbolID_(symbolID),
+      propertyFlags_(propertyFlags),
+      numProperties_(numProperties),
+      flags_(flags) {
+  assert(propertyFlags.isValid() && "propertyFlags must be valid");
+}
+
+/// \return the object's parent. May be nullptr.
+inline JSObject *HiddenClass::getObjectParent(PointerBase &pb) const {
+  return objectParent_.get(pb);
+}
+
+inline HiddenClass *HiddenClass::updateObjectParent(
+    Handle<HiddenClass> selfHandle,
+    Runtime &runtime,
+    PseudoHandle<JSObject> newParentPH) {
+  if (newParentPH.get() == selfHandle->objectParent_.get(runtime))
+    return *selfHandle;
+
+  return HiddenClass::updateObjectParentSlowPath(
+      selfHandle, runtime, std::move(newParentPH));
+}
+
+} // namespace hermes::vm

--- a/include/hermes/VM/HiddenClass.h
+++ b/include/hermes/VM/HiddenClass.h
@@ -99,13 +99,20 @@ struct ClassFlags {
       /// state.
       uint16_t indexedStorage : 1;
 
+      /// This flag is set when any object using this HiddenClass (or any object
+      /// in its parent chain) is cached in the AddPropertyCache.
+      /// If the flag is set, then changing the parent or HiddenClass of objects
+      /// with this class in their parent chain will increment the
+      /// parentCacheEpoch in Runtime.
+      uint16_t isCachedUsingEpoch : 1;
+
       /// The number of times the parent of the object has been changed.
       /// If this counter maxes out, the HiddenClass changes to dictionary mode
       /// to avoid an infinite chain.
       uint16_t parentChangeCounter : kParentChangeCounterSize;
 
       /// Unused bits, tracked explicitly for convenience.
-      uint16_t unusedPadding : 2;
+      uint16_t unusedPadding : 1;
     };
 
     uint16_t _flags;
@@ -532,6 +539,23 @@ class HiddenClass final : public GCCell {
     flags_.noExtend = 1;
     flags_.sealed = 1;
     flags_.frozen = 1;
+  }
+
+  /// \return true if this HiddenClass is used by objects cached using the
+  /// parent cache epoch mechanism.
+  bool getIsCachedUsingEpoch() const {
+    return flags_.isCachedUsingEpoch;
+  }
+
+  /// Mark this HiddenClass as being used by objects cached using the parent
+  /// cache epoch mechanism.
+  /// \return the resulting class
+  static HiddenClass *markAsCachedUsingEpoch(
+      Handle<HiddenClass> selfHandle,
+      Runtime &runtime) {
+    ClassFlags newFlags = selfHandle->flags_;
+    newFlags.isCachedUsingEpoch = 1;
+    return HiddenClass::updateClassFlags(selfHandle, runtime, newFlags);
   }
 
   /// \return The for-in cache if one has been set, otherwise nullptr.

--- a/include/hermes/VM/HiddenClass.h
+++ b/include/hermes/VM/HiddenClass.h
@@ -68,13 +68,26 @@ struct ClassFlags {
       /// the property map must never be null.
       uint16_t typed : 1;
 
+      /// This flag indicates this is a special object whose properties are
+      /// managed by C++ code, and not via the standard property storage
+      /// mechanisms.
+      uint16_t hostObject : 1;
+
+      /// This is lazily created object that must be initialized before it can
+      /// be used. Note that lazy objects must have no properties defined on
+      /// them.
+      uint16_t lazyObject : 1;
+
+      /// This flag indicates this is a proxy exotic Object
+      uint16_t proxyObject : 1;
+
       /// The number of times the parent of the object has been changed.
       /// If this counter maxes out, the HiddenClass changes to dictionary mode
       /// to avoid an infinite chain.
       uint16_t parentChangeCounter : kParentChangeCounterSize;
 
       /// Unused bits, tracked explicitly for convenience.
-      uint16_t unusedPadding : 9;
+      uint16_t unusedPadding : 6;
     };
 
     uint16_t _flags;
@@ -383,9 +396,8 @@ class HiddenClass final : public GCCell {
 
   /// Create a "root" hidden class - one that doesn't define any properties, but
   /// is a starting point for a hierarchy.
-  static HiddenClass *createRoot(
-      Runtime &runtime,
-      Handle<JSObject> objectParent);
+  static HiddenClass *
+  createRoot(Runtime &runtime, Handle<JSObject> objectParent, ClassFlags flags);
 
   /// Create a "root" hidden class for a typed object - one that doesn't define
   /// any properties yet but reserves space for a property map.
@@ -435,6 +447,21 @@ class HiddenClass final : public GCCell {
   /// don't (normally) result in creation of new classes.
   bool isDictionary() const {
     return flags_.dictionaryMode;
+  }
+
+  /// \return true if the class is for a lazy object.
+  bool isLazyObject() const {
+    return flags_.lazyObject;
+  }
+
+  /// \return true if the class is for a HostObject.
+  bool isHostObject() const {
+    return flags_.hostObject;
+  }
+
+  /// \return true if the class is for a JS Proxy.
+  bool isProxyObject() const {
+    return flags_.proxyObject;
   }
 
   /// \return true if this class is in "non-cacheable dictionary mode"

--- a/include/hermes/VM/HiddenClass.h
+++ b/include/hermes/VM/HiddenClass.h
@@ -11,10 +11,11 @@
 #include "hermes/Support/OptValue.h"
 #include "hermes/VM/ArrayStorage.h"
 #include "hermes/VM/DictPropertyMap.h"
-#include "hermes/VM/GCPointer-inline.h"
 #include "hermes/VM/JIT/Config.h"
 #include "hermes/VM/PropertyDescriptor.h"
 #include "hermes/VM/WeakValueMap.h"
+#include "hermes/VM/WeakValueObjectMap.h"
+#include "hermes/VM/sh_mirror.h"
 
 #include <functional>
 #include "llvh/ADT/ArrayRef.h"
@@ -59,6 +60,12 @@ struct ClassFlags {
   /// for a typed object, which means it doesn't have any transitions and the
   /// property map must never be null.
   uint8_t typed : 1;
+
+  /// The number of times the parent of the object has been changed.
+  /// If this counter maxes out, the HiddenClass changes to dictionary mode to
+  /// avoid an infinite chain.
+  static constexpr size_t kParentChangeCounterSize = 2;
+  uint8_t parentChangeCounter : kParentChangeCounterSize;
 
   ClassFlags() {
     ::memset(this, 0, sizeof(*this));
@@ -284,9 +291,16 @@ class HiddenClass final : public GCCell {
   /// parent.
   GCPointer<HiddenClass> parent_;
 
+  /// The JSObject which is the parent of the object.
+  GCPointer<JSObject> objectParent_{nullptr};
+
   /// Cache that contains for-in property names for objects of this class.
   /// Never used in dictionary mode.
   GCPointer<ArrayStorageSmall> forInCache_{};
+
+  /// This hash table encodes the transitions from this class to child classes
+  /// keyed on the property being added (or updated) and its flags.
+  GCPointer<WeakValueObjectMap<HiddenClass>> parentTransitionMap_;
 
   /// The symbol that was added when transitioning to this hidden class.
   const GCSymbolID symbolID_;
@@ -322,20 +336,14 @@ class HiddenClass final : public GCCell {
 
   static const VTable vt;
 
-  HiddenClass(
+  inline HiddenClass(
       Runtime &runtime,
       ClassFlags flags,
       Handle<HiddenClass> parent,
+      Handle<JSObject> objectParent,
       SymbolID symbolID,
       PropertyFlags propertyFlags,
-      unsigned numProperties)
-      : parent_(runtime, *parent, runtime.getHeap()),
-        symbolID_(symbolID),
-        propertyFlags_(propertyFlags),
-        numProperties_(numProperties),
-        flags_(flags) {
-    assert(propertyFlags.isValid() && "propertyFlags must be valid");
-  }
+      unsigned numProperties);
 
   static constexpr CellKind getCellKind() {
     return CellKind::HiddenClassKind;
@@ -351,14 +359,19 @@ class HiddenClass final : public GCCell {
 
   /// Create a "root" hidden class - one that doesn't define any properties, but
   /// is a starting point for a hierarchy.
-  static HiddenClass *createRoot(Runtime &runtime);
+  static HiddenClass *createRoot(
+      Runtime &runtime,
+      Handle<JSObject> objectParent);
 
   /// Create a "root" hidden class for a typed object - one that doesn't define
   /// any properties yet but reserves space for a property map.
   /// \param capacity the number of properties in the typed object,
   ///  used to reserve space in the property map.
   /// \pre capacity < maxNumProperties().
-  static HiddenClass *createForTypedObject(Runtime &runtime, uint32_t capacity);
+  static HiddenClass *createForTypedObject(
+      Runtime &runtime,
+      Handle<JSObject> objectParent,
+      uint32_t capacity);
 
   /// \return true if this hidden class is guaranteed to be a leaf.
   /// It can return false negatives, so it should only be used for stats
@@ -375,6 +388,14 @@ class HiddenClass final : public GCCell {
     lazyJITId_ = id;
   }
 #endif
+
+  /// \return the object's parent. May be nullptr.
+  const GCPointer<JSObject> &getObjectParentGCPtr() const {
+    return objectParent_;
+  }
+
+  /// \return the object's parent. May be nullptr.
+  inline JSObject *getObjectParent(PointerBase &pb) const;
 
   /// \return the number of own properties described by this hidden class.
   /// This corresponds to the size of the property map, if it is initialized.
@@ -544,6 +565,22 @@ class HiddenClass final : public GCCell {
     return newSlot;
   }
 
+  /// Update the object's parent and return the resulting class.
+  /// If the parent has changed more than parentChangeCounter can handle,
+  /// the resulting HiddenClass will be in dictionary mode.
+  /// \param newParent may be null if the parent is being deleted.
+  static inline HiddenClass *updateObjectParent(
+      Handle<HiddenClass> selfHandle,
+      Runtime &runtime,
+      PseudoHandle<JSObject> newParent);
+
+  /// The slow path for updating the object parent.
+  /// Only called if the parent actually needs to be updated.
+  static HiddenClass *updateObjectParentSlowPath(
+      Handle<HiddenClass> selfHandle,
+      Runtime &runtime,
+      PseudoHandle<JSObject> newParent);
+
   /// Mark all properties as non-configurable.
   /// \return the resulting class
   static Handle<HiddenClass> makeAllNonConfigurable(
@@ -592,12 +629,17 @@ class HiddenClass final : public GCCell {
   /// \return true if all properties are non-writable and non-configurable
   static bool areAllReadOnly(Handle<HiddenClass> selfHandle, Runtime &runtime);
 
+  /// Verify that the mirror struct SHHiddenClass has the correct layout.
+  /// This function is never called - it only exists to contain static asserts.
+  static void staticAsserts();
+
  private:
   /// Allocate a new hidden class instance with the supplied parameters.
   static HiddenClass *create(
       Runtime &runtime,
       ClassFlags flags,
       Handle<HiddenClass> parent,
+      Handle<JSObject> objectParent,
       SymbolID symbolID,
       PropertyFlags propertyFlags,
       unsigned numProperties);
@@ -749,6 +791,45 @@ inline OptValue<HiddenClass::PropertyPos> HiddenClass::findProperty(
     desc = DictPropertyMap::getDescriptorPair(propMap, *found)->second;
     return *found;
   }
+}
+
+inline void HiddenClass::staticAsserts() {
+  static_assert(sizeof(detail::Transition) == sizeof(SHTransition));
+  static_assert(sizeof(detail::TransitionMap) == sizeof(SHTransitionMap));
+
+  static_assert(sizeof(HiddenClass) == sizeof(SHHiddenClass));
+  static_assert(
+      offsetof(HiddenClass, propertyMap_) ==
+      offsetof(SHHiddenClass, propertyMap));
+  static_assert(
+      offsetof(HiddenClass, parent_) == offsetof(SHHiddenClass, parent));
+  static_assert(
+      offsetof(HiddenClass, objectParent_) ==
+      offsetof(SHHiddenClass, objectParent));
+  static_assert(
+      offsetof(HiddenClass, forInCache_) ==
+      offsetof(SHHiddenClass, forInCache));
+  static_assert(
+      offsetof(HiddenClass, parentTransitionMap_) ==
+      offsetof(SHHiddenClass, parentTransitionMap));
+  static_assert(
+      offsetof(HiddenClass, symbolID_) == offsetof(SHHiddenClass, symbolID));
+  static_assert(
+      offsetof(HiddenClass, propertyFlags_) ==
+      offsetof(SHHiddenClass, propertyFlags));
+  static_assert(
+      offsetof(HiddenClass, numProperties_) ==
+      offsetof(SHHiddenClass, numProperties));
+#if HERMESVM_JIT
+  static_assert(
+      offsetof(HiddenClass, lazyJITId_) == offsetof(SHHiddenClass, lazyJITId));
+#endif
+  static_assert(
+      offsetof(HiddenClass, flags_) == offsetof(SHHiddenClass, flags));
+  static_assert(
+      offsetof(HiddenClass, transitionMap_) ==
+      offsetof(SHHiddenClass, transitionMap));
+  llvm_unreachable("staticAsserts must never be called.");
 }
 
 } // namespace vm

--- a/include/hermes/VM/HiddenClass.h
+++ b/include/hermes/VM/HiddenClass.h
@@ -94,13 +94,18 @@ struct ClassFlags {
       /// This flag indicates this is a proxy exotic Object
       uint16_t proxyObject : 1;
 
+      /// This object has indexed storage. This flag will not change at runtime,
+      /// it is set at construction and its value never changes. It is not a
+      /// state.
+      uint16_t indexedStorage : 1;
+
       /// The number of times the parent of the object has been changed.
       /// If this counter maxes out, the HiddenClass changes to dictionary mode
       /// to avoid an infinite chain.
       uint16_t parentChangeCounter : kParentChangeCounterSize;
 
       /// Unused bits, tracked explicitly for convenience.
-      uint16_t unusedPadding : 3;
+      uint16_t unusedPadding : 2;
     };
 
     uint16_t _flags;
@@ -490,6 +495,11 @@ class HiddenClass final : public GCCell {
   /// \return true if the class is for a JS Proxy.
   bool isProxyObject() const {
     return flags_.proxyObject;
+  }
+
+  /// \return true if the class is frozen.
+  bool hasIndexedStorage() const {
+    return flags_.indexedStorage;
   }
 
   /// \return true if this class is in "non-cacheable dictionary mode"
@@ -922,6 +932,9 @@ inline OptValue<HiddenClass::PropertyPos> HiddenClass::findProperty(
 }
 
 inline void HiddenClass::staticAsserts() {
+  static_assert(sizeof(PropertyFlags) == 2);
+  static_assert(sizeof(ClassFlags) == 2);
+  static_assert(sizeof(detail::Transition) == sizeof(SHTransition));
   static_assert(sizeof(detail::Transition) == sizeof(SHTransition));
   static_assert(sizeof(detail::TransitionMap) == sizeof(SHTransitionMap));
   static_assert(sizeof(ClassFlags) == 2);

--- a/include/hermes/VM/HiddenClass.h
+++ b/include/hermes/VM/HiddenClass.h
@@ -72,6 +72,9 @@ struct ClassFlags {
       /// If this counter maxes out, the HiddenClass changes to dictionary mode
       /// to avoid an infinite chain.
       uint16_t parentChangeCounter : kParentChangeCounterSize;
+
+      /// Unused bits, tracked explicitly for convenience.
+      uint16_t unusedPadding : 9;
     };
 
     uint16_t _flags;
@@ -821,6 +824,7 @@ inline OptValue<HiddenClass::PropertyPos> HiddenClass::findProperty(
 inline void HiddenClass::staticAsserts() {
   static_assert(sizeof(detail::Transition) == sizeof(SHTransition));
   static_assert(sizeof(detail::TransitionMap) == sizeof(SHTransitionMap));
+  static_assert(sizeof(ClassFlags) == 2);
 
   static_assert(sizeof(HiddenClass) == sizeof(SHHiddenClass));
   static_assert(

--- a/include/hermes/VM/HiddenClass.h
+++ b/include/hermes/VM/HiddenClass.h
@@ -28,47 +28,64 @@ using PropStorage = ArrayStorageSmall;
 
 /// Flags associated with a hidden class.
 struct ClassFlags {
-  /// This class is in dictionary mode, meaning that adding and removing fields
-  /// doesn't cause transitions but simply updates the property map.  (We may
-  /// still change hidden classes; see dictionaryNoCacheMode, below).
-  uint8_t dictionaryMode : 1;
-
-  /// If dictionaryMode is set, this indicates whether the hidden class can
-  /// be used as the key in property caches.  If we delete properties, or update
-  /// properties, we create a new hidden class for the owning object
-  /// (to invalidate any property caches referencing the old hidden
-  /// class).  We may decide to limit the number of hidden classes
-  /// created this way (currently we allow just one).  To do this, we
-  /// set this property of the hidden class property, so that the new
-  /// hidden class is never added to an property cache.
-  uint8_t dictionaryNoCacheMode : 1;
-
-  /// Set when we have index-like named properties (e.g. "0", "1", etc) defined
-  /// using defineOwnProperty. Array accesses will have to check the named
-  /// properties first. The absence of this flag is important as it indicates
-  /// that named properties whose name is an integer index don't need to be
-  /// searched for - they don't exist.
-  uint8_t hasIndexLikeProperties : 1;
-
-  /// There may be a accessor property somewhere in the entire chain of leading
-  /// up to this HiddenClass. Set when a property is an accessor, and can never
-  /// be unset. That means this is a pessimistic flag: if a getter/setter
-  /// property is set and then deleted, this will still be set to true.
-  uint8_t mayHaveAccessor : 1;
-
-  /// This is not in dictionary mode, but it is a class allocated
-  /// for a typed object, which means it doesn't have any transitions and the
-  /// property map must never be null.
-  uint8_t typed : 1;
-
-  /// The number of times the parent of the object has been changed.
-  /// If this counter maxes out, the HiddenClass changes to dictionary mode to
-  /// avoid an infinite chain.
+  /// Size of parentChangeCounter below in the bitfield.
   static constexpr size_t kParentChangeCounterSize = 2;
-  uint8_t parentChangeCounter : kParentChangeCounterSize;
+
+  union {
+    struct {
+      /// This class is in dictionary mode, meaning that adding and removing
+      /// fields doesn't cause transitions but simply updates the property map.
+      /// (We may still change hidden classes; see dictionaryNoCacheMode,
+      /// below).
+      uint16_t dictionaryMode : 1;
+
+      /// If dictionaryMode is set, this indicates whether the hidden class can
+      /// be used as the key in property caches.  If we delete properties, or
+      /// update properties, we create a new hidden class for the owning object
+      /// (to invalidate any property caches referencing the old hidden
+      /// class).  We may decide to limit the number of hidden classes
+      /// created this way (currently we allow just one).  To do this, we
+      /// set this property of the hidden class property, so that the new
+      /// hidden class is never added to an property cache.
+      uint16_t dictionaryNoCacheMode : 1;
+
+      /// Set when we have index-like named properties (e.g. "0", "1", etc)
+      /// defined using defineOwnProperty. Array accesses will have to check the
+      /// named properties first. The absence of this flag is important as it
+      /// indicates that named properties whose name is an integer index don't
+      /// need to be searched for - they don't exist.
+      uint16_t hasIndexLikeProperties : 1;
+
+      /// There may be a accessor property somewhere in the entire chain of
+      /// leading up to this HiddenClass. Set when a property is an accessor,
+      /// and can never be unset. That means this is a pessimistic flag: if a
+      /// getter/setter property is set and then deleted, this will still be set
+      /// to true.
+      uint16_t mayHaveAccessor : 1;
+
+      /// This is not in dictionary mode, but it is a class allocated
+      /// for a typed object, which means it doesn't have any transitions and
+      /// the property map must never be null.
+      uint16_t typed : 1;
+
+      /// The number of times the parent of the object has been changed.
+      /// If this counter maxes out, the HiddenClass changes to dictionary mode
+      /// to avoid an infinite chain.
+      uint16_t parentChangeCounter : kParentChangeCounterSize;
+    };
+
+    uint16_t _flags;
+  };
 
   ClassFlags() {
-    ::memset(this, 0, sizeof(*this));
+    _flags = 0;
+  }
+
+  bool operator==(ClassFlags f) const {
+    return _flags == f._flags;
+  }
+  bool operator!=(ClassFlags f) const {
+    return _flags != f._flags;
   }
 };
 
@@ -146,17 +163,21 @@ namespace detail {
 /// a llvh::DenseMapInfo<> trait for it.
 class Transition {
  public:
+  /// The name for the property being modified.
+  /// Empty and Deleted are reserved for use by the DenseMapInfo.
   SymbolID symbolID;
   PropertyFlags propertyFlags;
+  ClassFlags classFlags;
 
   /// An explicit constructor for creating DenseMap sentinel values.
-  explicit Transition(SymbolID symbolID)
-      : symbolID(symbolID), propertyFlags() {}
+  explicit Transition(SymbolID symbolID, ClassFlags classFlags)
+      : symbolID(symbolID), propertyFlags(), classFlags(classFlags) {}
   Transition(SymbolID symbolID, PropertyFlags flags)
       : symbolID(symbolID), propertyFlags(flags) {}
 
   bool operator==(const Transition &a) const {
-    return symbolID == a.symbolID && propertyFlags == a.propertyFlags;
+    return symbolID == a.symbolID && propertyFlags == a.propertyFlags &&
+        classFlags == a.classFlags;
   }
 };
 
@@ -263,7 +284,7 @@ class TransitionMap {
     return u.large_;
   }
 
-  Transition smallKey_{SymbolID::empty()};
+  Transition smallKey_{SymbolID::empty(), ClassFlags{}};
   union U {
     U() : smallValue_((WeakRefSlot *)nullptr) {}
     WeakRef<HiddenClass> smallValue_;
@@ -401,6 +422,10 @@ class HiddenClass final : public GCCell {
   /// This corresponds to the size of the property map, if it is initialized.
   unsigned getNumProperties() const {
     return numProperties_;
+  }
+
+  ClassFlags getFlags() const {
+    return flags_;
   }
 
   /// \return true if this class is in "dictionary mode" - i.e. changes to it
@@ -843,11 +868,11 @@ using namespace hermes::vm;
 template <>
 struct DenseMapInfo<HiddenClass::Transition> {
   static inline HiddenClass::Transition getEmptyKey() {
-    return HiddenClass::Transition(SymbolID::empty());
+    return HiddenClass::Transition(SymbolID::empty(), ClassFlags{});
   }
 
   static inline HiddenClass::Transition getTombstoneKey() {
-    return HiddenClass::Transition(SymbolID::deleted());
+    return HiddenClass::Transition(SymbolID::deleted(), ClassFlags{});
   }
 
   static inline unsigned getHashValue(HiddenClass::Transition transition) {

--- a/include/hermes/VM/HiddenClass.h
+++ b/include/hermes/VM/HiddenClass.h
@@ -68,6 +68,19 @@ struct ClassFlags {
       /// the property map must never be null.
       uint16_t typed : 1;
 
+      /// New properties cannot be added.
+      uint16_t noExtend : 1;
+
+      /// \c Object.seal() has been invoked on this object, marking all
+      /// properties as non-configurable. When \c Sealed is set, \c NoExtend is
+      /// always set too.
+      uint16_t sealed : 1;
+
+      /// \c Object.freeze() has been invoked on this object, marking all
+      /// properties as non-configurable and non-writable. When \c Frozen is
+      /// set, \c Sealed and must \c NoExtend are always set too.
+      uint16_t frozen : 1;
+
       /// This flag indicates this is a special object whose properties are
       /// managed by C++ code, and not via the standard property storage
       /// mechanisms.
@@ -87,7 +100,7 @@ struct ClassFlags {
       uint16_t parentChangeCounter : kParentChangeCounterSize;
 
       /// Unused bits, tracked explicitly for convenience.
-      uint16_t unusedPadding : 6;
+      uint16_t unusedPadding : 3;
     };
 
     uint16_t _flags;
@@ -449,6 +462,21 @@ class HiddenClass final : public GCCell {
     return flags_.dictionaryMode;
   }
 
+  /// \return true if the class is noExtend.
+  bool isExtensible() const {
+    return !flags_.noExtend;
+  }
+
+  /// \return true if the class is sealed.
+  bool isSealed() const {
+    return flags_.sealed;
+  }
+
+  /// \return true if the class is frozen.
+  bool isFrozen() const {
+    return flags_.frozen;
+  }
+
   /// \return true if the class is for a lazy object.
   bool isLazyObject() const {
     return flags_.lazyObject;
@@ -485,6 +513,15 @@ class HiddenClass final : public GCCell {
 
   bool isTyped() const {
     return flags_.typed;
+  }
+
+  /// Mark a typed HiddenClass as frozen/sealed/noExtend.
+  /// \pre The class must be typed (unshared orphan).
+  void markTypedAsFrozen() {
+    assert(flags_.typed && "must be typed");
+    flags_.noExtend = 1;
+    flags_.sealed = 1;
+    flags_.frozen = 1;
   }
 
   /// \return The for-in cache if one has been set, otherwise nullptr.
@@ -636,17 +673,53 @@ class HiddenClass final : public GCCell {
       Runtime &runtime,
       PseudoHandle<JSObject> newParent);
 
+  /// Update the ClassFlags and return the new HiddenClass.
+  /// Updates the transition table to cache the new HiddenClass.
+  static HiddenClass *updateClassFlags(
+      Handle<HiddenClass> selfHandle,
+      Runtime &runtime,
+      ClassFlags newFlags);
+
   /// Mark all properties as non-configurable.
   /// \return the resulting class
-  static Handle<HiddenClass> makeAllNonConfigurable(
+  static HiddenClass *seal(Handle<HiddenClass> selfHandle, Runtime &runtime);
+
+  /// Mark the HiddenClass as being sealed.
+  /// \return the resulting class
+  static HiddenClass *markAsSealed(
       Handle<HiddenClass> selfHandle,
-      Runtime &runtime);
+      Runtime &runtime) {
+    ClassFlags sealedFlags = selfHandle->flags_;
+    sealedFlags.noExtend = 1;
+    sealedFlags.sealed = 1;
+    return HiddenClass::updateClassFlags(selfHandle, runtime, sealedFlags);
+  }
 
   /// Mark all properties as non-writable and non-configurable.
   /// \return the resulting class
-  static Handle<HiddenClass> makeAllReadOnly(
+  static HiddenClass *freeze(Handle<HiddenClass> selfHandle, Runtime &runtime);
+
+  /// Mark the HiddenClass as being sealed.
+  /// \return the resulting class
+  static HiddenClass *markAsFrozen(
       Handle<HiddenClass> selfHandle,
-      Runtime &runtime);
+      Runtime &runtime) {
+    ClassFlags sealedFlags = selfHandle->flags_;
+    sealedFlags.noExtend = 1;
+    sealedFlags.frozen = 1;
+    sealedFlags.sealed = 1;
+    return HiddenClass::updateClassFlags(selfHandle, runtime, sealedFlags);
+  }
+
+  /// Mark the HiddenClass as being sealed.
+  /// \return the resulting class
+  static HiddenClass *markNoExtend(
+      Handle<HiddenClass> selfHandle,
+      Runtime &runtime) {
+    ClassFlags noExtendFlags = selfHandle->flags_;
+    noExtendFlags.noExtend = 1;
+    return HiddenClass::updateClassFlags(selfHandle, runtime, noExtendFlags);
+  }
 
   /// Update the flags for the properties in the list \p props with \p
   /// flagsToClear and \p flagsToSet. If in dictionary mode, the properties are

--- a/include/hermes/VM/InternalProperties.def
+++ b/include/hermes/VM/InternalProperties.def
@@ -34,6 +34,8 @@ NAMED_PROP(ExternalMemoryPressure)
 
 /// A reserved symbol ID to use for the HC transition to the frozen state.
 NAMED_PROP(FreezeTransition)
+/// A reserved symbol ID to use for the HC transition between ClassFlags.
+NAMED_PROP(FlagsTransition)
 
 #undef PROP
 #undef NAMED_PROP

--- a/include/hermes/VM/Interpreter.h
+++ b/include/hermes/VM/Interpreter.h
@@ -337,6 +337,7 @@ class Interpreter {
       PinnedHermesValue *callee,
       PinnedHermesValue *newTarget,
       uint8_t cacheIdx,
+      uint32_t shapeTableIdx,
       CodeBlock *curCodeBlock);
 
   /// Create a class, as per ES2023 15.7.14.

--- a/include/hermes/VM/Interpreter.h
+++ b/include/hermes/VM/Interpreter.h
@@ -165,6 +165,15 @@ class Interpreter {
   /// Constructs an object via literal buffers in the bytecode file.
   /// \param parent the parent of the newly created object.
   /// \param shapeTableIndex the index of the shape element.
+  static PseudoHandle<> createObjectWithParent(
+      Runtime &runtime,
+      CodeBlock *curCodeBlock,
+      Handle<JSObject> parent,
+      unsigned shapeTableIndex);
+
+  /// Constructs an object via literal buffers in the bytecode file.
+  /// \param parent the parent of the newly created object.
+  /// \param shapeTableIndex the index of the shape element.
   /// \param valBufferOffset the first element of the val buffer to read.
   /// \param parentObject the object to be used as the parent of the new object.
   /// \param allocKind the kind of allocation being performed.

--- a/include/hermes/VM/JSArray.h
+++ b/include/hermes/VM/JSArray.h
@@ -325,7 +325,7 @@ class JSArray final : public ArrayImpl {
   /// Construct an instance of the hidden class describing the layout of JSArray
   /// instances.
   /// \param rootClazz the starting HiddenClass for the JSArray.
-  static Handle<HiddenClass> createClass(
+  static HiddenClass *createClass(
       Runtime &runtime,
       Handle<JSObject> prototypeHandle,
       Handle<HiddenClass> rootClazz);

--- a/include/hermes/VM/JSArray.h
+++ b/include/hermes/VM/JSArray.h
@@ -196,8 +196,9 @@ class ArrayImpl : public JSObject {
       HiddenClass *clazz,
       NeedsBarriers needsBarriers)
       : JSObject(runtime, parent, clazz, needsBarriers) {
-    flags_.indexedStorage = true;
-    flags_.fastIndexProperties = true;
+    assert(hasIndexedStorage(runtime) && "must have indexed storage");
+    assert(
+        hasFastIndexProperties(runtime) && "must have fast index properties");
   }
 
   /// Default needsBarriers to Yes.

--- a/include/hermes/VM/JSArray.h
+++ b/include/hermes/VM/JSArray.h
@@ -324,9 +324,11 @@ class JSArray final : public ArrayImpl {
 
   /// Construct an instance of the hidden class describing the layout of JSArray
   /// instances.
+  /// \param rootClazz the starting HiddenClass for the JSArray.
   static Handle<HiddenClass> createClass(
       Runtime &runtime,
-      Handle<JSObject> prototypeHandle);
+      Handle<JSObject> prototypeHandle,
+      Handle<HiddenClass> rootClazz);
 
   static constexpr CellKind getCellKind() {
     return CellKind::JSArrayKind;
@@ -376,16 +378,7 @@ class JSArray final : public ArrayImpl {
       Runtime &runtime,
       Handle<JSObject> prototypeHandle,
       size_type capacity,
-      size_type length) {
-    return createNoAllocPropStorage(
-        runtime,
-        prototypeHandle,
-        *prototypeHandle == *runtime.arrayPrototype
-            ? runtime.arrayClass
-            : createClass(runtime, prototypeHandle),
-        capacity,
-        length);
-  }
+      size_type length);
   static CallResult<PseudoHandle<JSArray>> create(
       Runtime &runtime,
       Handle<JSObject> prototypeHandle) {

--- a/include/hermes/VM/JSArray.h
+++ b/include/hermes/VM/JSArray.h
@@ -99,7 +99,9 @@ class ArrayImpl : public JSObject {
       SmallHermesValue value) {
     // The array must be extendable (and by implication is not frozen or sealed)
     // because we don't know whether the element being set is empty or not.
-    assert(!self->flags_.noExtend && "this array cannot be extended");
+    assert(
+        self->getClass(runtime)->isExtensible() &&
+        "this array cannot be extended");
 
     assert(
         index >= self->beginIndex_ && index < self->getEndIndex() &&

--- a/include/hermes/VM/JSArrayBuffer.h
+++ b/include/hermes/VM/JSArrayBuffer.h
@@ -34,6 +34,9 @@ class JSArrayBuffer final : public JSObject {
     return cell->getKind() == CellKind::JSArrayBufferKind;
   }
 
+  /// Create a JSArrayBuffer using the standard ArrayBuffer prototype.
+  static PseudoHandle<JSArrayBuffer> create(Runtime &runtime);
+
   static PseudoHandle<JSArrayBuffer> create(
       Runtime &runtime,
       Handle<JSObject> prototype);

--- a/include/hermes/VM/JSDataView.h
+++ b/include/hermes/VM/JSDataView.h
@@ -33,6 +33,9 @@ class JSDataView final : public JSObject {
     return cell->getKind() == CellKind::JSDataViewKind;
   }
 
+  /// Create a JSDataView using the standard DataView prototype.
+  static PseudoHandle<JSDataView> create(Runtime &runtime);
+
   static PseudoHandle<JSDataView> create(
       Runtime &runtime,
       Handle<JSObject> prototype);

--- a/include/hermes/VM/JSDate.h
+++ b/include/hermes/VM/JSDate.h
@@ -28,14 +28,10 @@ class JSDate final : public JSObject {
     return cell->getKind() == CellKind::JSDateKind;
   }
 
+  static PseudoHandle<JSDate> create(Runtime &runtime, double value);
+
   static PseudoHandle<JSDate>
   create(Runtime &runtime, double value, Handle<JSObject> prototype);
-
-  static PseudoHandle<JSDate> create(
-      Runtime &runtime,
-      Handle<JSObject> prototype) {
-    return create(runtime, std::numeric_limits<double>::quiet_NaN(), prototype);
-  }
 
   /// \return the [[PrimitiveValue]] internal property.
   double getPrimitiveValue() {

--- a/include/hermes/VM/JSLib.h
+++ b/include/hermes/VM/JSLib.h
@@ -25,6 +25,8 @@ namespace vm {
 
 // External forward declarations.
 class Runtime;
+class JSArray;
+class HiddenClass;
 struct JSLibStorage;
 
 /// Flags controlling the initialization of the global object.
@@ -104,8 +106,8 @@ enum class TypeErrorKind {
 /// \return whether we can use the fast path for Array methods on \p arr.
 bool arrayFastPathCheck(
     Runtime &runtime,
-    JSArray *arr,
-    HiddenClass *arrayClass,
+    Handle<JSArray> arr,
+    Handle<HiddenClass> arrayClass,
     uint32_t len);
 
 } // namespace vm

--- a/include/hermes/VM/JSMapImpl.h
+++ b/include/hermes/VM/JSMapImpl.h
@@ -43,6 +43,9 @@ class JSMapImpl final : public JSObject,
     return cell->getKind() == C;
   }
 
+  /// Create a JSMapImpl using the appropriate prototype from runtime.
+  static PseudoHandle<JSMapImpl<C>> create(Runtime &runtime);
+
   static PseudoHandle<JSMapImpl<C>> create(
       Runtime &runtime,
       Handle<JSObject> parentHandle);

--- a/include/hermes/VM/JSObject-inline.h
+++ b/include/hermes/VM/JSObject-inline.h
@@ -62,7 +62,7 @@ LLVM_ATTRIBUTE_ALWAYS_INLINE
   // Fall-back fast path for other objects with fast index properties.
   // Make sure that the index is within 32-bit range, since getOwnIndexed()
   // only works for 32-bit indexes.
-  else if (index <= UINT32_MAX && obj->hasFastIndexProperties()) {
+  else if (index <= UINT32_MAX && obj->hasFastIndexProperties(runtime)) {
     GCScopeMarkerRAII marker{runtime};
     HermesValue hv =
         JSObject::getOwnIndexed(createPseudoHandle(obj), runtime, index);

--- a/include/hermes/VM/JSObject.h
+++ b/include/hermes/VM/JSObject.h
@@ -381,7 +381,7 @@ class JSObject : public GCCell {
   /// Attempts to allocate a JSObject with the standard Object prototype.
   /// If allocation fails, the GC declares an OOM.
   static PseudoHandle<JSObject> create(Runtime &runtime) {
-    return create(runtime, Handle<JSObject>::vmcast(&runtime.objectPrototype));
+    return create(runtime, runtime.objectPrototype, runtime.classJSObject);
   }
 
   /// Attempts to allocate a JSObject with the standard Object prototype and
@@ -390,6 +390,8 @@ class JSObject : public GCCell {
   /// \param propertyCount number of property storage slots preallocated.
   static PseudoHandle<JSObject> create(
       Runtime &runtime,
+      Handle<JSObject> parentHandle,
+      Handle<HiddenClass> clazz,
       unsigned propertyCount);
 
   /// Allocates a JSObject with the given hidden class and prototype.
@@ -397,7 +399,9 @@ class JSObject : public GCCell {
   static PseudoHandle<JSObject> create(
       Runtime &runtime,
       Handle<JSObject> parentHandle,
-      Handle<HiddenClass> clazz);
+      Handle<HiddenClass> clazz) {
+    return create(runtime, parentHandle, clazz, clazz->getNumProperties());
+  }
 
   ~JSObject() = default;
 
@@ -1602,6 +1606,10 @@ class JSObject : public GCCell {
     auto excess = (aligned - directPropsOffset()) / sizeof(GCSmallHermesValue);
     return std::min<size_t>(excess, DIRECT_PROPERTY_SLOTS);
   }
+
+  /// Dynamically dispatches to the correct numOverlapSlots<> template.
+  /// \return the number of overlap slots for the given cell kind \p k.
+  static size_t numOverlapSlotsForCellKind(CellKind k);
 };
 
 /// Convenience class for accessing the direct property slots of a JSObject.

--- a/include/hermes/VM/JSObject.h
+++ b/include/hermes/VM/JSObject.h
@@ -460,11 +460,11 @@ class JSObject : public GCCell {
 
   /// \return the `__proto__` internal property, which may be nullptr.
   JSObject *getParent(PointerBase &runtime) const {
-    return getParentGCPtr().get(runtime);
+    return getParentGCPtr(runtime).get(runtime);
   }
 
   /// \return the `__proto__` internal property, which may be nullptr.
-  const GCPointer<JSObject> &getParentGCPtr() const {
+  const GCPointer<JSObject> &getParentGCPtr(PointerBase &runtime) const {
     assert(
         !flags_.proxyObject && "getParent cannot be used with proxy objects");
     return parent_;

--- a/include/hermes/VM/JSObject.h
+++ b/include/hermes/VM/JSObject.h
@@ -458,8 +458,9 @@ class JSObject : public GCCell {
 
   /// \return true if this object has fast indexed storage, meaning no property
   ///   checks need to be made when reading an indexed value.
-  bool hasFastIndexProperties() const {
-    return flags_.fastIndexProperties;
+  bool hasFastIndexProperties(PointerBase &pb) const {
+    auto *clazz = getClass(pb);
+    return clazz->hasIndexedStorage() && !clazz->getHasIndexLikeProperties();
   }
 
   /// \return the `__proto__` internal property, which may be nullptr.
@@ -1240,6 +1241,12 @@ class JSObject : public GCCell {
   /// [[Extensible]] is false.
   static bool isFrozen(PseudoHandle<JSObject> self, Runtime &runtime);
 
+  /// \return true if the object has indexed storage (based on the HiddenClass
+  /// flag).
+  bool hasIndexedStorage(PointerBase &pb) const {
+    return getClass(pb)->hasIndexedStorage();
+  }
+
   /// Update the property flags in the list \p props on \p selfHandle,
   /// with provided \p flagsToClear and \p flagsToSet, and if it is not
   /// provided, update all properties.
@@ -1976,7 +1983,7 @@ inline CallResult<PseudoHandle<>> JSObject::getComputedSlotValue(
     ComputedPropertyDescriptor desc) {
   if (LLVM_LIKELY(desc.flags.indexed)) {
     assert(
-        self->flags_.indexedStorage &&
+        self->getClass(runtime)->hasIndexedStorage() &&
         "indexed flag set but no indexed storage");
     return createPseudoHandle(
         getOwnIndexed(std::move(self), runtime, desc.slot));
@@ -2002,7 +2009,7 @@ inline HermesValue JSObject::getComputedSlotValueUnsafe(
     ComputedPropertyDescriptor desc) {
   if (LLVM_LIKELY(desc.flags.indexed)) {
     assert(
-        self->flags_.indexedStorage &&
+        self->getClass(runtime)->hasIndexedStorage() &&
         "indexed flag set but no indexed storage");
     return getOwnIndexed(std::move(self), runtime, desc.slot);
   }
@@ -2019,7 +2026,7 @@ inline CallResult<bool> JSObject::setComputedSlotValue(
     Handle<> value) {
   if (LLVM_LIKELY(desc.flags.indexed)) {
     assert(
-        selfHandle->flags_.indexedStorage &&
+        selfHandle->getClass(runtime)->hasIndexedStorage() &&
         "indexed flag set but no indexed storage");
     return setOwnIndexed(selfHandle, runtime, desc.slot, value);
   }
@@ -2046,7 +2053,7 @@ inline ExecutionStatus JSObject::setComputedSlotValueUnsafe(
     Handle<> value) {
   if (LLVM_LIKELY(desc.flags.indexed)) {
     assert(
-        selfHandle->flags_.indexedStorage &&
+        selfHandle->getClass(runtime)->hasIndexedStorage() &&
         "indexed flag set but no indexed storage");
     return setOwnIndexed(selfHandle, runtime, desc.slot, value).getStatus();
   }
@@ -2193,8 +2200,9 @@ inline OptValue<HiddenClass::PropertyPos> JSObject::findProperty(
 }
 
 inline bool JSObject::shouldCacheForIn(Runtime &runtime) const {
-  return !getClass(runtime)->isDictionary() && !flags_.indexedStorage &&
-      !isHostObject(runtime) && !isProxyObject(runtime);
+  return !getClass(runtime)->isDictionary() &&
+      !getClass(runtime)->hasIndexedStorage() && !isHostObject(runtime) &&
+      !isProxyObject(runtime);
 }
 
 /// Attempt to get the value of an indexed property from an object cheaply,

--- a/include/hermes/VM/JSObject.h
+++ b/include/hermes/VM/JSObject.h
@@ -428,18 +428,18 @@ class JSObject : public GCCell {
   }
 
   /// true if this a lazy object that must be initialized prior to use.
-  bool isLazy() const {
-    return flags_.lazyObject;
+  bool isLazy(PointerBase &pb) const {
+    return getClass(pb)->isLazyObject();
   }
 
   /// \return true if this is a HostObject.
-  bool isHostObject() const {
-    return flags_.hostObject;
+  bool isHostObject(PointerBase &pb) const {
+    return getClass(pb)->isHostObject();
   }
 
   /// \return true if this is a proxy exotic object.
-  bool isProxyObject() const {
-    return flags_.proxyObject;
+  bool isProxyObject(PointerBase &pb) const {
+    return getClass(pb)->isProxyObject();
   }
 
   /// Record that this object is being used in a form of caching optimisation
@@ -470,7 +470,8 @@ class JSObject : public GCCell {
   /// \return the `__proto__` internal property, which may be nullptr.
   const GCPointer<JSObject> &getParentGCPtr(PointerBase &runtime) const {
     assert(
-        !flags_.proxyObject && "getParent cannot be used with proxy objects");
+        !isProxyObject(runtime) &&
+        "getParent cannot be used with proxy objects");
     return getClass(runtime)->getObjectParentGCPtr();
   }
 
@@ -629,7 +630,7 @@ class JSObject : public GCCell {
       NamedPropertyDescriptor desc) {
     assert(
         desc.flags.privateName ||
-        !self->flags_.proxyObject && !desc.flags.proxyObject &&
+        !self->isProxyObject(runtime) && !desc.flags.proxyObject &&
             "getNamedSlotValueUnsafe called on a Proxy");
     assert(
         desc.flags.privateName ||
@@ -1206,7 +1207,7 @@ class JSObject : public GCCell {
   /// ES5.1 15.2.3.10.
   /// Set [[Extensible]] slot on an ordinary object to false, preventing adding
   /// more properties.
-  static void preventExtensions(JSObject *self);
+  static void preventExtensionsNonProxy(Handle<JSObject> self, PointerBase &pb);
   /// ES9 [[PreventExtensons]] internal method.  This works on Proxy
   /// objects and ordinary objects. If opFlags.getThrowOnError() is
   /// true, then this will throw an appropriate TypeError if the
@@ -2075,8 +2076,8 @@ inline OptValue<bool> JSObject::tryGetOwnNamedDescriptorFast(
 inline OptValue<SmallHermesValue>
 JSObject::tryGetNamedNoAlloc(JSObject *self, PointerBase &base, SymbolID name) {
   for (JSObject *curr = self; curr; curr = curr->getParent(base)) {
-    if (LLVM_UNLIKELY(curr->isProxyObject()) ||
-        LLVM_UNLIKELY(curr->isHostObject())) {
+    if (LLVM_UNLIKELY(curr->isProxyObject(base)) ||
+        LLVM_UNLIKELY(curr->isHostObject(base))) {
       // Fail if there is a proxy or host object in the chain,
       // because walking the prototype chain without allocating can't be done.
       return llvh::None;
@@ -2185,14 +2186,15 @@ inline OptValue<HiddenClass::PropertyPos> JSObject::findProperty(
   auto ret = HiddenClass::findProperty(
       createPseudoHandle(selfHandle->getClass(runtime)), runtime, name, desc);
   assert(
-      (desc.flags.privateName || !(selfHandle->flags_.proxyObject && ret)) &&
+      (desc.flags.privateName ||
+       !(selfHandle->isProxyObject(runtime) && ret)) &&
       "Proxy objects should never have own non-private properties");
   return ret;
 }
 
 inline bool JSObject::shouldCacheForIn(Runtime &runtime) const {
   return !getClass(runtime)->isDictionary() && !flags_.indexedStorage &&
-      !flags_.hostObject && !flags_.proxyObject;
+      !isHostObject(runtime) && !isProxyObject(runtime);
 }
 
 /// Attempt to get the value of an indexed property from an object cheaply,

--- a/include/hermes/VM/JSObject.h
+++ b/include/hermes/VM/JSObject.h
@@ -423,8 +423,8 @@ class JSObject : public GCCell {
   }
 
   /// ES9 9.1 O.[[Extensible]] internal slot
-  bool isExtensible() const {
-    return !flags_.noExtend;
+  bool isExtensible(PointerBase &pb) const {
+    return getClass(pb)->isExtensible();
   }
 
   /// true if this a lazy object that must be initialized prior to use.
@@ -1207,7 +1207,9 @@ class JSObject : public GCCell {
   /// ES5.1 15.2.3.10.
   /// Set [[Extensible]] slot on an ordinary object to false, preventing adding
   /// more properties.
-  static void preventExtensionsNonProxy(Handle<JSObject> self, PointerBase &pb);
+  static void preventExtensionsNonProxy(
+      Handle<JSObject> self,
+      Runtime &runtime);
   /// ES9 [[PreventExtensons]] internal method.  This works on Proxy
   /// objects and ordinary objects. If opFlags.getThrowOnError() is
   /// true, then this will throw an appropriate TypeError if the
@@ -1219,10 +1221,8 @@ class JSObject : public GCCell {
 
   /// Mark this object as having been created from typed code.
   /// \pre object was allocated with a typed HiddenClass.
-  void markAsTyped() {
-    flags_.frozen = 1;
-    flags_.sealed = 1;
-    flags_.noExtend = 1;
+  void markAsTyped(PointerBase &pb) {
+    getClass(pb)->markTypedAsFrozen();
   }
 
   /// ES9 9.1.3 [[IsExtensible]] internal method

--- a/include/hermes/VM/JSObject.h
+++ b/include/hermes/VM/JSObject.h
@@ -445,8 +445,12 @@ class JSObject : public GCCell {
   /// Record that this object is being used in a form of caching optimisation
   /// such that any change to its hidden class or parent must update the epoch
   /// in the runtime.
-  void setCachedUsingEpoch() {
-    flags_.isCachedUsingEpoch = true;
+  static void setCachedUsingEpoch(Handle<JSObject> self, Runtime &runtime);
+
+  /// \return true if this object's HiddenClass is marked as being cached using
+  /// the epoch mechanism.
+  bool isCachedUsingEpoch(PointerBase &pb) const {
+    return getClass(pb)->getIsCachedUsingEpoch();
   }
 
   /// Returns whether the object has any of properties set in \p flags.
@@ -1436,14 +1440,33 @@ class JSObject : public GCCell {
   /// \param clazz the new class, must not be null.
   void updateClass(Runtime &runtime, HiddenClass *clazz) {
     assert(clazz && "clazz cannot be null");
+
     clazzDoNotAccessDirectly_.setNonNull(runtime, clazz, runtime.getHeap());
 
     // Changing the HiddenClass may result in adding a setter/readonly property
     // in the parent chain that would prevent adding the property to the cached
     // HiddenClass.
     // We must break the cache, so increment the epoch.
-    if (LLVM_UNLIKELY(flags_.isCachedUsingEpoch))
+    if (LLVM_UNLIKELY(isCachedUsingEpoch(runtime)))
       runtime.incParentCacheEpoch();
+  }
+
+  /// Update the hidden class of this object to \p clazz,
+  /// but ignore the parent cache epoch.
+  /// SAFETY: this function must only be used when we know that the
+  /// class change doesn't introduce any setter/readonly properties that require
+  /// incrementing the epoch, for example just setting the isCachedUsingEpoch
+  /// flag on the HiddenClass.
+  /// This does not allocate indirect property storage, it is an internal API.
+  ///
+  /// \param clazz the new class, must not be null.
+  void updateClassIgnoringEpochUnsafe(Runtime &runtime, HiddenClass *clazz) {
+    assert(clazz && "clazz cannot be null");
+    assert(
+        clazz->getNumProperties() ==
+            clazzDoNotAccessDirectly_.getNonNull(runtime)->getNumProperties() &&
+        "Do not change the number of properties without incrementing the epoch");
+    clazzDoNotAccessDirectly_.setNonNull(runtime, clazz, runtime.getHeap());
   }
 
   /// Allocate storage for a new slot after the slot index itself has been

--- a/include/hermes/VM/JSObject.h
+++ b/include/hermes/VM/JSObject.h
@@ -279,9 +279,6 @@ class JSObject : public GCCell {
   /// Flags affecting the entire object.
   SHObjectFlags flags_{};
 
-  /// The prototype of this object.
-  GCPointer<JSObject> parent_;
-
   /// The dynamically derived "class" of the object, describing its fields in
   /// order.
   /// Modification of this field *MUST* be done via setClass within JSObject
@@ -301,8 +298,7 @@ class JSObject : public GCCell {
       JSObject *parent,
       HiddenClass *clazz,
       NeedsBarriers needsBarriers)
-      : parent_(runtime, parent, runtime.getHeap(), needsBarriers),
-        clazzDoNotAccessDirectly_(
+      : clazzDoNotAccessDirectly_(
             runtime,
             clazz,
             runtime.getHeap(),
@@ -320,8 +316,7 @@ class JSObject : public GCCell {
       Handle<JSObject> parent,
       Handle<HiddenClass> clazz,
       NeedsBarriers needsBarriers)
-      : parent_(runtime, *parent, runtime.getHeap(), needsBarriers),
-        clazzDoNotAccessDirectly_(
+      : clazzDoNotAccessDirectly_(
             runtime,
             *clazz,
             runtime.getHeap(),
@@ -476,10 +471,6 @@ class JSObject : public GCCell {
   const GCPointer<JSObject> &getParentGCPtr(PointerBase &runtime) const {
     assert(
         !flags_.proxyObject && "getParent cannot be used with proxy objects");
-    assert(
-        parent_.get(runtime) ==
-            getClass(runtime)->getObjectParentGCPtr().get(runtime) &&
-        "get failed");
     return getClass(runtime)->getObjectParentGCPtr();
   }
 
@@ -1841,8 +1832,14 @@ inline T *JSObject::initDirectPropStorage(Runtime &runtime, T *self) {
           nullptr);
       [[fallthrough]];
     case 5:
+      new (&self->directProps()[5]) GCSmallHermesValue(
+          SmallHermesValue::encodeRawZeroValueUnsafe(),
+          runtime.getHeap(),
+          nullptr);
+      [[fallthrough]];
+    case 6:
       static_assert(
-          DIRECT_PROPERTY_SLOTS == 5,
+          DIRECT_PROPERTY_SLOTS == 6,
           "Must update this switch if we add or remove direct properties");
       break;
   }
@@ -2077,7 +2074,7 @@ inline OptValue<bool> JSObject::tryGetOwnNamedDescriptorFast(
 
 inline OptValue<SmallHermesValue>
 JSObject::tryGetNamedNoAlloc(JSObject *self, PointerBase &base, SymbolID name) {
-  for (JSObject *curr = self; curr; curr = curr->parent_.get(base)) {
+  for (JSObject *curr = self; curr; curr = curr->getParent(base)) {
     if (LLVM_UNLIKELY(curr->isProxyObject()) ||
         LLVM_UNLIKELY(curr->isHostObject())) {
       // Fail if there is a proxy or host object in the chain,

--- a/include/hermes/VM/JSObject.h
+++ b/include/hermes/VM/JSObject.h
@@ -308,6 +308,9 @@ class JSObject : public GCCell {
             runtime.getHeap(),
             needsBarriers),
         propStorage_(nullptr) {
+    assert(
+        parent == clazz->getObjectParentGCPtr().get(runtime) &&
+        "creation failed");
     // Direct property slots are initialized by initDirectPropStorage.
   }
 
@@ -324,6 +327,9 @@ class JSObject : public GCCell {
             runtime.getHeap(),
             needsBarriers),
         propStorage_(nullptr) {
+    assert(
+        *parent == clazz->getObjectParentGCPtr().get(runtime) &&
+        "creation failed");
     // Direct property slots are initialized by initDirectPropStorage.
   }
 
@@ -332,6 +338,9 @@ class JSObject : public GCCell {
   /// (defaulting to NoBarriers).
   JSObject(Runtime &runtime, JSObject *parent, HiddenClass *clazz)
       : JSObject(runtime, parent, clazz, GCPointerBase::NoBarriers()) {
+    assert(
+        parent == clazz->getObjectParentGCPtr().get(runtime) &&
+        "creation failed");
     // Direct property slots are initialized by initDirectPropStorage.
   }
 
@@ -467,7 +476,11 @@ class JSObject : public GCCell {
   const GCPointer<JSObject> &getParentGCPtr(PointerBase &runtime) const {
     assert(
         !flags_.proxyObject && "getParent cannot be used with proxy objects");
-    return parent_;
+    assert(
+        parent_.get(runtime) ==
+            getClass(runtime)->getObjectParentGCPtr().get(runtime) &&
+        "get failed");
+    return getClass(runtime)->getObjectParentGCPtr();
   }
 
   /// \return the hidden class of this object.

--- a/include/hermes/VM/JSRegExp.h
+++ b/include/hermes/VM/JSRegExp.h
@@ -33,15 +33,12 @@ class JSRegExp final : public JSObject {
   }
 
   /// Create a JSRegExp, with the empty string for pattern and flags.
+  static PseudoHandle<JSRegExp> create(Runtime &runtime);
+
+  /// Create a JSRegExp, with the empty string for pattern and flags.
   static PseudoHandle<JSRegExp> create(
       Runtime &runtime,
       Handle<JSObject> prototype);
-
-  /// Create a JSRegExp, with the standard RegExp prototype and the empty string
-  /// for pattern and flags.
-  static PseudoHandle<JSRegExp> create(Runtime &runtime) {
-    return create(runtime, Handle<JSObject>::vmcast(&runtime.regExpPrototype));
-  }
 
   /// Creates the hidden class for Regular Expression match objects.
   /// \p arrayClass should be hidden class for JSArray objects, and it will be

--- a/include/hermes/VM/JSTypedArray.h
+++ b/include/hermes/VM/JSTypedArray.h
@@ -406,7 +406,8 @@ class JSTypedArray final : public JSTypedArrayBase {
 
   static PseudoHandle<JSTypedArray<T, C>> create(
       Runtime &runtime,
-      Handle<JSObject> prototype);
+      Handle<JSObject> prototype,
+      Handle<HiddenClass> clazz);
 
   T *begin(PointerBase &base) {
     return reinterpret_cast<T *>(data(base));
@@ -427,6 +428,7 @@ class JSTypedArray final : public JSTypedArrayBase {
   }
 
   static Handle<JSObject> getPrototype(const Runtime &runtime);
+  static Handle<HiddenClass> getRootHiddenClass(const Runtime &runtime);
   static Handle<Callable> getConstructor(const Runtime &runtime);
   static SymbolID getName(Runtime &runtime);
 

--- a/include/hermes/VM/JSWeakMapImpl.h
+++ b/include/hermes/VM/JSWeakMapImpl.h
@@ -335,6 +335,9 @@ class JSWeakMapImpl final : public JSWeakMapImplBase {
   }
 
   /// Create a new WeakMap with prototype property \p parentHandle.
+  /// Create a JSWeakMapImpl using the appropriate prototype from runtime.
+  static CallResult<PseudoHandle<JSWeakMapImpl<C>>> create(Runtime &runtime);
+
   static CallResult<PseudoHandle<JSWeakMapImpl<C>>> create(
       Runtime &runtime,
       Handle<JSObject> parentHandle);

--- a/include/hermes/VM/JSWeakRef.h
+++ b/include/hermes/VM/JSWeakRef.h
@@ -29,6 +29,9 @@ class JSWeakRef final : public JSObject {
     return cell->getKind() == CellKind::JSWeakRefKind;
   }
 
+  /// Create a new WeakRef using the standard WeakRef prototype.
+  static PseudoHandle<JSWeakRef> create(Runtime &runtime);
+
   /// Create a new WeakRef with prototype property \p parentHandle.
   static PseudoHandle<JSWeakRef> create(
       Runtime &runtime,

--- a/include/hermes/VM/PrimitiveBox.h
+++ b/include/hermes/VM/PrimitiveBox.h
@@ -69,8 +69,9 @@ class JSString final : public JSObject {
       Handle<HiddenClass> clazz)
       : JSObject(runtime, *parent, *clazz),
         primitiveValue_(runtime, *value, runtime.getHeap()) {
-    flags_.indexedStorage = true;
-    flags_.fastIndexProperties = true;
+    assert(hasIndexedStorage(runtime) && "must have indexed storage");
+    assert(
+        hasFastIndexProperties(runtime) && "must have fast index properties");
   }
 
  protected:

--- a/include/hermes/VM/PrimitiveBox.h
+++ b/include/hermes/VM/PrimitiveBox.h
@@ -33,6 +33,11 @@ class JSString final : public JSObject {
     return cell->getKind() == CellKind::JSStringKind;
   }
 
+  /// Create a JSString using the standard String prototype.
+  static CallResult<Handle<JSString>> create(
+      Runtime &runtime,
+      Handle<StringPrimitive> value);
+
   static CallResult<Handle<JSString>> create(
       Runtime &runtime,
       Handle<StringPrimitive> value,
@@ -40,12 +45,9 @@ class JSString final : public JSObject {
 
   static CallResult<Handle<JSString>> create(
       Runtime &runtime,
-      Handle<JSObject> prototype) {
-    return create(
-        runtime,
-        runtime.getPredefinedStringHandle(Predefined::emptyString),
-        prototype);
-  }
+      Handle<StringPrimitive> value,
+      Handle<JSObject> prototype,
+      Handle<HiddenClass> clazz);
 
   /// Set the [[PrimitiveValue]] internal property from a string.
   static void setPrimitiveString(
@@ -239,14 +241,17 @@ class JSNumber final : public JSObject {
     return cell->getKind() == CellKind::JSNumberKind;
   }
 
+  /// Create a JSNumber using the standard Number prototype.
+  static PseudoHandle<JSNumber> create(Runtime &runtime, double value);
+
   static PseudoHandle<JSNumber>
   create(Runtime &runtime, double value, Handle<JSObject> prototype);
 
   static PseudoHandle<JSNumber> create(
       Runtime &runtime,
-      Handle<JSObject> prototype) {
-    return create(runtime, 0.0, prototype);
-  }
+      double value,
+      Handle<JSObject> prototype,
+      Handle<HiddenClass> clazz);
 
   JSNumber(
       Runtime &runtime,
@@ -279,14 +284,17 @@ class JSBoolean final : public JSObject {
     return cell->getKind() == CellKind::JSBooleanKind;
   }
 
+  /// Create a JSBoolean using the standard Boolean prototype.
+  static PseudoHandle<JSBoolean> create(Runtime &runtime, bool value);
+
   static PseudoHandle<JSBoolean>
   create(Runtime &runtime, bool value, Handle<JSObject> prototype);
 
   static PseudoHandle<JSBoolean> create(
       Runtime &runtime,
-      Handle<JSObject> prototype) {
-    return create(runtime, false, prototype);
-  }
+      bool value,
+      Handle<JSObject> prototype,
+      Handle<HiddenClass> clazz);
 
   JSBoolean(
       Runtime &runtime,
@@ -326,9 +334,9 @@ class JSSymbol final : public JSObject {
 
   static PseudoHandle<JSSymbol> create(
       Runtime &runtime,
-      Handle<JSObject> prototype) {
-    return create(runtime, SymbolID{}, prototype);
-  }
+      SymbolID value,
+      Handle<JSObject> prototype,
+      Handle<HiddenClass> clazz);
 
   /// Return the [[PrimitiveValue]] internal property as a SymbolID.
   PseudoHandle<SymbolID> getPrimitiveSymbol() const {

--- a/include/hermes/VM/Runtime-inline.h
+++ b/include/hermes/VM/Runtime-inline.h
@@ -9,7 +9,7 @@
 #define HERMES_VM_RUNTIME_INLINE_H
 
 #include "hermes/FrontEndDefs/Builtins.h"
-#include "hermes/VM/HiddenClass.h"
+#include "hermes/VM/HiddenClass-inline.h"
 #include "hermes/VM/Runtime.h"
 
 namespace hermes {
@@ -37,13 +37,24 @@ inline Handle<HiddenClass> Runtime::getHiddenClassForPrototype(
     JSObject *proto,
     Handle<HiddenClass> root) {
   assert(root && "root must be non-null");
-  return root;
+  clazzForPrototypeTmp = HermesValue::encodeObjectValue(
+      HiddenClass::updateObjectParent(root, *this, createPseudoHandle(proto)));
+  return Handle<HiddenClass>::vmcast(&clazzForPrototypeTmp);
 }
 
 inline Handle<HiddenClass> Runtime::getLazyHiddenClassForPrototype(
     JSObject *proto) {
   const PinnedValue<HiddenClass> *clazz = &lazyObjectClass_;
-  return Handle<HiddenClass>::vmcast(clazz);
+  auto clazzWithNullObjParent = Handle<HiddenClass>::vmcast(clazz);
+  if (!proto)
+    return clazzWithNullObjParent;
+  clazzForPrototypeTmp = HermesValue::encodeObjectValue(proto);
+  clazzForPrototypeTmp = HermesValue::encodeObjectValue(
+      HiddenClass::updateObjectParent(
+          clazzWithNullObjParent,
+          *this,
+          Handle<JSObject>::vmcast(&clazzForPrototypeTmp)));
+  return Handle<HiddenClass>::vmcast(&clazzForPrototypeTmp);
 }
 
 } // namespace vm

--- a/include/hermes/VM/Runtime-inline.h
+++ b/include/hermes/VM/Runtime-inline.h
@@ -9,6 +9,7 @@
 #define HERMES_VM_RUNTIME_INLINE_H
 
 #include "hermes/FrontEndDefs/Builtins.h"
+#include "hermes/VM/HiddenClass.h"
 #include "hermes/VM/Runtime.h"
 
 namespace hermes {
@@ -34,12 +35,14 @@ inline void Runtime::enqueueJob(Callable *job) {
 
 inline Handle<HiddenClass> Runtime::getHiddenClassForPrototype(
     JSObject *proto,
-    unsigned reservedSlots) {
-  assert(
-      reservedSlots <= InternalProperty::NumAnonymousInternalProperties &&
-      "out of bounds");
-  PinnedHermesValue *clazz = &rootClazzes_[reservedSlots];
-  assert(!clazz->isUndefined() && "must initialize root classes before use");
+    Handle<HiddenClass> root) {
+  assert(root && "root must be non-null");
+  return root;
+}
+
+inline Handle<HiddenClass> Runtime::getLazyHiddenClassForPrototype(
+    JSObject *proto) {
+  const PinnedValue<HiddenClass> *clazz = &lazyObjectClass_;
   return Handle<HiddenClass>::vmcast(clazz);
 }
 

--- a/include/hermes/VM/Runtime.h
+++ b/include/hermes/VM/Runtime.h
@@ -610,6 +610,9 @@ class Runtime : public RuntimeBase, public HandleRootOwner {
   /// and CellKind.
   /// \param root the root HiddenClass to use when making a new class,
   ///   must be non-null.
+  /// IMPORTANT: This returns a Handle that is stored in a Runtime PHV field,
+  /// so DO NOT hold the result of this function call through another
+  /// getHiddenClassForPrototype call.
   inline Handle<HiddenClass> getHiddenClassForPrototype(
       JSObject *proto,
       Handle<HiddenClass> root);
@@ -618,6 +621,9 @@ class Runtime : public RuntimeBase, public HandleRootOwner {
   /// for a lazy object.
   /// Lazy objects have a different HiddenClass hierarchy in order to avoid
   /// collisions with real objects.
+  /// IMPORTANT: This returns a Handle that is stored in a Runtime PHV field,
+  /// so DO NOT hold the result of this function call through another
+  /// getHiddenClassForPrototype call.
   inline Handle<HiddenClass> getLazyHiddenClassForPrototype(JSObject *proto);
 
   /// Return the global object.

--- a/include/hermes/VM/Runtime.h
+++ b/include/hermes/VM/Runtime.h
@@ -607,10 +607,18 @@ class Runtime : public RuntimeBase, public HandleRootOwner {
   void clearThrownValue();
 
   /// Return a hidden class corresponding to the specified prototype object
-  /// and number of reserved slots. For now we only use the latter.
+  /// and CellKind.
+  /// \param root the root HiddenClass to use when making a new class,
+  ///   must be non-null.
   inline Handle<HiddenClass> getHiddenClassForPrototype(
       JSObject *proto,
-      unsigned reservedSlots);
+      Handle<HiddenClass> root);
+
+  /// Return a hidden class corresponding to the specified prototype object
+  /// for a lazy object.
+  /// Lazy objects have a different HiddenClass hierarchy in order to avoid
+  /// collisions with real objects.
+  inline Handle<HiddenClass> getLazyHiddenClassForPrototype(JSObject *proto);
 
   /// Return the global object.
   Handle<JSObject> getGlobal();
@@ -1140,6 +1148,9 @@ class Runtime : public RuntimeBase, public HandleRootOwner {
   /// character.
   void initCharacterStrings();
 
+  /// Initialize the root HiddenClasses for all the GCCells.
+  void initRootHiddenClasses();
+
   /// \param methodIndex is the index of the method in the table that lists
   ///   all the builtin methods, which is what we are iterating over.
   /// \param objectName is the id for the name of the object in the list of the
@@ -1328,13 +1339,6 @@ class Runtime : public RuntimeBase, public HandleRootOwner {
   /// Used to guard against stack overflow. Either uses real stack checking or
   /// call depth counter checking.
   StackOverflowGuard overflowGuard_;
-
-  /// rootClazzes_[i] is a PinnedHermesValue pointing to a hidden class with
-  /// its i first slots pre-reserved.
-  std::array<
-      PinnedHermesValue,
-      InternalProperty::NumAnonymousInternalProperties + 1>
-      rootClazzes_;
 
   /// Caches for property lookups in non-JS code.
   WritePropertyCacheEntry fixedWritePropCache_[(size_t)PropCacheID::_COUNT];

--- a/include/hermes/VM/RuntimeHermesValueFields.def
+++ b/include/hermes/VM/RuntimeHermesValueFields.def
@@ -79,6 +79,8 @@ RUNTIME_HV_FIELD(throwTypeErrorAccessor, PropertyAccessor)
 RUNTIME_HV_FIELD(regExpMatchClass, HiddenClass)
 RUNTIME_HV_FIELD(lazyObjectClass_, HiddenClass)
 
+RUNTIME_HV_FIELD(classJSObjectNullParent, HiddenClass)
+
 #define CELL_JSOBJECT_NAME(name, vmClassName) \
     RUNTIME_HV_FIELD(class##name, HiddenClass)
 #include "hermes/VM/CellKinds.def"
@@ -110,6 +112,10 @@ RUNTIME_HV_FIELD(functionPrototypeSymbolHasInstance, NativeFunction)
 // we record specialCodeBlockDomain_ and create runtimemodule later need to
 // revisit this in stage 2
 RUNTIME_HV_FIELD(specialCodeBlockDomain_, Domain)
+
+// A dummy object used as the key for the "null" parent transition in
+// HiddenClass.
+RUNTIME_HV_FIELD(nullParentTransitionObject, JSObject)
 
 RUNTIME_HV_FIELD(thrownValue_, HermesValue)
 RUNTIME_HV_FIELD(keptObjects_, JSMapImpl<CellKind::JSSetKind>)

--- a/include/hermes/VM/RuntimeHermesValueFields.def
+++ b/include/hermes/VM/RuntimeHermesValueFields.def
@@ -76,13 +76,18 @@ RUNTIME_HV_FIELD(strForSymbolNoDescription, StringPrimitive)
 RUNTIME_HV_FIELD(regExpLastRegExp, JSRegExp)
 
 RUNTIME_HV_FIELD(throwTypeErrorAccessor, PropertyAccessor)
-RUNTIME_HV_FIELD(arrayClass, HiddenClass)
-RUNTIME_HV_FIELD(fastArrayClass, HiddenClass)
 RUNTIME_HV_FIELD(regExpMatchClass, HiddenClass)
-RUNTIME_HV_FIELD(lazyObjectClass, HiddenClass)
-RUNTIME_HV_FIELD(proxyClass, HiddenClass)
-RUNTIME_HV_FIELD(callableProxyClass, HiddenClass)
-RUNTIME_HV_FIELD(hostObjectClass, HiddenClass)
+RUNTIME_HV_FIELD(lazyObjectClass_, HiddenClass)
+
+#define CELL_JSOBJECT_NAME(name, vmClassName) \
+    RUNTIME_HV_FIELD(class##name, HiddenClass)
+#include "hermes/VM/CellKinds.def"
+
+// This is used when we need one extra slot for Proxies/DecoratedObjects.
+// Note that this is a slight hack and isn't flexible.
+// If the user needs more properties then we should do it properly.
+RUNTIME_HV_FIELD(classNativeFunction1Reserved, HiddenClass)
+RUNTIME_HV_FIELD(classDecoratedObject1Reserved, HiddenClass)
 
 RUNTIME_HV_FIELD(iteratorPrototype, JSObject)
 RUNTIME_HV_FIELD(arrayIteratorPrototype, JSObject)

--- a/include/hermes/VM/RuntimeModule.h
+++ b/include/hermes/VM/RuntimeModule.h
@@ -422,6 +422,7 @@ class RuntimeModule final : public llvh::ilist_node<RuntimeModule> {
       uint32_t shapeTableIndex) const;
 
   /// Set the cached hidden class for a given shape.
+  /// If shapeTableIndex == SHAPE_TABLE_CACHING_DISABLED, do nothing.
   /// \param shapeTableIndex is the ID of an object literal shape.
   /// \param clazz the hidden class to cache.
   void setCachedLiteralHiddenClass(

--- a/include/hermes/VM/RuntimeModule.h
+++ b/include/hermes/VM/RuntimeModule.h
@@ -415,10 +415,12 @@ class RuntimeModule final : public llvh::ilist_node<RuntimeModule> {
 #endif
 
   /// Find the cached hidden class for an object literal, if one exists.
+  /// \param parent is the parent object that we expect to find.
   /// \param shapeTableIndex is the ID of an object literal shape.
   /// \return the cached hidden class.
   HiddenClass *findCachedLiteralHiddenClass(
       Runtime &runtime,
+      JSObject *parent,
       uint32_t shapeTableIndex) const;
 
   /// Set the cached hidden class for a given shape.

--- a/include/hermes/VM/RuntimePHVFields.def
+++ b/include/hermes/VM/RuntimePHVFields.def
@@ -12,4 +12,7 @@
 
 RUNTIME_PHV_FIELD(hvStorageTmp)
 
+// Field for storing the HiddenClass when running getHiddenClassForPrototype.
+RUNTIME_PHV_FIELD(clazzForPrototypeTmp)
+
 #undef RUNTIME_PHV_FIELD

--- a/include/hermes/VM/RuntimePHVFields.def
+++ b/include/hermes/VM/RuntimePHVFields.def
@@ -14,5 +14,6 @@ RUNTIME_PHV_FIELD(hvStorageTmp)
 
 // Field for storing the HiddenClass when running getHiddenClassForPrototype.
 RUNTIME_PHV_FIELD(clazzForPrototypeTmp)
+RUNTIME_PHV_FIELD(jsArrayClazzTmp)
 
 #undef RUNTIME_PHV_FIELD

--- a/include/hermes/VM/SingleObject.h
+++ b/include/hermes/VM/SingleObject.h
@@ -28,14 +28,17 @@ class SingleObject final : public JSObject {
   }
 
   /// Create a SingleObject.
-  static CallResult<HermesValue> create(
-      Runtime &runtime,
-      Handle<JSObject> parentHandle) {
+  static CallResult<HermesValue> create(Runtime &runtime) {
+    Handle<HiddenClass> clazz = runtime.classJSMath;
+    if constexpr (kind == CellKind::JSMathKind) {
+      clazz = runtime.classJSMath;
+    } else {
+      static_assert(kind == CellKind::JSJSONKind, "Unknown SingleObject kind");
+      clazz = runtime.classJSJSON;
+    }
+
     auto *cell = runtime.makeAFixed<SingleObject>(
-        runtime,
-        parentHandle,
-        runtime.getHiddenClassForPrototype(
-            *parentHandle, numOverlapSlots<SingleObject>()));
+        runtime, runtime.objectPrototype, clazz);
     return JSObjectInit::initToHermesValue(runtime, cell);
   }
 

--- a/include/hermes/VM/WeakValueObjectMap.h
+++ b/include/hermes/VM/WeakValueObjectMap.h
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "hermes/VM/ArrayStorage.h"
+#include "hermes/VM/GCCell.h"
+#include "hermes/VM/GCPointer.h"
+#include "hermes/VM/Handle.h"
+#include "hermes/VM/Metadata.h"
+#include "hermes/VM/Runtime.h"
+#include "hermes/VM/WeakRef.h"
+
+#include "llvh/ADT/SmallVector.h"
+#include "llvh/Support/ErrorHandling.h"
+
+namespace hermes::vm {
+
+/// Impl class for WeakValueObjectMap that handles GC integration and metadata.
+/// This class contains the template-independent parts.
+/// Users must create WeakValueObjectMap directly.
+class WeakValueObjectMapImpl : public GCCell {
+ public:
+  friend void WeakValueObjectMapBuildMeta(
+      const GCCell *cell,
+      Metadata::Builder &mb);
+  using size_type = uint32_t;
+
+ private:
+  /// Minimum capacity of a non-empty map.
+  static constexpr size_type kMinCapacity = 8;
+
+  /// Maximum capacity of a non-empty map.
+  static constexpr size_type kMaxCapacity =
+      ArrayStorage::maxCapacityNoOverflow();
+
+  /// The multiplier that the hash table grows or shrinks by each rehash.
+  static constexpr size_type kGrowOrShrinkFactor = 2;
+
+  /// The initial (minimum) pruneLimit_.
+  static constexpr size_type kMinPruneLimit = 5;
+
+ protected:
+  /// Storage for the GC-managed keys (strong references).
+  GCPointer<ArrayStorage> keys_{nullptr};
+
+  /// Storage for the WeakRef values, allocated with calloc.
+  /// The capacity_ of the WeakValueObjectMap is the number of elements of the
+  /// values_ array.
+  /// Raw pointer to avoid calling a WeakRef constructor for unused entries.
+  /// All the memory management is manual.
+  WeakRef<GCCell> *values_{nullptr};
+
+  /// Bit vector of the same size as the values_ array, indicating
+  /// whether a WeakRef has been allocated at the given index.
+  /// Store this explicitly because keys_ will not be accessible from the
+  /// finalizer to check for validity.
+  llvh::BitVector allocatedWeakRefs_{};
+
+  /// The number of allocated slots in the keys_ and values_ arrays.
+  size_type capacity_{0};
+
+  /// Number of elements known to be stored in the map.
+  /// NOTE: May overcount, because weak references may have been freed at some
+  /// point without the size_ being updated.
+  /// Used only to compute the pruneLimit_.
+  size_type size_{0};
+
+  /// When the map grows beyond this size, the invalid WeakRef-s are deleted.
+  size_type pruneLimit_{kMinPruneLimit};
+
+ protected:
+  WeakValueObjectMapImpl() = default;
+
+ public:
+  ~WeakValueObjectMapImpl();
+
+  WeakValueObjectMapImpl(const WeakValueObjectMapImpl &) = delete;
+  WeakValueObjectMapImpl &operator=(const WeakValueObjectMapImpl &) = delete;
+
+  static const VTable vt;
+
+  static constexpr CellKind getCellKind() {
+    return CellKind::WeakValueObjectMapKind;
+  }
+
+  static bool classof(const GCCell *cell) {
+    return cell->getKind() == getCellKind();
+  }
+
+  /// Return true if the map is known to be empty.
+  /// May return false negatives if it contains only invalid weak references.
+  bool isKnownEmpty() const {
+    return capacity() == 0;
+  }
+
+  /// Return the current capacity of the hash table.
+  size_type capacity() const {
+    return capacity_;
+  }
+
+  /// Return the memory size of the base components.
+  size_t getMemorySize() const {
+    return sizeof(values_[0]) * capacity_;
+  }
+
+ protected:
+  /// Find the index for \p key in the hash table.
+  /// If no slot is found, return capacity_.
+  /// If a slot is found, the caller can check the keys_ element at that slot
+  /// to see if it contains an Object HermesValue to see if the key was already
+  /// inserted.
+  size_type findIndex(Runtime &runtime, JSObject *key) const;
+
+  /// Rehash the hash table with the specified new capacity.
+  static void rehash(
+      Handle<WeakValueObjectMapImpl> self,
+      Runtime &runtime,
+      size_type newCapacity);
+
+  /// Insert a new key-value pair.
+  /// \return true if inserted, false if insertion failed (either the key
+  /// already exists or we failed to allocate enough in the ArrayStorage).
+  static bool insertNew(
+      Handle<WeakValueObjectMapImpl> self,
+      Runtime &runtime,
+      JSObject *key,
+      GCCell *value);
+
+  /// Remove the entry with the given key.
+  /// \return true if the key was found and removed.
+  static bool erase(
+      Handle<WeakValueObjectMapImpl> self,
+      Runtime &runtime,
+      JSObject *key,
+      GC &gc);
+
+ private:
+  /// Return true if the table should grow.
+  bool shouldGrow(size_type capacity, size_type size) const {
+    // Grow when load factor exceeds 0.75.
+    return capacity == 0 || size >= capacity / 4 * 3;
+  }
+
+  /// Return true if the table should shrink.
+  bool shouldShrink(size_type capacity, size_type size) const {
+    // Shrink when size is 1/8 of capacity, but don't shrink below minimum.
+    static constexpr size_type kMinCapacity = 8;
+    return capacity_ > kMinCapacity && size_ <= capacity_ / 8;
+  }
+
+  /// Update the prune limit to be the larger of the minimum or 2*size-1.
+  void recalcPruneLimit() {
+    pruneLimit_ = std::max(size_ * 2 + 1, toRValue(kMinPruneLimit));
+  }
+
+  /// Prune invalid references from the hash table.
+  static void
+  pruneInvalid(Handle<WeakValueObjectMapImpl> self, Runtime &runtime, GC &gc);
+
+  /// Free all non-GC managed resources associated with the object.
+  static void _finalizeImpl(GCCell *cell, GC &gc);
+
+  /// \return the amount of non-GC memory being used by the given \p cell, which
+  /// is assumed to be a HiddenClass.
+  static size_t _mallocSizeImpl(GCCell *cell);
+};
+
+/// A map where the values are weak references and the keys are JSObject.
+/// Note that in the "usual" weak map semantics the keys are weak, not the
+/// values.
+/// This is a type-specialized wrapper around WeakValueObjectMapImpl,
+/// so users must instantiate this directly.
+///
+/// The keys are stored in ArrayStorage as HermesValue and the values
+/// are stored as std::vector of WeakRefs in the base class.
+/// It's implemented as a quadratically probed hash table.
+template <class ValueT>
+class WeakValueObjectMap : public WeakValueObjectMapImpl {
+ public:
+  WeakValueObjectMap() = default;
+
+  /// Base class destructor handles cleanup.
+  ~WeakValueObjectMap() = default;
+
+  /// Create a new WeakValueObjectMap with the specified initial capacity.
+  static WeakValueObjectMap<ValueT> *create(Runtime &runtime) {
+    return runtime.makeAFixed<WeakValueObjectMap, HasFinalizer::Yes>();
+  }
+
+  /// Look up the value for the given key.
+  /// \return nullptr if key not found or if the weak value has been freed.
+  ValueT *lookup(Runtime &runtime, JSObject *key) const {
+    NoAllocScope noAlloc{runtime};
+    size_type idx = WeakValueObjectMapImpl::findIndex(runtime, key);
+    if (idx < capacity()) {
+      ArrayStorage *keys = keys_.getNonNull(runtime);
+      HermesValue storedKey = keys->at(idx);
+      if (storedKey.isObject() && values_[idx].isValid()) {
+        return vmcast<ValueT>(values_[idx].get(runtime));
+      }
+    }
+    return nullptr;
+  }
+
+  /// \return true if the map contains the given key with a valid value.
+  bool containsKey(Runtime &runtime, JSObject *key) const {
+    NoAllocScope noAlloc{runtime};
+    return lookup(runtime, key) != nullptr;
+  }
+
+  /// Insert a new key-value pair.
+  /// \return true if inserted, false if insertion failed (either the key
+  /// already exists or we failed to allocate enough in the ArrayStorage).
+  static bool insertNew(
+      Handle<WeakValueObjectMap> self,
+      Runtime &runtime,
+      JSObject *key,
+      ValueT *value) {
+    return WeakValueObjectMapImpl::insertNew(self, runtime, key, value);
+  }
+
+  /// Remove the entry with the given key.
+  /// \return true if the key was found and removed.
+  static bool erase(
+      Handle<WeakValueObjectMap> self,
+      Runtime &runtime,
+      JSObject *key,
+      GC &gc) {
+    return WeakValueObjectMapImpl::erase(self, runtime, key, gc);
+  }
+};
+
+} // namespace hermes::vm

--- a/include/hermes/VM/WeakValueObjectMap.h
+++ b/include/hermes/VM/WeakValueObjectMap.h
@@ -149,7 +149,6 @@ class WeakValueObjectMapImpl : public GCCell {
   /// Return true if the table should shrink.
   bool shouldShrink(size_type capacity, size_type size) const {
     // Shrink when size is 1/8 of capacity, but don't shrink below minimum.
-    static constexpr size_type kMinCapacity = 8;
     return capacity_ > kMinCapacity && size_ <= capacity_ / 8;
   }
 

--- a/include/hermes/VM/sh_config.h
+++ b/include/hermes/VM/sh_config.h
@@ -11,7 +11,7 @@
 #include "libhermesvm-config.h"
 
 /// Number of property slots allocated directly inside the object.
-enum { HERMESVM_DIRECT_PROPERTY_SLOTS = 5 };
+enum { HERMESVM_DIRECT_PROPERTY_SLOTS = 6 };
 
 #ifndef __cplusplus
 // uchar.h is not universally available, so just define our own.

--- a/include/hermes/VM/sh_legacy_value.h
+++ b/include/hermes/VM/sh_legacy_value.h
@@ -440,19 +440,6 @@ static inline bool _sh_ljs_are_both_non_nan_numbers(
 /// Flags associated with an object.
 typedef union {
   struct {
-    /// New properties cannot be added.
-    uint32_t noExtend : 1;
-
-    /// \c Object.seal() has been invoked on this object, marking all properties
-    /// as non-configurable. When \c Sealed is set, \c NoExtend is always set
-    /// too.
-    uint32_t sealed : 1;
-
-    /// \c Object.freeze() has been invoked on this object, marking all
-    /// properties as non-configurable and non-writable. When \c Frozen is set,
-    /// \c Sealed and must \c NoExtend are always set too.
-    uint32_t frozen : 1;
-
     /// This object has indexed storage. This flag will not change at runtime,
     /// it is set at construction and its value never changes. It is not a
     /// state.
@@ -476,7 +463,7 @@ typedef union {
     /// A non-zero object id value, assigned lazily. It is 0 before it is
     /// assigned. If an object started out as lazy, the objectID is the lazy
     /// object index used to identify when it gets initialized.
-    uint32_t objectID : 26;
+    uint32_t objectID : 29;
   };
   uint32_t bits;
 } SHObjectFlags;

--- a/include/hermes/VM/sh_legacy_value.h
+++ b/include/hermes/VM/sh_legacy_value.h
@@ -440,16 +440,6 @@ static inline bool _sh_ljs_are_both_non_nan_numbers(
 /// Flags associated with an object.
 typedef union {
   struct {
-    /// This object has indexed storage. This flag will not change at runtime,
-    /// it is set at construction and its value never changes. It is not a
-    /// state.
-    uint32_t indexedStorage : 1;
-
-    /// This flag is set to true when \c IndexedStorage is true and
-    /// \c class->hasIndexLikeProperties are false. It allows our fast paths to
-    /// do a simple bit check.
-    uint32_t fastIndexProperties : 1;
-
     /// This flag is set when any other objects which contain this object in
     /// their parent chain are cached in the AddPropertyCache, or if this object
     /// was found in the prototype chain of an array.
@@ -463,7 +453,7 @@ typedef union {
     /// A non-zero object id value, assigned lazily. It is 0 before it is
     /// assigned. If an object started out as lazy, the objectID is the lazy
     /// object index used to identify when it gets initialized.
-    uint32_t objectID : 29;
+    uint32_t objectID : 31;
   };
   uint32_t bits;
 } SHObjectFlags;

--- a/include/hermes/VM/sh_legacy_value.h
+++ b/include/hermes/VM/sh_legacy_value.h
@@ -463,18 +463,6 @@ typedef union {
     /// do a simple bit check.
     uint32_t fastIndexProperties : 1;
 
-    /// This flag indicates this is a special object whose properties are
-    /// managed by C++ code, and not via the standard property storage
-    /// mechanisms.
-    uint32_t hostObject : 1;
-
-    /// this is lazily created object that must be initialized before it can be
-    /// used. Note that lazy objects must have no properties defined on them,
-    uint32_t lazyObject : 1;
-
-    /// This flag indicates this is a proxy exotic Object
-    uint32_t proxyObject : 1;
-
     /// This flag is set when any other objects which contain this object in
     /// their parent chain are cached in the AddPropertyCache, or if this object
     /// was found in the prototype chain of an array.
@@ -488,7 +476,7 @@ typedef union {
     /// A non-zero object id value, assigned lazily. It is 0 before it is
     /// assigned. If an object started out as lazy, the objectID is the lazy
     /// object index used to identify when it gets initialized.
-    uint32_t objectID : 23;
+    uint32_t objectID : 26;
   };
   uint32_t bits;
 } SHObjectFlags;

--- a/include/hermes/VM/sh_legacy_value.h
+++ b/include/hermes/VM/sh_legacy_value.h
@@ -440,20 +440,10 @@ static inline bool _sh_ljs_are_both_non_nan_numbers(
 /// Flags associated with an object.
 typedef union {
   struct {
-    /// This flag is set when any other objects which contain this object in
-    /// their parent chain are cached in the AddPropertyCache, or if this object
-    /// was found in the prototype chain of an array.
-    ///
-    /// If the flag is set, then changing the parent or HiddenClass of this
-    /// object will increment the parentCacheEpoch in Runtime.
-    /// Note that property adds are not cached if any object in the parent chain
-    /// is in dictionary mode.
-    uint32_t isCachedUsingEpoch : 1;
-
     /// A non-zero object id value, assigned lazily. It is 0 before it is
     /// assigned. If an object started out as lazy, the objectID is the lazy
     /// object index used to identify when it gets initialized.
-    uint32_t objectID : 31;
+    uint32_t objectID : 32;
   };
   uint32_t bits;
 } SHObjectFlags;

--- a/include/hermes/VM/sh_mirror.h
+++ b/include/hermes/VM/sh_mirror.h
@@ -8,6 +8,7 @@
 #ifndef HERMES_SH_MIRROR_H
 #define HERMES_SH_MIRROR_H
 
+#include "hermes/VM/JIT/Config.h"
 #include "hermes/VM/sh_legacy_value.h"
 #include "hermes/VM/sh_runtime.h"
 
@@ -17,6 +18,7 @@ typedef uint32_t SHCompressedPointerRawType;
 typedef uintptr_t SHCompressedPointerRawType;
 #endif
 
+typedef uint32_t SHSymbolID;
 typedef uint32_t SHWeakRootSymbolID;
 
 typedef struct SHNativeFuncInfo SHNativeFuncInfo;
@@ -127,5 +129,35 @@ typedef struct SHBoxedDouble {
   SHGCCell base;
   double value_;
 } SHBoxedDouble;
+
+/// Struct mirroring the layout of detail::Transition.
+typedef struct SHHiddenClassTransition {
+  uint32_t symbolID;
+  uint16_t propertyFlags;
+} SHTransition;
+
+/// Struct mirroring the layout of detail::TransitionMap.
+typedef struct SHHiddenClassTransitionMap {
+  SHTransition smallKey;
+  void *unionMember;
+} SHTransitionMap;
+
+/// Struct mirroring the layout of HiddenClass.
+typedef struct SHHiddenClass {
+  SHGCCell base;
+  SHCompressedPointerRawType propertyMap;
+  SHCompressedPointerRawType parent;
+  SHCompressedPointerRawType objectParent;
+  SHCompressedPointerRawType forInCache;
+  SHCompressedPointerRawType parentTransitionMap;
+  SHSymbolID symbolID;
+  uint16_t propertyFlags;
+  unsigned numProperties;
+#if HERMESVM_JIT
+  uint16_t lazyJITId;
+#endif
+  uint8_t flags;
+  SHTransitionMap transitionMap;
+} SHHiddenClass;
 
 #endif

--- a/include/hermes/VM/sh_mirror.h
+++ b/include/hermes/VM/sh_mirror.h
@@ -133,6 +133,7 @@ typedef struct SHBoxedDouble {
 typedef struct SHHiddenClassTransition {
   uint32_t symbolID;
   uint16_t propertyFlags;
+  uint16_t classFlags;
 } SHTransition;
 
 /// Struct mirroring the layout of detail::TransitionMap.

--- a/include/hermes/VM/sh_mirror.h
+++ b/include/hermes/VM/sh_mirror.h
@@ -156,7 +156,7 @@ typedef struct SHHiddenClass {
 #if HERMESVM_JIT
   uint16_t lazyJITId;
 #endif
-  uint8_t flags;
+  uint16_t flags;
   SHTransitionMap transitionMap;
 } SHHiddenClass;
 

--- a/include/hermes/VM/sh_mirror.h
+++ b/include/hermes/VM/sh_mirror.h
@@ -59,7 +59,6 @@ typedef struct SHGCCell {
 typedef struct SHJSObject {
   SHGCCell base;
   SHObjectFlags flags;
-  SHCompressedPointerRawType parent;
   SHCompressedPointerRawType clazz;
   SHCompressedPointerRawType propStorage;
 } SHJSObject;

--- a/include/hermes/VM/static_h.h
+++ b/include/hermes/VM/static_h.h
@@ -1229,8 +1229,11 @@ SHERMES_EXPORT SHLegacyValue _sh_ljs_typeof(SHRuntime *shr, SHLegacyValue *v);
 SHERMES_EXPORT bool _sh_ljs_typeof_is(SHLegacyValue val, uint16_t types);
 
 SHERMES_EXPORT SHLegacyValue _sh_ljs_new_object(SHRuntime *shr);
-SHERMES_EXPORT SHLegacyValue
-_sh_ljs_new_object_with_parent(SHRuntime *shr, const SHLegacyValue *parent);
+SHERMES_EXPORT SHLegacyValue _sh_ljs_new_object_with_parent(
+    SHRuntime *shr,
+    SHUnit *unit,
+    const SHLegacyValue *parent,
+    uint32_t shapeTableIndex);
 
 /// \p shapeTableIndex the entry index in the literal shape table.
 /// \p valBufferOffset the beginning offset in the literal value buffer.

--- a/include/hermes/VM/static_h.h
+++ b/include/hermes/VM/static_h.h
@@ -27,7 +27,6 @@ extern "C" {
 #endif
 
 typedef struct SHUnitExt SHUnitExt;
-typedef uint32_t SHSymbolID;
 typedef struct SHUnit SHUnit;
 
 /// Encodes the set of keys to be used to construct an object literal.
@@ -1596,10 +1595,15 @@ static inline SHLegacyValue _sh_ljs_load_parent_no_traps(
     SHRuntime *shr,
     SHLegacyValue object) {
   SHJSObject *objectPtr = (SHJSObject *)_sh_ljs_get_pointer(object);
+  SHCompressedPointer clazzCompressed = {.raw = objectPtr->clazz};
+  SHHiddenClass *clazz =
+      (SHHiddenClass *)_sh_cp_decode_non_null(shr, clazzCompressed);
   assert(!objectPtr->flags.proxyObject && "proxy is not supported");
-  if (objectPtr->parent) {
-    SHCompressedPointer parent = {.raw = objectPtr->parent};
-    return _sh_ljs_object(_sh_cp_decode_non_null(shr, parent));
+  if (clazz->objectParent) {
+    SHCompressedPointer parent = {.raw = clazz->objectParent};
+    SHJSObject *parentPtr = (SHJSObject *)_sh_cp_decode_non_null(shr, parent);
+    assert(clazz->objectParent == objectPtr->parent && "get failed");
+    return _sh_ljs_object(parentPtr);
   }
   return _sh_ljs_null();
 }
@@ -1607,9 +1611,16 @@ static inline SHLegacyValue _sh_ljs_load_parent_no_traps(
 static inline SHLegacyValue _sh_typed_load_parent(
     SHRuntime *shr,
     const SHLegacyValue *object) {
-  SHCompressedPointer parent = {
-      .raw = ((SHJSObject *)_sh_ljs_get_pointer(*object))->parent};
-  return _sh_ljs_object(_sh_cp_decode_non_null(shr, parent));
+  SHCompressedPointer clazzCompressed = {
+      .raw = ((SHJSObject *)_sh_ljs_get_pointer(*object))->clazz};
+  SHHiddenClass *clazz =
+      (SHHiddenClass *)_sh_cp_decode_non_null(shr, clazzCompressed);
+  SHCompressedPointer parentCompressed = {.raw = clazz->objectParent};
+  assert(
+      clazz->objectParent ==
+          ((SHJSObject *)_sh_ljs_get_pointer(*object))->parent &&
+      "get failed");
+  return _sh_ljs_object(_sh_cp_decode(shr, parentCompressed));
 }
 
 /// If the double value is within representable integer range, convert it,

--- a/include/hermes/VM/static_h.h
+++ b/include/hermes/VM/static_h.h
@@ -1589,6 +1589,9 @@ static inline SHLegacyValue _sh_fastarray_length(
 #endif
 }
 
+/// \return true if the given JSObject is a proxy.
+SHERMES_EXPORT bool _sh_ljs_is_proxy(SHRuntime *shr, SHLegacyValue object);
+
 /// \return the parent of the legacy, ordinary object \p object. It must not be
 /// a proxy.
 static inline SHLegacyValue _sh_ljs_load_parent_no_traps(
@@ -1598,7 +1601,7 @@ static inline SHLegacyValue _sh_ljs_load_parent_no_traps(
   SHCompressedPointer clazzCompressed = {.raw = objectPtr->clazz};
   SHHiddenClass *clazz =
       (SHHiddenClass *)_sh_cp_decode_non_null(shr, clazzCompressed);
-  assert(!objectPtr->flags.proxyObject && "proxy is not supported");
+  assert(!_sh_ljs_is_proxy(shr, object) && "proxy is not supported");
   if (clazz->objectParent) {
     SHCompressedPointer parent = {.raw = clazz->objectParent};
     SHJSObject *parentPtr = (SHJSObject *)_sh_cp_decode_non_null(shr, parent);

--- a/include/hermes/VM/static_h.h
+++ b/include/hermes/VM/static_h.h
@@ -1602,7 +1602,6 @@ static inline SHLegacyValue _sh_ljs_load_parent_no_traps(
   if (clazz->objectParent) {
     SHCompressedPointer parent = {.raw = clazz->objectParent};
     SHJSObject *parentPtr = (SHJSObject *)_sh_cp_decode_non_null(shr, parent);
-    assert(clazz->objectParent == objectPtr->parent && "get failed");
     return _sh_ljs_object(parentPtr);
   }
   return _sh_ljs_null();
@@ -1616,10 +1615,6 @@ static inline SHLegacyValue _sh_typed_load_parent(
   SHHiddenClass *clazz =
       (SHHiddenClass *)_sh_cp_decode_non_null(shr, clazzCompressed);
   SHCompressedPointer parentCompressed = {.raw = clazz->objectParent};
-  assert(
-      clazz->objectParent ==
-          ((SHJSObject *)_sh_ljs_get_pointer(*object))->parent &&
-      "get failed");
   return _sh_ljs_object(_sh_cp_decode(shr, parentCompressed));
 }
 

--- a/lib/BCGen/HBC/ISel.cpp
+++ b/lib/BCGen/HBC/ISel.cpp
@@ -2152,16 +2152,25 @@ void HBCISel::generateLIRReifyArgumentsStrictInst(
 void HBCISel::generateCreateThisInst(CreateThisInst *Inst, BasicBlock *next) {
   auto output = encodeValue(Inst);
   auto closure = encodeValue(Inst->getClosure());
+  LiteralBufferBuilder::LiteralOffset literalOffset =
+      BCFGen_->getBytecodeModuleGenerator().serializedLiteralOffsetFor(Inst);
+  uint32_t shapeTableIdx = literalOffset.shapeTableIdx <= UINT16_MAX
+      ? literalOffset.shapeTableIdx
+      : hbc::SHAPE_TABLE_CACHING_DISABLED;
   if (Inst->getNewTarget() == Inst->getClosure()) {
     BCFGen_->emitCreateThisForNew(
-        output, closure, acquirePropertyReadCacheIndex(prototypeIdent_));
+        output,
+        closure,
+        acquirePropertyReadCacheIndex(prototypeIdent_),
+        shapeTableIdx);
   } else {
     auto newTarget = encodeValue(Inst->getNewTarget());
     BCFGen_->emitCreateThisForSuper(
         output,
         closure,
         newTarget,
-        acquirePropertyReadCacheIndex(prototypeIdent_));
+        acquirePropertyReadCacheIndex(prototypeIdent_),
+        shapeTableIdx);
   }
 }
 void HBCISel::generateGetConstructedObjectInst(

--- a/lib/BCGen/HBC/ISel.cpp
+++ b/lib/BCGen/HBC/ISel.cpp
@@ -1359,12 +1359,8 @@ void HBCISel::generateAllocObjectLiteralInst(
   assert(
       Inst->getKeyValuePairCount() == 0 &&
       "AllocObjectLiteralInst with properties should be lowered to LIRAllocObjectFromBufferInst");
-  if (llvh::isa<EmptySentinel>(Inst->getParentObject())) {
-    BCFGen_->emitNewObject(result);
-  } else {
-    auto parentReg = encodeValue(Inst->getParentObject());
-    BCFGen_->emitNewObjectWithParent(result, parentReg);
-  }
+  assert(llvh::isa<EmptySentinel>(Inst->getParentObject()));
+  BCFGen_->emitNewObject(result);
 }
 void HBCISel::generateAllocTypedObjectInst(
     AllocTypedObjectInst *Inst,
@@ -1373,8 +1369,8 @@ void HBCISel::generateAllocTypedObjectInst(
   assert(
       Inst->getKeyValuePairCount() == 0 &&
       "AllocTypedObjectInst with properties should be lowered to LIRAllocObjectFromBufferInst");
-  auto parentReg = encodeValue(Inst->getParentObject());
-  BCFGen_->emitNewObjectWithParent(result, parentReg);
+  assert(llvh::isa<EmptySentinel>(Inst->getParentObject()));
+  BCFGen_->emitNewObject(result);
 }
 void HBCISel::generateAllocTypedNonEnumObjectInst(
     AllocTypedNonEnumObjectInst *Inst,
@@ -1383,8 +1379,8 @@ void HBCISel::generateAllocTypedNonEnumObjectInst(
   assert(
       Inst->getKeyValuePairCount() == 0 &&
       "AllocTypedNonEnumObjectInst with properties should be lowered to LIRAllocTypedNonEnumObjectFromBufferInst");
-  auto parentReg = encodeValue(Inst->getParentObject());
-  BCFGen_->emitNewObjectWithParent(result, parentReg);
+  assert(llvh::isa<EmptySentinel>(Inst->getParentObject()));
+  BCFGen_->emitNewObject(result);
 }
 void HBCISel::generateAllocArrayInst(AllocArrayInst *Inst, BasicBlock *next) {
   auto dstReg = encodeValue(Inst);
@@ -1437,7 +1433,13 @@ void HBCISel::generateLIRAllocObjectFromBufferInst(
   auto result = encodeValue(Inst);
   auto buffIdxs =
       BCFGen_->getBytecodeModuleGenerator().serializedLiteralOffsetFor(Inst);
-  if (!llvh::isa<EmptySentinel>(Inst->getParentObject())) {
+  if (Inst->getKeyValuePairCount() == 0) {
+    assert(
+        !llvh::isa<EmptySentinel>(Inst->getParentObject()) &&
+        "must have a parent, otherwise we should use AllocObjectLiteral");
+    BCFGen_->emitNewObjectWithParent(
+        result, encodeValue(Inst->getParentObject()), buffIdxs.shapeTableIdx);
+  } else if (!llvh::isa<EmptySentinel>(Inst->getParentObject())) {
     BCFGen_->emitNewObjectWithBufferAndParent(
         result,
         encodeValue(Inst->getParentObject()),
@@ -1461,12 +1463,16 @@ void HBCISel::generateLIRAllocTypedObjectFromBufferInst(
   auto parent = encodeValue(Inst->getParentObject());
   auto buffIdxs =
       BCFGen_->getBytecodeModuleGenerator().serializedLiteralOffsetFor(Inst);
-  BCFGen_->emitNewTypedObjectWithBuffer(
-      result,
-      parent,
-      buffIdxs.shapeTableIdx,
-      buffIdxs.valueBufferOffset,
-      /* nonEnumerable */ 0);
+  if (Inst->getKeyValuePairCount() == 0) {
+    BCFGen_->emitNewObjectWithParent(result, parent, buffIdxs.shapeTableIdx);
+  } else {
+    BCFGen_->emitNewTypedObjectWithBuffer(
+        result,
+        parent,
+        buffIdxs.shapeTableIdx,
+        buffIdxs.valueBufferOffset,
+        /* nonEnumerable */ 0);
+  }
 }
 
 void HBCISel::generateLIRAllocTypedNonEnumObjectFromBufferInst(
@@ -1476,12 +1482,16 @@ void HBCISel::generateLIRAllocTypedNonEnumObjectFromBufferInst(
   auto parent = encodeValue(Inst->getParentObject());
   auto buffIdxs =
       BCFGen_->getBytecodeModuleGenerator().serializedLiteralOffsetFor(Inst);
-  BCFGen_->emitNewTypedObjectWithBuffer(
-      result,
-      parent,
-      buffIdxs.shapeTableIdx,
-      buffIdxs.valueBufferOffset,
-      /* nonEnumerable */ 1);
+  if (Inst->getKeyValuePairCount() == 0) {
+    BCFGen_->emitNewObjectWithParent(result, parent, buffIdxs.shapeTableIdx);
+  } else {
+    BCFGen_->emitNewTypedObjectWithBuffer(
+        result,
+        parent,
+        buffIdxs.shapeTableIdx,
+        buffIdxs.valueBufferOffset,
+        /* nonEnumerable */ 1);
+  }
 }
 
 void HBCISel::generateCatchInst(CatchInst *Inst, BasicBlock *next) {

--- a/lib/BCGen/LiteralBufferBuilder.cpp
+++ b/lib/BCGen/LiteralBufferBuilder.cpp
@@ -486,11 +486,19 @@ void Builder::serializeLiteralFor(AllocArrayInst *AAI) {
 
 void Builder::serializeLiteralFor(LIRAllocObjectFromBufferInst *AOFB) {
   unsigned e = AOFB->getKeyValuePairCount();
-  if (!e)
-    return;
 
   llvh::SmallVector<Literal *, 8> objKeys;
   llvh::SmallVector<Literal *, 8> objVals;
+
+  if (e == 0) {
+    // Empty object literal, we're just going to use the shape table for the
+    // parent.
+    objInst_.push_back({AOFB, {objKeys_.size(), values_.size()}});
+    objKeys_.push_back({});
+    values_.push_back({});
+    return;
+  }
+
   for (unsigned ind = 0; ind != e; ++ind) {
     auto keyValuePair = AOFB->getKeyValuePair(ind);
     objKeys.push_back(cast<Literal>(keyValuePair.first));
@@ -504,8 +512,14 @@ void Builder::serializeLiteralFor(LIRAllocObjectFromBufferInst *AOFB) {
 
 void Builder::serializeLiteralFor(LIRAllocTypedObjectFromBufferInst *AOFB) {
   unsigned e = AOFB->getKeyValuePairCount();
-  if (!e)
+
+  if (e == 0) {
+    // Empty typed object literal, just use the shape table for the parent.
+    objInst_.push_back({AOFB, {objKeys_.size(), values_.size()}});
+    objKeys_.push_back({});
+    values_.push_back({});
     return;
+  }
 
   llvh::SmallVector<Literal *, 8> objKeys;
   llvh::SmallVector<Literal *, 8> objVals;
@@ -523,8 +537,15 @@ void Builder::serializeLiteralFor(LIRAllocTypedObjectFromBufferInst *AOFB) {
 void Builder::serializeLiteralFor(
     LIRAllocTypedNonEnumObjectFromBufferInst *AOFB) {
   unsigned e = AOFB->getKeyValuePairCount();
-  if (!e)
+
+  if (e == 0) {
+    // Empty typed non-enum object literal, just use the shape table for the
+    // parent.
+    objInst_.push_back({AOFB, {objKeys_.size(), values_.size()}});
+    objKeys_.push_back({});
+    values_.push_back({});
     return;
+  }
 
   llvh::SmallVector<Literal *, 8> objKeys;
   llvh::SmallVector<Literal *, 8> objVals;

--- a/lib/BCGen/LiteralBufferBuilder.cpp
+++ b/lib/BCGen/LiteralBufferBuilder.cpp
@@ -10,13 +10,14 @@
 #include "hermes/BCGen/SerializedLiteralParser.h"
 #include "hermes/BCGen/ShapeTableEntry.h"
 #include "hermes/IR/IR.h"
+#include "hermes/IR/IRBuilder.h"
 #include "hermes/IR/Instrs.h"
 #include "hermes/Inst/Inst.h"
 #include "hermes/Inst/InstDecode.h"
 #include "hermes/VM/ObjectAllocKind.h"
 
 namespace hermes::LiteralBufferBuilder::detail {
-/// The key with which to to deduplicate shape table entries in coordToIdx.
+/// The key with which to deduplicate shape table entries in coordToIdx.
 struct ShapeTableDedupKey {
   /// The offset of the first key in the key buffer.
   uint32_t keyBufferOffset;
@@ -26,6 +27,10 @@ struct ShapeTableDedupKey {
   /// We don't share shape table entries between different allocation kinds
   /// because they use different property flags, make new HiddenClasses, etc.
   ValueKind allocKind;
+  /// The parent object.
+  /// We store the parent to avoid sharing cache entries between instructions
+  /// that will likely never match.
+  Value *parent;
 };
 } // namespace hermes::LiteralBufferBuilder::detail
 
@@ -38,23 +43,29 @@ struct DenseMapInfo<ShapeTableDedupKey> {
     return {
         DenseMapInfo<uint32_t>::getEmptyKey(),
         DenseMapInfo<uint32_t>::getEmptyKey(),
-        hermes::ValueKind::AllocObjectLiteralInstKind};
+        hermes::ValueKind::AllocObjectLiteralInstKind,
+        DenseMapInfo<hermes::Value *>::getEmptyKey()};
   }
   static inline ShapeTableDedupKey getTombstoneKey() {
     return {
         DenseMapInfo<uint32_t>::getTombstoneKey(),
         DenseMapInfo<uint32_t>::getTombstoneKey(),
-        hermes::ValueKind::AllocObjectLiteralInstKind};
+        hermes::ValueKind::AllocObjectLiteralInstKind,
+        DenseMapInfo<hermes::Value *>::getTombstoneKey()};
   }
   static inline unsigned getHashValue(const ShapeTableDedupKey &key) {
     return hash_combine(
-        key.keyBufferOffset, key.numProps, static_cast<uint8_t>(key.allocKind));
+        key.keyBufferOffset,
+        key.numProps,
+        static_cast<uint8_t>(key.allocKind),
+        DenseMapInfo<hermes::Value *>::getHashValue(key.parent));
   }
   static inline bool isEqual(
       const ShapeTableDedupKey &lhs,
       const ShapeTableDedupKey &rhs) {
     return lhs.keyBufferOffset == rhs.keyBufferOffset &&
-        lhs.numProps == rhs.numProps && lhs.allocKind == rhs.allocKind;
+        lhs.numProps == rhs.numProps && lhs.allocKind == rhs.allocKind &&
+        lhs.parent == rhs.parent;
   }
 };
 
@@ -202,8 +213,8 @@ class Builder {
   // module.
   std::vector<ShapeTableEntry> objShapeTable_{};
 
-  /// This maps a <keyBufferOffset, numProps, allocKind> key to an element index
-  /// in \p objShapeTable_.
+  /// This maps a <keyBufferOffset, numProps, allocKind, parent> key to an
+  /// element index in \c objShapeTable_.
   llvh::DenseMap<detail::ShapeTableDedupKey, uint32_t> keyOffsetToShapeIdx_;
 
   /// Each element is the keys portion of a serialized object literal.
@@ -327,6 +338,7 @@ void Builder::reseedFromBaseBytecode() {
   objShapeTable_ = shapeTable.vec();
   llvh::ArrayRef<unsigned char> keyBuf = bcProvider_->getObjectKeyBuffer();
   std::vector<StringTableEntry> keyStrTable;
+  IRBuilder builder{M_};
   keyStrTable.reserve(objShapeTable_.size());
   for (size_t i = 0, e = objShapeTable_.size(); i < e; ++i) {
     auto numProps = objShapeTable_[i].numProps;
@@ -338,10 +350,16 @@ void Builder::reseedFromBaseBytecode() {
         llvh::StringRef{
             reinterpret_cast<const char *>(keyBuf.data() + keyBufferOffset),
             sizeInBytes});
+    // Add to keyOffsetToShapeIdx_ here because the common way to
+    // instantiate an object is without a custom parent.
+    // If a non-standard parent is used, a new shape table entry will be
+    // created. It's possible this will waste an entry, but it's the only way to
+    // do it without storing the parent somehow in the bytecode.
     keyOffsetToShapeIdx_.insert(
         {{keyBufferOffset,
           numProps,
-          ValueKind::LIRAllocObjectFromBufferInstKind},
+          ValueKind::LIRAllocObjectFromBufferInstKind,
+          builder.getEmptySentinel()},
          (uint32_t)i});
   }
   keyStorage_ =
@@ -400,15 +418,19 @@ LiteralBufferBuilder::Result Builder::generate() {
     const auto [keyIdx, valIdx] = indices;
     ValueKind allocKind = Inst->getKind();
     uint32_t len;
+    Value *parent;
     if (auto *typed = llvh::dyn_cast<LIRAllocTypedObjectFromBufferInst>(Inst)) {
       len = typed->getKeyValuePairCount();
+      parent = typed->getParentObject();
     } else if (
         auto *typedNonEnum =
             llvh::dyn_cast<LIRAllocTypedNonEnumObjectFromBufferInst>(Inst)) {
       len = typedNonEnum->getKeyValuePairCount();
+      parent = typedNonEnum->getParentObject();
     } else {
-      len = llvh::cast<LIRAllocObjectFromBufferInst>(Inst)
-                ->getKeyValuePairCount();
+      auto *obj = llvh::cast<LIRAllocObjectFromBufferInst>(Inst);
+      len = obj->getKeyValuePairCount();
+      parent = obj->getParentObject();
     }
     assert(
         literalOffsetMap.count(Inst) == 0 &&
@@ -417,7 +439,8 @@ LiteralBufferBuilder::Result Builder::generate() {
     uint32_t valIndexInSet = values_.indexInSet(valIdx);
     uint32_t keyBufferOffset = keyView[keyIndexInSet].getOffset();
     const auto [iter, success] = keyOffsetToShapeIdx_.insert(
-        {{keyBufferOffset, len, allocKind}, keyOffsetToShapeIdx_.size()});
+        {{keyBufferOffset, len, allocKind, parent},
+         (uint32_t)objShapeTable_.size()});
     auto shapeID = iter->second;
     if (success) {
       // This is a new entry, add it to the shape table.

--- a/lib/BCGen/LiteralBufferBuilder.cpp
+++ b/lib/BCGen/LiteralBufferBuilder.cpp
@@ -148,7 +148,12 @@ class Builder {
         shouldVisitFunction_(shouldVisitFunction),
         optimize_(optimize),
         literalGenerator_(getIdentifier, getString),
-        bcProvider_(bcProvider) {}
+        bcProvider_(bcProvider) {
+    static_assert(
+        hbc::SHAPE_TABLE_CACHING_DISABLED == 0,
+        "first shape table entry has no caching");
+    objShapeTable_.push_back({0, 0});
+  }
 
   /// Do everything: collect the literals, optionally deduplicate them.
   Result generate();
@@ -170,6 +175,7 @@ class Builder {
   void serializeLiteralFor(LIRAllocObjectFromBufferInst *AOFB);
   void serializeLiteralFor(LIRAllocTypedObjectFromBufferInst *AOFB);
   void serializeLiteralFor(LIRAllocTypedNonEnumObjectFromBufferInst *AOFB);
+  void serializeLiteralFor(CreateThisInst *createThis);
 
   /// Serialize the the input literals \p elements into the UniquedStringVector
   /// \p dest.
@@ -211,6 +217,7 @@ class Builder {
 
   // This contains all the unique shapes of all the object literals in the
   // module.
+  // The first entry is a dummy entry because we don't use it for caching.
   std::vector<ShapeTableEntry> objShapeTable_{};
 
   /// This maps a <keyBufferOffset, numProps, allocKind, parent> key to an
@@ -233,6 +240,9 @@ class Builder {
   /// * LIRAllocTypedNonEnumObjectFromBufferInst
   std::vector<std::pair<const Instruction *, std::pair<size_t, size_t>>>
       objInst_{};
+
+  /// List of CreateThis instructions.
+  std::vector<CreateThisInst *> createThisInst_{};
 };
 
 void Builder::reseedFromBaseBytecode() {
@@ -343,6 +353,17 @@ void Builder::reseedFromBaseBytecode() {
   for (size_t i = 0, e = objShapeTable_.size(); i < e; ++i) {
     auto numProps = objShapeTable_[i].numProps;
     auto keyBufferOffset = objShapeTable_[i].keyBufferOffset;
+    if (numProps == 0) {
+      // Account for empty shape table entries (used for caching by, e.g.,
+      // CreateThis).
+      keyOffsetToShapeIdx_.insert(
+          {{keyBufferOffset,
+            numProps,
+            ValueKind::CreateThisInstKind,
+            builder.getEmptySentinel()},
+           (uint32_t)i});
+      continue;
+    }
     auto sizeInBytes = SerializedLiteralParser::parseKeyBuffer(
         keyBuf.slice(keyBufferOffset), numProps, emptyVisitor);
     keyStrTable.push_back({keyBufferOffset, (uint32_t)sizeInBytes, false});
@@ -450,6 +471,13 @@ LiteralBufferBuilder::Result Builder::generate() {
         LiteralOffset{shapeID, valView[valIndexInSet].getOffset()};
   }
 
+  for (size_t i = 0, e = createThisInst_.size(); i != e; ++i) {
+    const auto *inst = createThisInst_[i];
+    uint32_t shapeID = objShapeTable_.size();
+    objShapeTable_.push_back({0, 0});
+    literalOffsetMap[inst] = LiteralOffset{shapeID, UINT32_MAX};
+  }
+
   return {
       std::move(valueStorage_).acquireStringTableAndStorage().second,
       std::move(keyStorage_).acquireStringTableAndStorage().second,
@@ -477,6 +505,8 @@ void Builder::traverse() {
             auto *AOFB =
                 llvh::dyn_cast<LIRAllocTypedNonEnumObjectFromBufferInst>(&I)) {
           serializeLiteralFor(AOFB);
+        } else if (auto *createThis = llvh::dyn_cast<CreateThisInst>(&I)) {
+          serializeLiteralFor(createThis);
         }
       }
     }
@@ -505,6 +535,10 @@ void Builder::serializeLiteralFor(AllocArrayInst *AAI) {
 
   arraysInst_.push_back({AAI, values_.size()});
   serializeInto(values_, elements, false);
+}
+
+void Builder::serializeLiteralFor(CreateThisInst *inst) {
+  createThisInst_.push_back(inst);
 }
 
 void Builder::serializeLiteralFor(LIRAllocObjectFromBufferInst *AOFB) {

--- a/lib/BCGen/Lowering.cpp
+++ b/lib/BCGen/Lowering.cpp
@@ -155,9 +155,13 @@ bool LowerAllocObjectLiteral::lowerAllocObjectBuffer(
   IRBuilder builder(F);
   uint32_t size = allocInst->getKeyValuePairCount();
 
-  // Should not create lowered instruction for an object with 0
-  // properties.
-  if (size == 0) {
+  // Handle empty object literals.
+  // If there's no parent object, don't lower it so that we don't allocate a
+  // shape table entry.
+  // If there is a parent object, we want to lower it in order to create a
+  // shape table entry because we want to cache the HiddenClass (which
+  // contains the parent), so just let this function complete as usual.
+  if (size == 0 && llvh::isa<EmptySentinel>(allocInst->getParentObject())) {
     return false;
   }
 

--- a/lib/BCGen/SH/SH.cpp
+++ b/lib/BCGen/SH/SH.cpp
@@ -1690,42 +1690,35 @@ class InstrGen {
     assert(
         inst.getKeyValuePairCount() == 0 &&
         "AllocObjectLiteralInst with properties should be lowered to LIRAllocObjectFromBufferInst");
+    assert(llvh::isa<EmptySentinel>(inst.getParentObject()));
     os_.indent(2);
     generateRegister(inst);
     os_ << " = ";
     // TODO: Utilize sizeHint.
-    if (llvh::isa<EmptySentinel>(inst.getParentObject())) {
-      os_ << "_sh_ljs_new_object(shr)";
-    } else {
-      os_ << "_sh_ljs_new_object_with_parent(shr, &";
-      generateValue(*inst.getParentObject());
-      os_ << ")";
-    }
+    os_ << "_sh_ljs_new_object(shr)";
     os_ << ";\n";
   }
   void generateAllocTypedObjectInst(AllocTypedObjectInst &inst) {
     assert(
         inst.getKeyValuePairCount() == 0 &&
         "AllocTypedObjectInst with properties should be lowered to LIRAllocObjectFromBufferInst");
+    assert(llvh::isa<EmptySentinel>(inst.getParentObject()));
     os_.indent(2);
     generateRegister(inst);
     os_ << " = ";
     // TODO: Utilize sizeHint.
-    os_ << "_sh_ljs_new_object_with_parent(shr, &";
-    generateValue(*inst.getParentObject());
-    os_ << ")";
+    os_ << "_sh_ljs_new_object(shr)";
     os_ << ";\n";
   }
   void generateAllocTypedNonEnumObjectInst(AllocTypedNonEnumObjectInst &inst) {
     assert(
         inst.getKeyValuePairCount() == 0 &&
         "AllocTypedNonEnumObjectInst with properties should be lowered to LIRAllocTypedNonEnumObjectFromBufferInst");
+    assert(llvh::isa<EmptySentinel>(inst.getParentObject()));
     os_.indent(2);
     generateRegister(inst);
     os_ << " = ";
-    os_ << "_sh_ljs_new_object_with_parent(shr, &";
-    generateValue(*inst.getParentObject());
-    os_ << ")";
+    os_ << "_sh_ljs_new_object(shr)";
     os_ << ";\n";
   }
   void generateCreateArgumentsLooseInst(CreateArgumentsLooseInst &inst) {
@@ -2181,15 +2174,24 @@ class InstrGen {
         moduleGen_.literalBuffers.serializedLiteralOffsetFor(&inst);
 
     os_ << " = ";
-    if (llvh::isa<EmptySentinel>(inst.getParentObject())) {
+    if (inst.getKeyValuePairCount() == 0) {
+      assert(
+          !llvh::isa<EmptySentinel>(inst.getParentObject()) &&
+          "must have a parent, otherwise we should use AllocObjectLiteral");
+      os_ << "_sh_ljs_new_object_with_parent(shr, shUnit, ";
+      generateRegisterPtr(*inst.getParentObject());
+      os_ << ", " << shapeIdx << ")";
+    } else if (llvh::isa<EmptySentinel>(inst.getParentObject())) {
       os_ << "_sh_ljs_new_object_with_buffer(shr, shUnit, ";
     } else {
       os_ << "_sh_ljs_new_object_with_buffer_and_parent(shr, shUnit, ";
       generateRegisterPtr(*inst.getParentObject());
       os_ << ", ";
     }
-    os_ << shapeIdx << ", ";
-    os_ << valIdx << ")";
+    if (inst.getKeyValuePairCount() > 0) {
+      os_ << shapeIdx << ", ";
+      os_ << valIdx << ")";
+    }
     os_ << ";\n";
   }
   void generateLIRAllocTypedObjectFromBufferInst(
@@ -2201,12 +2203,19 @@ class InstrGen {
         moduleGen_.literalBuffers.serializedLiteralOffsetFor(&inst);
 
     os_ << " = ";
-    os_ << "_sh_new_typed_object_with_buffer(shr, shUnit, ";
-    generateRegisterPtr(*inst.getParentObject());
-    os_ << ", ";
-    os_ << shapeIdx << ", ";
-    os_ << valIdx;
-    os_ << ");\n";
+    if (inst.getKeyValuePairCount() == 0) {
+      os_ << "_sh_ljs_new_object_with_parent(shr, shUnit, ";
+      generateRegisterPtr(*inst.getParentObject());
+      os_ << ", " << shapeIdx << ")";
+    } else {
+      os_ << "_sh_new_typed_object_with_buffer(shr, shUnit, ";
+      generateRegisterPtr(*inst.getParentObject());
+      os_ << ", ";
+      os_ << shapeIdx << ", ";
+      os_ << valIdx;
+      os_ << ")";
+    }
+    os_ << ";\n";
   }
   void generateLIRAllocTypedNonEnumObjectFromBufferInst(
       LIRAllocTypedNonEnumObjectFromBufferInst &inst) {
@@ -2217,12 +2226,19 @@ class InstrGen {
         moduleGen_.literalBuffers.serializedLiteralOffsetFor(&inst);
 
     os_ << " = ";
-    os_ << "_sh_new_typed_non_enum_object_with_buffer(shr, shUnit, ";
-    generateRegisterPtr(*inst.getParentObject());
-    os_ << ", ";
-    os_ << shapeIdx << ", ";
-    os_ << valIdx;
-    os_ << ");\n";
+    if (inst.getKeyValuePairCount() == 0) {
+      os_ << "_sh_ljs_new_object_with_parent(shr, shUnit, ";
+      generateRegisterPtr(*inst.getParentObject());
+      os_ << ", " << shapeIdx << ")";
+    } else {
+      os_ << "_sh_new_typed_non_enum_object_with_buffer(shr, shUnit, ";
+      generateRegisterPtr(*inst.getParentObject());
+      os_ << ", ";
+      os_ << shapeIdx << ", ";
+      os_ << valIdx;
+      os_ << ")";
+    }
+    os_ << ";\n";
   }
   void generateHBCProfilePointInst(HBCProfilePointInst &inst) {
     unimplemented(inst);

--- a/lib/ConsoleHost/ConsoleHost.cpp
+++ b/lib/ConsoleHost/ConsoleHost.cpp
@@ -450,14 +450,7 @@ void installConsoleBindings(
                               unsigned paramCount) -> void {
     vm::GCScopeMarkerRAII marker{runtime};
     auto func = vm::NativeFunction::create(
-        runtime,
-        runtime.functionPrototype,
-        vm::Runtime::makeNullHandle<vm::Environment>(),
-        context,
-        functionPtr,
-        name,
-        paramCount,
-        vm::Runtime::makeNullHandle<vm::JSObject>());
+        runtime, context, functionPtr, name, paramCount);
     auto res = vm::JSObject::defineOwnProperty(
         runtime.getGlobal(), runtime, name, normalDPF, func);
     (void)res;
@@ -561,14 +554,7 @@ void installConsoleBindings(
                              runtime, llvh::createASCIIRef(name)))
                      .get();
       auto func = vm::NativeFunction::create(
-          runtime,
-          runtime.functionPrototype,
-          vm::Runtime::makeNullHandle<vm::Environment>(),
-          context,
-          functionPtr,
-          sym,
-          paramCount,
-          vm::Runtime::makeNullHandle<vm::JSObject>());
+          runtime, context, functionPtr, sym, paramCount);
       auto res = vm::JSObject::defineOwnProperty(
           hermescliObj, runtime, sym, normalDPF, func);
       (void)res;

--- a/lib/IR/IRVerifier.cpp
+++ b/lib/IR/IRVerifier.cpp
@@ -1483,10 +1483,6 @@ bool Verifier::visitHBCProfilePointInst(const HBCProfilePointInst &Inst) {
 
 bool Verifier::visitLIRAllocObjectFromBufferInst(
     const hermes::LIRAllocObjectFromBufferInst &Inst) {
-  AssertIWithMsg(
-      Inst,
-      Inst.getKeyValuePairCount() > 0,
-      "Cannot allocate an empty LIRAllocObjectFromBufferInst");
   return true;
 }
 
@@ -1494,11 +1490,7 @@ bool Verifier::visitLIRAllocTypedObjectFromBufferInst(
     const hermes::LIRAllocTypedObjectFromBufferInst &Inst) {
   AssertIWithMsg(
       Inst,
-      Inst.getKeyValuePairCount() > 0,
-      "Cannot allocate an empty LIRAllocTypedObjectFromBufferInst");
-  AssertIWithMsg(
-      Inst,
-      !llvh::isa<EmptySentinel>(Inst.getParent()),
+      !llvh::isa<EmptySentinel>(Inst.getParentObject()),
       "LIRAllocTypedObjectFromBufferInst requires a parent object");
   return true;
 }
@@ -1507,11 +1499,7 @@ bool Verifier::visitLIRAllocTypedNonEnumObjectFromBufferInst(
     const hermes::LIRAllocTypedNonEnumObjectFromBufferInst &Inst) {
   AssertIWithMsg(
       Inst,
-      Inst.getKeyValuePairCount() > 0,
-      "Cannot allocate an empty LIRAllocTypedNonEnumObjectFromBufferInst");
-  AssertIWithMsg(
-      Inst,
-      !llvh::isa<EmptySentinel>(Inst.getParent()),
+      !llvh::isa<EmptySentinel>(Inst.getParentObject()),
       "LIRAllocTypedNonEnumObjectFromBufferInst requires a parent object");
   return true;
 }

--- a/lib/IRGen/ESTreeIRGen-expr.cpp
+++ b/lib/IRGen/ESTreeIRGen-expr.cpp
@@ -2476,7 +2476,8 @@ Value *ESTreeIRGen::genRegExpLiteral(ESTree::RegExpLiteralNode *RE) {
       auto *val = Builder.getLiteralNumber(groupIdx);
       propMap.emplace_back(key, val);
     }
-    auto literalObj = Builder.createAllocObjectLiteralInst(propMap);
+    auto literalObj =
+        Builder.createAllocObjectLiteralInst(propMap, Builder.getLiteralNull());
 
     Value *params[] = {exp, literalObj};
     Builder.createCallBuiltinInst(

--- a/lib/VM/CMakeLists.txt
+++ b/lib/VM/CMakeLists.txt
@@ -73,6 +73,7 @@ set(source_files
   SymbolRegistry.cpp
   TimeLimitMonitor.cpp
   TwineChar16.cpp
+  WeakValueObjectMap.cpp
   StringRefUtils.cpp
   VTable.cpp
   Metadata.cpp

--- a/lib/VM/Callable.cpp
+++ b/lib/VM/Callable.cpp
@@ -132,6 +132,7 @@ void Callable::defineLazyProperties(Handle<Callable> fn, Runtime &runtime) {
     const CodeBlock *codeBlock = jsFun->getCodeBlock();
 
     // Set the actual non-lazy hidden class.
+    // Preserve the object's parent and CellKind.
     Handle<HiddenClass> newClass = runtime.getHiddenClassForPrototype(
         jsFun->getParent(runtime),
         vmisa<JSClass>(*jsFun) ? runtime.classJSClass
@@ -683,8 +684,7 @@ CallResult<HermesValue> BoundFunction::create(
   auto *cell = runtime.makeAFixed<BoundFunction>(
       runtime,
       lv.proto,
-      runtime.getHiddenClassForPrototype(
-          runtime.functionPrototypeRawPtr, runtime.classBoundFunction),
+      runtime.getHiddenClassForPrototype(*lv.proto, runtime.classBoundFunction),
       target,
       lv.arrStorage);
   lv.self = JSObjectInit::initToPointer(runtime, cell);

--- a/lib/VM/Callable.cpp
+++ b/lib/VM/Callable.cpp
@@ -137,7 +137,12 @@ void Callable::defineLazyProperties(Handle<Callable> fn, Runtime &runtime) {
         jsFun->getParent(runtime),
         vmisa<JSClass>(*jsFun) ? runtime.classJSClass
                                : runtime.classJSFunction);
-    jsFun->updateClassNoAllocPropStorageUnsafe(runtime, *newClass);
+    // Need to preserve the ClassFlags of the lazy object.
+    ClassFlags flags = fn->getClass(runtime)->getFlags();
+    flags.lazyObject = 0;
+    HiddenClass *newClassWithFlags =
+        HiddenClass::updateClassFlags(newClass, runtime, flags);
+    jsFun->updateClassNoAllocPropStorageUnsafe(runtime, newClassWithFlags);
 
     // Create empty object for prototype.
     auto prototypeParent = Callable::isGeneratorFunction(*jsFun)
@@ -171,7 +176,12 @@ void Callable::defineLazyProperties(Handle<Callable> fn, Runtime &runtime) {
         nativeFun->getParent(runtime),
         vmisa<NativeJSClass>(*nativeFun) ? runtime.classNativeJSClass
                                          : runtime.classNativeJSFunction);
-    nativeFun->updateClassNoAllocPropStorageUnsafe(runtime, *newClass);
+    // Need to preserve the ClassFlags of the lazy object.
+    ClassFlags flags = fn->getClass(runtime)->getFlags();
+    flags.lazyObject = 0;
+    HiddenClass *newClassWithFlags =
+        HiddenClass::updateClassFlags(newClass, runtime, flags);
+    nativeFun->updateClassNoAllocPropStorageUnsafe(runtime, newClassWithFlags);
 
     auto prototypeParent = Callable::isGeneratorFunction(*nativeFun)
         ? Handle<JSObject>::vmcast(&runtime.generatorPrototype)

--- a/lib/VM/Callable.cpp
+++ b/lib/VM/Callable.cpp
@@ -133,9 +133,9 @@ void Callable::defineLazyProperties(Handle<Callable> fn, Runtime &runtime) {
 
     // Set the actual non-lazy hidden class.
     Handle<HiddenClass> newClass = runtime.getHiddenClassForPrototype(
-        *inferredParent(
-            runtime, (FuncKind)codeBlock->getHeaderFlags().getKind()),
-        numOverlapSlots<JSFunction>());
+        jsFun->getParent(runtime),
+        vmisa<JSClass>(*jsFun) ? runtime.classJSClass
+                               : runtime.classJSFunction);
     jsFun->updateClassNoAllocPropStorageUnsafe(runtime, *newClass);
 
     // Create empty object for prototype.
@@ -167,8 +167,9 @@ void Callable::defineLazyProperties(Handle<Callable> fn, Runtime &runtime) {
   } else if (auto nativeFun = Handle<NativeJSFunction>::dyn_vmcast(fn)) {
     // Set the actual non-lazy hidden class.
     Handle<HiddenClass> newClass = runtime.getHiddenClassForPrototype(
-        *inferredParent(runtime, (FuncKind)nativeFun->getFunctionInfo()->kind),
-        numOverlapSlots<NativeJSFunction>());
+        nativeFun->getParent(runtime),
+        vmisa<NativeJSClass>(*nativeFun) ? runtime.classNativeJSClass
+                                         : runtime.classNativeJSFunction);
     nativeFun->updateClassNoAllocPropStorageUnsafe(runtime, *newClass);
 
     auto prototypeParent = Callable::isGeneratorFunction(*nativeFun)
@@ -683,7 +684,7 @@ CallResult<HermesValue> BoundFunction::create(
       runtime,
       lv.proto,
       runtime.getHiddenClassForPrototype(
-          runtime.functionPrototypeRawPtr, numOverlapSlots<BoundFunction>()),
+          runtime.functionPrototypeRawPtr, runtime.classBoundFunction),
       target,
       lv.arrStorage);
   lv.self = JSObjectInit::initToPointer(runtime, cell);
@@ -988,7 +989,7 @@ Handle<NativeJSFunction> NativeJSFunction::create(
   auto *cell = runtime.makeAFixed<NativeJSFunction>(
       runtime,
       parentHandle,
-      runtime.lazyObjectClass,
+      runtime.getLazyHiddenClassForPrototype(*parentHandle),
       parentEnvHandle,
       functionPtr,
       funcInfo,
@@ -1095,7 +1096,7 @@ Handle<NativeJSClass> NativeJSClass::create(
   auto *cell = runtime.makeAFixed<NativeJSClass>(
       runtime,
       parentHandle,
-      runtime.lazyObjectClass,
+      runtime.getLazyHiddenClassForPrototype(*parentHandle),
       parentEnvHandle,
       functionPtr,
       funcInfo,
@@ -1154,23 +1155,18 @@ std::string NativeFunction::_snapshotNameImpl(GCCell *cell, GC &gc) {
 Handle<NativeFunction> NativeFunction::create(
     Runtime &runtime,
     Handle<JSObject> parentHandle,
+    Handle<HiddenClass> clazz,
     Handle<Environment> parentEnvHandle,
     void *context,
     NativeFunctionPtr functionPtr,
     SymbolID name,
     unsigned paramCount,
-    Handle<JSObject> prototypeObjectHandle,
-    unsigned additionalSlotCount) {
-  size_t reservedSlots =
-      numOverlapSlots<NativeFunction>() + additionalSlotCount;
+    Handle<JSObject> prototypeObjectHandle) {
   auto *cell = runtime.makeAFixed<NativeFunction>(
-      runtime,
-      parentHandle,
-      runtime.getHiddenClassForPrototype(*parentHandle, reservedSlots),
-      parentEnvHandle,
-      context,
-      functionPtr);
+      runtime, parentHandle, clazz, parentEnvHandle, context, functionPtr);
   auto selfHandle = JSObjectInit::initToHandle(runtime, cell);
+
+  size_t reservedSlots = clazz->getNumProperties();
 
   // Allocate a propStorage if the number of additional slots requires it.
   runtime.ignoreAllocationFailure(
@@ -1392,7 +1388,7 @@ PseudoHandle<JSFunction> JSFunction::create(
       runtime,
       domain,
       parentHandle,
-      runtime.lazyObjectClass,
+      runtime.getLazyHiddenClassForPrototype(*parentHandle),
       envHandle,
       codeBlock);
   auto self = JSObjectInit::initToPseudoHandle(runtime, cell);
@@ -1546,7 +1542,7 @@ PseudoHandle<JSClass> JSClass::create(
       runtime,
       domain,
       parentHandle,
-      runtime.lazyObjectClass,
+      runtime.getLazyHiddenClassForPrototype(*parentHandle),
       envHandle,
       codeBlock);
   auto self = JSObjectInit::initToPseudoHandle(runtime, cell);

--- a/lib/VM/Callable.cpp
+++ b/lib/VM/Callable.cpp
@@ -560,7 +560,7 @@ CallResult<double> Callable::extractOwnLengthProperty_RJS(
           desc)) {
     propRes = JSObject::getNamedPropertyValue_RJS(
         selfHandle, runtime, selfHandle, desc);
-  } else if (selfHandle->isProxyObject()) {
+  } else if (selfHandle->isProxyObject(runtime)) {
     ComputedPropertyDescriptor desc;
     CallResult<bool> hasLength = JSProxy::getOwnProperty(
         selfHandle,
@@ -700,7 +700,7 @@ ExecutionStatus BoundFunction::initializeLengthAndName_RJS(
     Runtime &runtime,
     Handle<Callable> target,
     unsigned argCount) {
-  if (LLVM_UNLIKELY(target->isLazy())) {
+  if (LLVM_UNLIKELY(target->isLazy(runtime))) {
     Callable::initializeLazyObject(runtime, target);
   }
 
@@ -995,7 +995,7 @@ Handle<NativeJSFunction> NativeJSFunction::create(
       funcInfo,
       unit);
   auto selfHandle = JSObjectInit::initToHandle(runtime, cell);
-  selfHandle->flags_.lazyObject = 1;
+  assert(selfHandle->isLazy(runtime) && "NativeJSFunction must be lazy");
   return selfHandle;
 }
 
@@ -1102,7 +1102,7 @@ Handle<NativeJSClass> NativeJSClass::create(
       funcInfo,
       unit);
   auto selfHandle = JSObjectInit::initToHandle(runtime, cell);
-  selfHandle->flags_.lazyObject = 1;
+  assert(selfHandle->isLazy(runtime) && "NativeJSClass must be lazy");
   return selfHandle;
 }
 
@@ -1392,7 +1392,7 @@ PseudoHandle<JSFunction> JSFunction::create(
       envHandle,
       codeBlock);
   auto self = JSObjectInit::initToPseudoHandle(runtime, cell);
-  self->flags_.lazyObject = 1;
+  assert(cell->isLazy(runtime) && "JSFunction must be lazy");
   return self;
 }
 
@@ -1546,7 +1546,7 @@ PseudoHandle<JSClass> JSClass::create(
       envHandle,
       codeBlock);
   auto self = JSObjectInit::initToPseudoHandle(runtime, cell);
-  self->flags_.lazyObject = 1;
+  assert(cell->isLazy(runtime) && "JSClass must be lazy");
   return self;
 }
 

--- a/lib/VM/DecoratedObject.cpp
+++ b/lib/VM/DecoratedObject.cpp
@@ -44,19 +44,19 @@ void DecoratedObjectBuildMeta(const GCCell *cell, Metadata::Builder &mb) {
 PseudoHandle<DecoratedObject> DecoratedObject::create(
     Runtime &runtime,
     Handle<JSObject> parentHandle,
-    std::unique_ptr<Decoration> decoration,
-    unsigned int additionalSlotCount) {
-  const size_t reservedSlots =
-      numOverlapSlots<DecoratedObject>() + additionalSlotCount;
+    Handle<HiddenClass> clazz,
+    std::unique_ptr<Decoration> decoration) {
+  const size_t reservedSlots = clazz->getNumProperties();
+
   auto *cell = runtime.makeAFixed<DecoratedObject, HasFinalizer::Yes>(
-      runtime,
-      parentHandle,
-      runtime.getHiddenClassForPrototype(*parentHandle, reservedSlots),
-      std::move(decoration));
+      runtime, parentHandle, clazz, std::move(decoration));
   auto self = JSObjectInit::initToPseudoHandle(runtime, cell);
   // Allocate a propStorage if the number of additional slots requires it.
   auto selfWithSlots = runtime.ignoreAllocationFailure(
       JSObject::allocatePropStorage(std::move(self), runtime, reservedSlots));
+
+  assert(*parentHandle == selfWithSlots->getParent(runtime));
+
   return PseudoHandle<DecoratedObject>::vmcast(std::move(selfWithSlots));
 }
 

--- a/lib/VM/Domain.cpp
+++ b/lib/VM/Domain.cpp
@@ -142,13 +142,10 @@ ExecutionStatus Domain::importCJSModuleTable(
 
     auto requireFn = NativeFunction::create(
         runtime,
-        Handle<JSObject>::vmcast(&runtime.functionPrototype),
-        Runtime::makeNullHandle<Environment>(),
         (void *)TypeErrorKind::InvalidDynamicRequire,
         throwTypeError,
         Predefined::getSymbolID(Predefined::emptyString),
-        0,
-        Runtime::makeNullHandle<JSObject>());
+        0);
 
     auto context = RequireContext::create(
         runtime,
@@ -338,12 +335,8 @@ Handle<RequireContext> RequireContext::create(
     Runtime &runtime,
     Handle<Domain> domain,
     Handle<StringPrimitive> dirname) {
-  auto objProto = Handle<JSObject>::vmcast(&runtime.objectPrototype);
   auto *cell = runtime.makeAFixed<RequireContext>(
-      runtime,
-      objProto,
-      runtime.getHiddenClassForPrototype(
-          *objProto, numOverlapSlots<RequireContext>()));
+      runtime, runtime.objectPrototype, runtime.classRequireContext);
   auto self = JSObjectInit::initToHandle(runtime, cell);
   self->domain_.set(runtime, *domain, runtime.getHeap());
   self->dirname_.set(runtime, *dirname, runtime.getHeap());

--- a/lib/VM/FastArray.cpp
+++ b/lib/VM/FastArray.cpp
@@ -63,10 +63,8 @@ void FastArray::staticAsserts() {
 
 Handle<HiddenClass> FastArray::createClass(
     Runtime &runtime,
-    Handle<JSObject> prototypeHandle) {
-  Handle<HiddenClass> classHandle = runtime.getHiddenClassForPrototype(
-      *prototypeHandle, numOverlapSlots<FastArray>());
-
+    Handle<JSObject> prototypeHandle,
+    Handle<HiddenClass> rootClazz) {
   // Add the length property.
   PropertyFlags pf{};
   pf.enumerable = 0;
@@ -74,16 +72,16 @@ Handle<HiddenClass> FastArray::createClass(
   pf.configurable = 0;
 
   auto added = HiddenClass::addProperty(
-      classHandle, runtime, Predefined::getSymbolID(Predefined::length), pf);
+      rootClazz, runtime, Predefined::getSymbolID(Predefined::length), pf);
   assert(
       added != ExecutionStatus::EXCEPTION &&
       "Adding the first properties shouldn't cause overflow");
   assert(
       added->second == lengthPropIndex() &&
       "FastArray.length has invalid index");
-  classHandle = added->first;
+  rootClazz = added->first;
 
-  return classHandle;
+  return rootClazz;
 }
 
 CallResult<HermesValue> FastArray::create(Runtime &runtime, size_t capacity) {
@@ -97,7 +95,7 @@ CallResult<HermesValue> FastArray::create(Runtime &runtime, size_t capacity) {
       runtime.makeAFixed<FastArray>(
           runtime,
           runtime.fastArrayPrototype,
-          Handle<HiddenClass>::vmcast(&runtime.fastArrayClass),
+          runtime.classFastArray,
           GCPointerBase::NoBarriers()));
 
   auto arrRes = ArrayStorageSmall::create(runtime, capacity);

--- a/lib/VM/FastArray.cpp
+++ b/lib/VM/FastArray.cpp
@@ -54,7 +54,9 @@ const ObjectVTable FastArray::vt{
 void FastArray::staticAsserts() {
   // Add the size of the length property when comparing sizes.
   static_assert(
-      sizeof(FastArray) + sizeof(GCSmallHermesValue) == sizeof(SHFastArray));
+      llvh::alignTo<sizeof(GCSmallHermesValue)>(sizeof(FastArray)) +
+          sizeof(GCSmallHermesValue) ==
+      sizeof(SHFastArray));
   static_assert(
       offsetof(FastArray, indexedStorage_) ==
       offsetof(SHFastArray, indexedStorage));

--- a/lib/VM/HiddenClass.cpp
+++ b/lib/VM/HiddenClass.cpp
@@ -11,8 +11,10 @@
 #include "hermes/Support/Statistic.h"
 #include "hermes/VM/ArrayStorage.h"
 #include "hermes/VM/GCPointer-inline.h"
+#include "hermes/VM/HiddenClass-inline.h"
 #include "hermes/VM/JSArray.h"
 #include "hermes/VM/JSObject.h"
+#include "hermes/VM/JSWeakMapImpl.h"
 #include "hermes/VM/Operations.h"
 #include "hermes/VM/StringView.h"
 
@@ -26,6 +28,10 @@ HERMES_SLOW_STATISTIC(
 HERMES_SLOW_STATISTIC(
     NumHCMapSteal,
     "NumHCMapSteal: Number of map steals from parent HiddenClass.");
+HERMES_SLOW_STATISTIC(
+    NumHCObjectParentChanges,
+    "NumHCObjectParentChanges: Number of HiddenClass ObjectParent change slow "
+    "path calls.");
 
 namespace hermes {
 namespace vm {
@@ -121,10 +127,12 @@ const VTable HiddenClass::vt{
 void HiddenClassBuildMeta(const GCCell *cell, Metadata::Builder &mb) {
   const auto *self = static_cast<const HiddenClass *>(cell);
   mb.setVTable(&HiddenClass::vt);
+  mb.addField("objectParent", &self->objectParent_);
   mb.addField("symbol", &self->symbolID_);
   mb.addField("parent", &self->parent_);
   mb.addField("propertyMap", &self->propertyMap_);
   mb.addField("forInCache", &self->forInCache_);
+  mb.addField("parentTransitionMap", &self->parentTransitionMap_);
 }
 
 void HiddenClass::_finalizeImpl(GCCell *cell, GC &gc) {
@@ -167,11 +175,14 @@ void HiddenClass::_snapshotAddNodesImpl(
 }
 #endif
 
-HiddenClass *HiddenClass::createRoot(Runtime &runtime) {
+HiddenClass *HiddenClass::createRoot(
+    Runtime &runtime,
+    Handle<JSObject> objectParent) {
   return create(
       runtime,
       ClassFlags{},
       Runtime::makeNullHandle<HiddenClass>(),
+      objectParent,
       SymbolID{},
       PropertyFlags{},
       0);
@@ -179,6 +190,7 @@ HiddenClass *HiddenClass::createRoot(Runtime &runtime) {
 
 HiddenClass *HiddenClass::createForTypedObject(
     Runtime &runtime,
+    Handle<JSObject> objectParent,
     uint32_t capacity) {
   assert(capacity <= maxNumProperties() && "too many properties");
 
@@ -197,6 +209,7 @@ HiddenClass *HiddenClass::createForTypedObject(
       runtime,
       flags,
       Runtime::makeNullHandle<HiddenClass>(),
+      objectParent,
       SymbolID{},
       PropertyFlags{},
       0);
@@ -212,6 +225,7 @@ HiddenClass *HiddenClass::create(
     Runtime &runtime,
     ClassFlags flags,
     Handle<HiddenClass> parent,
+    Handle<JSObject> objectParent,
     SymbolID symbolID,
     PropertyFlags propertyFlags,
     unsigned numProperties) {
@@ -220,7 +234,13 @@ HiddenClass *HiddenClass::create(
       "non-empty non-dictionary orphan");
   auto *obj =
       runtime.makeAFixed<HiddenClass, HasFinalizer::Yes, LongLived::Yes>(
-          runtime, flags, parent, symbolID, propertyFlags, numProperties);
+          runtime,
+          flags,
+          parent,
+          objectParent,
+          symbolID,
+          propertyFlags,
+          numProperties);
   return obj;
 }
 
@@ -231,6 +251,11 @@ Handle<HiddenClass> HiddenClass::copyToNewDictionary(
   assert(
       !selfHandle->isDictionaryNoCache() && "class already in no-cache mode");
 
+  struct : public Locals {
+    PinnedValue<JSObject> objectParent;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
+
   auto newFlags = selfHandle->flags_;
   newFlags.dictionaryMode = true;
   // If the requested, transition to no-cache mode.
@@ -239,10 +264,12 @@ Handle<HiddenClass> HiddenClass::copyToNewDictionary(
   }
 
   /// Allocate a new class without a parent.
+  lv.objectParent = selfHandle->objectParent_.get(runtime);
   auto newClassHandle = runtime.makeHandle<HiddenClass>(HiddenClass::create(
       runtime,
       newFlags,
       Runtime::makeNullHandle<HiddenClass>(),
+      lv.objectParent,
       SymbolID{},
       PropertyFlags{},
       selfHandle->numProperties_));
@@ -472,11 +499,18 @@ CallResult<std::pair<Handle<HiddenClass>, SlotIndex>> HiddenClass::addProperty(
           .hasValue();
   auto newFlags = computeFlags(selfHandle->flags_, propertyFlags, isIndexLike);
 
+  struct : public Locals {
+    PinnedValue<JSObject> objectParent;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
+
   // Allocate the child.
+  lv.objectParent = selfHandle->objectParent_.get(runtime);
   auto childHandle = runtime.makeHandle<HiddenClass>(HiddenClass::create(
       runtime,
       newFlags,
       selfHandle,
+      lv.objectParent,
       name,
       propertyFlags,
       selfHandle->numProperties_ + 1));
@@ -595,15 +629,22 @@ Handle<HiddenClass> HiddenClass::updateProperty(
     return runtime.makeHandle(existingChild);
   }
 
+  struct : public Locals {
+    PinnedValue<JSObject> objectParent;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
+
   // We are updating the existing property and adding a transition to a new
   // hidden class.
   descPair->second.flags = newFlags;
 
   // Allocate the child.
+  lv.objectParent = selfHandle->objectParent_.get(runtime);
   auto childHandle = runtime.makeHandle<HiddenClass>(HiddenClass::create(
       runtime,
       computeFlags(selfHandle->flags_, newFlags, false),
       selfHandle,
+      lv.objectParent,
       name,
       transitionFlags,
       selfHandle->numProperties_));
@@ -661,6 +702,107 @@ SlotIndex HiddenClass::addNewTypedPublicProperty(
       selfHandle, runtime, name, NamedPropertyDescriptor(propFlags, newSlot));
 
   return newSlot;
+}
+
+HiddenClass *HiddenClass::updateObjectParentSlowPath(
+    Handle<HiddenClass> selfHandle,
+    Runtime &runtime,
+    PseudoHandle<JSObject> newParentPH) {
+  ++NumHCObjectParentChanges;
+  assert(
+      newParentPH.get() != selfHandle->objectParent_.get(runtime) &&
+      "don't call slow path if the parent isn't changing");
+
+  // In dictionary mode, update the objectParent directly without making a new
+  // HiddenClass.
+  if (LLVM_UNLIKELY(selfHandle->isDictionary())) {
+    selfHandle->objectParent_.set(
+        runtime, newParentPH.get(), runtime.getHeap());
+    return *selfHandle;
+  }
+
+  struct : public Locals {
+    PinnedValue<WeakValueObjectMap<HiddenClass>> parentTransitionMap;
+    PinnedValue<HiddenClass> child;
+    PinnedValue<JSObject> newParent;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
+
+  lv.newParent = std::move(newParentPH);
+
+  // Check if incrementing parentChangeCounter would exceed the maximum.
+  constexpr uint8_t maxCounter =
+      (1 << ClassFlags::kParentChangeCounterSize) - 1;
+  if (LLVM_UNLIKELY(selfHandle->flags_.parentChangeCounter >= maxCounter)) {
+    // Convert to dictionary mode and update the objectParent directly.
+    Handle<HiddenClass> dictionaryHandle =
+        copyToNewDictionary(selfHandle, runtime);
+    dictionaryHandle->objectParent_.set(
+        runtime, *lv.newParent, runtime.getHeap());
+    return *dictionaryHandle;
+  }
+
+  // Check for existing transition in parentTransitionMap_
+  if (selfHandle->parentTransitionMap_) {
+    lv.parentTransitionMap =
+        selfHandle->parentTransitionMap_.getNonNull(runtime);
+    HiddenClass *existingChild = lv.parentTransitionMap->lookup(
+        runtime,
+        *lv.newParent ? *lv.newParent : *runtime.nullParentTransitionObject);
+    // Found the existing HiddenClass, return it directly.
+    if (existingChild)
+      return vmcast<HiddenClass>(existingChild);
+  }
+
+  // Create new flags with incremented parentChangeCounter
+  ClassFlags newClassFlags = selfHandle->flags_;
+  ++newClassFlags.parentChangeCounter;
+
+  // Create a new HiddenClass with the new objectParent.
+  lv.child = HiddenClass::create(
+      runtime,
+      newClassFlags,
+      selfHandle,
+      lv.newParent,
+      SymbolID::empty(),
+      PropertyFlags{},
+      selfHandle->numProperties_);
+
+  if (LLVM_UNLIKELY(!selfHandle->parentTransitionMap_)) {
+    // parentTransitionMap_ needs to be allocated.
+    auto *map = WeakValueObjectMap<HiddenClass>::create(runtime);
+    selfHandle->parentTransitionMap_.set(runtime, map, runtime.getHeap());
+    lv.parentTransitionMap =
+        selfHandle->parentTransitionMap_.getNonNull(runtime);
+  }
+
+  // Store the transition in the map.
+  bool inserted = WeakValueObjectMap<HiddenClass>::insertNew(
+      lv.parentTransitionMap,
+      runtime,
+      *lv.newParent ? *lv.newParent : *runtime.nullParentTransitionObject,
+      *lv.child);
+  if (LLVM_UNLIKELY(!inserted)) {
+    // If we failed to insert, it can't be because the key already exists (we
+    // already checked that above). So we must not have enough space in the
+    // array. Clear out the transition table and start over - that's the only
+    // thing to do. This isn't really an OOM so we have no reason to fatal.
+    lv.parentTransitionMap = WeakValueObjectMap<HiddenClass>::create(runtime);
+    selfHandle->parentTransitionMap_.set(
+        runtime, *lv.parentTransitionMap, runtime.getHeap());
+    inserted = WeakValueObjectMap<HiddenClass>::insertNew(
+        lv.parentTransitionMap,
+        runtime,
+        *lv.newParent ? *lv.newParent : *runtime.nullParentTransitionObject,
+        *lv.child);
+    if (LLVM_UNLIKELY(!inserted)) {
+      // Failed to insert even after reallocating a fresh map, there's nothing
+      // else productive we can do.
+      runtime.getHeap().oom(OOMError::MaxHeapReached);
+    }
+  }
+
+  return *lv.child;
 }
 
 Handle<HiddenClass> HiddenClass::makeAllNonConfigurable(
@@ -897,6 +1039,9 @@ void HiddenClass::initializeMissingPropertyMap(
     NoAllocScope _(runtime);
     for (auto *cur = *selfHandle; cur->numProperties_ > 0;
          cur = cur->parent_.getNonNull(runtime)) {
+      // Only visit the HiddenClasses which involve properties.
+      if (LLVM_UNLIKELY(cur->symbolID_.isInvalid()))
+        continue;
       auto tmpFlags = cur->propertyFlags_;
       tmpFlags.flagsTransition = 0;
       entries.emplace_back(cur->symbolID_, tmpFlags);
@@ -959,6 +1104,12 @@ void HiddenClass::stealPropertyMapFromParent(
       self->parent_.getNonNull(runtime)->propertyMap_,
       runtime.getHeap());
   self->parent_.getNonNull(runtime)->propertyMap_.setNull(runtime.getHeap());
+
+  if (LLVM_UNLIKELY(self->symbolID_.isInvalid())) {
+    // No changes to make to the property map, because only the object's parent
+    // was updated.
+    return;
+  }
 
   // Does our class add a new property?
   if (LLVM_LIKELY(!self->propertyFlags_.flagsTransition)) {

--- a/lib/VM/HiddenClass.cpp
+++ b/lib/VM/HiddenClass.cpp
@@ -705,6 +705,67 @@ SlotIndex HiddenClass::addNewTypedPublicProperty(
   return newSlot;
 }
 
+HiddenClass *HiddenClass::updateClassFlags(
+    Handle<HiddenClass> selfHandle,
+    Runtime &runtime,
+    ClassFlags newFlags) {
+  if (selfHandle->flags_ == newFlags) {
+    // Nothing to do, return immediately.
+    return *selfHandle;
+  }
+
+  // In dictionary mode we simply update our map (which must exist).
+  if (LLVM_UNLIKELY(selfHandle->isDictionary())) {
+    assert(
+        selfHandle->propertyMap_ &&
+        "propertyMap must exist in dictionary mode");
+    selfHandle->flags_ = newFlags;
+    // If it's still cacheable, make it non-cacheable.
+    if (!selfHandle->isDictionaryNoCache()) {
+      selfHandle = copyToNewDictionary(selfHandle, runtime, /*noCache*/ true);
+    }
+    return *selfHandle;
+  }
+
+  // Check whether we have already cached the final state.
+  assert(!selfHandle->isDictionary());
+  if (auto *hc = selfHandle->transitionMap_.lookup(
+          runtime,
+          Transition(
+              getSymbolID(Predefined::InternalPropertyFlagsTransition),
+              newFlags))) {
+    return hc;
+  }
+
+  // Otherwise, update ClassFlags by making a new HiddenClass.
+
+  struct : public Locals {
+    PinnedValue<JSObject> objectParent;
+    PinnedValue<HiddenClass> newClazz;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
+
+  lv.objectParent = selfHandle->getObjectParent(runtime);
+
+  lv.newClazz = HiddenClass::create(
+      runtime,
+      newFlags,
+      selfHandle,
+      lv.objectParent,
+      SymbolID::empty(),
+      PropertyFlags{},
+      selfHandle->numProperties_);
+
+  // Cache the transition to the final class.
+  selfHandle->transitionMap_.insertNew(
+      runtime,
+      Transition(
+          getSymbolID(Predefined::InternalPropertyFlagsTransition), newFlags),
+      lv.newClazz);
+
+  return *lv.newClazz;
+}
+
 HiddenClass *HiddenClass::updateObjectParentSlowPath(
     Handle<HiddenClass> selfHandle,
     Runtime &runtime,
@@ -806,7 +867,7 @@ HiddenClass *HiddenClass::updateObjectParentSlowPath(
   return *lv.child;
 }
 
-Handle<HiddenClass> HiddenClass::makeAllNonConfigurable(
+HiddenClass *HiddenClass::seal(
     Handle<HiddenClass> selfHandle,
     Runtime &runtime) {
   if (!selfHandle->propertyMap_)
@@ -816,48 +877,63 @@ Handle<HiddenClass> HiddenClass::makeAllNonConfigurable(
       dbgs() << "Class:" << selfHandle->getDebugAllocationId()
              << " making all non-configurable\n");
 
+  struct : public Locals {
+    PinnedValue<HiddenClass> cur;
+    PinnedValue<DictPropertyMap> map;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
+
   // Keep a handle to our initial map. The order of properties in it will
   // remain the same as long as we are only doing property updates.
-  auto mapHandle = runtime.makeHandle(selfHandle->propertyMap_);
+  lv.map = selfHandle->propertyMap_.getNonNull(runtime);
 
-  MutableHandle<HiddenClass> curHandle{runtime, *selfHandle};
+  lv.cur = *selfHandle;
 
   // TODO: this can be made much more efficient at the expense of moving some
   // logic from updateOwnProperty() here.
   DictPropertyMap::forEachProperty(
-      mapHandle,
+      lv.map,
       runtime,
-      [&runtime, &curHandle](SymbolID id, NamedPropertyDescriptor desc) {
+      [&runtime, &lv](SymbolID id, NamedPropertyDescriptor desc) {
         if (!desc.flags.configurable)
           return;
         PropertyFlags newFlags = desc.flags;
         newFlags.configurable = 0;
 
         assert(
-            curHandle->propertyMap_ &&
+            lv.cur->propertyMap_ &&
             "propertyMap must exist after updateOwnProperty()");
 
-        auto found = DictPropertyMap::find(
-            curHandle->propertyMap_.getNonNull(runtime), id);
+        auto found =
+            DictPropertyMap::find(lv.cur->propertyMap_.getNonNull(runtime), id);
         assert(found && "property not found during enumeration");
-        curHandle = *updateProperty(curHandle, runtime, *found, newFlags);
+        lv.cur = *updateProperty(lv.cur, runtime, *found, newFlags);
       });
-  return std::move(curHandle);
+
+  ClassFlags sealedFlags = lv.cur->flags_;
+  sealedFlags.noExtend = 1;
+  sealedFlags.sealed = 1;
+  lv.cur = HiddenClass::updateClassFlags(lv.cur, runtime, sealedFlags);
+
+  return *lv.cur;
 }
 
-Handle<HiddenClass> HiddenClass::makeAllReadOnly(
+HiddenClass *HiddenClass::freeze(
     Handle<HiddenClass> selfHandle,
     Runtime &runtime) {
   // Check whether we have already cached the final state of freezing this
   // class.
   if (LLVM_LIKELY(!selfHandle->isDictionary())) {
     ClassFlags flags = selfHandle->flags_;
+    flags.noExtend = 1;
+    flags.sealed = 1;
+    flags.frozen = 1;
     if (auto *hc = selfHandle->transitionMap_.lookup(
             runtime,
             Transition(
                 getSymbolID(Predefined::InternalPropertyFreezeTransition),
                 flags))) {
-      return runtime.makeHandle(hc);
+      return hc;
     }
   }
 
@@ -872,14 +948,19 @@ Handle<HiddenClass> HiddenClass::makeAllReadOnly(
   // remain the same as long as we are only doing property updates.
   auto mapHandle = runtime.makeHandle(selfHandle->propertyMap_);
 
-  MutableHandle<HiddenClass> curHandle{runtime, *selfHandle};
+  struct : public Locals {
+    PinnedValue<HiddenClass> cur;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
+
+  lv.cur = *selfHandle;
 
   // TODO: this can be made much more efficient at the expense of moving some
   // logic from updateOwnProperty() here.
   DictPropertyMap::forEachProperty(
       mapHandle,
       runtime,
-      [&runtime, &curHandle](SymbolID id, NamedPropertyDescriptor desc) {
+      [&runtime, &lv](SymbolID id, NamedPropertyDescriptor desc) {
         PropertyFlags newFlags = desc.flags;
         if (!newFlags.accessor) {
           newFlags.writable = 0;
@@ -891,26 +972,32 @@ Handle<HiddenClass> HiddenClass::makeAllReadOnly(
           return;
 
         assert(
-            curHandle->propertyMap_ &&
+            lv.cur->propertyMap_ &&
             "propertyMap must exist after updateOwnProperty()");
 
         auto found =
-            DictPropertyMap::find(curHandle->propertyMap_.get(runtime), id);
+            DictPropertyMap::find(lv.cur->propertyMap_.get(runtime), id);
         assert(found && "property not found during enumeration");
-        curHandle = *updateProperty(curHandle, runtime, *found, newFlags);
+        lv.cur = *updateProperty(lv.cur, runtime, *found, newFlags);
       });
 
-  // Cache the transition to the final read-only class.
-  if (!selfHandle->isDictionary()) {
-    ClassFlags flags = selfHandle->flags_;
+  ClassFlags frozenFlags = lv.cur->flags_;
+  frozenFlags.sealed = 1;
+  frozenFlags.noExtend = 1;
+  frozenFlags.frozen = 1;
+  lv.cur = HiddenClass::updateClassFlags(lv.cur, runtime, frozenFlags);
+
+  if (LLVM_LIKELY(!selfHandle->isDictionary())) {
+    // Cache the transition to the final class.
     selfHandle->transitionMap_.insertNew(
         runtime,
         Transition(
-            getSymbolID(Predefined::InternalPropertyFreezeTransition), flags),
-        curHandle);
+            getSymbolID(Predefined::InternalPropertyFreezeTransition),
+            frozenFlags),
+        lv.cur);
   }
 
-  return std::move(curHandle);
+  return *lv.cur;
 }
 
 Handle<HiddenClass> HiddenClass::updatePropertyFlagsWithoutTransitions(

--- a/lib/VM/HiddenClass.cpp
+++ b/lib/VM/HiddenClass.cpp
@@ -850,10 +850,12 @@ Handle<HiddenClass> HiddenClass::makeAllReadOnly(
   // Check whether we have already cached the final state of freezing this
   // class.
   if (LLVM_LIKELY(!selfHandle->isDictionary())) {
+    ClassFlags flags = selfHandle->flags_;
     if (auto *hc = selfHandle->transitionMap_.lookup(
             runtime,
             Transition(
-                getSymbolID(Predefined::InternalPropertyFreezeTransition)))) {
+                getSymbolID(Predefined::InternalPropertyFreezeTransition),
+                flags))) {
       return runtime.makeHandle(hc);
     }
   }
@@ -899,9 +901,11 @@ Handle<HiddenClass> HiddenClass::makeAllReadOnly(
 
   // Cache the transition to the final read-only class.
   if (!selfHandle->isDictionary()) {
+    ClassFlags flags = selfHandle->flags_;
     selfHandle->transitionMap_.insertNew(
         runtime,
-        Transition(getSymbolID(Predefined::InternalPropertyFreezeTransition)),
+        Transition(
+            getSymbolID(Predefined::InternalPropertyFreezeTransition), flags),
         curHandle);
   }
 

--- a/lib/VM/HiddenClass.cpp
+++ b/lib/VM/HiddenClass.cpp
@@ -177,10 +177,11 @@ void HiddenClass::_snapshotAddNodesImpl(
 
 HiddenClass *HiddenClass::createRoot(
     Runtime &runtime,
-    Handle<JSObject> objectParent) {
+    Handle<JSObject> objectParent,
+    ClassFlags flags) {
   return create(
       runtime,
-      ClassFlags{},
+      flags,
       Runtime::makeNullHandle<HiddenClass>(),
       objectParent,
       SymbolID{},

--- a/lib/VM/HostModel.cpp
+++ b/lib/VM/HostModel.cpp
@@ -129,7 +129,9 @@ CallResult<HermesValue> HostObject::createWithoutPrototype(
           *parentHandle, runtime.classHostObject),
       std::move(proxy));
 
-  hostObj->flags_.hostObject = true;
+  assert(
+      hostObj->isHostObject(runtime) &&
+      "new HostObject made with the wrong HiddenClass");
 
   return JSObjectInit::initToHermesValue(runtime, hostObj);
 }

--- a/lib/VM/HostModel.cpp
+++ b/lib/VM/HostModel.cpp
@@ -72,7 +72,7 @@ CallResult<HermesValue> FinalizableNativeFunction::createWithoutPrototype(
       runtime,
       parentHandle,
       runtime.getHiddenClassForPrototype(
-          *parentHandle, numOverlapSlots<FinalizableNativeFunction>()),
+          *parentHandle, runtime.classFinalizableNativeFunction),
       context,
       functionPtr,
       finalizePtr);
@@ -123,7 +123,11 @@ CallResult<HermesValue> HostObject::createWithoutPrototype(
   auto parentHandle = Handle<JSObject>::vmcast(&runtime.objectPrototype);
 
   HostObject *hostObj = runtime.makeAFixed<HostObject, HasFinalizer::Yes>(
-      runtime, parentHandle, runtime.hostObjectClass, std::move(proxy));
+      runtime,
+      parentHandle,
+      runtime.getHiddenClassForPrototype(
+          *parentHandle, runtime.classHostObject),
+      std::move(proxy));
 
   hostObj->flags_.hostObject = true;
 

--- a/lib/VM/Interpreter-slowpaths.cpp
+++ b/lib/VM/Interpreter-slowpaths.cpp
@@ -1864,8 +1864,8 @@ CallResult<HiddenClass *> Interpreter::getHiddenClassForBuffer(
             return runtimeModule->getSymbolIDMustExist(id);
           });
     } else {
-      auto *rootClazz = *runtime.getHiddenClassForPrototype(
-          *runtime.objectPrototype, JSObject::numOverlapSlots<JSObject>());
+      auto *rootClazz =
+          *runtime.getHiddenClassForPrototype(*parent, runtime.classJSObject);
 
       // Ensure that the hidden class does not start out with any properties, so
       // we just need to check the shape table entry.
@@ -1918,6 +1918,7 @@ CallResult<PseudoHandle<>> Interpreter::createObjectFromBuffer(
   // Note that the built-in constructor is empty, so we don't actually need to
   // call it.
   lv.obj = JSObject::create(runtime, parent, lv.clazz).get();
+  assert(lv.obj->getParent(runtime) == *parent);
   auto numLiterals = lv.clazz->getNumProperties();
 
   // Set up the visitor to populate property values in the object.

--- a/lib/VM/Interpreter-slowpaths.cpp
+++ b/lib/VM/Interpreter-slowpaths.cpp
@@ -2004,7 +2004,7 @@ CallResult<PseudoHandle<>> Interpreter::createObjectFromBuffer(
 
   if (isTypedAllocKind(allocKind)) {
     // Freeze the object from the perspective of untyped code.
-    lv.obj->markAsTyped();
+    lv.obj->markAsTyped(runtime);
   }
 
   return createPseudoHandle(lv.obj.getHermesValue());

--- a/lib/VM/Interpreter-slowpaths.cpp
+++ b/lib/VM/Interpreter-slowpaths.cpp
@@ -869,6 +869,7 @@ CallResult<HermesValue> Interpreter::createThisImpl(
     PinnedHermesValue *callee,
     PinnedHermesValue *newTarget,
     uint8_t cacheIdx,
+    uint32_t shapeTableIdx,
     CodeBlock *curCodeBlock) {
   if (LLVM_UNLIKELY(!callee->isObject())) {
     // Add a leading space because the value will come first when we use
@@ -936,6 +937,8 @@ CallResult<HermesValue> Interpreter::createThisImpl(
     PinnedValue<Callable> newTarget;
     // This is the .prototype of new.target
     PinnedValue<JSObject> newTargetPrototype;
+    // HiddenClass for the new object.
+    PinnedValue<HiddenClass> clazz;
   } lv;
   LocalsRAII lraii(runtime, &lv);
   lv.newTarget = correctNewTarget;
@@ -971,7 +974,19 @@ CallResult<HermesValue> Interpreter::createThisImpl(
     }
   }
 
-  return JSObject::create(runtime, lv.newTargetPrototype).getHermesValue();
+  RuntimeModule *runtimeModule = curCodeBlock->getRuntimeModule();
+  if (auto *cachedClazz =
+          runtimeModule->findCachedLiteralHiddenClass(runtime, shapeTableIdx)) {
+    lv.clazz = cachedClazz;
+  } else {
+    lv.clazz = *runtime.getHiddenClassForPrototype(
+        *lv.newTargetPrototype, runtime.classJSObject);
+  }
+
+  // Avoid passing just the prototype to avoid a lookup and a HiddenClass
+  // transition. We use the cache to prepopulate the clazz.
+  return JSObject::create(runtime, lv.newTargetPrototype, lv.clazz)
+      .getHermesValue();
 }
 
 ExecutionStatus Interpreter::implCallBuiltin(

--- a/lib/VM/Interpreter-slowpaths.cpp
+++ b/lib/VM/Interpreter-slowpaths.cpp
@@ -975,12 +975,14 @@ CallResult<HermesValue> Interpreter::createThisImpl(
   }
 
   RuntimeModule *runtimeModule = curCodeBlock->getRuntimeModule();
-  if (auto *cachedClazz =
-          runtimeModule->findCachedLiteralHiddenClass(runtime, shapeTableIdx)) {
+  if (auto *cachedClazz = runtimeModule->findCachedLiteralHiddenClass(
+          runtime, *lv.newTargetPrototype, shapeTableIdx)) {
     lv.clazz = cachedClazz;
   } else {
     lv.clazz = *runtime.getHiddenClassForPrototype(
         *lv.newTargetPrototype, runtime.classJSObject);
+    runtimeModule->setCachedLiteralHiddenClass(
+        runtime, shapeTableIdx, *lv.clazz);
   }
 
   // Avoid passing just the prototype to avoid a lookup and a HiddenClass
@@ -1850,8 +1852,9 @@ CallResult<HiddenClass *> Interpreter::getHiddenClassForBuffer(
   LocalsRAII lraii(runtime, &lv);
 
   if (auto *cachedClazz = runtimeModule->findCachedLiteralHiddenClass(
-          runtime, shapeTableIndex)) {
+          runtime, *parent, shapeTableIndex)) {
     lv.clazz = cachedClazz;
+    assert(lv.clazz->getObjectParent(runtime) == *parent && "wrong parent");
   } else {
     const auto *shapeInfo =
         &runtimeModule->getBytecode()->getObjectShapeTable()[shapeTableIndex];
@@ -1867,8 +1870,8 @@ CallResult<HiddenClass *> Interpreter::getHiddenClassForBuffer(
     if (isTypedAllocKind(allocKind)) {
       bool propertiesEnumerable =
           allocKind != ObjectAllocKind::TypedNonEnumerable;
-      lv.clazz =
-          HiddenClass::createForTypedObject(runtime, shapeInfo->numProps);
+      lv.clazz = HiddenClass::createForTypedObject(
+          runtime, parent, shapeInfo->numProps);
       addTypedBufferPropertiesToHiddenClass(
           runtime,
           keyBuffer,

--- a/lib/VM/Interpreter-slowpaths.cpp
+++ b/lib/VM/Interpreter-slowpaths.cpp
@@ -1894,6 +1894,30 @@ CallResult<HiddenClass *> Interpreter::getHiddenClassForBuffer(
   return *lv.clazz;
 }
 
+PseudoHandle<> Interpreter::createObjectWithParent(
+    Runtime &runtime,
+    CodeBlock *curCodeBlock,
+    Handle<JSObject> parent,
+    unsigned shapeTableIndex) {
+  struct : public Locals {
+    PinnedValue<HiddenClass> clazz;
+  } lv;
+  LocalsRAII lraii(runtime, &lv);
+
+  CallResult<HiddenClass *> clazzRes = getHiddenClassForBuffer(
+      runtime, curCodeBlock, parent, shapeTableIndex, ObjectAllocKind::Untyped);
+  assert(
+      clazzRes != ExecutionStatus::EXCEPTION &&
+      "no properties, so this can't throw");
+  lv.clazz = *clazzRes;
+
+  // Create a new object using the built-in constructor or cached hidden class.
+  // Note that the built-in constructor is empty, so we don't actually need to
+  // call it.
+  return createPseudoHandle(
+      JSObject::create(runtime, parent, lv.clazz).getHermesValue());
+}
+
 CallResult<PseudoHandle<>> Interpreter::createObjectFromBuffer(
     Runtime &runtime,
     CodeBlock *curCodeBlock,

--- a/lib/VM/Interpreter-slowpaths.cpp
+++ b/lib/VM/Interpreter-slowpaths.cpp
@@ -1047,7 +1047,7 @@ ExecutionStatus Interpreter::declareGlobalVarImpl(
       PropOpFlags().plusThrowOnError());
   if (LLVM_UNLIKELY(res == ExecutionStatus::EXCEPTION)) {
     assert(
-        !runtime.getGlobal()->isProxyObject() &&
+        !runtime.getGlobal()->isProxyObject(runtime) &&
         "global can't be a proxy object");
     // If the property already exists, this should be a noop.
     // Instead of incurring the cost to check every time, do it
@@ -1486,7 +1486,7 @@ ExecutionStatus doGetByIdSlowPath_RJS(
     }
 
     assert(
-        !obj->isProxyObject() &&
+        !obj->isProxyObject(runtime) &&
         "tryGetOwnNamedDescriptorFast returned true on Proxy");
     O1REG(GetById) = JSObject::getNamedSlotValueUnsafe(obj, runtime, desc)
                          .unboxToHV(runtime);

--- a/lib/VM/Interpreter.cpp
+++ b/lib/VM/Interpreter.cpp
@@ -1906,7 +1906,7 @@ tailCall:
       assert(!obj->getFlags().proxyObject);                                   \
       assert(!obj->getFlags().hostObject);                                    \
       assert(!obj->getFlags().lazyObject);                                    \
-      const GCPointer<JSObject> &parentGCPtr = obj->getParentGCPtr();         \
+      const GCPointer<JSObject> &parentGCPtr = obj->getParentGCPtr(runtime);  \
       if (LLVM_LIKELY(parentGCPtr)) {                                         \
         JSObject *parent = parentGCPtr.getNonNull(runtime);                   \
         if (LLVM_LIKELY(cacheEntry->clazz == parent->getClassGCPtr())) {      \
@@ -2076,7 +2076,7 @@ tailCall:
             LLVM_LIKELY(
                 addCacheEntry.getParentEpoch() ==
                 runtime.getParentCacheEpoch()) &&
-            LLVM_LIKELY(addCacheEntry.parent == obj->getParentGCPtr())) {
+            LLVM_LIKELY(addCacheEntry.parent == obj->getParentGCPtr(runtime))) {
           HiddenClass *resultClazz =
               addCacheEntry.resultClazz.getNonNull(runtime, runtime.getHeap());
           ++NumPutByIdTransitionHits;

--- a/lib/VM/Interpreter.cpp
+++ b/lib/VM/Interpreter.cpp
@@ -2655,16 +2655,17 @@ tailCall:
         DISPATCH;
       }
       CASE(NewObjectWithParent) {
-        CAPTURE_IP(
-            O1REG(NewObjectWithParent) =
-                JSObject::create(
-                    runtime,
-                    O2REG(NewObjectWithParent).isObject()
-                        ? Handle<JSObject>::vmcast(&O2REG(NewObjectWithParent))
-                        : O2REG(NewObjectWithParent).isNull()
-                        ? Runtime::makeNullHandle<JSObject>()
-                        : Handle<JSObject>::vmcast(&runtime.objectPrototype))
-                    .getHermesValue());
+        CAPTURE_IP_ASSIGN(
+            O1REG(NewObjectWithParent),
+            createObjectWithParent(
+                runtime,
+                curCodeBlock,
+                O2REG(NewObjectWithParent).isObject()
+                    ? Handle<JSObject>::vmcast(&O2REG(NewObjectWithParent))
+                    : O2REG(NewObjectWithParent).isNull()
+                    ? Runtime::makeNullHandle<JSObject>()
+                    : Handle<JSObject>::vmcast(&runtime.objectPrototype),
+                ip->iNewObjectWithParent.op3));
         assert(
             gcScope.getHandleCountDbg() == KEEP_HANDLES &&
             "Should not create handles.");

--- a/lib/VM/Interpreter.cpp
+++ b/lib/VM/Interpreter.cpp
@@ -1853,7 +1853,8 @@ tailCall:
 
       CASE(LoadParentNoTraps) {
         assert(
-            !vmcast<JSObject>(O2REG(LoadParentNoTraps))->isProxyObject() &&
+            !vmcast<JSObject>(O2REG(LoadParentNoTraps))
+                 ->isProxyObject(runtime) &&
             "proxy is not supported");
         auto *parent =
             vmcast<JSObject>(O2REG(LoadParentNoTraps))->getParent(runtime);
@@ -1903,9 +1904,9 @@ tailCall:
     if (LLVM_LIKELY(cacheEntry->negMatchClazz == clazzPtr)) {                 \
       /* Proxy, HostObject and lazy objects have special hidden classes, so   \
        * they should never match the cached class. */                         \
-      assert(!obj->getFlags().proxyObject);                                   \
-      assert(!obj->getFlags().hostObject);                                    \
-      assert(!obj->getFlags().lazyObject);                                    \
+      assert(!obj->isProxyObject(runtime));                                   \
+      assert(!obj->isHostObject(runtime));                                    \
+      assert(!obj->isLazy(runtime));                                          \
       const GCPointer<JSObject> &parentGCPtr = obj->getParentGCPtr(runtime);  \
       if (LLVM_LIKELY(parentGCPtr)) {                                         \
         JSObject *parent = parentGCPtr.getNonNull(runtime);                   \

--- a/lib/VM/Interpreter.cpp
+++ b/lib/VM/Interpreter.cpp
@@ -2871,6 +2871,7 @@ tailCall:
                 &O2REG(CreateThisForSuper),
                 &O3REG(CreateThisForSuper),
                 ip->iCreateThisForSuper.op4,
+                ip->iCreateThisForSuper.op5,
                 curCodeBlock));
         if (LLVM_UNLIKELY(res == ExecutionStatus::EXCEPTION)) {
           goto exception;
@@ -2888,6 +2889,7 @@ tailCall:
                 &O2REG(CreateThisForNew),
                 &O2REG(CreateThisForNew),
                 ip->iCreateThisForNew.op3,
+                ip->iCreateThisForNew.op4,
                 curCodeBlock));
         if (LLVM_UNLIKELY(res == ExecutionStatus::EXCEPTION)) {
           goto exception;

--- a/lib/VM/JIT/RuntimeOffsets.h
+++ b/lib/VM/JIT/RuntimeOffsets.h
@@ -64,6 +64,8 @@ struct RuntimeOffsets {
 
   static constexpr uint32_t hiddenClassLazyJITId =
       offsetof(HiddenClass, lazyJITId_);
+  static constexpr uint32_t hiddenClassObjectParent =
+      offsetof(HiddenClass, objectParent_);
 #if HERMESVM_GCKIND == _HERMESVM_GCVALUE_HADES
   static constexpr uint32_t runtimeHadesYGLevel =
       offsetof(Runtime, heap_.youngGen_.level_);

--- a/lib/VM/JIT/RuntimeOffsets.h
+++ b/lib/VM/JIT/RuntimeOffsets.h
@@ -81,9 +81,6 @@ struct RuntimeOffsets {
   static constexpr uint32_t gcCellMagicValue = GCCell::kMagic;
 #endif
 
-  static constexpr uint32_t runtimeRootClazzes =
-      offsetof(Runtime, rootClazzes_);
-
   using IdentifierTableLookupEntryType = IdentifierTable::LookupEntry;
   using IdentifierTableLookupVectorType =
       decltype(IdentifierTable::lookupVector_);

--- a/lib/VM/JIT/arm64/JIT.cpp
+++ b/lib/VM/JIT/arm64/JIT.cpp
@@ -1144,7 +1144,7 @@ inline void JITContext::Compiler::emitNewObject(
 
 inline void JITContext::Compiler::emitNewObjectWithParent(
     const inst::NewObjectWithParentInst *inst) {
-  em_.newObjectWithParent(FR(inst->op1), FR(inst->op2));
+  em_.newObjectWithParent(FR(inst->op1), FR(inst->op2), inst->op3);
 }
 
 #define EMIT_NEW_OBJECT_WITH_BUFFER(name)                                      \

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -2964,25 +2964,50 @@ void Emitter::newObject(FR frRes) {
        }});
 }
 
-void Emitter::newObjectWithParent(FR frRes, FR frParent) {
+void Emitter::newObjectWithParent(
+    FR frRes,
+    FR frParent,
+    uint32_t shapeTableIndex) {
   comment("// NewObjectWithParent r%u, r%u", frRes.index(), frParent.index());
   syncAllFRTempExcept(frRes != frParent ? frRes : FR());
   syncToFrame(frParent);
   auto hwParent = getOrAllocFRInGpX(frParent, true);
   auto hwNewObjPtr = allocTempGpX();
+  auto hwClazz = allocTempGpX();
   auto hwTemp1 = allocTempGpX();
   auto hwTemp2 = allocTempGpX();
   auto xParent = hwParent.a64GpX();
   auto xNewObjPtr = hwNewObjPtr.a64GpX();
+  auto xClazz = hwClazz.a64GpX();
   auto xTemp1 = hwTemp1.a64GpX();
   auto xTemp2 = hwTemp2.a64GpX();
   freeAllFRTempExcept({});
   freeReg(hwNewObjPtr);
+  freeReg(hwClazz);
   freeReg(hwTemp1);
   freeReg(hwTemp2);
 
   asmjit::Label slowPathLab = newSlowPathLabel();
   asmjit::Label contLab = newContLabel();
+
+  // Load the HC from the cache.
+  static_assert(
+      std::is_same_v<
+          TransparentConservativeVector<WeakRoot<HiddenClass>>,
+          RuntimeOffsets::RuntimeModuleObjectLiteralHiddenClassesType>,
+      "objectLiteralHiddenClasses_ must be transparent");
+  loadBits64InGp(
+      xTemp1, (uint64_t)codeBlock_->getRuntimeModule(), "RuntimeModule");
+  a.ldr(
+      xTemp1,
+      a64::Mem(
+          xTemp1, RuntimeOffsets::runtimeModuleObjectLiteralHiddenClasses));
+  emit_load_cp(
+      a,
+      xClazz,
+      a64::Mem(xTemp1, shapeTableIndex * sizeof(WeakRoot<HiddenClass>)));
+  // If the HC isn't cached, slow path.
+  a.cbz(xClazz, slowPathLab);
 
   allocInYoung(
       CellKind::JSObjectKind,
@@ -3018,7 +3043,7 @@ void Emitter::newObjectWithParent(FR frRes, FR frParent) {
   a.bind(parentDoneLab);
 
   // Initialize the object.
-  emit_jsobject_init(a, xNewObjPtr, xParent, xTemp1, false);
+  emit_jsobject_init(a, xNewObjPtr, xParent, xTemp1, false, xClazz);
 
   auto hwRes = getOrAllocFRInGpX(frRes, false, HWReg::gpX(0));
   frUpdatedWithHW(frRes, hwRes, FRType::Pointer);
@@ -3034,6 +3059,7 @@ void Emitter::newObjectWithParent(FR frRes, FR frParent) {
        .frRes = frRes,
        .frInput1 = frParent,
        .hwRes = hwRes,
+       .sizeOrIdx = shapeTableIndex,
        .emittingIP = emittingIP,
        .emit = [](Emitter &em, SlowPath &sl) {
          em.comment(
@@ -3042,12 +3068,15 @@ void Emitter::newObjectWithParent(FR frRes, FR frParent) {
              sl.frInput1.index());
          em.a.bind(sl.slowPathLab);
          em.a.mov(a64::x0, xRuntime);
-         em.loadFrameAddr(a64::x1, sl.frInput1);
+         em.loadBits64InGp(a64::x1, (uint64_t)em.codeBlock_, "CodeBlock");
+         em.loadFrameAddr(a64::x2, sl.frInput1);
+         em.a.mov(a64::w3, sl.sizeOrIdx);
 
          EMIT_RUNTIME_CALL(
              em,
-             SHLegacyValue (*)(SHRuntime *, const SHLegacyValue *),
-             _sh_ljs_new_object_with_parent);
+             SHLegacyValue (*)(
+                 Runtime &, CodeBlock *, PinnedHermesValue *, uint32_t),
+             _interpreter_create_object_with_parent);
          em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
          em.a.b(sl.contLab);
        }});

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -863,11 +863,7 @@ void emit_jsobject_init(
   const a64::GpX &xTemp = xTempOrPropStorageOpt;
 
   if (!xClazzOpt.isValid()) {
-    // Load the hidden class compressed pointer into xClazz.
-    static_assert(
-        JSObject::numOverlapSlots<JSObject>() == 0,
-        "Cannot use 0 property root class.");
-    a.ldr(xTemp, a64::Mem(xRuntime, RuntimeOffsets::runtimeRootClazzes));
+    a.ldr(xTemp, a64::Mem(xRuntime, offsetof(Runtime, classJSObject)));
     emit_sh_ljs_get_pointer(a, xTemp, xTemp);
     emit_sh_cp_encode_non_null(a, xTemp);
   }

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -3008,6 +3008,16 @@ void Emitter::newObjectWithParent(
       a64::Mem(xTemp1, shapeTableIndex * sizeof(WeakRoot<HiddenClass>)));
   // If the HC isn't cached, slow path.
   a.cbz(xClazz, slowPathLab);
+  // If the parent isn't correct, slow path.
+  auto &xClazzDecoded =
+      emit_sh_cp_decode_non_null_preserve_input(a, xTemp1, xClazz);
+  emit_load_cp(
+      a,
+      xTemp1,
+      a64::Mem(xClazzDecoded, RuntimeOffsets::hiddenClassObjectParent));
+  emit_sh_cp_decode(a, xTemp1);
+  a.cmp(xTemp1, xParent);
+  a.b_ne(slowPathLab);
 
   allocInYoung(
       CellKind::JSObjectKind,
@@ -3211,8 +3221,7 @@ void Emitter::newObjectWithBuffer(
   }
 
   // Get the parent.
-  a.ldr(xTmp, a64::Mem(xRuntime, offsetof(Runtime, objectPrototype)));
-  emit_sh_ljs_get_pointer(a, xTmp, xTmp);
+  a.ldr(xTmp, a64::Mem(xRuntime, offsetof(Runtime, objectPrototypeRawPtr)));
   emit_sh_cp_encode_non_null(a, xTmp);
 
   // Initialize the JSObject to have the correct parent/HC.
@@ -4630,7 +4639,10 @@ void Emitter::loadParentNoTraps(FR frRes, FR frObj) {
   a64::GpX xRes = hwRes.a64GpX();
   emit_sh_ljs_get_pointer(a, xTmp, hwObj.a64GpX());
   // xTmp contains the unencoded pointer value.
-  emit_load_cp(a, xTmp, a64::Mem(xTmp, offsetof(SHJSObject, parent)));
+  emit_load_cp(a, xTmp, a64::Mem(xTmp, offsetof(SHJSObject, clazz)));
+  emit_sh_cp_decode_non_null(a, xTmp);
+  emit_load_cp(
+      a, xTmp, a64::Mem(xTmp, RuntimeOffsets::hiddenClassObjectParent));
   emit_sh_cp_decode(a, xTmp);
   // Check whether it is nullptr and set flags.
   // TODO: Combine this null check with the one in emit_load_and_sh_cp_decode.
@@ -4652,7 +4664,10 @@ void Emitter::typedLoadParent(FR frRes, FR frObj) {
   HWReg hwRes = getOrAllocFRInGpX(frRes, false);
   a64::GpX xRes = hwRes.a64GpX();
   emit_sh_ljs_get_pointer(a, xRes, hwObj.a64GpX());
-  emit_load_cp(a, xRes, a64::Mem(xRes, offsetof(SHJSObject, parent)));
+  emit_load_cp(a, xRes, a64::Mem(xRes, offsetof(SHJSObject, clazz)));
+  emit_sh_cp_decode_non_null(a, xRes);
+  emit_load_cp(
+      a, xRes, a64::Mem(xRes, RuntimeOffsets::hiddenClassObjectParent));
   emit_sh_cp_decode_non_null(a, xRes);
   emit_sh_ljs_object(a, xRes);
 
@@ -5193,7 +5208,10 @@ class HERMES_ATTRIBUTE_INTERNAL_LINKAGE Emitter::GetByIdImpl {
     a.b_ne(failSpecLab);
 
     // Get the parent.
-    emit_load_cp(a, xTemp1, a64::Mem(xTemp1, offsetof(SHJSObject, parent)));
+    emit_load_cp(a, xTemp1, a64::Mem(xTemp1, offsetof(SHJSObject, clazz)));
+    emit_sh_cp_decode_non_null(a, xTemp1);
+    emit_load_cp(
+        a, xTemp1, a64::Mem(xTemp1, RuntimeOffsets::hiddenClassObjectParent));
     // If no parent, fail.
     a.cbz(xTemp1, failSpecLab);
     emit_sh_cp_decode_non_null(a, xTemp1);

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -833,7 +833,6 @@ void emit_stringprim_get_length_and_flags(
 
 /// Emit code to initialize the fields on a JSObject.
 /// \param xObj contains a pointer to the object to initialise.
-/// \param xParent contains a compressed pointer to the parent object.
 /// \param xTempOrPropStorageOpt is a temporary register. It may contain
 ///   a pointer to the PropStorage. If \p HasPropStorage is true, it's
 ///   used to initialize the PropStorage, otherwise it's used as a temporary
@@ -844,7 +843,6 @@ void emit_stringprim_get_length_and_flags(
 void emit_jsobject_init(
     a64::Assembler &a,
     const a64::GpX &xObj,
-    const a64::GpX &xParent,
     const a64::GpX &xTempOrPropStorageOpt,
     bool hasPropStorage,
     const a64::GpX &xClazzOpt = a64::GpX{}) {
@@ -874,15 +872,7 @@ void emit_jsobject_init(
   // obj->parent = xParent
   // obj->clazz = xClazz (may be the same as xTemp).
   assert(xClazz.isValid());
-  static_assert(
-      offsetof(SHJSObject, clazz) - offsetof(SHJSObject, parent) ==
-          sizeof(CompressedPointer),
-      "clazz and parent must be adjacent to use stp");
-  if constexpr (sizeof(CompressedPointer) == 4)
-    a.stp(
-        xParent.w(), xClazz.w(), a64::Mem(xObj, offsetof(SHJSObject, parent)));
-  else
-    a.stp(xParent, xClazz, a64::Mem(xObj, offsetof(SHJSObject, parent)));
+  emit_store_cp(a, xClazz, a64::Mem(xObj, offsetof(SHJSObject, clazz)));
 
   // If !hasPropStorage, obj->propStorage = nullptr.
 
@@ -2934,13 +2924,7 @@ void Emitter::newObject(FR frRes) {
       xTemp2,
       slowPathLab);
 
-  // Get the parent.
-  a.ldr(xTemp1, a64::Mem(xRuntime, offsetof(Runtime, objectPrototype)));
-  emit_sh_ljs_get_pointer(a, xTemp1, xTemp1);
-  emit_sh_cp_encode_non_null(a, xTemp1);
-
-  emit_jsobject_init(
-      a, xRes, /* xParent */ xTemp1, /* xTempOrPropStorageOpt */ xTemp2, false);
+  emit_jsobject_init(a, xRes, /* xTempOrPropStorageOpt */ xTemp2, false);
 
   // Add the object tag to the result.
   emit_sh_ljs_object(a, xRes);
@@ -3053,7 +3037,7 @@ void Emitter::newObjectWithParent(
   a.bind(parentDoneLab);
 
   // Initialize the object.
-  emit_jsobject_init(a, xNewObjPtr, xParent, xTemp1, false, xClazz);
+  emit_jsobject_init(a, xNewObjPtr, xTemp1, false, xClazz);
 
   auto hwRes = getOrAllocFRInGpX(frRes, false, HWReg::gpX(0));
   frUpdatedWithHW(frRes, hwRes, FRType::Pointer);
@@ -3220,15 +3204,10 @@ void Emitter::newObjectWithBuffer(
         slowPathLab);
   }
 
-  // Get the parent.
-  a.ldr(xTmp, a64::Mem(xRuntime, offsetof(Runtime, objectPrototypeRawPtr)));
-  emit_sh_cp_encode_non_null(a, xTmp);
-
   // Initialize the JSObject to have the correct parent/HC.
   emit_jsobject_init(
       a,
       xObj,
-      /* xParent */ xTmp,
       /* xTempOrPropStorageOpt */ xTmp2,
       numIndirectSlots > 0,
       /* xClazz */ xClazz);

--- a/lib/VM/JIT/arm64/JitEmitter.h
+++ b/lib/VM/JIT/arm64/JitEmitter.h
@@ -799,7 +799,7 @@ class Emitter {
   asmjit::Label newPrefLabel(const char *pref, size_t index);
 
   void newObject(FR frRes);
-  void newObjectWithParent(FR frRes, FR frParent);
+  void newObjectWithParent(FR frRes, FR frParent, uint32_t shapeTableIndex);
   void newObjectWithBuffer(
       FR frRes,
       uint32_t shapeTableIndex,

--- a/lib/VM/JIT/arm64/JitHandlers.cpp
+++ b/lib/VM/JIT/arm64/JitHandlers.cpp
@@ -374,7 +374,7 @@ void _jit_put_by_id(
         LLVM_LIKELY(addCacheEntry.resultClazz) &&
         LLVM_LIKELY(
             addCacheEntry.getParentEpoch() == runtime.getParentCacheEpoch()) &&
-        LLVM_LIKELY(addCacheEntry.parent == obj->getParentGCPtr())) {
+        LLVM_LIKELY(addCacheEntry.parent == obj->getParentGCPtr(runtime))) {
       HiddenClass *resultClazz =
           addCacheEntry.resultClazz.getNonNull(runtime, runtime.getHeap());
       JSObject::addNewOwnPropertyInSlot(

--- a/lib/VM/JIT/arm64/JitHandlers.cpp
+++ b/lib/VM/JIT/arm64/JitHandlers.cpp
@@ -181,6 +181,33 @@ SHLegacyValue _interpreter_create_typed_non_enum_object_from_buffer(
   return res->getHermesValue();
 }
 
+SHLegacyValue _interpreter_create_object_with_parent(
+    Runtime &runtime,
+    CodeBlock *codeBlock,
+    PinnedHermesValue *parent,
+    uint32_t shapeTableIndex) {
+  auto *parentPHV = toPHV(parent);
+  Handle<JSObject> parentHandle = parentPHV->isObject()
+      ? Handle<JSObject>::vmcast(parentPHV)
+      : parentPHV->isNull()
+      ? Runtime::makeNullHandle<JSObject>()
+      : Handle<JSObject>::vmcast(&runtime.objectPrototype);
+  struct : public Locals {
+    PinnedValue<HiddenClass> clazz;
+    PinnedValue<JSObject> res;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
+
+  lv.clazz = runtime.ignoreAllocationFailure(
+      Interpreter::getHiddenClassForBuffer(
+          runtime,
+          codeBlock,
+          parentHandle,
+          shapeTableIndex,
+          ObjectAllocKind::Untyped));
+  return JSObject::create(runtime, parentHandle, lv.clazz).getHermesValue();
+}
+
 /// Wrapper around Interpreter::createArrayFromBuffer.
 SHLegacyValue _interpreter_create_array_from_buffer(
     SHRuntime *shr,

--- a/lib/VM/JIT/arm64/JitHandlers.h
+++ b/lib/VM/JIT/arm64/JitHandlers.h
@@ -65,6 +65,11 @@ SHLegacyValue _interpreter_create_object_from_buffer_with_parent(
     SHLegacyValue *parent,
     uint32_t shapeTableIndex,
     uint32_t valBufferOffset);
+SHLegacyValue _interpreter_create_object_with_parent(
+    Runtime &runtime,
+    CodeBlock *codeBlock,
+    PinnedHermesValue *parent,
+    uint32_t shapeTableIndex);
 
 /// Wrapper around Interpreter::createObjectFromBuffer.
 SHLegacyValue _interpreter_create_typed_object_from_buffer(

--- a/lib/VM/JSArray.cpp
+++ b/lib/VM/JSArray.cpp
@@ -522,11 +522,18 @@ void JSArrayBuildMeta(const GCCell *cell, Metadata::Builder &mb) {
   mb.setVTable(&JSArray::vt);
 }
 
-Handle<HiddenClass> JSArray::createClass(
+HiddenClass *JSArray::createClass(
     Runtime &runtime,
     Handle<JSObject> prototypeHandle,
     Handle<HiddenClass> rootClazz) {
   assert(rootClazz && "must have a starting point");
+
+  struct : public Locals {
+    PinnedValue<HiddenClass> clazz;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
+  lv.clazz = runtime.getHiddenClassForPrototype(*prototypeHandle, rootClazz);
+
   PropertyFlags pf{};
   pf.enumerable = 0;
   pf.writable = 1;
@@ -534,19 +541,19 @@ Handle<HiddenClass> JSArray::createClass(
   pf.internalSetter = 1;
 
   auto added = HiddenClass::addProperty(
-      rootClazz, runtime, Predefined::getSymbolID(Predefined::length), pf);
+      lv.clazz, runtime, Predefined::getSymbolID(Predefined::length), pf);
   assert(
       added != ExecutionStatus::EXCEPTION &&
       "Adding the first properties shouldn't cause overflow");
   assert(
       added->second == lengthPropIndex() && "JSArray.length has invalid index");
-  rootClazz = added->first;
+  lv.clazz = added->first;
 
   assert(
-      rootClazz->getNumProperties() == jsArrayPropertyCount() &&
+      lv.clazz->getNumProperties() == jsArrayPropertyCount() &&
       "JSArray class defined with incorrect number of properties");
 
-  return rootClazz;
+  return *lv.clazz;
 }
 
 CallResult<PseudoHandle<JSArray>> JSArray::createNoAllocPropStorage(
@@ -558,6 +565,7 @@ CallResult<PseudoHandle<JSArray>> JSArray::createNoAllocPropStorage(
   assert(length <= capacity && "length must be <= capacity");
 
   assert(
+      classHandle &&
       classHandle->getNumProperties() >= jsArrayPropertyCount() &&
       "invalid number of properties in JSArray hidden class");
 

--- a/lib/VM/JSArray.cpp
+++ b/lib/VM/JSArray.cpp
@@ -13,6 +13,7 @@
 #include "hermes/VM/JSTypedArray.h"
 #include "hermes/VM/Operations.h"
 #include "hermes/VM/PropertyAccessor.h"
+#include "hermes/VM/Runtime-inline.h"
 
 namespace hermes {
 namespace vm {
@@ -408,7 +409,7 @@ CallResult<PseudoHandle<Arguments>> Arguments::create(
   } lv;
   LocalsRAII lraii{runtime, &lv};
   auto clazz = runtime.getHiddenClassForPrototype(
-      runtime.objectPrototypeRawPtr, numOverlapSlots<Arguments>());
+      runtime.objectPrototypeRawPtr, runtime.classArguments);
   auto obj = runtime.makeAFixed<Arguments>(
       runtime, Handle<JSObject>::vmcast(&runtime.objectPrototype), clazz);
   lv.self = JSObjectInit::initToPointer(runtime, obj);
@@ -523,10 +524,9 @@ void JSArrayBuildMeta(const GCCell *cell, Metadata::Builder &mb) {
 
 Handle<HiddenClass> JSArray::createClass(
     Runtime &runtime,
-    Handle<JSObject> prototypeHandle) {
-  Handle<HiddenClass> classHandle = runtime.getHiddenClassForPrototype(
-      *prototypeHandle, numOverlapSlots<JSArray>());
-
+    Handle<JSObject> prototypeHandle,
+    Handle<HiddenClass> rootClazz) {
+  assert(rootClazz && "must have a starting point");
   PropertyFlags pf{};
   pf.enumerable = 0;
   pf.writable = 1;
@@ -534,19 +534,19 @@ Handle<HiddenClass> JSArray::createClass(
   pf.internalSetter = 1;
 
   auto added = HiddenClass::addProperty(
-      classHandle, runtime, Predefined::getSymbolID(Predefined::length), pf);
+      rootClazz, runtime, Predefined::getSymbolID(Predefined::length), pf);
   assert(
       added != ExecutionStatus::EXCEPTION &&
       "Adding the first properties shouldn't cause overflow");
   assert(
       added->second == lengthPropIndex() && "JSArray.length has invalid index");
-  classHandle = added->first;
+  rootClazz = added->first;
 
   assert(
-      classHandle->getNumProperties() == jsArrayPropertyCount() &&
+      rootClazz->getNumProperties() == jsArrayPropertyCount() &&
       "JSArray class defined with incorrect number of properties");
 
-  return classHandle;
+  return rootClazz;
 }
 
 CallResult<PseudoHandle<JSArray>> JSArray::createNoAllocPropStorage(
@@ -647,14 +647,24 @@ CallResult<PseudoHandle<JSArray>> JSArray::createAndAllocPropStorage(
   return PseudoHandle<JSArray>::create(*lv.arr);
 }
 
+CallResult<PseudoHandle<JSArray>> JSArray::create(
+    Runtime &runtime,
+    Handle<JSObject> prototypeHandle,
+    size_type capacity,
+    size_type length) {
+  return createNoAllocPropStorage(
+      runtime,
+      prototypeHandle,
+      runtime.getHiddenClassForPrototype(
+          *prototypeHandle, runtime.classJSArray),
+      capacity,
+      length);
+}
+
 CallResult<PseudoHandle<JSArray>>
 JSArray::create(Runtime &runtime, size_type capacity, size_type length) {
   return JSArray::createNoAllocPropStorage(
-      runtime,
-      Handle<JSObject>::vmcast(&runtime.arrayPrototype),
-      Handle<HiddenClass>::vmcast(&runtime.arrayClass),
-      capacity,
-      length);
+      runtime, runtime.arrayPrototype, runtime.classJSArray, capacity, length);
 }
 
 CallResult<bool> JSArray::setLength(
@@ -854,8 +864,8 @@ PseudoHandle<JSArrayIterator> JSArrayIterator::create(
     Handle<JSObject> array,
     IterationKind iterationKind) {
   auto proto = Handle<JSObject>::vmcast(&runtime.arrayIteratorPrototype);
-  auto clazz = runtime.getHiddenClassForPrototype(
-      *proto, numOverlapSlots<JSArrayIterator>());
+  auto clazz =
+      runtime.getHiddenClassForPrototype(*proto, runtime.classJSArrayIterator);
   auto *obj = runtime.makeAFixed<JSArrayIterator>(
       runtime, proto, clazz, array, iterationKind);
   return JSObjectInit::initToPseudoHandle(runtime, obj);

--- a/lib/VM/JSArray.cpp
+++ b/lib/VM/JSArray.cpp
@@ -94,9 +94,9 @@ OptValue<PropertyFlags> ArrayImpl::_getOwnIndexedPropertyFlagsImpl(
     indexedElementFlags.writable = 1;
     indexedElementFlags.configurable = 1;
 
-    if (LLVM_UNLIKELY(self->flags_.sealed)) {
+    if (LLVM_UNLIKELY(self->getClass(runtime)->isSealed())) {
       indexedElementFlags.configurable = 0;
-      if (LLVM_UNLIKELY(self->flags_.frozen))
+      if (LLVM_UNLIKELY(self->getClass(runtime)->isFrozen()))
         indexedElementFlags.writable = 0;
     }
 
@@ -191,7 +191,7 @@ CallResult<bool> ArrayImpl::_setOwnIndexedImpl(
   auto *self = vmcast<ArrayImpl>(selfHandle.get());
   auto beginIndex = self->beginIndex_;
 
-  if (LLVM_UNLIKELY(self->flags_.frozen))
+  if (LLVM_UNLIKELY(self->getClass(runtime)->isFrozen()))
     return false;
 
   // Check whether the index is within the storage.
@@ -331,7 +331,7 @@ bool ArrayImpl::_deleteOwnIndexedImpl(
   if (index < self->elemCount_) {
     auto *indexedStorage = self->getIndexedStorageUnsafe(runtime);
     // Cannot delete indexed elements if we are sealed.
-    if (LLVM_UNLIKELY(self->flags_.sealed)) {
+    if (LLVM_UNLIKELY(self->getClass(runtime)->isSealed())) {
       SmallHermesValue elem = indexedStorage->at(index);
       if (!elem.isEmpty())
         return false;
@@ -746,7 +746,7 @@ CallResult<bool> JSArray::setLength(
   uint32_t adjustedLength = newLength;
 
   // If we are sealed, we can't shrink past non-empty properties.
-  if (LLVM_UNLIKELY(selfHandle->flags_.sealed)) {
+  if (LLVM_UNLIKELY(selfHandle->getClass(runtime)->isSealed())) {
     // We must scan backwards looking for a non-empty property. We only have
     // to scan in the intersection between the range of present values and
     // the range between the current length and the new length.

--- a/lib/VM/JSArrayBuffer.cpp
+++ b/lib/VM/JSArrayBuffer.cpp
@@ -49,6 +49,12 @@ void JSArrayBufferBuildMeta(const GCCell *cell, Metadata::Builder &mb) {
   mb.setVTable(&JSArrayBuffer::vt);
 }
 
+PseudoHandle<JSArrayBuffer> JSArrayBuffer::create(Runtime &runtime) {
+  auto *cell = runtime.makeAFixed<JSArrayBuffer, HasFinalizer::Yes>(
+      runtime, runtime.arrayBufferPrototype, runtime.classJSArrayBuffer);
+  return JSObjectInit::initToPseudoHandle(runtime, cell);
+}
+
 PseudoHandle<JSArrayBuffer> JSArrayBuffer::create(
     Runtime &runtime,
     Handle<JSObject> parentHandle) {
@@ -56,7 +62,7 @@ PseudoHandle<JSArrayBuffer> JSArrayBuffer::create(
       runtime,
       parentHandle,
       runtime.getHiddenClassForPrototype(
-          *parentHandle, numOverlapSlots<JSArrayBuffer>()));
+          *parentHandle, runtime.classJSArrayBuffer));
   return JSObjectInit::initToPseudoHandle(runtime, cell);
 }
 

--- a/lib/VM/JSCallSite.cpp
+++ b/lib/VM/JSCallSite.cpp
@@ -60,7 +60,7 @@ CallResult<HermesValue> JSCallSite::create(
       runtime,
       jsCallSiteProto,
       runtime.getHiddenClassForPrototype(
-          *jsCallSiteProto, numOverlapSlots<JSCallSite>()),
+          *jsCallSiteProto, runtime.classJSCallSite),
       errorHandle,
       stackFrameIndex);
 

--- a/lib/VM/JSCallableProxy.cpp
+++ b/lib/VM/JSCallableProxy.cpp
@@ -45,7 +45,9 @@ PseudoHandle<JSCallableProxy> JSCallableProxy::create(Runtime &runtime) {
       runtime.getHiddenClassForPrototype(
           nullptr, runtime.classJSCallableProxy));
 
-  cproxy->flags_.proxyObject = true;
+  assert(
+      cproxy->isProxyObject(runtime) &&
+      "new Proxy made with the wrong HiddenClass");
 
   return JSObjectInit::initToPseudoHandle(runtime, cproxy);
 }

--- a/lib/VM/JSCallableProxy.cpp
+++ b/lib/VM/JSCallableProxy.cpp
@@ -42,7 +42,8 @@ PseudoHandle<JSCallableProxy> JSCallableProxy::create(Runtime &runtime) {
   auto *cproxy = runtime.makeAFixed<JSCallableProxy>(
       runtime,
       HandleRootOwner::makeNullHandle<JSObject>(),
-      runtime.callableProxyClass);
+      runtime.getHiddenClassForPrototype(
+          nullptr, runtime.classJSCallableProxy));
 
   cproxy->flags_.proxyObject = true;
 

--- a/lib/VM/JSDataView.cpp
+++ b/lib/VM/JSDataView.cpp
@@ -32,14 +32,19 @@ void JSDataViewBuildMeta(const GCCell *cell, Metadata::Builder &mb) {
   mb.addField("buffer", &self->buffer_);
 }
 
+PseudoHandle<JSDataView> JSDataView::create(Runtime &runtime) {
+  auto *cell = runtime.makeAFixed<JSDataView>(
+      runtime, runtime.dataViewPrototype, runtime.classJSDataView);
+  return JSObjectInit::initToPseudoHandle(runtime, cell);
+}
+
 PseudoHandle<JSDataView> JSDataView::create(
     Runtime &runtime,
     Handle<JSObject> prototype) {
   auto *cell = runtime.makeAFixed<JSDataView>(
       runtime,
       prototype,
-      runtime.getHiddenClassForPrototype(
-          *prototype, numOverlapSlots<JSDataView>()));
+      runtime.getHiddenClassForPrototype(*prototype, runtime.classJSDataView));
   return JSObjectInit::initToPseudoHandle(runtime, cell);
 }
 

--- a/lib/VM/JSDate.cpp
+++ b/lib/VM/JSDate.cpp
@@ -33,14 +33,19 @@ void JSDateBuildMeta(const GCCell *cell, Metadata::Builder &mb) {
   mb.setVTable(&JSDate::vt);
 }
 
+PseudoHandle<JSDate> JSDate::create(Runtime &runtime, double value) {
+  auto *cell = runtime.makeAFixed<JSDate>(
+      runtime, value, runtime.datePrototype, runtime.classJSDate);
+  return JSObjectInit::initToPseudoHandle(runtime, cell);
+}
+
 PseudoHandle<JSDate>
 JSDate::create(Runtime &runtime, double value, Handle<JSObject> parentHandle) {
   auto *cell = runtime.makeAFixed<JSDate>(
       runtime,
       value,
       parentHandle,
-      runtime.getHiddenClassForPrototype(
-          *parentHandle, numOverlapSlots<JSDate>()));
+      runtime.getHiddenClassForPrototype(*parentHandle, runtime.classJSDate));
   return JSObjectInit::initToPseudoHandle(runtime, cell);
 }
 

--- a/lib/VM/JSError.cpp
+++ b/lib/VM/JSError.cpp
@@ -78,7 +78,7 @@ static llvh::Optional<Handle<JSError>> getErrorFromStackTarget(
       return Handle<JSError>::vmcast(targetHandle);
     }
 
-    if (LLVM_UNLIKELY(targetHandle->isProxyObject())) {
+    if (LLVM_UNLIKELY(targetHandle->isProxyObject(runtime))) {
       return llvh::None;
     }
 

--- a/lib/VM/JSError.cpp
+++ b/lib/VM/JSError.cpp
@@ -205,26 +205,23 @@ CallResult<HermesValue> errorStackSetter(void *, Runtime &runtime) {
 
 PseudoHandle<JSError> JSError::create(
     Runtime &runtime,
-    Handle<JSObject> parentHandle) {
-  return create(runtime, parentHandle, /*catchable*/ true);
+    Handle<JSObject> prototype) {
+  auto *cell = runtime.makeAFixed<JSError, HasFinalizer::Yes>(
+      runtime,
+      prototype,
+      runtime.getHiddenClassForPrototype(*prototype, runtime.classJSError),
+      /* catchable */ true);
+  return JSObjectInit::initToPseudoHandle(runtime, cell);
 }
 
 PseudoHandle<JSError> JSError::createUncatchable(
     Runtime &runtime,
     Handle<JSObject> parentHandle) {
-  return create(runtime, parentHandle, /*catchable*/ false);
-}
-
-PseudoHandle<JSError> JSError::create(
-    Runtime &runtime,
-    Handle<JSObject> parentHandle,
-    bool catchable) {
   auto *cell = runtime.makeAFixed<JSError, HasFinalizer::Yes>(
       runtime,
       parentHandle,
-      runtime.getHiddenClassForPrototype(
-          *parentHandle, numOverlapSlots<JSError>()),
-      catchable);
+      runtime.getHiddenClassForPrototype(*parentHandle, runtime.classJSError),
+      /* catchable */ false);
   return JSObjectInit::initToPseudoHandle(runtime, cell);
 }
 

--- a/lib/VM/JSFinalizationRegistry.cpp
+++ b/lib/VM/JSFinalizationRegistry.cpp
@@ -123,7 +123,7 @@ PseudoHandle<JSFinalizationRegistry> JSFinalizationRegistry::create(
       runtime,
       parentHandle,
       runtime.getHiddenClassForPrototype(
-          *parentHandle, numOverlapSlots<JSFinalizationRegistry>()),
+          *parentHandle, runtime.classJSFinalizationRegistry),
       cleanupCallback);
   return JSObjectInit::initToPseudoHandle(runtime, cell);
 }

--- a/lib/VM/JSGeneratorObject.cpp
+++ b/lib/VM/JSGeneratorObject.cpp
@@ -42,7 +42,7 @@ CallResult<PseudoHandle<JSGeneratorObject>> JSGeneratorObject::create(
       runtime,
       parentHandle,
       runtime.getHiddenClassForPrototype(
-          *parentHandle, numOverlapSlots<JSGeneratorObject>()));
+          *parentHandle, runtime.classJSGeneratorObject));
   cell->innerFunction_.set(runtime, *innerFunction, runtime.getHeap());
   return JSObjectInit::initToPseudoHandle(runtime, cell);
 }

--- a/lib/VM/JSLib/Array.cpp
+++ b/lib/VM/JSLib/Array.cpp
@@ -379,9 +379,6 @@ HermesValue createArrayConstructor(Runtime &runtime) {
 static constexpr void setArrayFastPathObjectFlags(SHObjectFlags &res) {
   // This code should set every field in SHObjectFlags to make sure we don't
   // miss one, which is checked by the assert in arrayFastPathCheck.
-  res.noExtend = 0;
-  res.sealed = 0;
-  res.frozen = 0;
   res.indexedStorage = 1;
   res.fastIndexProperties = 1;
   res.isCachedUsingEpoch = 0;
@@ -401,6 +398,9 @@ static constexpr void setArrayFastPathClassFlags(ClassFlags &res) {
   res.hasIndexLikeProperties = 0;
   res.mayHaveAccessor = 0;
   res.typed = 0;
+  res.noExtend = 0;
+  res.sealed = 0;
+  res.frozen = 0;
   res.hostObject = 0;
   res.lazyObject = 0;
   res.proxyObject = 0;

--- a/lib/VM/JSLib/Array.cpp
+++ b/lib/VM/JSLib/Array.cpp
@@ -392,6 +392,7 @@ static constexpr void setArrayFastPathClassFlags(ClassFlags &res) {
   res.hostObject = 0;
   res.lazyObject = 0;
   res.proxyObject = 0;
+  res.isCachedUsingEpoch = 0;
   res.parentChangeCounter = 0;
   res.unusedPadding = 0;
 }
@@ -404,38 +405,44 @@ static constexpr void setArrayFastPathClassFlags(ClassFlags &res) {
 /// \return true if the prototype chain does not contain any index-like
 /// properties, false otherwise.
 static bool checkAndCacheProtoForFastPath(Runtime &runtime) {
-  auto *arrParent = *runtime.arrayPrototype;
-  arrParent->setCachedUsingEpoch();
+  Handle<JSObject> arrParent = runtime.arrayPrototype;
+  JSObject::setCachedUsingEpoch(arrParent, runtime);
 
   // If the parent has any index-like properties, bail.
   if (LLVM_UNLIKELY(arrParent->getClass(runtime)->getHasIndexLikeProperties()))
     return false;
 
+  struct : public Locals {
+    PinnedValue<JSObject> curParent;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
+
   // Check if there are any index-like properties in any parent.
   // If so, we can't use the fast path.
-  for (JSObject *curParent = arrParent->getParent(runtime);
-       curParent != nullptr;
-       curParent = curParent->getParent(runtime)) {
+  for (lv.curParent = arrParent->getParent(runtime);
+       lv.curParent.get() != nullptr;
+       lv.curParent = lv.curParent->getParent(runtime)) {
     // If the object may have index-like properties that are not reflected on
     // the hidden class or indexed storage, bail.
     if (LLVM_UNLIKELY(
-            curParent->isHostObject(runtime) ||
-            curParent->isProxyObject(runtime) || curParent->isLazy(runtime)))
+            lv.curParent->isHostObject(runtime) ||
+            lv.curParent->isProxyObject(runtime) ||
+            lv.curParent->isLazy(runtime)))
       return false;
 
     // Any index-like properties in the parent means we can't use the fast path
     // because we might trigger an accessor or have to check property flags.
     if (LLVM_UNLIKELY(
-            curParent->getClass(runtime)->getHasIndexLikeProperties()))
+            lv.curParent->getClass(runtime)->getHasIndexLikeProperties()))
       return false;
 
     // Unlike the immediate parent, we do not expect any parent further up the
     // chain to have indexed storage. Disqualify anything with indexed storage,
     // since actually checking the "indexed range" is costly.
-    if (LLVM_UNLIKELY(curParent->hasIndexedStorage(runtime)))
+    if (LLVM_UNLIKELY(lv.curParent->hasIndexedStorage(runtime)))
       return false;
 
-    curParent->setCachedUsingEpoch();
+    JSObject::setCachedUsingEpoch(lv.curParent, runtime);
   }
   runtime.setArrayFastPathParentEpoch();
 
@@ -445,71 +452,77 @@ static bool checkAndCacheProtoForFastPath(Runtime &runtime) {
 /// Declared in JSLib.h so it can be used outside of JSLib
 bool arrayFastPathCheck(
     Runtime &runtime,
-    JSArray *arr,
-    HiddenClass *arrayClass,
+    Handle<JSArray> arr,
+    Handle<HiddenClass> arrayClass,
     uint32_t len) {
-  NoAllocScope noAlloc{runtime};
-  assert(arr && "arr must be non-null");
+  {
+    NoAllocScope noAlloc{runtime};
+    assert(arr && "arr must be non-null");
 
-  // Optionally check that 'length' hasn't been reconfigured.
-  if (arrayClass && arr->getClass(runtime) != arrayClass)
-    return false;
+    // Optionally check that 'length' hasn't been reconfigured.
+    if (arrayClass && arr->getClass(runtime) != arrayClass.get())
+      return false;
 
-  // To use the fast path, the object has to be an array with fast index
-  // properties (no index-like properties that we can't read quickly).
-  // Make our own SHObjectFlags here to compare against quickly, to avoid having
-  // to use lots of accessors on JSObject.
-  ClassFlags arrayFastPathClassFlags{};
-  setArrayFastPathClassFlags(arrayFastPathClassFlags);
+    // To use the fast path, the object has to be an array with fast index
+    // properties (no index-like properties that we can't read quickly).
+    // Make our own SHObjectFlags here to compare against quickly, to avoid
+    // having to use lots of accessors on JSObject.
+    ClassFlags arrayFastPathClassFlags{};
+    setArrayFastPathClassFlags(arrayFastPathClassFlags);
 
 #ifndef NDEBUG
-  // Test that all the flags are handled in setArrayFastPathObjectFlags
-  // by starting with all the bits reversed and calling the function,
-  // and making sure the result is the same.
-  ClassFlags classFlagsForAssert{};
-  std::memset(&classFlagsForAssert, 0xff, sizeof(ClassFlags));
-  setArrayFastPathClassFlags(classFlagsForAssert);
-  assert(
-      std::memcmp(
-          &classFlagsForAssert, &arrayFastPathClassFlags, sizeof(ClassFlags)) ==
-          0 &&
-      "setArrayFastPathClassFlags is missing a flag");
+    // Test that all the flags are handled in setArrayFastPathObjectFlags
+    // by starting with all the bits reversed and calling the function,
+    // and making sure the result is the same.
+    ClassFlags classFlagsForAssert{};
+    std::memset(&classFlagsForAssert, 0xff, sizeof(ClassFlags));
+    setArrayFastPathClassFlags(classFlagsForAssert);
+    assert(
+        std::memcmp(
+            &classFlagsForAssert,
+            &arrayFastPathClassFlags,
+            sizeof(ClassFlags)) == 0 &&
+        "setArrayFastPathClassFlags is missing a flag");
 #endif
 
-  ClassFlags arrClassFlags = arr->getClass(runtime)->getFlags();
-  // Clear the flags we don't care about checking.
-  arrClassFlags.parentChangeCounter = 0;
-  arrClassFlags.typed = 0;
+    ClassFlags arrClassFlags = arr->getClass(runtime)->getFlags();
+    // Clear the flags we don't care about checking.
+    arrClassFlags.parentChangeCounter = 0;
+    arrClassFlags.typed = 0;
+    arrClassFlags.isCachedUsingEpoch = 0;
 
-  static_assert(
-      sizeof(ClassFlags) == sizeof(uint16_t), "SHObjectFlags must be uint16_t");
-  if (LLVM_UNLIKELY(
-          std::memcmp(
-              &arrayFastPathClassFlags, &arrClassFlags, sizeof(uint16_t)) != 0))
-    return false;
+    static_assert(
+        sizeof(ClassFlags) == sizeof(uint16_t),
+        "SHObjectFlags must be uint16_t");
+    if (LLVM_UNLIKELY(
+            std::memcmp(
+                &arrayFastPathClassFlags, &arrClassFlags, sizeof(uint16_t)) !=
+            0))
+      return false;
 
-  // Fast path assumes that the array storage goes from 0 to len.
-  if (arr->getBeginIndex() != 0 || arr->getElemCount() != len)
-    return false;
+    // Fast path assumes that the array storage goes from 0 to len.
+    if (arr->getBeginIndex() != 0 || arr->getElemCount() != len)
+      return false;
 
-  JSArray *arrParent = *runtime.arrayPrototype;
+    JSArray *arrParent = *runtime.arrayPrototype;
 
-  // If the parent has been modified, bail.
-  if (LLVM_UNLIKELY(arr->getParent(runtime) != arrParent))
-    return false;
+    // If the parent has been modified, bail.
+    if (LLVM_UNLIKELY(arr->getParent(runtime) != arrParent))
+      return false;
 
-  // If there are any indexed properties in the parent we can't use the fast
-  // path. We check this specially because Array.prototype is itself
-  // an array that starts with no actual indexed properties.
-  //
-  // NOTE: It may be possible to use the fast path if the indexed properties
-  // don't overlap with the array's own indexed range, but that seems
-  // unnecessary to check for now given that this check is really to make sure
-  // that Array.prototype isn't filled with properties, and keeping track of
-  // the upper bound on the length here takes more effort and is potentially
-  // error-prone.
-  if (LLVM_UNLIKELY(arrParent->getElemCount()))
-    return false;
+    // If there are any indexed properties in the parent we can't use the fast
+    // path. We check this specially because Array.prototype is itself
+    // an array that starts with no actual indexed properties.
+    //
+    // NOTE: It may be possible to use the fast path if the indexed properties
+    // don't overlap with the array's own indexed range, but that seems
+    // unnecessary to check for now given that this check is really to make sure
+    // that Array.prototype isn't filled with properties, and keeping track of
+    // the upper bound on the length here takes more effort and is potentially
+    // error-prone.
+    if (LLVM_UNLIKELY(arrParent->getElemCount()))
+      return false;
+  }
 
   if (LLVM_UNLIKELY(!runtime.checkArrayFastPathParentEpoch()))
     return checkAndCacheProtoForFastPath(runtime);
@@ -1055,6 +1068,7 @@ CallResult<HermesValue> arrayPrototypeJoin(void *, Runtime &runtime) {
   NativeArgs args = runtime.getCurrentFrame().getNativeArgs();
   struct : Locals {
     PinnedValue<JSObject> O;
+    PinnedValue<JSArray> arr;
     PinnedValue<> lenProp;
     PinnedValue<StringPrimitive> sep;
     PinnedValue<JSArray::StorageType> strings;
@@ -1115,20 +1129,26 @@ CallResult<HermesValue> arrayPrototypeJoin(void *, Runtime &runtime) {
   uint32_t fastPathEnd = 0;
 
   // 1. Fast Path: Process as many elements as possible quickly.
-  if (JSArray *arr = dyn_vmcast<JSArray>(lv.O.get());
-      arr && arrayFastPathCheck(runtime, arr, nullptr, (uint32_t)len)) {
+  if (vmisa<JSArray>(lv.O.get()) &&
+      arrayFastPathCheck(
+          runtime,
+          Handle<JSArray>::vmcast(&lv.O),
+          Runtime::makeNullHandle<HiddenClass>(),
+          (uint32_t)len)) {
     // Accumulate the size of the strings in the array, stopping at the first
     // element that is not a string, null, or undefined.
+    lv.arr.castAndSetHermesValue<JSArray>(lv.O.getHermesValue());
 
     assert(
         len != 0 &&
         "we already checled len is not 0, so storage should be non-null");
-    auto *storage = arr->getIndexedStorageUnsafe(runtime);
+    auto *storage = lv.arr->getIndexedStorageUnsafe(runtime);
     // Save it for later.
     lv.inputStorage = storage;
 
     uint32_t i;
     for (i = 0; i < len; ++i) {
+      NoAllocScope noAlloc{runtime};
       SmallHermesValue elem = storage->at(i); // Direct access
       uint32_t elemLen;
       if (elem.isString())
@@ -1426,11 +1446,11 @@ CallResult<HermesValue> arrayPrototypePush(void *, Runtime &runtime) {
   OptValue<uint32_t> lenOpt = llvh::None;
   if (LLVM_LIKELY(vmisa<JSArray>(args.getThisArg()))) {
     // Fast path for getting the length.
-    JSArray *arr = vmcast<JSArray>(args.getThisArg());
-    uint32_t len = JSArray::getLength(arr, runtime);
+    auto arr = args.vmcastThis<JSArray>();
+    uint32_t len = JSArray::getLength(*arr, runtime);
 
     if (LLVM_LIKELY(len < UINT32_MAX - argCount) &&
-        arrayFastPathCheck(runtime, arr, *runtime.classJSArray, len)) {
+        arrayFastPathCheck(runtime, arr, runtime.classJSArray, len)) {
       return arrayPrototypePushFastPath(
           runtime, args.vmcastThis<JSArray>(), len, args);
     }
@@ -2610,8 +2630,8 @@ CallResult<HermesValue> arrayPrototypeSplice(void *, Runtime &runtime) {
 
   // If we can use the fast path, do so.
   if (LLVM_LIKELY(*lv.OArray) &&
-      LLVM_LIKELY(arrayFastPathCheck(
-          runtime, *lv.OArray, *runtime.classJSArray, len)) &&
+      LLVM_LIKELY(
+          arrayFastPathCheck(runtime, lv.OArray, runtime.classJSArray, len)) &&
       LLVM_LIKELY(len - actualDeleteCount < UINT32_MAX - itemCount)) {
     // These can be cast to uint32_t because we know that O is a JSArray.
     assert(actualStart <= len && "actualStart out of range");
@@ -3021,10 +3041,10 @@ CallResult<HermesValue> arrayPrototypePop(void *, Runtime &runtime) {
   uint64_t len;
   if (LLVM_LIKELY(vmisa<JSArray>(args.getThisArg()))) {
     // Fast path for getting the length.
-    JSArray *arr = vmcast<JSArray>(args.getThisArg());
-    len = JSArray::getLength(arr, runtime);
+    auto arr = args.vmcastThis<JSArray>();
+    len = JSArray::getLength(*arr, runtime);
 
-    if (arrayFastPathCheck(runtime, arr, *runtime.classJSArray, len)) {
+    if (arrayFastPathCheck(runtime, arr, runtime.classJSArray, len)) {
       return arrayPrototypePopFastPath(
           runtime, args.vmcastThis<JSArray>(), len);
     }
@@ -4163,14 +4183,20 @@ CallResult<HermesValue> arrayPrototypeReverse(void *, Runtime &runtime) {
   NativeArgs args = runtime.getCurrentFrame().getNativeArgs();
   // Fast path for a JSArray with a contiguous storage and no numeric props
   // in the prototype.
-  if (auto *arr = llvh::dyn_vmcast<JSArray>(args.getThisArg())) {
-    NoAllocScope noAllocScope{runtime};
-    uint32_t len = JSArray::getLength(arr, runtime);
+  if (vmisa<JSArray>(args.getThisArg())) {
+    uint32_t len =
+        JSArray::getLength(vmcast<JSArray>(args.getThisArg()), runtime);
     if (len <= 1)
       return args.getThisArg();
 
-    if (arrayFastPathCheck(runtime, arr, nullptr, len)) {
-      auto *storage = arr->getIndexedStorageNullable(runtime);
+    if (arrayFastPathCheck(
+            runtime,
+            args.vmcastThis<JSArray>(),
+            Runtime::makeNullHandle<HiddenClass>(),
+            len)) {
+      NoAllocScope noAllocScope{runtime};
+      auto *storage = vmcast<JSArray>(args.getThisArg())
+                          ->getIndexedStorageNullable(runtime);
       for (uint32_t l = 0, u = len - 1; l < u; ++l, --u) {
         assert(storage && "storage should not be null");
         auto lowerValue = storage->at(l);
@@ -4447,7 +4473,9 @@ CallResult<HermesValue> arrayPrototypeToReversed(void *, Runtime &runtime) {
   }
 
   // Fast Path: Input is a JSArray and arrayFastPathCheck passes.
-  if (jsArr && arrayFastPathCheck(runtime, jsArr.get(), nullptr, len32)) {
+  if (jsArr &&
+      arrayFastPathCheck(
+          runtime, jsArr, Runtime::makeNullHandle<HiddenClass>(), len32)) {
     NoAllocScope noAllocScope{runtime};
     auto *srcStorage = jsArr->getIndexedStorageNullable(runtime);
     auto *destStorage = lv.A->getIndexedStorageNullable(runtime);

--- a/lib/VM/JSLib/Array.cpp
+++ b/lib/VM/JSLib/Array.cpp
@@ -530,7 +530,8 @@ CallResult<HermesValue> arrayConstructor(void *, Runtime &runtime) {
           (args.getNewTarget().getRaw() ==
            runtime.arrayConstructor.getHermesValue().getRaw()))) {
     CallResult<PseudoHandle<JSArray>> selfRes =
-        JSArray::create(runtime, runtime.arrayPrototype);
+        JSArray::createNoAllocPropStorage(
+            runtime, runtime.arrayPrototype, runtime.classJSArray);
     if (LLVM_UNLIKELY(selfRes == ExecutionStatus::EXCEPTION)) {
       return ExecutionStatus::EXCEPTION;
     }
@@ -1424,7 +1425,7 @@ CallResult<HermesValue> arrayPrototypePush(void *, Runtime &runtime) {
     uint32_t len = JSArray::getLength(arr, runtime);
 
     if (LLVM_LIKELY(len < UINT32_MAX - argCount) &&
-        arrayFastPathCheck(runtime, arr, *runtime.arrayClass, len)) {
+        arrayFastPathCheck(runtime, arr, *runtime.classJSArray, len)) {
       return arrayPrototypePushFastPath(
           runtime, args.vmcastThis<JSArray>(), len, args);
     }
@@ -2602,8 +2603,8 @@ CallResult<HermesValue> arrayPrototypeSplice(void *, Runtime &runtime) {
 
   // If we can use the fast path, do so.
   if (LLVM_LIKELY(*lv.OArray) &&
-      LLVM_LIKELY(
-          arrayFastPathCheck(runtime, *lv.OArray, *runtime.arrayClass, len)) &&
+      LLVM_LIKELY(arrayFastPathCheck(
+          runtime, *lv.OArray, *runtime.classJSArray, len)) &&
       LLVM_LIKELY(len - actualDeleteCount < UINT32_MAX - itemCount)) {
     // These can be cast to uint32_t because we know that O is a JSArray.
     assert(actualStart <= len && "actualStart out of range");
@@ -3016,7 +3017,7 @@ CallResult<HermesValue> arrayPrototypePop(void *, Runtime &runtime) {
     JSArray *arr = vmcast<JSArray>(args.getThisArg());
     len = JSArray::getLength(arr, runtime);
 
-    if (arrayFastPathCheck(runtime, arr, *runtime.arrayClass, len)) {
+    if (arrayFastPathCheck(runtime, arr, *runtime.classJSArray, len)) {
       return arrayPrototypePopFastPath(
           runtime, args.vmcastThis<JSArray>(), len);
     }

--- a/lib/VM/JSLib/Array.cpp
+++ b/lib/VM/JSLib/Array.cpp
@@ -391,6 +391,22 @@ static constexpr void setArrayFastPathObjectFlags(SHObjectFlags &res) {
   res.objectID = 0;
 }
 
+/// Populate \p flags with the flags to be used to check for fast path for array
+/// methods.
+/// Ensures that there's a fast indexed storage with no non-default behaviors
+/// applied to it, along with an objectID of 0 (for easy comparison).
+static constexpr void setArrayFastPathClassFlags(ClassFlags &res) {
+  // This code should set every field in SHObjectFlags to make sure we don't
+  // miss one, which is checked by the assert in arrayFastPathCheck.
+  res.dictionaryMode = 0;
+  res.dictionaryNoCacheMode = 0;
+  res.typed = 0;
+  res.hasIndexLikeProperties = 0;
+  res.mayHaveAccessor = 0;
+  res.parentChangeCounter = 0;
+  res.unusedPadding = 0;
+}
+
 /// Check that the prototype chain of arrays starting at Array.prototype does
 /// not contain any index-like properties. If it does not, update the epoch in
 /// the runtime so that calling this function can be skipped when the epoch
@@ -481,6 +497,39 @@ bool arrayFastPathCheck(
 
   // Optionally check that 'length' hasn't been reconfigured.
   if (arrayClass && arr->getClass(runtime) != arrayClass)
+    return false;
+
+  // To use the fast path, the object has to be an array with fast index
+  // properties (no index-like properties that we can't read quickly).
+  // Make our own SHObjectFlags here to compare against quickly, to avoid having
+  // to use lots of accessors on JSObject.
+  ClassFlags arrayFastPathClassFlags{};
+  setArrayFastPathClassFlags(arrayFastPathClassFlags);
+
+#ifndef NDEBUG
+  // Test that all the flags are handled in setArrayFastPathObjectFlags
+  // by starting with all the bits reversed and calling the function,
+  // and making sure the result is the same.
+  ClassFlags classFlagsForAssert{};
+  std::memset(&classFlagsForAssert, 0xff, sizeof(ClassFlags));
+  setArrayFastPathClassFlags(classFlagsForAssert);
+  assert(
+      std::memcmp(
+          &classFlagsForAssert, &arrayFastPathClassFlags, sizeof(ClassFlags)) ==
+          0 &&
+      "setArrayFastPathClassFlags is missing a flag");
+#endif
+
+  ClassFlags arrClassFlags = arr->getClass(runtime)->getFlags();
+  // Clear the flags we don't care about checking.
+  arrClassFlags.parentChangeCounter = 0;
+  arrClassFlags.typed = 0;
+
+  static_assert(
+      sizeof(ClassFlags) == sizeof(uint16_t), "SHObjectFlags must be uint16_t");
+  if (LLVM_UNLIKELY(
+          std::memcmp(
+              &arrayFastPathClassFlags, &arrClassFlags, sizeof(uint16_t)) != 0))
     return false;
 
   // Fast path assumes that the array storage goes from 0 to len.

--- a/lib/VM/JSLib/Array.cpp
+++ b/lib/VM/JSLib/Array.cpp
@@ -376,19 +376,6 @@ HermesValue createArrayConstructor(Runtime &runtime) {
 /// methods.
 /// Ensures that there's a fast indexed storage with no non-default behaviors
 /// applied to it, along with an objectID of 0 (for easy comparison).
-static constexpr void setArrayFastPathObjectFlags(SHObjectFlags &res) {
-  // This code should set every field in SHObjectFlags to make sure we don't
-  // miss one, which is checked by the assert in arrayFastPathCheck.
-  res.indexedStorage = 1;
-  res.fastIndexProperties = 1;
-  res.isCachedUsingEpoch = 0;
-  res.objectID = 0;
-}
-
-/// Populate \p flags with the flags to be used to check for fast path for array
-/// methods.
-/// Ensures that there's a fast indexed storage with no non-default behaviors
-/// applied to it, along with an objectID of 0 (for easy comparison).
 static constexpr void setArrayFastPathClassFlags(ClassFlags &res) {
   // This code should set every field in SHObjectFlags to make sure we don't
   // miss one, which is checked by the assert in arrayFastPathCheck.
@@ -396,6 +383,7 @@ static constexpr void setArrayFastPathClassFlags(ClassFlags &res) {
   res.dictionaryNoCacheMode = 0;
   res.typed = 0;
   res.hasIndexLikeProperties = 0;
+  res.indexedStorage = 1;
   res.mayHaveAccessor = 0;
   res.typed = 0;
   res.noExtend = 0;
@@ -444,7 +432,7 @@ static bool checkAndCacheProtoForFastPath(Runtime &runtime) {
     // Unlike the immediate parent, we do not expect any parent further up the
     // chain to have indexed storage. Disqualify anything with indexed storage,
     // since actually checking the "indexed range" is costly.
-    if (LLVM_UNLIKELY(curParent->getFlags().indexedStorage))
+    if (LLVM_UNLIKELY(curParent->hasIndexedStorage(runtime)))
       return false;
 
     curParent->setCachedUsingEpoch();
@@ -462,39 +450,6 @@ bool arrayFastPathCheck(
     uint32_t len) {
   NoAllocScope noAlloc{runtime};
   assert(arr && "arr must be non-null");
-
-  // To use the fast path, the object has to be an array with fast index
-  // properties (no index-like properties that we can't read quickly).
-  // Make our own SHObjectFlags here to compare against quickly, to avoid having
-  // to use lots of accessors on JSObject.
-  SHObjectFlags arrayFastPathObjectFlags{};
-  setArrayFastPathObjectFlags(arrayFastPathObjectFlags);
-
-#ifndef NDEBUG
-  // Test that all the flags are handled in setArrayFastPathObjectFlags
-  // by starting with all the bits reversed and calling the function,
-  // and making sure the result is the same.
-  SHObjectFlags flagsForAssert{};
-  std::memset(&flagsForAssert, 0xff, sizeof(SHObjectFlags));
-  setArrayFastPathObjectFlags(flagsForAssert);
-  assert(
-      std::memcmp(
-          &flagsForAssert, &arrayFastPathObjectFlags, sizeof(SHObjectFlags)) ==
-          0 &&
-      "setArrayFastPathObjectFlags is missing a flag");
-#endif
-
-  SHObjectFlags arrFlags = arr->getFlags();
-  // Ensure the objectIDs are the same for comparison purposes.
-  arrFlags.objectID = 0;
-
-  static_assert(
-      sizeof(SHObjectFlags) == sizeof(uint32_t),
-      "SHObjectFlags must be uint32_t");
-  if (LLVM_UNLIKELY(
-          std::memcmp(&arrayFastPathObjectFlags, &arrFlags, sizeof(uint32_t)) !=
-          0))
-    return false;
 
   // Optionally check that 'length' hasn't been reconfigured.
   if (arrayClass && arr->getClass(runtime) != arrayClass)
@@ -1926,7 +1881,7 @@ CallResult<HermesValue> arrayPrototypeSort(void *, Runtime &runtime) {
   // first copies all existing properties into an array and sorts that.
   // Proxies and host objects however are excluded because they are weird.
   if (!lv.O->isProxyObject(runtime) && !lv.O->isHostObject(runtime) &&
-      !lv.O->hasFastIndexProperties())
+      !lv.O->hasFastIndexProperties(runtime))
     return sortSparse(runtime, lv.O, compareFn, len);
 
   // This is the "fast" path. We are sorting an array with indexed storage.
@@ -2447,7 +2402,9 @@ static CallResult<HermesValue> arrayPrototypeSpliceFastPath(
     uint32_t actualDeleteCount,
     uint32_t itemCount,
     NativeArgs args) {
-  assert(O->hasFastIndexProperties() && "O must have fast index properties");
+  assert(
+      O->hasFastIndexProperties(runtime) &&
+      "O must have fast index properties");
   assert(!O->isProxyObject(runtime) && "O must not be proxy");
   assert(O->getBeginIndex() == 0 && "incorrect begin index");
   assert(O->getEndIndex() == len && "incorrect end index");

--- a/lib/VM/JSLib/Array.cpp
+++ b/lib/VM/JSLib/Array.cpp
@@ -384,9 +384,6 @@ static constexpr void setArrayFastPathObjectFlags(SHObjectFlags &res) {
   res.frozen = 0;
   res.indexedStorage = 1;
   res.fastIndexProperties = 1;
-  res.hostObject = 0;
-  res.lazyObject = 0;
-  res.proxyObject = 0;
   res.isCachedUsingEpoch = 0;
   res.objectID = 0;
 }
@@ -403,6 +400,10 @@ static constexpr void setArrayFastPathClassFlags(ClassFlags &res) {
   res.typed = 0;
   res.hasIndexLikeProperties = 0;
   res.mayHaveAccessor = 0;
+  res.typed = 0;
+  res.hostObject = 0;
+  res.lazyObject = 0;
+  res.proxyObject = 0;
   res.parentChangeCounter = 0;
   res.unusedPadding = 0;
 }
@@ -430,8 +431,8 @@ static bool checkAndCacheProtoForFastPath(Runtime &runtime) {
     // If the object may have index-like properties that are not reflected on
     // the hidden class or indexed storage, bail.
     if (LLVM_UNLIKELY(
-            curParent->isHostObject() || curParent->isProxyObject() ||
-            curParent->isLazy()))
+            curParent->isHostObject(runtime) ||
+            curParent->isProxyObject(runtime) || curParent->isLazy(runtime)))
       return false;
 
     // Any index-like properties in the parent means we can't use the fast path
@@ -1771,7 +1772,7 @@ CallResult<HermesValue> sortSparse(
   GCScope gcScope{runtime};
 
   assert(
-      !O->isHostObject() && !O->isProxyObject() &&
+      !O->isHostObject(runtime) && !O->isProxyObject(runtime) &&
       "only non-exotic objects can be sparsely sorted");
 
   struct : Locals {
@@ -1924,7 +1925,7 @@ CallResult<HermesValue> arrayPrototypeSort(void *, Runtime &runtime) {
   // If we are not sorting a regular dense array, use a special routine which
   // first copies all existing properties into an array and sorts that.
   // Proxies and host objects however are excluded because they are weird.
-  if (!lv.O->isProxyObject() && !lv.O->isHostObject() &&
+  if (!lv.O->isProxyObject(runtime) && !lv.O->isHostObject(runtime) &&
       !lv.O->hasFastIndexProperties())
     return sortSparse(runtime, lv.O, compareFn, len);
 
@@ -2447,7 +2448,7 @@ static CallResult<HermesValue> arrayPrototypeSpliceFastPath(
     uint32_t itemCount,
     NativeArgs args) {
   assert(O->hasFastIndexProperties() && "O must have fast index properties");
-  assert(!O->isProxyObject() && "O must not be proxy");
+  assert(!O->isProxyObject(runtime) && "O must not be proxy");
   assert(O->getBeginIndex() == 0 && "incorrect begin index");
   assert(O->getEndIndex() == len && "incorrect end index");
 

--- a/lib/VM/JSLib/Date.cpp
+++ b/lib/VM/JSLib/Date.cpp
@@ -485,8 +485,7 @@ CallResult<HermesValue> dateConstructor_RJS(void *, Runtime &runtime) {
   if (LLVM_LIKELY(
           args.getNewTarget().getRaw() ==
           runtime.dateConstructor.getHermesValue().getRaw())) {
-    return JSDate::create(runtime, finalDate, runtime.datePrototype)
-        .getHermesValue();
+    return JSDate::create(runtime, finalDate).getHermesValue();
   }
   CallResult<PseudoHandle<JSObject>> thisParentRes =
       NativeConstructor::parentForNewThis_RJS(

--- a/lib/VM/JSLib/DebuggerInternal.cpp
+++ b/lib/VM/JSLib/DebuggerInternal.cpp
@@ -44,7 +44,7 @@ Handle<JSObject> createDebuggerInternalObject(Runtime &runtime) {
       true,
       false);
 
-  JSObject::preventExtensions(*intern);
+  JSObject::preventExtensionsNonProxy(intern, runtime);
 
   return intern;
 }

--- a/lib/VM/JSLib/Error.cpp
+++ b/lib/VM/JSLib/Error.cpp
@@ -63,23 +63,17 @@ HermesValue createErrorConstructor(Runtime &runtime) {
 
   auto getter = NativeFunction::create(
       runtime,
-      Handle<JSObject>::vmcast(&runtime.functionPrototype),
-      Runtime::makeNullHandle<Environment>(),
       nullptr,
       errorStackGetter,
       Predefined::getSymbolID(Predefined::emptyString),
-      0,
-      Runtime::makeNullHandle<JSObject>());
+      0);
 
   auto setter = NativeFunction::create(
       runtime,
-      Handle<JSObject>::vmcast(&runtime.functionPrototype),
-      Runtime::makeNullHandle<Environment>(),
       nullptr,
       errorStackSetter,
       Predefined::getSymbolID(Predefined::emptyString),
-      1,
-      Runtime::makeNullHandle<JSObject>());
+      1);
 
   // Save the accessors on the runtime so we can use them for captureStackTrace.
   runtime.jsErrorStackAccessor =
@@ -194,7 +188,7 @@ static CallResult<HermesValue> constructErrorObject(
           !args.isConstructorCall() ||
           (args.getNewTarget().getRaw() ==
            errConstructor->getHermesValue().getRaw()))) {
-    lv.selfParent = *errConstructorProto;
+    lv.self = JSError::create(runtime, *errConstructorProto);
   } else {
     CallResult<PseudoHandle<JSObject>> thisParentRes =
         NativeConstructor::parentForNewThis_RJS(
@@ -205,8 +199,8 @@ static CallResult<HermesValue> constructErrorObject(
       return ExecutionStatus::EXCEPTION;
     }
     lv.selfParent = std::move(*thisParentRes);
+    lv.self = JSError::create(runtime, lv.selfParent);
   }
-  lv.self = JSError::create(runtime, lv.selfParent);
 
   // Record the stack trace, skipping this entry.
   JSError::recordStackTrace(lv.self, runtime, true);

--- a/lib/VM/JSLib/Error.cpp
+++ b/lib/VM/JSLib/Error.cpp
@@ -384,8 +384,8 @@ CallResult<HermesValue> errorCaptureStackTrace(void *, Runtime &runtime) {
 
   // Get the target object.
   auto targetHandle = args.dyncastArg<JSObject>(0);
-  if (!targetHandle || targetHandle->isHostObject() ||
-      targetHandle->isProxyObject()) {
+  if (!targetHandle || targetHandle->isHostObject(runtime) ||
+      targetHandle->isProxyObject(runtime)) {
     return runtime.raiseTypeError("Invalid argument");
   }
 

--- a/lib/VM/JSLib/GlobalObject.cpp
+++ b/lib/VM/JSLib/GlobalObject.cpp
@@ -300,6 +300,11 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
   clearConfigurableDPF.setConfigurable = 1;
   clearConfigurableDPF.configurable = 0;
 
+  ClassFlags hostObjectFlags{};
+  hostObjectFlags.hostObject = 1;
+  ClassFlags proxyFlags{};
+  proxyFlags.proxyObject = 1;
+
   // Define a function on the global object with name \p name.
   // Allocates a NativeObject and puts it in the global object.
   auto defineGlobalFunc =
@@ -317,9 +322,12 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
   /// Create a root HiddenClass for the given CellKind.
   /// Has the base number of reserved slots for \p kind.
   auto createRootHiddenClassWithParent =
-      [&runtime, &lv](CellKind kind, Handle<JSObject> parent) -> HiddenClass * {
+      [&runtime, &lv](
+          CellKind kind,
+          Handle<JSObject> parent,
+          ClassFlags flags = {}) -> HiddenClass * {
     size_t baseNumSlots = JSObject::numOverlapSlotsForCellKind(kind);
-    lv.tempClazzCreateRoot = HiddenClass::createRoot(runtime, parent);
+    lv.tempClazzCreateRoot = HiddenClass::createRoot(runtime, parent, flags);
     // Add the base number of slots.
     for (size_t i = 0; i < baseNumSlots; ++i) {
       GCScopeMarkerRAII marker{runtime};
@@ -339,6 +347,9 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
 #define CREATE_CLASS_FOR_PARENT(kind, parentField) \
   runtime.class##kind =                            \
       createRootHiddenClassWithParent(CellKind::kind##Kind, parentField);
+#define CREATE_CLASS_FOR_PARENT_FLAGS(kind, parentField, flags) \
+  runtime.class##kind = createRootHiddenClassWithParent(        \
+      CellKind::kind##Kind, parentField, flags);
 
   // 15.1.1.1 NaN.
   lv.value = HermesValue::encodeNaNValue();
@@ -419,7 +430,8 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
   CREATE_CLASS_FOR_PARENT(NativeFunction, runtime.functionPrototype)
   CREATE_CLASS_FOR_PARENT(FinalizableNativeFunction, runtime.functionPrototype)
   CREATE_CLASS_FOR_PARENT(NativeConstructor, runtime.functionPrototype)
-  CREATE_CLASS_FOR_PARENT(JSCallableProxy, runtime.functionPrototype)
+  CREATE_CLASS_FOR_PARENT_FLAGS(
+      JSCallableProxy, runtime.functionPrototype, proxyFlags)
   CREATE_CLASS_FOR_PARENT(NativeJSClass, runtime.functionPrototype)
   CREATE_CLASS_FOR_PARENT(JSClass, runtime.functionPrototype)
   CREATE_CLASS_FOR_PARENT(JSFunction, runtime.functionPrototype)
@@ -575,7 +587,8 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
   // Populate the root classes for each JSObject.
 
   CREATE_CLASS_FOR_PARENT(DecoratedObject, runtime.objectPrototype)
-  CREATE_CLASS_FOR_PARENT(HostObject, runtime.objectPrototype)
+  CREATE_CLASS_FOR_PARENT_FLAGS(
+      HostObject, runtime.objectPrototype, hostObjectFlags)
   CREATE_CLASS_FOR_PARENT(JSError, runtime.ErrorPrototype)
   CREATE_CLASS_FOR_PARENT(JSCallSite, runtime.callSitePrototype)
   CREATE_CLASS_FOR_PARENT(Arguments, runtime.objectPrototype)
@@ -605,16 +618,17 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
       JSRegExpStringIterator, runtime.regExpStringIteratorPrototype)
   CREATE_CLASS_FOR_PARENT(RequireContext, runtime.objectPrototype)
   CREATE_CLASS_FOR_PARENT(JSGeneratorObject, runtime.generatorPrototype)
-  CREATE_CLASS_FOR_PARENT(JSProxy, runtime.objectPrototype)
+  CREATE_CLASS_FOR_PARENT_FLAGS(JSProxy, runtime.objectPrototype, proxyFlags)
   CREATE_CLASS_FOR_PARENT(JSFinalizationRegistry, runtime.objectPrototype)
   CREATE_CLASS_FOR_PARENT(JSBigInt, runtime.bigintPrototype)
   CREATE_CLASS_FOR_PARENT(FastArray, runtime.fastArrayPrototype)
 
 #undef CREATE_CLASS_FOR_PARENT
+#undef CREATE_CLASS_FOR_PARENT_FLAGS
 
   // Declare the fast array class.
   runtime.classFastArray = createRootHiddenClassWithParent(
-      CellKind::FastArrayKind, runtime.fastArrayPrototype);
+      CellKind::FastArrayKind, runtime.fastArrayPrototype, ClassFlags{});
   runtime.classFastArray = FastArray::createClass(
       runtime, runtime.fastArrayPrototype, runtime.classFastArray);
 

--- a/lib/VM/JSLib/GlobalObject.cpp
+++ b/lib/VM/JSLib/GlobalObject.cpp
@@ -11,6 +11,8 @@
 //===----------------------------------------------------------------------===//
 #include "hermes/Platform/Intl/PlatformIntl.h"
 #include "hermes/Support/FastStrToDouble.h"
+#include "hermes/VM/Callable.h"
+#include "hermes/VM/DecoratedObject.h"
 #include "hermes/VM/FastArray.h"
 #include "hermes/VM/JSArrayBuffer.h"
 #include "hermes/VM/JSDataView.h"
@@ -268,6 +270,8 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
 
   struct : public Locals {
     PinnedValue<JSObject> tempHandle;
+    PinnedValue<HiddenClass> tempClazzCreateRoot;
+    PinnedValue<HiddenClass> tempClazzForPrototype;
     PinnedValue<> value;
   } lv;
   LocalsRAII lraii(runtime, &lv);
@@ -303,19 +307,31 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
         gcScope.clearAllHandles();
 
         auto func = NativeFunction::create(
-            runtime,
-            runtime.functionPrototype,
-            Runtime::makeNullHandle<Environment>(),
-            nullptr,
-            functionPtr,
-            name,
-            paramCount,
-            Runtime::makeNullHandle<JSObject>());
+            runtime, nullptr, functionPtr, name, paramCount);
         runtime.ignoreAllocationFailure(
             JSObject::defineOwnProperty(
                 runtime.getGlobal(), runtime, name, normalDPF, func));
         return func;
       };
+
+  /// Create a root HiddenClass for the given CellKind.
+  /// Has the base number of reserved slots for \p kind.
+  auto createRootHiddenClassWithParent =
+      [&runtime, &lv](CellKind kind, Handle<JSObject> parent) -> HiddenClass * {
+    size_t baseNumSlots = JSObject::numOverlapSlotsForCellKind(kind);
+    lv.tempClazzCreateRoot = HiddenClass::createRoot(runtime);
+    // Add the base number of slots.
+    for (size_t i = 0; i < baseNumSlots; ++i) {
+      GCScopeMarkerRAII marker{runtime};
+      auto addResult =
+          HiddenClass::reserveSlot(lv.tempClazzCreateRoot, runtime);
+      assert(
+          addResult != ExecutionStatus::EXCEPTION &&
+          "Could not possibly grow larger than the limit");
+      lv.tempClazzCreateRoot = *addResult->first;
+    }
+    return *lv.tempClazzCreateRoot;
+  };
 
   // 15.1.1.1 NaN.
   lv.value = HermesValue::encodeNaNValue();
@@ -353,7 +369,7 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
 
   // "Forward declaration" of Error.prototype. Its properties will be populated
   // later.
-  runtime.ErrorPrototype = JSObject::create(runtime);
+  runtime.ErrorPrototype = JSObject::create(runtime, runtime.objectPrototype);
 
 // "Forward declaration" of the prototype for native error types. Their
 // properties will be populated later.
@@ -369,9 +385,12 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
 
   // "Forward declaration" of Function.prototype. Its properties will be
   // populated later.
+  lv.tempClazzForPrototype = createRootHiddenClassWithParent(
+      CellKind::NativeFunctionKind, runtime.objectPrototype);
   runtime.functionPrototype = NativeFunction::create(
       runtime,
       runtime.objectPrototype,
+      lv.tempClazzForPrototype,
       Runtime::makeNullHandle<Environment>(),
       nullptr,
       emptyFunction,
@@ -387,41 +406,25 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
           configurableOnlyPDF,
           Runtime::getZeroValue()));
 
-  // [[ThrowTypeError]].
-  auto throwTypeErrorFunction = NativeFunction::create(
-      runtime,
-      runtime.functionPrototype,
-      Runtime::makeNullHandle<Environment>(),
-      (void *)TypeErrorKind::RestrictedProperty,
-      throwTypeError,
-      Predefined::getSymbolID(Predefined::emptyString),
-      0,
-      Runtime::makeNullHandle<JSObject>());
-  runtime.ignoreAllocationFailure(
-      JSObject::defineOwnProperty(
-          throwTypeErrorFunction,
-          runtime,
-          Predefined::getSymbolID(Predefined::length),
-          clearConfigurableDPF,
-          Runtime::getUndefinedValue()));
-  runtime.throwTypeErrorAccessor = PropertyAccessor::create(
-      runtime, throwTypeErrorFunction, throwTypeErrorFunction);
-
-  // Define the 'parseInt' function.
-  runtime.parseIntFunction = defineGlobalFunc(
-      Predefined::getSymbolID(Predefined::parseInt), parseInt, 2);
-
-  // Define the 'parseFloat' function.
-  runtime.parseFloatFunction = defineGlobalFunc(
-      Predefined::getSymbolID(Predefined::parseFloat), parseFloat, 1);
+  // Initialize reserved HiddenClasses for 1 additional slot where necessary.
+  {
+    Handle<HiddenClass> prev =
+        Handle<HiddenClass>::vmcast(&runtime.classNativeFunction);
+    auto addResult = runtime.ignoreAllocationFailure(
+        HiddenClass::reserveSlot(prev, runtime));
+    runtime.classNativeFunction1Reserved = addResult.first.get();
+  }
 
   // "Forward declaration" of String.prototype. Its properties will be
   // populated later.
+  lv.tempClazzForPrototype = createRootHiddenClassWithParent(
+      CellKind::JSStringKind, runtime.objectPrototype);
   runtime.stringPrototype = runtime.ignoreAllocationFailure(
       JSString::create(
           runtime,
           runtime.getPredefinedStringHandle(Predefined::emptyString),
-          runtime.objectPrototype));
+          runtime.objectPrototype,
+          lv.tempClazzForPrototype));
 
   // "Forward declaration" of BigInt.prototype. Its properties will be
   // populated later.
@@ -429,13 +432,17 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
 
   // "Forward declaration" of Number.prototype. Its properties will be
   // populated later.
-  runtime.numberPrototype =
-      JSNumber::create(runtime, +0.0, runtime.objectPrototype);
+  lv.tempClazzForPrototype = createRootHiddenClassWithParent(
+      CellKind::JSNumberKind, runtime.objectPrototype);
+  runtime.numberPrototype = JSNumber::create(
+      runtime, +0.0, runtime.objectPrototype, lv.tempClazzForPrototype);
 
   // "Forward declaration" of Boolean.prototype. Its properties will be
   // populated later.
-  runtime.booleanPrototype =
-      JSBoolean::create(runtime, false, runtime.objectPrototype);
+  lv.tempClazzForPrototype = createRootHiddenClassWithParent(
+      CellKind::JSBooleanKind, runtime.objectPrototype);
+  runtime.booleanPrototype = JSBoolean::create(
+      runtime, false, runtime.objectPrototype, lv.tempClazzForPrototype);
 
   // "Forward declaration" of Symbol.prototype. Its properties will be
   // populated later.
@@ -450,27 +457,24 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
 
   // "Forward declaration" of Array.prototype. Its properties will be
   // populated later.
+  lv.tempClazzForPrototype = createRootHiddenClassWithParent(
+      CellKind::JSArrayKind, runtime.objectPrototype);
   runtime.arrayPrototype = runtime.ignoreAllocationFailure(
       JSArray::createNoAllocPropStorage(
           runtime,
           runtime.objectPrototype,
-          JSArray::createClass(runtime, runtime.objectPrototype),
+          JSArray::createClass(
+              runtime, runtime.objectPrototype, lv.tempClazzForPrototype),
           0,
           0));
-
-  // Declare the array class.
-  runtime.arrayClass = JSArray::createClass(runtime, runtime.arrayPrototype);
+  runtime.classJSArray = JSArray::createClass(
+      runtime, runtime.arrayPrototype, runtime.classJSArray);
+  assert(
+      Handle<JSObject>::vmcast(&runtime.arrayPrototype)->getParent(runtime) ==
+      runtime.objectPrototype.get());
 
   // TODO: Give FastArray its own prototype so methods like push will work.
   runtime.fastArrayPrototype = *runtime.objectPrototype;
-
-  // Declare the fast array class.
-  runtime.fastArrayClass =
-      FastArray::createClass(runtime, runtime.fastArrayPrototype);
-
-  // Declare the regexp match object class.
-  runtime.regExpMatchClass =
-      JSRegExp::createMatchClass(runtime, runtime.arrayClass);
 
   // "Forward declaration" of ArrayBuffer.prototype. Its properties will be
   // populated later.
@@ -550,6 +554,49 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
   // "Forward declaration" of %AsyncFunction.prototype%
   runtime.asyncFunctionPrototype =
       JSObject::create(runtime, runtime.functionPrototype);
+
+  // Declare the fast array class.
+  runtime.classFastArray = createRootHiddenClassWithParent(
+      CellKind::FastArrayKind, runtime.fastArrayPrototype);
+  runtime.classFastArray = FastArray::createClass(
+      runtime, runtime.fastArrayPrototype, runtime.classFastArray);
+
+  // Declare the regexp match object class.
+  runtime.regExpMatchClass =
+      JSRegExp::createMatchClass(runtime, runtime.classJSArray);
+
+  {
+    Handle<HiddenClass> prev =
+        Handle<HiddenClass>::vmcast(&runtime.classDecoratedObject);
+    auto addResult = runtime.ignoreAllocationFailure(
+        HiddenClass::reserveSlot(prev, runtime));
+    runtime.classDecoratedObject1Reserved = addResult.first.get();
+  }
+
+  // [[ThrowTypeError]].
+  auto throwTypeErrorFunction = NativeFunction::create(
+      runtime,
+      (void *)TypeErrorKind::RestrictedProperty,
+      throwTypeError,
+      Predefined::getSymbolID(Predefined::emptyString),
+      0);
+  runtime.ignoreAllocationFailure(
+      JSObject::defineOwnProperty(
+          throwTypeErrorFunction,
+          runtime,
+          Predefined::getSymbolID(Predefined::length),
+          clearConfigurableDPF,
+          Runtime::getUndefinedValue()));
+  runtime.throwTypeErrorAccessor = PropertyAccessor::create(
+      runtime, throwTypeErrorFunction, throwTypeErrorFunction);
+
+  // Define the 'parseInt' function.
+  runtime.parseIntFunction = defineGlobalFunc(
+      Predefined::getSymbolID(Predefined::parseInt), parseInt, 2);
+
+  // Define the 'parseFloat' function.
+  runtime.parseFloatFunction = defineGlobalFunc(
+      Predefined::getSymbolID(Predefined::parseFloat), parseFloat, 1);
 
   // Object constructor.
   runtime.objectConstructor.castAndSetHermesValue<NativeConstructor>(
@@ -794,13 +841,10 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
   // Define the 'require' function.
   runtime.requireFunction = NativeFunction::create(
       runtime,
-      runtime.functionPrototype,
-      Runtime::makeNullHandle<Environment>(),
       nullptr,
       require,
       Predefined::getSymbolID(Predefined::require),
-      1,
-      Runtime::makeNullHandle<JSObject>());
+      1);
 
   if (jsLibFlags.enableHermesInternal) {
     // Define the 'gc' function.
@@ -820,6 +864,13 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
             normalDPF,
             lv.value));
   }
+#endif
+
+#ifndef NDEBUG
+  // Check that all the classes are HiddenClass type.
+#define CELL_JSOBJECT_NAME(name, vmClassName) \
+  assert(runtime.class##name.get() != nullptr);
+#include "hermes/VM/CellKinds.def"
 #endif
 }
 

--- a/lib/VM/JSLib/GlobalObject.cpp
+++ b/lib/VM/JSLib/GlobalObject.cpp
@@ -307,6 +307,9 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
   ClassFlags fastArrayFlags{};
   fastArrayFlags.noExtend = 1;
   fastArrayFlags.sealed = 1;
+  fastArrayFlags.indexedStorage = 1;
+  ClassFlags indexedStorageFlags{};
+  indexedStorageFlags.indexedStorage = 1;
 
   // Define a function on the global object with name \p name.
   // Allocates a NativeObject and puts it in the global object.
@@ -452,7 +455,7 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
   // "Forward declaration" of String.prototype. Its properties will be
   // populated later.
   lv.tempClazzForPrototype = createRootHiddenClassWithParent(
-      CellKind::JSStringKind, runtime.objectPrototype);
+      CellKind::JSStringKind, runtime.objectPrototype, indexedStorageFlags);
   runtime.stringPrototype = runtime.ignoreAllocationFailure(
       JSString::create(
           runtime,
@@ -492,7 +495,7 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
   // "Forward declaration" of Array.prototype. Its properties will be
   // populated later.
   lv.tempClazzForPrototype = createRootHiddenClassWithParent(
-      CellKind::JSArrayKind, runtime.objectPrototype);
+      CellKind::JSArrayKind, runtime.objectPrototype, indexedStorageFlags);
   runtime.classJSArray = JSArray::createClass(
       runtime, runtime.objectPrototype, lv.tempClazzForPrototype);
   runtime.arrayPrototype = runtime.ignoreAllocationFailure(
@@ -594,11 +597,13 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
       HostObject, runtime.objectPrototype, hostObjectFlags)
   CREATE_CLASS_FOR_PARENT(JSError, runtime.ErrorPrototype)
   CREATE_CLASS_FOR_PARENT(JSCallSite, runtime.callSitePrototype)
-  CREATE_CLASS_FOR_PARENT(Arguments, runtime.objectPrototype)
+  CREATE_CLASS_FOR_PARENT_FLAGS(
+      Arguments, runtime.objectPrototype, indexedStorageFlags)
   CREATE_CLASS_FOR_PARENT(JSArrayBuffer, runtime.arrayBufferPrototype)
   CREATE_CLASS_FOR_PARENT(JSDataView, runtime.dataViewPrototype)
-#define TYPED_ARRAY(name, type) \
-  CREATE_CLASS_FOR_PARENT(name##Array, runtime.name##ArrayPrototype)
+#define TYPED_ARRAY(name, type)  \
+  CREATE_CLASS_FOR_PARENT_FLAGS( \
+      name##Array, runtime.name##ArrayPrototype, indexedStorageFlags)
 #include "hermes/VM/TypedArrays.def"
   CREATE_CLASS_FOR_PARENT(JSArrayIterator, runtime.arrayIteratorPrototype)
   CREATE_CLASS_FOR_PARENT(JSSet, runtime.setPrototype)
@@ -609,7 +614,8 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
   CREATE_CLASS_FOR_PARENT(JSWeakSet, runtime.weakSetPrototype)
   CREATE_CLASS_FOR_PARENT(JSWeakRef, runtime.weakRefPrototype)
   CREATE_CLASS_FOR_PARENT(JSBoolean, runtime.booleanPrototype)
-  CREATE_CLASS_FOR_PARENT(JSString, runtime.stringPrototype)
+  CREATE_CLASS_FOR_PARENT_FLAGS(
+      JSString, runtime.stringPrototype, indexedStorageFlags)
   CREATE_CLASS_FOR_PARENT(JSNumber, runtime.numberPrototype)
   CREATE_CLASS_FOR_PARENT(JSSymbol, runtime.symbolPrototype)
   CREATE_CLASS_FOR_PARENT(JSStringIterator, runtime.stringIteratorPrototype)
@@ -632,7 +638,7 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
 
   // Declare the fast array class.
   runtime.classFastArray = createRootHiddenClassWithParent(
-      CellKind::FastArrayKind, runtime.fastArrayPrototype, ClassFlags{});
+      CellKind::FastArrayKind, runtime.fastArrayPrototype, indexedStorageFlags);
   runtime.classFastArray = FastArray::createClass(
       runtime, runtime.fastArrayPrototype, runtime.classFastArray);
 

--- a/lib/VM/JSLib/GlobalObject.cpp
+++ b/lib/VM/JSLib/GlobalObject.cpp
@@ -304,6 +304,9 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
   hostObjectFlags.hostObject = 1;
   ClassFlags proxyFlags{};
   proxyFlags.proxyObject = 1;
+  ClassFlags fastArrayFlags{};
+  fastArrayFlags.noExtend = 1;
+  fastArrayFlags.sealed = 1;
 
   // Define a function on the global object with name \p name.
   // Allocates a NativeObject and puts it in the global object.
@@ -621,7 +624,8 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
   CREATE_CLASS_FOR_PARENT_FLAGS(JSProxy, runtime.objectPrototype, proxyFlags)
   CREATE_CLASS_FOR_PARENT(JSFinalizationRegistry, runtime.objectPrototype)
   CREATE_CLASS_FOR_PARENT(JSBigInt, runtime.bigintPrototype)
-  CREATE_CLASS_FOR_PARENT(FastArray, runtime.fastArrayPrototype)
+  CREATE_CLASS_FOR_PARENT_FLAGS(
+      FastArray, runtime.fastArrayPrototype, fastArrayFlags)
 
 #undef CREATE_CLASS_FOR_PARENT
 #undef CREATE_CLASS_FOR_PARENT_FLAGS

--- a/lib/VM/JSLib/GlobalObject.cpp
+++ b/lib/VM/JSLib/GlobalObject.cpp
@@ -319,7 +319,7 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
   auto createRootHiddenClassWithParent =
       [&runtime, &lv](CellKind kind, Handle<JSObject> parent) -> HiddenClass * {
     size_t baseNumSlots = JSObject::numOverlapSlotsForCellKind(kind);
-    lv.tempClazzCreateRoot = HiddenClass::createRoot(runtime);
+    lv.tempClazzCreateRoot = HiddenClass::createRoot(runtime, parent);
     // Add the base number of slots.
     for (size_t i = 0; i < baseNumSlots; ++i) {
       GCScopeMarkerRAII marker{runtime};
@@ -330,8 +330,15 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
           "Could not possibly grow larger than the limit");
       lv.tempClazzCreateRoot = *addResult->first;
     }
+    lv.tempClazzCreateRoot =
+        runtime.getHiddenClassForPrototype(*parent, lv.tempClazzCreateRoot);
     return *lv.tempClazzCreateRoot;
   };
+
+  /// Make a root HiddenClass and store it in the Runtime.
+#define CREATE_CLASS_FOR_PARENT(kind, parentField) \
+  runtime.class##kind =                            \
+      createRootHiddenClassWithParent(CellKind::kind##Kind, parentField);
 
   // 15.1.1.1 NaN.
   lv.value = HermesValue::encodeNaNValue();
@@ -366,6 +373,8 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
 
   // "Forward declaration" of Object.prototype is in the Runtime constructor,
   // before the global object is allocated.
+
+  CREATE_CLASS_FOR_PARENT(JSObject, runtime.objectPrototype)
 
   // "Forward declaration" of Error.prototype. Its properties will be populated
   // later.
@@ -405,6 +414,16 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
           Predefined::getSymbolID(Predefined::length),
           configurableOnlyPDF,
           Runtime::getZeroValue()));
+
+  CREATE_CLASS_FOR_PARENT(BoundFunction, runtime.functionPrototype)
+  CREATE_CLASS_FOR_PARENT(NativeFunction, runtime.functionPrototype)
+  CREATE_CLASS_FOR_PARENT(FinalizableNativeFunction, runtime.functionPrototype)
+  CREATE_CLASS_FOR_PARENT(NativeConstructor, runtime.functionPrototype)
+  CREATE_CLASS_FOR_PARENT(JSCallableProxy, runtime.functionPrototype)
+  CREATE_CLASS_FOR_PARENT(NativeJSClass, runtime.functionPrototype)
+  CREATE_CLASS_FOR_PARENT(JSClass, runtime.functionPrototype)
+  CREATE_CLASS_FOR_PARENT(JSFunction, runtime.functionPrototype)
+  CREATE_CLASS_FOR_PARENT(NativeJSFunction, runtime.functionPrototype)
 
   // Initialize reserved HiddenClasses for 1 additional slot where necessary.
   {
@@ -459,19 +478,17 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
   // populated later.
   lv.tempClazzForPrototype = createRootHiddenClassWithParent(
       CellKind::JSArrayKind, runtime.objectPrototype);
+  runtime.classJSArray = JSArray::createClass(
+      runtime, runtime.objectPrototype, lv.tempClazzForPrototype);
   runtime.arrayPrototype = runtime.ignoreAllocationFailure(
       JSArray::createNoAllocPropStorage(
-          runtime,
-          runtime.objectPrototype,
-          JSArray::createClass(
-              runtime, runtime.objectPrototype, lv.tempClazzForPrototype),
-          0,
-          0));
-  runtime.classJSArray = JSArray::createClass(
-      runtime, runtime.arrayPrototype, runtime.classJSArray);
+          runtime, runtime.objectPrototype, runtime.classJSArray, 0, 0));
+  assert(runtime.arrayPrototype.get()->getClassGCPtr());
   assert(
-      Handle<JSObject>::vmcast(&runtime.arrayPrototype)->getParent(runtime) ==
+      runtime.arrayPrototype->getParent(runtime) ==
       runtime.objectPrototype.get());
+  runtime.classJSArray = JSArray::createClass(
+      runtime, runtime.arrayPrototype, lv.tempClazzForPrototype);
 
   // TODO: Give FastArray its own prototype so methods like push will work.
   runtime.fastArrayPrototype = *runtime.objectPrototype;
@@ -554,6 +571,46 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
   // "Forward declaration" of %AsyncFunction.prototype%
   runtime.asyncFunctionPrototype =
       JSObject::create(runtime, runtime.functionPrototype);
+
+  // Populate the root classes for each JSObject.
+
+  CREATE_CLASS_FOR_PARENT(DecoratedObject, runtime.objectPrototype)
+  CREATE_CLASS_FOR_PARENT(HostObject, runtime.objectPrototype)
+  CREATE_CLASS_FOR_PARENT(JSError, runtime.ErrorPrototype)
+  CREATE_CLASS_FOR_PARENT(JSCallSite, runtime.callSitePrototype)
+  CREATE_CLASS_FOR_PARENT(Arguments, runtime.objectPrototype)
+  CREATE_CLASS_FOR_PARENT(JSArrayBuffer, runtime.arrayBufferPrototype)
+  CREATE_CLASS_FOR_PARENT(JSDataView, runtime.dataViewPrototype)
+#define TYPED_ARRAY(name, type) \
+  CREATE_CLASS_FOR_PARENT(name##Array, runtime.name##ArrayPrototype)
+#include "hermes/VM/TypedArrays.def"
+  CREATE_CLASS_FOR_PARENT(JSArrayIterator, runtime.arrayIteratorPrototype)
+  CREATE_CLASS_FOR_PARENT(JSSet, runtime.setPrototype)
+  CREATE_CLASS_FOR_PARENT(JSMap, runtime.mapPrototype)
+  CREATE_CLASS_FOR_PARENT(JSSetIterator, runtime.setIteratorPrototype)
+  CREATE_CLASS_FOR_PARENT(JSMapIterator, runtime.mapIteratorPrototype)
+  CREATE_CLASS_FOR_PARENT(JSWeakMap, runtime.weakMapPrototype)
+  CREATE_CLASS_FOR_PARENT(JSWeakSet, runtime.weakSetPrototype)
+  CREATE_CLASS_FOR_PARENT(JSWeakRef, runtime.weakRefPrototype)
+  CREATE_CLASS_FOR_PARENT(JSBoolean, runtime.booleanPrototype)
+  CREATE_CLASS_FOR_PARENT(JSString, runtime.stringPrototype)
+  CREATE_CLASS_FOR_PARENT(JSNumber, runtime.numberPrototype)
+  CREATE_CLASS_FOR_PARENT(JSSymbol, runtime.symbolPrototype)
+  CREATE_CLASS_FOR_PARENT(JSStringIterator, runtime.stringIteratorPrototype)
+  CREATE_CLASS_FOR_PARENT(JSJSON, runtime.objectPrototype)
+  CREATE_CLASS_FOR_PARENT(JSMath, runtime.objectPrototype)
+  CREATE_CLASS_FOR_PARENT(JSDate, runtime.datePrototype)
+  CREATE_CLASS_FOR_PARENT(JSRegExp, runtime.regExpPrototype)
+  CREATE_CLASS_FOR_PARENT(
+      JSRegExpStringIterator, runtime.regExpStringIteratorPrototype)
+  CREATE_CLASS_FOR_PARENT(RequireContext, runtime.objectPrototype)
+  CREATE_CLASS_FOR_PARENT(JSGeneratorObject, runtime.generatorPrototype)
+  CREATE_CLASS_FOR_PARENT(JSProxy, runtime.objectPrototype)
+  CREATE_CLASS_FOR_PARENT(JSFinalizationRegistry, runtime.objectPrototype)
+  CREATE_CLASS_FOR_PARENT(JSBigInt, runtime.bigintPrototype)
+  CREATE_CLASS_FOR_PARENT(FastArray, runtime.fastArrayPrototype)
+
+#undef CREATE_CLASS_FOR_PARENT
 
   // Declare the fast array class.
   runtime.classFastArray = createRootHiddenClassWithParent(

--- a/lib/VM/JSLib/HermesBuiltin.cpp
+++ b/lib/VM/JSLib/HermesBuiltin.cpp
@@ -254,7 +254,7 @@ CallResult<HermesValue> copyDataPropertiesSlowPath_RJS(
     //     1. Set excluded to true.
     if (excludedItems) {
       assert(
-          !excludedItems->isProxyObject() &&
+          !excludedItems->isProxyObject(runtime) &&
           "internal excludedItems object is a proxy");
       ComputedPropertyDescriptor desc;
       CallResult<bool> cr = JSObject::getOwnComputedPrimitiveDescriptor(
@@ -278,7 +278,7 @@ CallResult<HermesValue> copyDataPropertiesSlowPath_RJS(
     //   ii. If desc is not undefined and desc.[[Enumerable]] is true, then
     // TODO(T141997867), move this special case behavior for host objects to
     // getOwnComputedDescriptor.
-    if ((*crb && desc.flags.enumerable) || from->isHostObject()) {
+    if ((*crb && desc.flags.enumerable) || from->isHostObject(runtime)) {
       //     1. Let propValue be ? Get(from, nextKey).
       CallResult<PseudoHandle<>> crv =
           JSObject::getComputed_RJS(from, runtime, lv.nextKeyHandle);
@@ -352,7 +352,7 @@ CallResult<HermesValue> hermesBuiltinCopyDataProperties(
   // propertyKeys
   Handle<JSObject> excludedItems = args.dyncastArg<JSObject>(2);
   assert(
-      (!excludedItems || !excludedItems->isProxyObject()) &&
+      (!excludedItems || !excludedItems->isProxyObject(runtime)) &&
       "excludedItems internal List is a Proxy");
 
   // We cannot use the fast path if the object is a proxy, host object, or when
@@ -360,7 +360,7 @@ CallResult<HermesValue> hermesBuiltinCopyDataProperties(
   // because in order to use JSObject::forEachOwnPropertyWhile, we must not
   // modify the underlying property map or hidden class. However, if we have an
   // accessor, we cannot guarantee that condition, so we use the slow path.
-  if (source->isProxyObject() || source->isHostObject() ||
+  if (source->isProxyObject(runtime) || source->isHostObject(runtime) ||
       source->getClass(runtime)->getMayHaveAccessor()) {
     return copyDataPropertiesSlowPath_RJS(
         runtime, target, source, excludedItems);
@@ -380,7 +380,7 @@ CallResult<HermesValue> hermesBuiltinCopyDataProperties(
 
         if (excludedItems) {
           assert(
-              !excludedItems->isProxyObject() &&
+              !excludedItems->isProxyObject(runtime) &&
               "internal excludedItems object is a proxy");
           ComputedPropertyDescriptor xdesc;
           auto cr = JSObject::getOwnComputedPrimitiveDescriptor(
@@ -830,7 +830,7 @@ CallResult<HermesValue> hermesBuiltinExportAll(void *, Runtime &runtime) {
   }
 
   Handle<JSObject> source = args.dyncastArg<JSObject>(1);
-  if (LLVM_UNLIKELY(!source) || LLVM_UNLIKELY(source->isProxyObject())) {
+  if (LLVM_UNLIKELY(!source) || LLVM_UNLIKELY(source->isProxyObject(runtime))) {
     return runtime.raiseTypeError(
         "exportAll() source argument must be non-Proxy object");
   }

--- a/lib/VM/JSLib/HermesBuiltin.cpp
+++ b/lib/VM/JSLib/HermesBuiltin.cpp
@@ -1026,13 +1026,10 @@ void createHermesBuiltins(Runtime &runtime) {
                                 uint8_t count = 0) {
     auto methodRes = NativeFunction::create(
         runtime,
-        Handle<JSObject>::vmcast(&runtime.functionPrototype),
-        Runtime::makeNullHandle<Environment>(),
         nullptr /* context */,
         func,
         Predefined::getSymbolID(symID),
-        count,
-        Runtime::makeNullHandle<JSObject>());
+        count);
     lv.method = std::move(*methodRes);
     runtime.registerBuiltin(builtinIndex, *lv.method);
   };

--- a/lib/VM/JSLib/HermesInternal.cpp
+++ b/lib/VM/JSLib/HermesInternal.cpp
@@ -423,7 +423,7 @@ CallResult<HermesValue> hermesInternalTTRCReached(void *, Runtime &runtime) {
 CallResult<HermesValue> hermesInternalIsProxy(void *, Runtime &runtime) {
   NativeArgs args = runtime.getCurrentFrame().getNativeArgs();
   Handle<JSObject> obj = args.dyncastArg<JSObject>(0);
-  return HermesValue::encodeBoolValue(obj && obj->isProxyObject());
+  return HermesValue::encodeBoolValue(obj && obj->isProxyObject(runtime));
 }
 
 CallResult<HermesValue> hermesInternalHasPromise(void *, Runtime &runtime) {
@@ -606,7 +606,7 @@ CallResult<HermesValue> hermesInternalGetFunctionLocation(
     assert(res != ExecutionStatus::EXCEPTION && "Failed to set fileName");
     (void)res;
   }
-  JSObject::preventExtensions(*lv.resultHandle);
+  JSObject::preventExtensionsNonProxy(lv.resultHandle, runtime);
   return lv.resultHandle.getHermesValue();
 }
 
@@ -842,7 +842,7 @@ HermesValue createHermesInternalObject(
 
   // All functions are known to be safe can be defined above this flag check.
   if (!flags.enableHermesInternal) {
-    JSObject::preventExtensions(*lv.intern);
+    JSObject::preventExtensionsNonProxy(lv.intern, runtime);
     return lv.intern.getHermesValue();
   }
 
@@ -886,7 +886,7 @@ HermesValue createHermesInternalObject(
     defineInternMethodAndSymbol("getCallStack", hermesInternalGetCallStack, 0);
   }
 
-  JSObject::preventExtensions(*lv.intern);
+  JSObject::preventExtensionsNonProxy(lv.intern, runtime);
 
   return lv.intern.getHermesValue();
 }

--- a/lib/VM/JSLib/Intl.cpp
+++ b/lib/VM/JSLib/Intl.cpp
@@ -241,7 +241,7 @@ CallResult<std::vector<std::u16string>> normalizeLocales(
     return ExecutionStatus::EXCEPTION;
   }
 
-  bool isProxy = lv.localeObj->isProxyObject();
+  bool isProxy = lv.localeObj->isProxyObject(runtime);
   if (LLVM_UNLIKELY(
           createListFromArrayLike_RJS(
               lv.localeObj,

--- a/lib/VM/JSLib/Intl.cpp
+++ b/lib/VM/JSLib/Intl.cpp
@@ -489,6 +489,8 @@ CallResult<HermesValue> intlServiceConstructor(
     Handle<NativeConstructor> serviceConstructor,
     Handle<JSObject> servicePrototype,
     unsigned int additionalSlots) {
+  assert(additionalSlots <= 1 && "can only use up to 1 slot");
+
   CallResult<std::vector<std::u16string>> localesRes =
       normalizeLocales(runtime, args.getArgHandle(0));
   if (LLVM_UNLIKELY(localesRes == ExecutionStatus::EXCEPTION)) {
@@ -538,7 +540,13 @@ CallResult<HermesValue> intlServiceConstructor(
     lv.selfParent = std::move(*thisParentRes);
   }
   lv.self = DecoratedObject::create(
-      runtime, servicePrototype, std::move(native), additionalSlots);
+      runtime,
+      servicePrototype,
+      runtime.getHiddenClassForPrototype(
+          *servicePrototype,
+          additionalSlots == 1 ? runtime.classDecoratedObject1Reserved
+                               : runtime.classDecoratedObject),
+      std::move(native));
 
   lv.typeVal =
       HermesValue::encodeTrustedNumberValue((uint32_t)T::getNativeType());
@@ -758,6 +766,8 @@ void defineIntlCollator(Runtime &runtime, Handle<JSObject> intl) {
 
 CallResult<HermesValue> intlCollatorConstructor(void *, Runtime &runtime) {
   NativeArgs args = runtime.getCurrentFrame().getNativeArgs();
+  static_assert(
+      (unsigned)CollatorSlotIndexes::COUNT == 1, "can only reserve 1 slot");
   return intlServiceConstructor<platform_intl::Collator>(
       runtime,
       args,
@@ -819,16 +829,19 @@ CallResult<HermesValue> intlCollatorPrototypeCompareGetter(
     return boundCompare.getHermesValue();
   }
 
+  static_assert(
+      (unsigned)CollatorCompareSlotIndexes::COUNT == 1,
+      "can only reserve 1 slot");
   Handle<NativeFunction> compare = NativeFunction::create(
       runtime,
       runtime.functionPrototype,
+      runtime.classNativeFunction1Reserved,
       Runtime::makeNullHandle<Environment>(),
       nullptr,
       intlCollatorCompare,
       Predefined::getSymbolID(Predefined::emptyString),
       2,
-      Runtime::makeNullHandle<JSObject>(),
-      static_cast<unsigned int>(CollatorCompareSlotIndexes::COUNT));
+      Runtime::makeNullHandle<JSObject>());
   setCollator(compare, runtime, collatorHandle);
 
   setBoundCompare(*collatorHandle, runtime, compare);
@@ -1010,6 +1023,8 @@ CallResult<HermesValue> intlDateTimeFormatConstructor(
     void *,
     Runtime &runtime) {
   NativeArgs args = runtime.getCurrentFrame().getNativeArgs();
+  static_assert(
+      (unsigned)DTFSlotIndexes::COUNT == 1, "can only reserve 1 slot");
   return intlServiceConstructor<platform_intl::DateTimeFormat>(
       runtime,
       args,
@@ -1107,16 +1122,18 @@ CallResult<HermesValue> intlDateTimeFormatPrototypeFormatGetter(
     return boundFormat.getHermesValue();
   }
 
+  static_assert(
+      (unsigned)DTFFormatSlotIndexes::COUNT == 1, "can only reserve 1 slot");
   Handle<NativeFunction> format = NativeFunction::create(
       runtime,
       runtime.functionPrototype,
+      runtime.classNativeFunction1Reserved,
       Runtime::makeNullHandle<Environment>(),
       nullptr,
       intlDateTimeFormatFormat,
       Predefined::getSymbolID(Predefined::emptyString),
       1,
-      Runtime::makeNullHandle<JSObject>(),
-      static_cast<unsigned int>(DTFFormatSlotIndexes::COUNT));
+      Runtime::makeNullHandle<JSObject>());
   setDateTimeFormat(format, runtime, dateTimeFormatHandle);
 
   setDTFBoundFormat(dateTimeFormatHandle, runtime, format);
@@ -1323,6 +1340,7 @@ void defineIntlNumberFormat(Runtime &runtime, Handle<JSObject> intl) {
 
 CallResult<HermesValue> intlNumberFormatConstructor(void *, Runtime &runtime) {
   NativeArgs args = runtime.getCurrentFrame().getNativeArgs();
+  static_assert((unsigned)NFSlotIndexes::COUNT == 1, "can only reserve 1 slot");
   return intlServiceConstructor<platform_intl::NumberFormat>(
       runtime,
       args,
@@ -1386,16 +1404,18 @@ CallResult<HermesValue> intlNumberFormatPrototypeFormatGetter(
     return boundFormat.getHermesValue();
   }
 
+  static_assert(
+      (unsigned)NFFormatSlotIndexes::COUNT == 1, "can only reserve 1 slot");
   Handle<NativeFunction> format = NativeFunction::create(
       runtime,
       runtime.functionPrototype,
+      runtime.classNativeFunction1Reserved,
       Runtime::makeNullHandle<Environment>(),
       nullptr,
       intlNumberFormatFormat,
       Predefined::getSymbolID(Predefined::emptyString),
       1,
-      Runtime::makeNullHandle<JSObject>(),
-      static_cast<unsigned int>(NFFormatSlotIndexes::COUNT));
+      Runtime::makeNullHandle<JSObject>());
   setNumberFormat(format, runtime, numberFormatHandle);
 
   setNFBoundFormat(numberFormatHandle, runtime, format);

--- a/lib/VM/JSLib/IteratorPrototype.cpp
+++ b/lib/VM/JSLib/IteratorPrototype.cpp
@@ -27,13 +27,10 @@ void populateIteratorPrototype(Runtime &runtime) {
   lv.iteratorFunc.castAndSetHermesValue<NativeFunction>(
       NativeFunction::create(
           runtime,
-          Handle<JSObject>::vmcast(&runtime.functionPrototype),
-          Runtime::makeNullHandle<Environment>(),
           nullptr,
           iteratorPrototypeIterator,
           Predefined::getSymbolID(Predefined::squareSymbolIterator),
-          0,
-          Runtime::makeNullHandle<JSObject>())
+          0)
           .getHermesValue());
 
   defineProperty(

--- a/lib/VM/JSLib/JSLibInternal.cpp
+++ b/lib/VM/JSLib/JSLibInternal.cpp
@@ -76,14 +76,7 @@ NativeFunction *defineMethod(
   GCScope gcScope{runtime};
 
   auto method = NativeFunction::create(
-      runtime,
-      Handle<JSObject>::vmcast(&runtime.functionPrototype),
-      Runtime::makeNullHandle<Environment>(),
-      context,
-      nativeFunctionPtr,
-      methodName,
-      paramCount,
-      Runtime::makeNullHandle<JSObject>());
+      runtime, context, nativeFunctionPtr, methodName, paramCount);
 
   auto res = JSObject::defineOwnProperty(
       objectHandle, runtime, propertyName, dpf, method);
@@ -175,15 +168,8 @@ void defineAccessor(
                     createPseudoHandle(vmcast<StringPrimitive>(strRes))))
             .get();
 
-    auto funcRes = NativeFunction::create(
-        runtime,
-        Handle<JSObject>::vmcast(&runtime.functionPrototype),
-        Runtime::makeNullHandle<Environment>(),
-        context,
-        getterFunc,
-        getterFuncName,
-        0,
-        Runtime::makeNullHandle<JSObject>());
+    auto funcRes =
+        NativeFunction::create(runtime, context, getterFunc, getterFuncName, 0);
     lv.getter = funcRes.get();
   }
   if (setterFunc) {
@@ -202,15 +188,8 @@ void defineAccessor(
                     createPseudoHandle(vmcast<StringPrimitive>(strRes))))
             .get();
 
-    auto funcRes = NativeFunction::create(
-        runtime,
-        Handle<JSObject>::vmcast(&runtime.functionPrototype),
-        Runtime::makeNullHandle<Environment>(),
-        context,
-        setterFunc,
-        setterFuncName,
-        1,
-        Runtime::makeNullHandle<JSObject>());
+    auto funcRes =
+        NativeFunction::create(runtime, context, setterFunc, setterFuncName, 1);
     lv.setter = funcRes.get();
   }
 

--- a/lib/VM/JSLib/JSON.cpp
+++ b/lib/VM/JSLib/JSON.cpp
@@ -19,8 +19,7 @@ namespace hermes {
 namespace vm {
 
 void createJSONObject(Runtime &runtime, MutableHandle<JSObject> result) {
-  auto objRes = JSJSON::create(
-      runtime, Handle<JSObject>::vmcast(&runtime.objectPrototype));
+  auto objRes = JSJSON::create(runtime);
   assert(
       objRes != ExecutionStatus::EXCEPTION && "unable to define JSON object");
 

--- a/lib/VM/JSLib/Math.cpp
+++ b/lib/VM/JSLib/Math.cpp
@@ -378,8 +378,7 @@ HermesValue createMathObject(Runtime &runtime) {
   } lv;
   LocalsRAII lraii{runtime, &lv};
 
-  auto objRes = JSMath::create(
-      runtime, Handle<JSObject>::vmcast(&runtime.objectPrototype));
+  auto objRes = JSMath::create(runtime);
   assert(objRes != ExecutionStatus::EXCEPTION && "unable to define Math");
   lv.math.castAndSetHermesValue<JSMath>(*objRes);
 

--- a/lib/VM/JSLib/Object.cpp
+++ b/lib/VM/JSLib/Object.cpp
@@ -26,6 +26,7 @@ namespace vm {
 /// Object.
 
 HermesValue createObjectConstructor(Runtime &runtime) {
+  assert(runtime.objectPrototype.get() != nullptr);
   auto objectPrototype = Handle<JSObject>::vmcast(&runtime.objectPrototype);
 
   struct : public Locals {

--- a/lib/VM/JSLib/Object.cpp
+++ b/lib/VM/JSLib/Object.cpp
@@ -366,7 +366,7 @@ CallResult<HermesValue> getOwnPropertyDescriptor(
       return ExecutionStatus::EXCEPTION;
     }
     if (!*result) {
-      if (LLVM_LIKELY(!object->isHostObject()))
+      if (LLVM_LIKELY(!object->isHostObject(runtime)))
         return HermesValue::encodeUndefinedValue();
       // For compatibility with polyfills we want to pretend that all HostObject
       // properties are "own" properties in hasOwnProperty() and in
@@ -654,7 +654,7 @@ objectDefinePropertiesInternal(Runtime &runtime, Handle<> obj, Handle<> props) {
           // setIncludeNonEnumerable for proxies is necessary to get the right
           // traps in the right order.  The non-enumerable props will be
           // filtered out below.
-          .setIncludeNonEnumerable(lv.propsHandle->isProxyObject()));
+          .setIncludeNonEnumerable(lv.propsHandle->isProxyObject(runtime)));
   if (cr == ExecutionStatus::EXCEPTION) {
     return ExecutionStatus::EXCEPTION;
   }
@@ -696,7 +696,7 @@ objectDefinePropertiesInternal(Runtime &runtime, Handle<> obj, Handle<> props) {
     if (LLVM_UNLIKELY(!*descRes || !desc.flags.enumerable)) {
       continue;
     }
-    CallResult<PseudoHandle<>> propRes = lv.propsHandle->isProxyObject()
+    CallResult<PseudoHandle<>> propRes = lv.propsHandle->isProxyObject(runtime)
         ? JSObject::getComputed_RJS(lv.propsHandle, runtime, lv.propName)
         : JSObject::getComputedPropertyValueInternal_RJS(
               lv.propsHandle, runtime, lv.propsHandle, desc);
@@ -889,7 +889,7 @@ CallResult<HermesValue> enumerableOwnProperties_RJS(
       objHandle,
       runtime,
       OwnKeysFlags().plusIncludeNonSymbols().setIncludeNonEnumerable(
-          objHandle->isProxyObject()));
+          objHandle->isProxyObject(runtime)));
   if (namesRes == ExecutionStatus::EXCEPTION) {
     return ExecutionStatus::EXCEPTION;
   }
@@ -902,7 +902,8 @@ CallResult<HermesValue> enumerableOwnProperties_RJS(
   } lv;
   LocalsRAII lraii(runtime, &lv);
 
-  if (kind == EnumerableOwnPropertiesKind::Key && !objHandle->isProxyObject()) {
+  if (kind == EnumerableOwnPropertiesKind::Key &&
+      !objHandle->isProxyObject(runtime)) {
     return *namesRes;
   }
   lv.names.castAndSetHermesValue<JSArray>(*namesRes);
@@ -944,7 +945,7 @@ CallResult<HermesValue> enumerableOwnProperties_RJS(
         return ExecutionStatus::EXCEPTION;
       }
       lv.value = std::move(*valueRes);
-    } else if (!objHandle->isProxyObject()) {
+    } else if (!objHandle->isProxyObject(runtime)) {
       continue;
     } else {
       // This is a proxy, so we need to call getOwnProperty() to see
@@ -990,7 +991,7 @@ CallResult<HermesValue> enumerableOwnProperties_RJS(
       lv.entry = lv.value.getHermesValue();
     } else {
       assert(
-          objHandle->isProxyObject() &&
+          objHandle->isProxyObject(runtime) &&
           "Key kind did not return early but not proxy");
       lv.entry = lv.names->at(runtime, i).unboxToHV(runtime);
     }
@@ -1160,7 +1161,7 @@ CallResult<HermesValue> objectAssign(void *, Runtime &runtime) {
         OwnKeysFlags()
             .plusIncludeSymbols()
             .plusIncludeNonSymbols()
-            .setIncludeNonEnumerable(fromHandle->isProxyObject()));
+            .setIncludeNonEnumerable(fromHandle->isProxyObject(runtime)));
     if (LLVM_UNLIKELY(cr == ExecutionStatus::EXCEPTION)) {
       // 5.c.ii. ReturnIfAbrupt(keys).
       return ExecutionStatus::EXCEPTION;
@@ -1194,7 +1195,7 @@ CallResult<HermesValue> objectAssign(void *, Runtime &runtime) {
       // changing it to make proxy work is is a surprisingly large
       // regression if used always, even with no Proxy objects.  So we
       // check if we can use getComputedPropertyValue_RJS and do so.
-      CallResult<PseudoHandle<>> propRes = fromHandle->isProxyObject()
+      CallResult<PseudoHandle<>> propRes = fromHandle->isProxyObject(runtime)
           ? JSObject::getComputed_RJS(fromHandle, runtime, nextKeyHandle)
           : JSObject::getComputedPropertyValue_RJS(
                 fromHandle, runtime, fromHandle, desc, nextKeyHandle);
@@ -1448,7 +1449,7 @@ objectHasOwnHelper(Runtime &runtime, Handle<JSObject> O, Handle<> P) {
   //      if (Object.hasOwnProperty(hostObj, key))
   //        ...
   //    }
-  if (LLVM_UNLIKELY(O->isHostObject())) {
+  if (LLVM_UNLIKELY(O->isHostObject(runtime))) {
     return HermesValue::encodeBoolValue(true);
   }
   return HermesValue::encodeBoolValue(false);

--- a/lib/VM/JSLib/Proxy.cpp
+++ b/lib/VM/JSLib/Proxy.cpp
@@ -173,16 +173,20 @@ CallResult<HermesValue> proxyRevocable(void *, Runtime &runtime) {
 
   // 2. Let steps be the algorithm steps defined in Proxy Revocation Functions.
   // 3. Let revoker be CreateBuiltinFunction(steps, « [[RevocableProxy]] »).
+  static_assert(
+      ProxySlotIndexes::COUNT == 1,
+      "COUNT must be 1. "
+      "Only 1 reserved slot in classNativeFunction1Reserved");
   Handle<NativeFunction> revoker = NativeFunction::create(
       runtime,
       runtime.functionPrototype,
+      runtime.classNativeFunction1Reserved,
       Runtime::makeNullHandle<Environment>(),
       nullptr,
       proxyRevocationSteps,
       Predefined::getSymbolID(Predefined::emptyString),
       0,
-      Runtime::makeNullHandle<JSObject>(),
-      ProxySlotIndexes::COUNT);
+      Runtime::makeNullHandle<JSObject>());
   // 4. Set revoker.[[RevocableProxy]] to p.
   auto shv = SmallHermesValue::encodeHermesValue(
       lv.finalProxy.getHermesValue(), runtime);

--- a/lib/VM/JSLib/Proxy.cpp
+++ b/lib/VM/JSLib/Proxy.cpp
@@ -129,7 +129,7 @@ CallResult<HermesValue> proxyRevocationSteps(void *, Runtime &runtime) {
   setRevocableProxySlot(revoker, runtime, SmallHermesValue::encodeNullValue());
   // 4. Assert: p is a Proxy object.
   JSObject *proxy = vmcast<JSObject>(proxyVal.getObject(runtime));
-  assert(proxy->isProxyObject() && "[[RevocableProxy]] is not a Proxy");
+  assert(proxy->isProxyObject(runtime) && "[[RevocableProxy]] is not a Proxy");
 
   struct : public Locals {
     PinnedValue<JSObject> proxyHandle;

--- a/lib/VM/JSLib/RegExp.cpp
+++ b/lib/VM/JSLib/RegExp.cpp
@@ -603,6 +603,9 @@ static ExecutionStatus makeMatchIndicesIndexPairArray(
   if (hasGroups) {
     // a. Let groups be OrdinaryObjectCreate(null).
     lv.mappingObjClazz = mappingObj->getClass(runtime);
+    assert(
+        lv.mappingObjClazz->getObjectParent(runtime) == nullptr &&
+        "must have been constructed correctly");
     auto groupsRes = JSObject::create(
         runtime, Runtime::makeNullHandle<JSObject>(), lv.mappingObjClazz);
     lv.groupsObj = groupsRes.get();

--- a/lib/VM/JSLib/RegExp.cpp
+++ b/lib/VM/JSLib/RegExp.cpp
@@ -766,8 +766,8 @@ ExecutionStatus directRegExpExec(
 
   auto arrRes = JSArray::createAndAllocPropStorage(
       runtime,
-      Handle<JSObject>::vmcast(&runtime.arrayPrototype),
-      Handle<HiddenClass>::vmcast(&runtime.regExpMatchClass),
+      runtime.arrayPrototype,
+      runtime.regExpMatchClass,
       match.size(),
       match.size());
   if (LLVM_UNLIKELY(arrRes == ExecutionStatus::EXCEPTION)) {

--- a/lib/VM/JSLib/RuntimeJSONParse.cpp
+++ b/lib/VM/JSLib/RuntimeJSONParse.cpp
@@ -439,7 +439,11 @@ CallResult<HermesValue> RuntimeJSONParser<Kind>::parseValue() {
           }
         } else {
           // Slowpath
-          lv.newObject = JSObject::create(runtime_, numElements);
+          lv.newObject = JSObject::create(
+              runtime_,
+              runtime_.objectPrototype,
+              runtime_.classJSObject,
+              numElements);
           for (size_t i = 0; i < numElements; i++) {
             gcScope.flushToMarker(marker);
             size_t propIdx = beginPropIdx + i;

--- a/lib/VM/JSLib/RuntimeJSONStringify.cpp
+++ b/lib/VM/JSLib/RuntimeJSONStringify.cpp
@@ -729,8 +729,8 @@ ExecutionStatus JSONStringifyer::operationJA() {
       !lv_.replacerFunction.get() &&
       arrayFastPathCheck(
           runtime_,
-          vmcast<JSArray>(*lv.arrayObject),
-          *runtime_.classJSArray,
+          Handle<JSArray>::vmcast(&lv.arrayObject),
+          runtime_.classJSArray,
           static_cast<uint32_t>(*lenRes))) {
     lv.initClazz = lv.arrayObject->getClass(runtime_);
     lv.jsArray = vmcast<JSArray>(*lv.arrayObject);

--- a/lib/VM/JSLib/RuntimeJSONStringify.cpp
+++ b/lib/VM/JSLib/RuntimeJSONStringify.cpp
@@ -730,7 +730,7 @@ ExecutionStatus JSONStringifyer::operationJA() {
       arrayFastPathCheck(
           runtime_,
           vmcast<JSArray>(*lv.arrayObject),
-          *runtime_.arrayClass,
+          *runtime_.classJSArray,
           static_cast<uint32_t>(*lenRes))) {
     lv.initClazz = lv.arrayObject->getClass(runtime_);
     lv.jsArray = vmcast<JSArray>(*lv.arrayObject);

--- a/lib/VM/JSLib/RuntimeJSONStringify.cpp
+++ b/lib/VM/JSLib/RuntimeJSONStringify.cpp
@@ -843,7 +843,7 @@ ExecutionStatus JSONStringifyer::operationJO() {
     lv.operationJOK = lv_.propertyList.get();
   } else {
     // JO.6.
-    if (LLVM_LIKELY(!lv.objHandle->isProxyObject())) {
+    if (LLVM_LIKELY(!lv.objHandle->isProxyObject(runtime_))) {
       HiddenClass *clazz = lv.objHandle->getClass(runtime_);
       // Check if object has any indexed properties via the virtual table
       // (e.g., TypedArrays store indices separately from HiddenClass).

--- a/lib/VM/JSLib/TypedArray.cpp
+++ b/lib/VM/JSLib/TypedArray.cpp
@@ -320,7 +320,8 @@ CallResult<HermesValue> typedArrayConstructor(
     Runtime &runtime,
     NativeArgs args,
     const PinnedValue<NativeConstructor> *arrayConstructor,
-    const PinnedValue<JSObject> *arrayPrototype) {
+    const PinnedValue<JSObject> *arrayPrototype,
+    const PinnedValue<HiddenClass> *arrayClazz) {
   // 1. If NewTarget is undefined, throw a TypeError exception.
   if (!args.isConstructorCall()) {
     return runtime.raiseTypeError(
@@ -329,6 +330,7 @@ CallResult<HermesValue> typedArrayConstructor(
 
   struct : public Locals {
     PinnedValue<JSObject> selfParent;
+    PinnedValue<HiddenClass> clazz;
     PinnedValue<JSTypedArray<T, C>> self;
   } lv;
   LocalsRAII lraii(runtime, &lv);
@@ -336,6 +338,7 @@ CallResult<HermesValue> typedArrayConstructor(
           args.getNewTarget().getRaw() ==
           arrayConstructor->getHermesValue().getRaw())) {
     lv.selfParent = *arrayPrototype;
+    lv.clazz = *arrayClazz;
   } else {
     CallResult<PseudoHandle<JSObject>> thisParentRes =
         NativeConstructor::parentForNewThis_RJS(
@@ -346,9 +349,10 @@ CallResult<HermesValue> typedArrayConstructor(
       return ExecutionStatus::EXCEPTION;
     }
     lv.selfParent = std::move(*thisParentRes);
+    lv.clazz = runtime.getHiddenClassForPrototype(*lv.selfParent, *arrayClazz);
   }
-  lv.self = JSTypedArray<T, C>::create(runtime, lv.selfParent);
-
+  assert(*lv.clazz && "must have a hidden class");
+  lv.self = JSTypedArray<T, C>::create(runtime, lv.selfParent, lv.clazz);
   if (args.getArgCount() == 0) {
     // ES6 22.2.1.1
     if (JSTypedArray<T, C>::createBuffer(runtime, lv.self, 0) ==
@@ -752,11 +756,16 @@ CallResult<HermesValue> typedArrayBaseConstructor(void *, Runtime &runtime) {
 
 /// @}
 
-#define TYPED_ARRAY(name, type)                                               \
-  CallResult<HermesValue> name##ArrayConstructor(void *ctx, Runtime &rt) {    \
-    NativeArgs args = rt.getCurrentFrame().getNativeArgs();                   \
-    return typedArrayConstructor<type, CellKind::name##ArrayKind>(            \
-        ctx, rt, args, &rt.name##ArrayConstructor, &rt.name##ArrayPrototype); \
+#define TYPED_ARRAY(name, type)                                            \
+  CallResult<HermesValue> name##ArrayConstructor(void *ctx, Runtime &rt) { \
+    NativeArgs args = rt.getCurrentFrame().getNativeArgs();                \
+    return typedArrayConstructor<type, CellKind::name##ArrayKind>(         \
+        ctx,                                                               \
+        rt,                                                                \
+        args,                                                              \
+        &rt.name##ArrayConstructor,                                        \
+        &rt.name##ArrayPrototype,                                          \
+        &rt.class##name##Array);                                           \
   }
 #include "hermes/VM/TypedArrays.def"
 #undef TYPED_ARRAY

--- a/lib/VM/JSMapImpl.cpp
+++ b/lib/VM/JSMapImpl.cpp
@@ -56,14 +56,37 @@ void JSMapImpl<C>::_finalizeImpl(GCCell *cell, GC &gc) {
 }
 
 template <CellKind C>
+PseudoHandle<JSMapImpl<C>> JSMapImpl<C>::create(Runtime &runtime) {
+  Handle<JSObject> prototype = runtime.mapPrototype;
+  Handle<HiddenClass> clazz = runtime.classJSMap;
+  if constexpr (C == CellKind::JSMapKind) {
+    prototype = runtime.mapPrototype;
+    clazz = runtime.classJSMap;
+  } else {
+    static_assert(C == CellKind::JSSetKind, "Unexpected CellKind");
+    prototype = runtime.setPrototype;
+    clazz = runtime.classJSSet;
+  }
+  auto *cell = runtime.makeAFixed<JSMapImpl, HasFinalizer::Yes>(
+      runtime, prototype, clazz);
+  return JSObjectInit::initToPseudoHandle(runtime, cell);
+}
+
+template <CellKind C>
 PseudoHandle<JSMapImpl<C>> JSMapImpl<C>::create(
     Runtime &runtime,
     Handle<JSObject> parentHandle) {
+  Handle<HiddenClass> clazz = runtime.classJSMap;
+  if constexpr (C == CellKind::JSMapKind) {
+    clazz =
+        runtime.getHiddenClassForPrototype(*parentHandle, runtime.classJSMap);
+  } else {
+    static_assert(C == CellKind::JSSetKind, "Unexpected CellKind");
+    clazz =
+        runtime.getHiddenClassForPrototype(*parentHandle, runtime.classJSSet);
+  }
   auto *cell = runtime.makeAFixed<JSMapImpl, HasFinalizer::Yes>(
-      runtime,
-      parentHandle,
-      runtime.getHiddenClassForPrototype(
-          *parentHandle, numOverlapSlots<JSMapImpl>()));
+      runtime, parentHandle, clazz);
   return JSObjectInit::initToPseudoHandle(runtime, cell);
 }
 
@@ -119,11 +142,17 @@ template <CellKind C>
 PseudoHandle<JSMapIteratorImpl<C>> JSMapIteratorImpl<C>::create(
     Runtime &runtime,
     Handle<JSObject> prototype) {
+  Handle<HiddenClass> clazz = runtime.classJSMapIterator;
+  if constexpr (C == CellKind::JSMapIteratorKind) {
+    clazz = runtime.getHiddenClassForPrototype(
+        *prototype, runtime.classJSMapIterator);
+  } else {
+    static_assert(C == CellKind::JSSetIteratorKind, "Unexpected CellKind");
+    clazz = runtime.getHiddenClassForPrototype(
+        *prototype, runtime.classJSSetIterator);
+  }
   auto *cell = runtime.makeAFixed<JSMapIteratorImpl<C>, HasFinalizer::Yes>(
-      runtime,
-      prototype,
-      runtime.getHiddenClassForPrototype(
-          *prototype, numOverlapSlots<JSMapIteratorImpl>()));
+      runtime, prototype, clazz);
   return JSObjectInit::initToPseudoHandle(runtime, cell);
 }
 

--- a/lib/VM/JSObject.cpp
+++ b/lib/VM/JSObject.cpp
@@ -293,7 +293,7 @@ CallResult<bool> JSObject::setParent(
   // parent chain that would prevent adding the property to the cached
   // HiddenClass.
   // We must break the cache, so increment the epoch.
-  if (LLVM_UNLIKELY(self->flags_.isCachedUsingEpoch)) {
+  if (LLVM_UNLIKELY(self->isCachedUsingEpoch(runtime))) {
     runtime.incParentCacheEpoch();
   }
 
@@ -2921,6 +2921,21 @@ bool JSObject::isFrozen(PseudoHandle<JSObject> self, Runtime &runtime) {
   return true;
 }
 
+void JSObject::setCachedUsingEpoch(Handle<JSObject> self, Runtime &runtime) {
+  struct : public Locals {
+    PinnedValue<HiddenClass> clazz;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
+
+  lv.clazz = self->getClass(runtime);
+  HiddenClass *newClazz =
+      HiddenClass::markAsCachedUsingEpoch(lv.clazz, runtime);
+  // Ensure that the epoch doesn't get incremented during this operation
+  // We're just flipping the flag on the HiddenClass, so it's safe to bypass the
+  // increment in this case.
+  self->updateClassIgnoringEpochUnsafe(runtime, newClazz);
+}
+
 CallResult<bool> JSObject::addOwnProperty(
     Handle<JSObject> selfHandle,
     Runtime &runtime,
@@ -2995,52 +3010,60 @@ void JSObject::tryCacheAddProperty(
       HiddenClass::kDictionaryThreshold < WritePropertyCacheEntry::kMaxSlot);
   assert(slot <= WritePropertyCacheEntry::kMaxSlot);
 
-  NoAllocScope noAlloc{runtime};
+  {
+    NoAllocScope noAlloc{runtime};
 
-  // If any parents are dictionaries, they won't have their HiddenClass change
-  // when properties are modified. Parent cache epoch is incremented when the
-  // HiddenClass changes, so we can't cache this add.
-  // Perform this check up here to avoid allocating an unused add cache entry if
-  // the check fails.
-  for (JSObject *cur = self->getParent(runtime); cur != nullptr;
-       cur = cur->getParent(runtime)) {
-    if (cur->getClass(runtime)->isDictionary())
-      return;
-  }
-
-  uint32_t parentCacheEpoch = runtime.getParentCacheEpoch();
-  uint32_t addCacheIndex = writeCacheEntry->getAddCacheIndex();
-  if (addCacheIndex == 0) {
-    // Need to allocate a new AddPropertyCacheEntry in the RuntimeModule.
-    if (auto optIdx = runtimeModule ? runtimeModule->allocateAddCacheEntry()
-                                    : sh_unit_allocate_add_cache_entry(unit)) {
-      addCacheIndex = *optIdx;
-      writeCacheEntry->setAddCacheIndex(addCacheIndex);
-    } else {
-      // Might fail if we're out of bits to use for the index.
-      return;
+    // If any parents are dictionaries, they won't have their HiddenClass change
+    // when properties are modified. Parent cache epoch is incremented when the
+    // HiddenClass changes, so we can't cache this add.
+    // Perform this check up here to avoid allocating an unused add cache entry
+    // if the check fails.
+    for (JSObject *cur = self->getParent(runtime); cur != nullptr;
+         cur = cur->getParent(runtime)) {
+      if (cur->getClass(runtime)->isDictionary())
+        return;
     }
+
+    uint32_t parentCacheEpoch = runtime.getParentCacheEpoch();
+    uint32_t addCacheIndex = writeCacheEntry->getAddCacheIndex();
+    if (addCacheIndex == 0) {
+      // Need to allocate a new AddPropertyCacheEntry in the RuntimeModule.
+      if (auto optIdx = runtimeModule
+              ? runtimeModule->allocateAddCacheEntry()
+              : sh_unit_allocate_add_cache_entry(unit)) {
+        addCacheIndex = *optIdx;
+        writeCacheEntry->setAddCacheIndex(addCacheIndex);
+      } else {
+        // Might fail if we're out of bits to use for the index.
+        return;
+      }
+    }
+
+    assert(
+        writeCacheEntry->getAddCacheIndex() == addCacheIndex &&
+        addCacheIndex != 0);
+
+    // Populate AddPropertyCacheEntry.
+    AddPropertyCacheEntry &addCacheEntry = runtimeModule
+        ? runtimeModule->getAddCacheEntry(addCacheIndex)
+        : sh_unit_get_add_cache_entry(unit, addCacheIndex);
+    addCacheEntry.setParentEpochAndSlot(parentCacheEpoch, slot);
+    addCacheEntry.startClazz =
+        CompressedPointer::encodeNonNull(startClazz, runtime);
+    addCacheEntry.resultClazz =
+        CompressedPointer::encodeNonNull(resultClazz, runtime);
+    addCacheEntry.parent = self->getParentGCPtr(runtime);
   }
 
-  assert(
-      writeCacheEntry->getAddCacheIndex() == addCacheIndex &&
-      addCacheIndex != 0);
-
-  // Populate AddPropertyCacheEntry.
-  AddPropertyCacheEntry &addCacheEntry = runtimeModule
-      ? runtimeModule->getAddCacheEntry(addCacheIndex)
-      : sh_unit_get_add_cache_entry(unit, addCacheIndex);
-  addCacheEntry.setParentEpochAndSlot(parentCacheEpoch, slot);
-  addCacheEntry.startClazz =
-      CompressedPointer::encodeNonNull(startClazz, runtime);
-  addCacheEntry.resultClazz =
-      CompressedPointer::encodeNonNull(resultClazz, runtime);
-  addCacheEntry.parent = self->getParentGCPtr(runtime);
+  struct : public Locals {
+    PinnedValue<JSObject> cur;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
 
   // Mark everything along the prototype chain as a cached parent.
-  for (JSObject *cur = self->getParent(runtime); cur != nullptr;
-       cur = cur->getParent(runtime)) {
-    cur->flags_.isCachedUsingEpoch = 1;
+  for (lv.cur = self->getParent(runtime); lv.cur.get() != nullptr;
+       lv.cur = lv.cur->getParent(runtime)) {
+    JSObject::setCachedUsingEpoch(lv.cur, runtime);
   }
 }
 

--- a/lib/VM/JSObject.cpp
+++ b/lib/VM/JSObject.cpp
@@ -301,8 +301,24 @@ CallResult<bool> JSObject::setParent(
     runtime.incParentCacheEpoch();
   }
 
+  struct : public Locals {
+    PinnedValue<HiddenClass> clazz;
+    PinnedValue<JSObject> self;
+    PinnedValue<JSObject> parent;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
+
+  lv.self = self;
+  lv.clazz = lv.self->getClass(runtime);
+  lv.parent = parent;
+
   // 9.
-  self->parent_.set(runtime, parent, runtime.getHeap());
+  lv.self->parent_.set(runtime, *lv.parent, runtime.getHeap());
+
+  lv.clazz = HiddenClass::updateObjectParent(
+      lv.clazz, runtime, createPseudoHandle(*lv.parent));
+  lv.self->updateClass(runtime, *lv.clazz);
+
   // 10.
   return true;
 }
@@ -1040,6 +1056,7 @@ JSObject *JSObject::getNamedDescriptorUnsafe(
         runtime, selfHandle->parent_.getNonNull(runtime)};
 
     do {
+      GCScopeMarkerRAII marker{runtime};
       // Check the most common case first, at the cost of some code duplication.
       if (LLVM_LIKELY(
               !mutableSelfHandle->flags_.lazyObject &&
@@ -2624,12 +2641,12 @@ void JSObject::_snapshotAddEdgesImpl(GCCell *cell, GC &gc, HeapSnapshot &snap) {
 
   // Add the prototype as a property edge, so it's easy for JS developers to
   // walk the prototype chain on their own.
-  if (self->parent_) {
+  if (self->getParentGCPtr(gc.getPointerBase())) {
     snap.addNamedEdge(
         HeapSnapshot::EdgeType::Property,
         // __proto__ chosen for similarity to V8.
         "__proto__",
-        gc.getObjectID(self->parent_));
+        gc.getObjectID(self->getParent(gc.getPointerBase())));
   }
 
   HiddenClass::forEachPropertyNoAlloc(

--- a/lib/VM/JSObject.cpp
+++ b/lib/VM/JSObject.cpp
@@ -270,7 +270,7 @@ CallResult<bool> JSObject::setParent(
         "Cannot set prototype of immutable prototype object");
   }
   // 5.
-  if (!self->isExtensible()) {
+  if (!self->isExtensible(runtime)) {
     if (opFlags.getThrowOnError()) {
       return runtime.raiseTypeError("Object is not extensible.");
     } else {
@@ -1910,7 +1910,7 @@ CallResult<bool> JSObject::putComputedWithReceiver_RJS(
   }
 
   /// Can we add more properties?
-  if (LLVM_UNLIKELY(!receiverHandle->isExtensible())) {
+  if (LLVM_UNLIKELY(!receiverHandle->isExtensible(runtime))) {
     if (opFlags.getThrowOnError()) {
       return runtime.raiseTypeError(
           "cannot add a new property"); // TODO: better message.
@@ -2398,7 +2398,7 @@ CallResult<bool> JSObject::defineOwnComputedPrimitive(
   }
 
   /// Can we add new properties?
-  if (!selfHandle->isExtensible()) {
+  if (!selfHandle->isExtensible(runtime)) {
     if (opFlags.getThrowOnError()) {
       return runtime.raiseTypeError(
           "cannot add a new property"); // TODO: better message.
@@ -2759,11 +2759,17 @@ HermesValue JSObject::_jitCallImpl(Runtime *runtime, JSObject *self) {
 
 void JSObject::preventExtensionsNonProxy(
     Handle<JSObject> self,
-    PointerBase &pb) {
+    Runtime &runtime) {
   assert(
-      !self->isProxyObject(pb) &&
+      !self->isProxyObject(runtime) &&
       "[[Extensible]] slot cannot be set directly on Proxy objects");
-  self->flags_.noExtend = true;
+  struct : public Locals {
+    PinnedValue<HiddenClass> clazz;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
+  lv.clazz = self->getClass(runtime);
+  HiddenClass *newClazz = HiddenClass::markNoExtend(lv.clazz, runtime);
+  self->updateClass(runtime, newClazz);
 }
 
 CallResult<bool> JSObject::preventExtensions(
@@ -2778,23 +2784,30 @@ CallResult<bool> JSObject::preventExtensions(
 }
 
 ExecutionStatus JSObject::seal(Handle<JSObject> selfHandle, Runtime &runtime) {
-  CallResult<bool> statusRes = JSObject::preventExtensions(
-      selfHandle, runtime, PropOpFlags().plusThrowOnError());
-  if (LLVM_UNLIKELY(statusRes == ExecutionStatus::EXCEPTION)) {
-    return ExecutionStatus::EXCEPTION;
+  if (LLVM_UNLIKELY(selfHandle->isProxyObject(runtime))) {
+    CallResult<bool> statusRes = JSProxy::preventExtensions(
+        selfHandle, runtime, PropOpFlags().plusThrowOnError());
+    if (LLVM_UNLIKELY(statusRes == ExecutionStatus::EXCEPTION)) {
+      return ExecutionStatus::EXCEPTION;
+    }
+    assert(
+        *statusRes &&
+        "seal preventExtensions with ThrowOnError returned false");
   }
-  assert(
-      *statusRes && "seal preventExtensions with ThrowOnError returned false");
+
+  struct : public Locals {
+    PinnedValue<HiddenClass> clazz;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
+
+  lv.clazz = selfHandle->getClass(runtime);
 
   // Already sealed?
-  if (selfHandle->flags_.sealed)
+  if (lv.clazz->isSealed())
     return ExecutionStatus::RETURNED;
 
-  auto newClazz = HiddenClass::makeAllNonConfigurable(
-      runtime.makeHandle(selfHandle->getClassGCPtr()), runtime);
-  selfHandle->updateClass(runtime, *newClazz);
-
-  selfHandle->flags_.sealed = true;
+  lv.clazz = HiddenClass::seal(lv.clazz, runtime);
+  selfHandle->updateClass(runtime, *lv.clazz);
 
   return ExecutionStatus::RETURNED;
 }
@@ -2802,25 +2815,28 @@ ExecutionStatus JSObject::seal(Handle<JSObject> selfHandle, Runtime &runtime) {
 ExecutionStatus JSObject::freeze(
     Handle<JSObject> selfHandle,
     Runtime &runtime) {
-  CallResult<bool> statusRes = JSObject::preventExtensions(
-      selfHandle, runtime, PropOpFlags().plusThrowOnError());
-  if (LLVM_UNLIKELY(statusRes == ExecutionStatus::EXCEPTION)) {
-    return ExecutionStatus::EXCEPTION;
+  if (LLVM_UNLIKELY(selfHandle->isProxyObject(runtime))) {
+    CallResult<bool> statusRes = JSProxy::preventExtensions(
+        selfHandle, runtime, PropOpFlags().plusThrowOnError());
+    if (LLVM_UNLIKELY(statusRes == ExecutionStatus::EXCEPTION)) {
+      return ExecutionStatus::EXCEPTION;
+    }
+    assert(*statusRes && "preventExtensions with ThrowOnError returned false");
   }
-  assert(
-      *statusRes &&
-      "freeze preventExtensions with ThrowOnError returned false");
+
+  struct : public Locals {
+    PinnedValue<HiddenClass> clazz;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
+
+  lv.clazz = selfHandle->getClass(runtime);
 
   // Already frozen?
-  if (selfHandle->flags_.frozen)
+  if (lv.clazz->isFrozen())
     return ExecutionStatus::RETURNED;
 
-  auto newClazz = HiddenClass::makeAllReadOnly(
-      runtime.makeHandle(selfHandle->getClassGCPtr()), runtime);
-  selfHandle->updateClass(runtime, *newClazz);
-
-  selfHandle->flags_.frozen = true;
-  selfHandle->flags_.sealed = true;
+  lv.clazz = HiddenClass::freeze(lv.clazz, runtime);
+  selfHandle->updateClass(runtime, *lv.clazz);
 
   return ExecutionStatus::RETURNED;
 }
@@ -2846,57 +2862,65 @@ CallResult<bool> JSObject::isExtensible(
   if (LLVM_UNLIKELY(self->isProxyObject(runtime))) {
     return JSProxy::isExtensible(runtime.makeHandle(std::move(self)), runtime);
   }
-  return self->isExtensible();
+  return self->isExtensible(runtime);
 }
 
 bool JSObject::isSealed(PseudoHandle<JSObject> self, Runtime &runtime) {
-  if (self->flags_.sealed)
+  if (self->getClass(runtime)->isSealed())
     return true;
-  if (!self->flags_.noExtend)
+  if (self->getClass(runtime)->isExtensible())
     return false;
 
-  auto selfHandle = runtime.makeHandle(std::move(self));
+  struct : public Locals {
+    PinnedValue<JSObject> self;
+    PinnedValue<HiddenClass> clazz;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
 
-  if (!HiddenClass::areAllNonConfigurable(
-          runtime.makeHandle(selfHandle->getClassGCPtr()), runtime)) {
+  lv.self = std::move(self);
+  lv.clazz = lv.self->getClass(runtime);
+
+  if (!HiddenClass::areAllNonConfigurable(lv.clazz, runtime)) {
     return false;
   }
 
   if (!checkAllOwnIndexed(
-          *selfHandle,
+          *lv.self,
           runtime,
           ObjectVTable::CheckAllOwnIndexedMode::NonConfigurable)) {
     return false;
   }
 
-  // Now that we know we are sealed, set the flag.
-  selfHandle->flags_.sealed = true;
+  lv.clazz = HiddenClass::markAsSealed(lv.clazz, runtime);
+  lv.self->updateClass(runtime, *lv.clazz);
+
   return true;
 }
 
 bool JSObject::isFrozen(PseudoHandle<JSObject> self, Runtime &runtime) {
-  if (self->flags_.frozen)
+  if (self->getClass(runtime)->isFrozen())
     return true;
-  if (!self->flags_.noExtend)
+  if (self->getClass(runtime)->isExtensible())
     return false;
 
-  auto selfHandle = runtime.makeHandle(std::move(self));
+  struct : public Locals {
+    PinnedValue<JSObject> self;
+    PinnedValue<HiddenClass> clazz;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
 
-  if (!HiddenClass::areAllReadOnly(
-          runtime.makeHandle(selfHandle->getClassGCPtr()), runtime)) {
+  lv.self = std::move(self);
+  lv.clazz = lv.self->getClass(runtime);
+
+  if (!HiddenClass::areAllReadOnly(lv.clazz, runtime)) {
     return false;
   }
 
   if (!checkAllOwnIndexed(
-          *selfHandle,
-          runtime,
-          ObjectVTable::CheckAllOwnIndexedMode::ReadOnly)) {
+          *lv.self, runtime, ObjectVTable::CheckAllOwnIndexedMode::ReadOnly)) {
     return false;
   }
 
-  // Now that we know we are sealed, set the flag.
-  selfHandle->flags_.frozen = true;
-  selfHandle->flags_.sealed = true;
   return true;
 }
 
@@ -2911,7 +2935,7 @@ CallResult<bool> JSObject::addOwnProperty(
     SHUnit *unit,
     WritePropertyCacheEntry *cacheEntry) {
   /// Can we add more properties?
-  if (!selfHandle->isExtensible() && !opFlags.getInternalForce()) {
+  if (!selfHandle->isExtensible(runtime) && !opFlags.getInternalForce()) {
     if (opFlags.getThrowOnError()) {
       return runtime.raiseTypeError(
           TwineChar16("Cannot add new property '") +

--- a/lib/VM/JSObject.cpp
+++ b/lib/VM/JSObject.cpp
@@ -80,7 +80,6 @@ void JSObjectBuildMeta(const GCCell *cell, Metadata::Builder &mb) {
   const auto *self = static_cast<const JSObject *>(cell);
   mb.setVTable(&JSObject::vt);
   mb.setJitCall(&JSObject::_jitCallImpl);
-  mb.addField("parent", &self->parent_);
   mb.addField("class", &self->clazzDoNotAccessDirectly_);
   mb.addField("propStorage", &self->propStorage_);
 
@@ -252,7 +251,7 @@ CallResult<bool> JSObject::setParent(
   }
   // ES9 9.1.2
   // 4.
-  if (self->parent_.get(runtime) == parent)
+  if (self->getParent(runtime) == parent)
     return true;
   // ES2022 10.4.7 Immutable Prototype Exotic Objects
   // The [[SetPrototypeOf]] for %Object.prototype% is supposed to be
@@ -279,7 +278,7 @@ CallResult<bool> JSObject::setParent(
     }
   }
   // 6-8. Check for a prototype cycle.
-  for (JSObject *cur = parent; cur; cur = cur->parent_.get(runtime)) {
+  for (JSObject *cur = parent; cur; cur = cur->getParent(runtime)) {
     if (cur == self) {
       if (opFlags.getThrowOnError()) {
         return runtime.raiseTypeError("Prototype cycle detected");
@@ -313,8 +312,6 @@ CallResult<bool> JSObject::setParent(
   lv.parent = parent;
 
   // 9.
-  lv.self->parent_.set(runtime, *lv.parent, runtime.getHeap());
-
   lv.clazz = HiddenClass::updateObjectParent(
       lv.clazz, runtime, createPseudoHandle(*lv.parent));
   lv.self->updateClass(runtime, *lv.clazz);
@@ -1051,9 +1048,8 @@ JSObject *JSObject::getNamedDescriptorUnsafe(
     return *selfHandle;
   }
 
-  if (selfHandle->parent_) {
-    MutableHandle<JSObject> mutableSelfHandle{
-        runtime, selfHandle->parent_.getNonNull(runtime)};
+  if (auto *parentRawPtr = selfHandle->getParent(runtime)) {
+    MutableHandle<JSObject> mutableSelfHandle{runtime, parentRawPtr};
 
     do {
       GCScopeMarkerRAII marker{runtime};
@@ -1085,7 +1081,7 @@ JSObject *JSObject::getNamedDescriptorUnsafe(
         desc.slot = name.unsafeGetRaw();
         return *mutableSelfHandle;
       }
-    } while ((mutableSelfHandle = mutableSelfHandle->parent_.get(runtime)));
+    } while ((mutableSelfHandle = mutableSelfHandle->getParent(runtime)));
   }
 
   return nullptr;

--- a/lib/VM/JSObject.cpp
+++ b/lib/VM/JSObject.cpp
@@ -2992,7 +2992,7 @@ void JSObject::tryCacheAddProperty(
       CompressedPointer::encodeNonNull(startClazz, runtime);
   addCacheEntry.resultClazz =
       CompressedPointer::encodeNonNull(resultClazz, runtime);
-  addCacheEntry.parent = self->getParentGCPtr();
+  addCacheEntry.parent = self->getParentGCPtr(runtime);
 
   // Mark everything along the prototype chain as a cached parent.
   for (JSObject *cur = self->getParent(runtime); cur != nullptr;

--- a/lib/VM/JSObject.cpp
+++ b/lib/VM/JSObject.cpp
@@ -176,9 +176,6 @@ PseudoHandle<JSObject> JSObject::create(
     result = JSObjectInit::initToPseudoHandle(runtime, obj);
   }
 
-  if (LLVM_UNLIKELY(result->getClass(runtime)->getHasIndexLikeProperties()))
-    result->flags_.fastIndexProperties = false;
-
   return result;
 }
 
@@ -866,7 +863,7 @@ inline CallResult<bool> getOwnComputedPrimitiveDescriptorImpl(
   // Try the fast paths first if we have "fast" index properties and the
   // property name is an obvious index.
   if (auto arrayIndex = toArrayIndexFastPath(*nameValHandle)) {
-    if (JSObject::Helper::flags(*selfHandle).fastIndexProperties) {
+    if (selfHandle->hasFastIndexProperties(runtime)) {
       auto res = JSObject::Helper::getOwnIndexedPropertyFlags(
           selfHandle.get(), runtime, *arrayIndex);
       if (res) {
@@ -905,7 +902,7 @@ inline CallResult<bool> getOwnComputedPrimitiveDescriptorImpl(
   }
 
   if (LLVM_LIKELY(
-          !JSObject::Helper::flags(*selfHandle).indexedStorage &&
+          !selfHandle->hasIndexedStorage(runtime) &&
           !selfHandle->isLazy(runtime) &&
           !selfHandle->isProxyObject(runtime))) {
     return false;
@@ -913,7 +910,7 @@ inline CallResult<bool> getOwnComputedPrimitiveDescriptorImpl(
 
   // If we have indexed storage, perform potentially expensive conversions
   // to array index and check it.
-  if (JSObject::Helper::flags(*selfHandle).indexedStorage) {
+  if (selfHandle->hasIndexedStorage(runtime)) {
     // If the name is a valid integer array index, store it here.
     OptValue<uint32_t> arrayIndex;
 
@@ -1243,7 +1240,7 @@ CallResult<PseudoHandle<>> JSObject::getNamedOrIndexed(
     Runtime &runtime,
     SymbolID name,
     PropOpFlags opFlags) {
-  if (LLVM_UNLIKELY(selfHandle->flags_.indexedStorage)) {
+  if (LLVM_UNLIKELY(selfHandle->hasIndexedStorage(runtime))) {
     // Note that getStringView can be satisfied without materializing the
     // Identifier.
     const auto strView =
@@ -1268,7 +1265,7 @@ CallResult<PseudoHandle<>> JSObject::getComputedWithReceiver_RJS(
     Handle<> receiver) {
   // Try the fast-path first: no "index-like" properties and the "name" already
   // is a valid integer index.
-  if (selfHandle->flags_.fastIndexProperties) {
+  if (selfHandle->hasFastIndexProperties(runtime)) {
     if (auto arrayIndex = toArrayIndexFastPath(*nameValHandle)) {
       // Do we have this value present in our array storage? If so, return it.
       PseudoHandle<> ourValue =
@@ -1353,14 +1350,14 @@ CallResult<bool> JSObject::hasNamedOrIndexed(
     Handle<JSObject> selfHandle,
     Runtime &runtime,
     SymbolID name) {
-  if (LLVM_UNLIKELY(selfHandle->flags_.indexedStorage)) {
+  if (LLVM_UNLIKELY(selfHandle->hasIndexedStorage(runtime))) {
     const auto strView =
         runtime.getIdentifierTable().getStringView(runtime, name);
     if (auto nameAsIndex = toArrayIndex(strView)) {
       if (haveOwnIndexed(selfHandle.get(), runtime, *nameAsIndex)) {
         return true;
       }
-      if (selfHandle->flags_.fastIndexProperties) {
+      if (selfHandle->hasFastIndexProperties(runtime)) {
         return false;
       }
     }
@@ -1377,7 +1374,7 @@ CallResult<bool> JSObject::hasComputed(
     Handle<> nameValHandle) {
   // Try the fast-path first: no "index-like" properties and the "name" already
   // is a valid integer index.
-  if (selfHandle->flags_.fastIndexProperties) {
+  if (selfHandle->hasFastIndexProperties(runtime)) {
     if (auto arrayIndex = toArrayIndexFastPath(*nameValHandle)) {
       // Do we have this value present in our array storage? If so, return true.
       if (haveOwnIndexed(selfHandle.get(), runtime, *arrayIndex)) {
@@ -1653,7 +1650,7 @@ CallResult<bool> JSObject::putNamedOrIndexed(
     SymbolID name,
     Handle<> valueHandle,
     PropOpFlags opFlags) {
-  if (LLVM_UNLIKELY(selfHandle->flags_.indexedStorage)) {
+  if (LLVM_UNLIKELY(selfHandle->hasIndexedStorage(runtime))) {
     // Note that getStringView can be satisfied without materializing the
     // Identifier.
     const auto strView =
@@ -1687,7 +1684,7 @@ CallResult<bool> JSObject::putComputedWithReceiver_RJS(
   // Try the fast-path first: has "index-like" properties, the "name"
   // already is a valid integer index, selfHandle and receiver are the
   // same, and it is present in storage.
-  if (selfHandle->flags_.fastIndexProperties) {
+  if (selfHandle->hasFastIndexProperties(runtime)) {
     if (auto arrayIndex = toArrayIndexFastPath(*nameValHandle)) {
       if (selfHandle.getHermesValue().getRaw() == receiver->getRaw()) {
         if (haveOwnIndexed(selfHandle.get(), runtime, *arrayIndex)) {
@@ -1920,7 +1917,7 @@ CallResult<bool> JSObject::putComputedWithReceiver_RJS(
 
   // If we have indexed storage we must check whether the property is an index,
   // and if it is, store it in indexed storage.
-  if (receiverHandle->flags_.indexedStorage) {
+  if (receiverHandle->hasIndexedStorage(runtime)) {
     OptValue<uint32_t> arrayIndex;
     StringPrimitive *strPrim = nullptr;
     TO_ARRAY_INDEX(runtime, nameValPrimitiveHandle, strPrim, arrayIndex);
@@ -2050,14 +2047,14 @@ CallResult<bool> JSObject::deleteComputed(
 
   // If we have indexed storage, we must attempt to convert the name to array
   // index, even if the conversion is expensive.
-  if (selfHandle->flags_.indexedStorage) {
+  if (selfHandle->hasIndexedStorage(runtime)) {
     StringPrimitive *strPrim = nullptr;
     TO_ARRAY_INDEX(runtime, nameValPrimitiveHandle, strPrim, arrayIndex);
   }
 
   // Try the fast-path first: the "name" is a valid array index and we don't
   // have "index-like" named properties.
-  if (arrayIndex && selfHandle->flags_.fastIndexProperties) {
+  if (arrayIndex && selfHandle->hasFastIndexProperties(runtime)) {
     // Delete the indexed property.
     if (deleteOwnIndexed(selfHandle, runtime, *arrayIndex))
       return true;
@@ -2277,7 +2274,7 @@ CallResult<bool> JSObject::defineOwnComputedPrimitive(
 
   // If we have indexed storage, we must attempt to convert the name to array
   // index, even if the conversion is expensive.
-  if (selfHandle->flags_.indexedStorage) {
+  if (selfHandle->hasIndexedStorage(runtime)) {
     StringPrimitive *strPrim = nullptr;
     TO_ARRAY_INDEX(runtime, nameValHandle, strPrim, arrayIndex);
   }
@@ -3086,10 +3083,6 @@ ExecutionStatus JSObject::addOwnPropertyImpl(
           ExecutionStatus::EXCEPTION)) {
     return ExecutionStatus::EXCEPTION;
   }
-
-  // If this is an index-like property, we need to clear the fast path flags.
-  if (LLVM_UNLIKELY(lv.resultClazz->getHasIndexLikeProperties()))
-    selfHandle->flags_.fastIndexProperties = false;
 
   if (cacheEntry && !lv.resultClazz->isDictionary()) {
     tryCacheAddProperty(

--- a/lib/VM/JSObject.cpp
+++ b/lib/VM/JSObject.cpp
@@ -10,14 +10,34 @@
 #include "SHUnitExt.h"
 #include "hermes/VM/BuildMetadata.h"
 #include "hermes/VM/Callable.h"
+#include "hermes/VM/DecoratedObject.h"
+#include "hermes/VM/Domain.h"
+#include "hermes/VM/FastArray.h"
 #include "hermes/VM/HostModel.h"
 #include "hermes/VM/InternalProperty.h"
 #include "hermes/VM/JSArray.h"
+#include "hermes/VM/JSCallSite.h"
+#include "hermes/VM/JSCallableProxy.h"
+#include "hermes/VM/JSDataView.h"
+#include "hermes/VM/JSDate.h"
+#include "hermes/VM/JSError.h"
+#include "hermes/VM/JSFinalizationRegistry.h"
+#include "hermes/VM/JSGeneratorObject.h"
+#include "hermes/VM/JSLib.h"
+#include "hermes/VM/JSLib/JSLibStorage.h"
+#include "hermes/VM/JSMapImpl.h"
 #include "hermes/VM/JSObject-inline.h"
 #include "hermes/VM/JSProxy.h"
+#include "hermes/VM/JSRegExp.h"
+#include "hermes/VM/JSRegExpStringIterator.h"
+#include "hermes/VM/JSTypedArray.h"
+#include "hermes/VM/JSWeakMapImpl.h"
+#include "hermes/VM/JSWeakRef.h"
 #include "hermes/VM/NativeState.h"
 #include "hermes/VM/Operations.h"
+#include "hermes/VM/PrimitiveBox.h"
 #include "hermes/VM/PropertyAccessor.h"
+#include "hermes/VM/SingleObject.h"
 #include "hermes/VM/StaticHUtils.h"
 
 #include "llvh/ADT/DenseSet.h"
@@ -78,94 +98,95 @@ void JSObjectBuildMeta(const GCCell *cell, Metadata::Builder &mb) {
   }
 }
 
-PseudoHandle<JSObject> JSObject::create(
-    Runtime &runtime,
-    Handle<JSObject> parentHandle) {
-  auto *cell = runtime.makeAFixed<JSObject>(
-      runtime,
-      parentHandle,
-      runtime.getHiddenClassForPrototype(
-          *parentHandle, numOverlapSlots<JSObject>()),
-      GCPointerBase::NoBarriers());
-  return JSObjectInit::initToPseudoHandle(runtime, cell);
+size_t JSObject::numOverlapSlotsForCellKind(CellKind k) {
+  switch (k) {
+#define CELL_JSOBJECT_NAME(name, vmClassName) \
+  case CellKind::name##Kind:                  \
+    return JSObject::numOverlapSlots<vmClassName>();
+#include "hermes/VM/CellKinds.def"
+    default:
+      hermes_fatal("CellKind does not have a known JS class");
+      return 0;
+  }
 }
 
 PseudoHandle<JSObject> JSObject::create(
     Runtime &runtime,
-    unsigned propertyCount) {
-  unsigned numIndirectSlots = propertyCount <= DIRECT_PROPERTY_SLOTS
-      ? 0
-      : propertyCount - DIRECT_PROPERTY_SLOTS;
-  if (numIndirectSlots == 0) {
-    // No indirect storage needed, so just pass through to create.
-    return create(runtime);
-  }
-
-  auto propStorageSize =
-      heapAlignSize(PropStorage::allocationSize(numIndirectSlots));
-  if (LLVM_UNLIKELY(propertyCount > maxYoungGenAllocationPropCount())) {
-    // The object and property storage together are too big to fit in the young
-    // gen together, so allocate them separately.
-    auto self = create(runtime);
-    return runtime.ignoreAllocationFailure(
-        JSObject::allocatePropStorage(std::move(self), runtime, propertyCount));
-  }
-
-  static_assert(
-      heapAlignSize(
-          PropStorage::allocationSize(
-              maxYoungGenAllocationPropCount() - DIRECT_PROPERTY_SLOTS) +
-              heapAlignSize(cellSize<JSObject>()) <=
-          GC::maxYoungGenAllocationSize()),
-      "maxYoungGenAllocationPropCount too large");
-
-  // Otherwise, allocate both parts together.
-  // This ensures both the object and the property storage are in the young gen.
-
-  auto parent = Handle<JSObject>::vmcast(&runtime.objectPrototype);
-  auto clazz =
-      runtime.getHiddenClassForPrototype(*parent, numOverlapSlots<JSObject>());
-
-  auto [obj, storage] = runtime.make2YoungGenUnsafe<JSObject, PropStorage>(
-      cellSize<JSObject>(),
-      std::tuple<
-          Runtime &,
-          Handle<JSObject>,
-          Handle<HiddenClass>,
-          GCPointerBase::NoBarriers>(
-          runtime, parent, clazz, GCPointerBase::NoBarriers()),
-      propStorageSize,
-      std::tuple{});
-
-  NoAllocScope noAlloc{runtime};
-
-  PropStorage::resizeWithinCapacity(storage, runtime, numIndirectSlots);
-  obj->propStorage_.set(runtime, storage, runtime.getHeap());
-
-  return JSObjectInit::initToPseudoHandle(runtime, obj);
+    Handle<JSObject> parentHandle) {
+  return create(
+      runtime,
+      parentHandle,
+      runtime.getHiddenClassForPrototype(*parentHandle, runtime.classJSObject));
 }
 
 PseudoHandle<JSObject> JSObject::create(
     Runtime &runtime,
     Handle<JSObject> parentHandle,
-    Handle<HiddenClass> clazz) {
-  auto obj = JSObject::create(runtime, clazz->getNumProperties());
-  obj->updateClass(runtime, *clazz);
-  // If the hidden class has index like property, we need to clear the fast path
-  // flag.
-  if (LLVM_UNLIKELY(obj->getClass(runtime)->getHasIndexLikeProperties()))
-    obj->flags_.fastIndexProperties = false;
-  obj->parent_.set(runtime, parentHandle.get(), runtime.getHeap());
-  return obj;
+    Handle<HiddenClass> clazz,
+    unsigned propertyCount) {
+  unsigned numIndirectSlots = propertyCount <= DIRECT_PROPERTY_SLOTS
+      ? 0
+      : propertyCount - DIRECT_PROPERTY_SLOTS;
+  auto propStorageSize =
+      heapAlignSize(PropStorage::allocationSize(numIndirectSlots));
+
+  PseudoHandle<JSObject> result;
+  if (numIndirectSlots == 0) {
+    // No indirect storage needed, so just create with no slots.
+    auto *cell = runtime.makeAFixed<JSObject>(
+        runtime, parentHandle, clazz, GCPointerBase::NoBarriers());
+    result = JSObjectInit::initToPseudoHandle(runtime, cell);
+  } else if (LLVM_UNLIKELY(propertyCount > maxYoungGenAllocationPropCount())) {
+    // The object and property storage together are too big to fit in the young
+    // gen together, so allocate them separately.
+    auto *cell = runtime.makeAFixed<JSObject>(
+        runtime, parentHandle, clazz, GCPointerBase::NoBarriers());
+    PseudoHandle<JSObject> self =
+        JSObjectInit::initToPseudoHandle(runtime, cell);
+    result = runtime.ignoreAllocationFailure(
+        JSObject::allocatePropStorage(std::move(self), runtime, propertyCount));
+  } else {
+    static_assert(
+        heapAlignSize(
+            PropStorage::allocationSize(
+                maxYoungGenAllocationPropCount() - DIRECT_PROPERTY_SLOTS) +
+                heapAlignSize(cellSize<JSObject>()) <=
+            GC::maxYoungGenAllocationSize()),
+        "maxYoungGenAllocationPropCount too large");
+
+    // Otherwise, allocate both parts together.
+    // This ensures both the object and the property storage are in the young
+    // gen.
+
+    auto [obj, storage] = runtime.make2YoungGenUnsafe<JSObject, PropStorage>(
+        cellSize<JSObject>(),
+        std::tuple<
+            Runtime &,
+            Handle<JSObject>,
+            Handle<HiddenClass>,
+            GCPointerBase::NoBarriers>(
+            runtime, parentHandle, clazz, GCPointerBase::NoBarriers()),
+        propStorageSize,
+        std::tuple{});
+
+    NoAllocScope noAlloc{runtime};
+
+    PropStorage::resizeWithinCapacity(storage, runtime, numIndirectSlots);
+    obj->propStorage_.set(runtime, storage, runtime.getHeap());
+
+    result = JSObjectInit::initToPseudoHandle(runtime, obj);
+  }
+
+  if (LLVM_UNLIKELY(result->getClass(runtime)->getHasIndexLikeProperties()))
+    result->flags_.fastIndexProperties = false;
+
+  return result;
 }
 
 void JSObject::initializeLazyObject(
     Runtime &runtime,
     Handle<JSObject> lazyObject) {
   assert(lazyObject->flags_.lazyObject && "object must be lazy");
-  assert(
-      lazyObject->getClass(runtime) == *runtime.lazyObjectClass &&
-      "lazy object must have lazy class");
   // object is now assumed to be a regular object.
   lazyObject->flags_.lazyObject = 0;
 

--- a/lib/VM/JSObject.cpp
+++ b/lib/VM/JSObject.cpp
@@ -185,13 +185,13 @@ PseudoHandle<JSObject> JSObject::create(
 void JSObject::initializeLazyObject(
     Runtime &runtime,
     Handle<JSObject> lazyObject) {
-  assert(lazyObject->flags_.lazyObject && "object must be lazy");
-  // object is now assumed to be a regular object.
-  lazyObject->flags_.lazyObject = 0;
+  assert(lazyObject->isLazy(runtime) && "object must be lazy");
 
   // only functions can be lazy.
   assert(vmisa<Callable>(lazyObject.get()) && "unexpected lazy object");
   Callable::defineLazyProperties(Handle<Callable>::vmcast(lazyObject), runtime);
+
+  assert(!lazyObject->isLazy(runtime) && "object must no longer be lazy");
 }
 
 ObjectID JSObject::getObjectID(JSObject *self, Runtime &runtime) {
@@ -210,7 +210,7 @@ ObjectID JSObject::getObjectID(JSObject *self, Runtime &runtime) {
 CallResult<PseudoHandle<JSObject>> JSObject::getPrototypeOf(
     PseudoHandle<JSObject> selfHandle,
     Runtime &runtime) {
-  if (LLVM_LIKELY(!selfHandle->isProxyObject())) {
+  if (LLVM_LIKELY(!selfHandle->isProxyObject(runtime))) {
     return createPseudoHandle(selfHandle->getParent(runtime));
   }
 
@@ -241,7 +241,7 @@ CallResult<bool> JSObject::setParent(
     Runtime &runtime,
     JSObject *parent,
     PropOpFlags opFlags) {
-  if (LLVM_UNLIKELY(self->isProxyObject())) {
+  if (LLVM_UNLIKELY(self->isProxyObject(runtime))) {
     return proxyOpFlags(
         runtime,
         opFlags,
@@ -285,7 +285,7 @@ CallResult<bool> JSObject::setParent(
       } else {
         return false;
       }
-    } else if (LLVM_UNLIKELY(cur->isProxyObject())) {
+    } else if (LLVM_UNLIKELY(cur->isProxyObject(runtime))) {
       // TODO this branch should also be used for module namespace and
       // immutable prototype exotic objects.
       break;
@@ -406,7 +406,7 @@ CallResult<PseudoHandle<>> JSObject::getComputedPropertyValueInternal_RJS(
     Handle<JSObject> propObj,
     ComputedPropertyDescriptor desc) {
   assert(
-      !selfHandle->flags_.proxyObject && !propObj->flags_.proxyObject &&
+      !selfHandle->isProxyObject(runtime) && !propObj->isProxyObject(runtime) &&
       "getComputedPropertyValue_RJS cannot be used with proxy objects");
 
   if (LLVM_LIKELY(!desc.flags.accessor))
@@ -460,8 +460,8 @@ CallResult<Handle<JSArray>> JSObject::getOwnPropertyKeys(
       (okFlags.getIncludeNonSymbols() || okFlags.getIncludeSymbols()) &&
       "Can't exclude symbols and strings");
   if (LLVM_UNLIKELY(
-          selfHandle->flags_.lazyObject || selfHandle->flags_.proxyObject)) {
-    if (selfHandle->flags_.proxyObject) {
+          selfHandle->isLazy(runtime) || selfHandle->isProxyObject(runtime))) {
+    if (selfHandle->isProxyObject(runtime)) {
       CallResult<PseudoHandle<JSArray>> proxyRes =
           JSProxy::ownPropertyKeys(selfHandle, runtime, okFlags);
       if (LLVM_UNLIKELY(proxyRes == ExecutionStatus::EXCEPTION)) {
@@ -469,7 +469,7 @@ CallResult<Handle<JSArray>> JSObject::getOwnPropertyKeys(
       }
       return runtime.makeHandle(std::move(*proxyRes));
     }
-    assert(selfHandle->flags_.lazyObject && "descriptor flags are impossible");
+    assert(selfHandle->isLazy(runtime) && "descriptor flags are impossible");
     initializeLazyObject(runtime, selfHandle);
   }
 
@@ -509,7 +509,7 @@ CallResult<Handle<JSArray>> JSObject::getOwnPropertyKeys(
   llvh::SmallVector<uint32_t, 8> indexNames{};
 
   // Get host object property names
-  if (LLVM_UNLIKELY(selfHandle->flags_.hostObject)) {
+  if (LLVM_UNLIKELY(selfHandle->isHostObject(runtime))) {
     assert(
         range.first == range.second && "Host objects cannot own indexed range");
     // Create a temporary handle to receive the host property names
@@ -883,8 +883,8 @@ inline CallResult<bool> getOwnComputedPrimitiveDescriptorImpl(
     }
 
     if (!selfHandle->getClass(runtime)->getHasIndexLikeProperties() &&
-        !selfHandle->isHostObject() && !selfHandle->isLazy() &&
-        !selfHandle->isProxyObject()) {
+        !selfHandle->isHostObject(runtime) && !selfHandle->isLazy(runtime) &&
+        !selfHandle->isProxyObject(runtime)) {
       // Early return to handle the case where an object definitely has no
       // index-like properties. This avoids allocating a new StringPrimitive and
       // uniquing it below.
@@ -906,7 +906,8 @@ inline CallResult<bool> getOwnComputedPrimitiveDescriptorImpl(
 
   if (LLVM_LIKELY(
           !JSObject::Helper::flags(*selfHandle).indexedStorage &&
-          !selfHandle->isLazy() && !selfHandle->isProxyObject())) {
+          !selfHandle->isLazy(runtime) &&
+          !selfHandle->isProxyObject(runtime))) {
     return false;
   }
 
@@ -935,13 +936,14 @@ inline CallResult<bool> getOwnComputedPrimitiveDescriptorImpl(
     return false;
   }
 
-  if (selfHandle->isLazy()) {
+  if (selfHandle->isLazy(runtime)) {
     JSObject::initializeLazyObject(runtime, selfHandle);
     return JSObject::getOwnComputedPrimitiveDescriptor(
         selfHandle, runtime, nameValHandle, ignoreProxy, desc);
   }
 
-  assert(selfHandle->isProxyObject() && "descriptor flags are impossible");
+  assert(
+      selfHandle->isProxyObject(runtime) && "descriptor flags are impossible");
   if (ignoreProxy == JSObject::IgnoreProxy::Yes) {
     return false;
   }
@@ -1002,7 +1004,7 @@ CallResult<bool> JSObject::getOwnComputedDescriptor(
         createPseudoHandle(selfHandle.get()), runtime, desc));
     return true;
   }
-  if (LLVM_UNLIKELY(selfHandle->isProxyObject())) {
+  if (LLVM_UNLIKELY(selfHandle->isProxyObject(runtime))) {
     return JSProxy::getOwnProperty(
         selfHandle, runtime, nameValHandle, desc, &valueOrAccessor);
   }
@@ -1024,16 +1026,16 @@ JSObject *JSObject::getNamedDescriptorUnsafe(
   // disambiguation however we want.  This is here in order to avoid
   // impacting perf for the common case where an own property exists
   // in normal storage.
-  if (LLVM_UNLIKELY(selfHandle->flags_.hostObject)) {
+  if (LLVM_UNLIKELY(selfHandle->isHostObject(runtime))) {
     desc.flags.hostObject = true;
     desc.flags.writable = true;
     desc.slot = name.unsafeGetRaw();
     return *selfHandle;
   }
 
-  if (LLVM_UNLIKELY(selfHandle->flags_.lazyObject)) {
+  if (LLVM_UNLIKELY(selfHandle->isLazy(runtime))) {
     assert(
-        !selfHandle->flags_.proxyObject &&
+        !selfHandle->isProxyObject(runtime) &&
         "Proxy objects should never be lazy");
     // Initialize the object and perform the lookup again.
     JSObject::initializeLazyObject(runtime, selfHandle);
@@ -1042,7 +1044,7 @@ JSObject *JSObject::getNamedDescriptorUnsafe(
       return *selfHandle;
   }
 
-  if (LLVM_UNLIKELY(selfHandle->flags_.proxyObject)) {
+  if (LLVM_UNLIKELY(selfHandle->isProxyObject(runtime))) {
     desc.flags.proxyObject = true;
     desc.slot = name.unsafeGetRaw();
     return *selfHandle;
@@ -1055,27 +1057,27 @@ JSObject *JSObject::getNamedDescriptorUnsafe(
       GCScopeMarkerRAII marker{runtime};
       // Check the most common case first, at the cost of some code duplication.
       if (LLVM_LIKELY(
-              !mutableSelfHandle->flags_.lazyObject &&
-              !mutableSelfHandle->flags_.hostObject &&
-              !mutableSelfHandle->flags_.proxyObject)) {
+              !mutableSelfHandle->isLazy(runtime) &&
+              !mutableSelfHandle->isHostObject(runtime) &&
+              !mutableSelfHandle->isProxyObject(runtime))) {
       findProp:
         if (findProperty(mutableSelfHandle, runtime, name, desc)) {
           assert(
-              !selfHandle->flags_.proxyObject &&
+              !selfHandle->isProxyObject(runtime) &&
               "Proxy object parents should never have own properties");
           return *mutableSelfHandle;
         }
-      } else if (LLVM_UNLIKELY(mutableSelfHandle->flags_.lazyObject)) {
+      } else if (LLVM_UNLIKELY(mutableSelfHandle->isLazy(runtime))) {
         JSObject::initializeLazyObject(runtime, mutableSelfHandle);
         goto findProp;
-      } else if (LLVM_UNLIKELY(mutableSelfHandle->flags_.hostObject)) {
+      } else if (LLVM_UNLIKELY(mutableSelfHandle->isHostObject(runtime))) {
         desc.flags.hostObject = true;
         desc.flags.writable = true;
         desc.slot = name.unsafeGetRaw();
         return *mutableSelfHandle;
       } else {
         assert(
-            mutableSelfHandle->flags_.proxyObject &&
+            mutableSelfHandle->isProxyObject(runtime) &&
             "descriptor flags are impossible");
         desc.flags.proxyObject = true;
         desc.slot = name.unsafeGetRaw();
@@ -1117,14 +1119,14 @@ ExecutionStatus JSObject::getComputedPrimitiveDescriptor(
       return ExecutionStatus::RETURNED;
     }
 
-    if (LLVM_UNLIKELY(propObj->flags_.hostObject)) {
+    if (LLVM_UNLIKELY(propObj->isHostObject(runtime))) {
       desc.flags.hostObject = true;
       desc.flags.writable = true;
       desc.slot = id.unsafeGetRaw();
       desc._tmpSymbolStorage.set(id);
       return ExecutionStatus::RETURNED;
     }
-    if (LLVM_UNLIKELY(propObj->flags_.proxyObject)) {
+    if (LLVM_UNLIKELY(propObj->isProxyObject(runtime))) {
       desc.flags.proxyObject = true;
       desc.slot = id.unsafeGetRaw();
       desc._tmpSymbolStorage.set(id);
@@ -1181,10 +1183,10 @@ CallResult<PseudoHandle<>> JSObject::getNamedWithReceiver_RJS(
     // The object must not be a proxy or HostObject, given that the descriptor
     // does not indicate them.
     assert(
-        !selfHandle->getFlags().proxyObject &&
-        !selfHandle->getFlags().hostObject);
+        !selfHandle->isProxyObject(runtime) &&
+        !selfHandle->isHostObject(runtime));
     // The object cannot be lazy after a lookup has occurred.
-    assert(!selfHandle->getFlags().lazyObject);
+    assert(!selfHandle->isLazy(runtime));
 
     // Populate the cache if requested.
     if (cacheEntry && desc.slot <= ReadPropertyCacheEntry::kMaxSlot &&
@@ -1433,7 +1435,7 @@ static ExecutionStatus raiseErrorForOverridingStaticBuiltin(
   auto *obj = JSObject::getNamedDescriptorPredefined(
       selfHandle, runtime, Predefined::name, desc);
   assert(
-      !selfHandle->isProxyObject() &&
+      !selfHandle->isProxyObject(runtime) &&
       "raiseErrorForOverridingStaticBuiltin cannot be used with proxy objects");
 
   if (!obj || desc.flags.accessor) {
@@ -1565,7 +1567,8 @@ CallResult<bool> JSObject::putNamedWithReceiver_RJS(
 
   MutableHandle<JSObject> receiverHandle{runtime, *selfHandle};
   if (selfHandle.getHermesValue().getRaw() != receiver->getRaw() ||
-      receiverHandle->isHostObject() || receiverHandle->isProxyObject()) {
+      receiverHandle->isHostObject(runtime) ||
+      receiverHandle->isProxyObject(runtime)) {
     if (selfHandle.getHermesValue().getRaw() != receiver->getRaw()) {
       receiverHandle = dyn_vmcast<JSObject>(*receiver);
     }
@@ -1579,7 +1582,8 @@ CallResult<bool> JSObject::putNamedWithReceiver_RJS(
       }
 
       assert(
-          !receiverHandle->isHostObject() && !receiverHandle->isProxyObject() &&
+          !receiverHandle->isHostObject(runtime) &&
+          !receiverHandle->isProxyObject(runtime) &&
           "getOwnNamedDescriptor never sets hostObject or proxyObject flags");
       auto shv = SmallHermesValue::encodeHermesValue(*valueHandle, runtime);
       setNamedSlotValueUnsafe(*receiverHandle, runtime, desc, shv);
@@ -1590,9 +1594,9 @@ CallResult<bool> JSObject::putNamedWithReceiver_RJS(
     // getOwnComputedPrimitiveDescriptor because it knows how to call
     // the [[getOwnProperty]] Proxy impl if needed.
     if (LLVM_UNLIKELY(
-            receiverHandle->isHostObject() ||
-            receiverHandle->isProxyObject())) {
-      if (receiverHandle->isHostObject()) {
+            receiverHandle->isHostObject(runtime) ||
+            receiverHandle->isProxyObject(runtime))) {
+      if (receiverHandle->isHostObject(runtime)) {
         return vmcast<HostObject>(receiverHandle.get())
             ->set(name, *valueHandle);
       }
@@ -1824,7 +1828,8 @@ CallResult<bool> JSObject::putComputedWithReceiver_RJS(
 
   MutableHandle<JSObject> receiverHandle{runtime, *selfHandle};
   if (selfHandle.getHermesValue().getRaw() != receiver->getRaw() ||
-      receiverHandle->isHostObject() || receiverHandle->isProxyObject()) {
+      receiverHandle->isHostObject(runtime) ||
+      receiverHandle->isProxyObject(runtime)) {
     if (selfHandle.getHermesValue().getRaw() != receiver->getRaw()) {
       receiverHandle = dyn_vmcast<JSObject>(*receiver);
     }
@@ -1850,8 +1855,8 @@ CallResult<bool> JSObject::putComputedWithReceiver_RJS(
 
       if (LLVM_LIKELY(
               !existingDesc.flags.internalSetter &&
-              !receiverHandle->isHostObject() &&
-              !receiverHandle->isProxyObject())) {
+              !receiverHandle->isHostObject(runtime) &&
+              !receiverHandle->isProxyObject(runtime))) {
         if (LLVM_UNLIKELY(
                 setComputedSlotValueUnsafe(
                     receiverHandle, runtime, existingDesc, valueHandle) ==
@@ -1866,13 +1871,13 @@ CallResult<bool> JSObject::putComputedWithReceiver_RJS(
     // but it's a corner case; or, there was no descriptor.
     if (LLVM_UNLIKELY(
             existingDesc.flags.internalSetter ||
-            receiverHandle->isHostObject() ||
-            receiverHandle->isProxyObject())) {
+            receiverHandle->isHostObject(runtime) ||
+            receiverHandle->isProxyObject(runtime))) {
       // If putComputed is called on a proxy whose target's prototype
       // is an array with a propname of 'length', then internalSetter
       // will be true, and the receiver will be a proxy.  In that case,
       // proxy wins.
-      if (receiverHandle->isProxyObject()) {
+      if (receiverHandle->isProxyObject(runtime)) {
         if (*descDefinedRes) {
           dpf.setValue = 1;
         } else {
@@ -1898,7 +1903,8 @@ CallResult<bool> JSObject::putComputedWithReceiver_RJS(
             opFlags);
       }
       assert(
-          receiverHandle->isHostObject() && "descriptor flags are impossible");
+          receiverHandle->isHostObject(runtime) &&
+          "descriptor flags are impossible");
       return vmcast<HostObject>(receiverHandle.get())->set(id, *valueHandle);
     }
   }
@@ -1979,17 +1985,18 @@ CallResult<bool> JSObject::deleteNamed(
   // If the property doesn't exist in this object, return success.
   if (!pos) {
     if (LLVM_LIKELY(
-            !selfHandle->flags_.lazyObject &&
-            !selfHandle->flags_.proxyObject)) {
+            !selfHandle->isLazy(runtime) &&
+            !selfHandle->isProxyObject(runtime))) {
       return true;
-    } else if (selfHandle->flags_.lazyObject) {
+    } else if (selfHandle->isLazy(runtime)) {
       // object is lazy, initialize and read again.
       initializeLazyObject(runtime, selfHandle);
       pos = findProperty(selfHandle, runtime, name, desc);
       if (!pos) // still not there, return true.
         return true;
     } else {
-      assert(selfHandle->flags_.proxyObject && "object flags are impossible");
+      assert(
+          selfHandle->isProxyObject(runtime) && "object flags are impossible");
       return proxyOpFlags(
           runtime,
           opFlags,
@@ -2064,7 +2071,7 @@ CallResult<bool> JSObject::deleteComputed(
   }
 
   // slow path, check if object is lazy before continuing.
-  if (LLVM_UNLIKELY(selfHandle->flags_.lazyObject)) {
+  if (LLVM_UNLIKELY(selfHandle->isLazy(runtime))) {
     // initialize and try again.
     initializeLazyObject(runtime, selfHandle);
     return deleteComputed(selfHandle, runtime, nameValHandle, opFlags);
@@ -2116,7 +2123,7 @@ CallResult<bool> JSObject::deleteComputed(
     auto newClazz = HiddenClass::deleteProperty(
         runtime.makeHandle(selfHandle->getClassGCPtr()), runtime, *pos);
     selfHandle->updateClass(runtime, *newClazz);
-  } else if (LLVM_UNLIKELY(selfHandle->flags_.proxyObject)) {
+  } else if (LLVM_UNLIKELY(selfHandle->isProxyObject(runtime))) {
     CallResult<Handle<>> key = toPropertyKey(runtime, nameValPrimitiveHandle);
     if (key == ExecutionStatus::EXCEPTION)
       return ExecutionStatus::EXCEPTION;
@@ -2172,8 +2179,8 @@ CallResult<bool> JSObject::defineOwnPropertyInternal(
   }
 
   if (LLVM_UNLIKELY(
-          selfHandle->flags_.lazyObject || selfHandle->flags_.proxyObject)) {
-    if (selfHandle->flags_.proxyObject) {
+          selfHandle->isLazy(runtime) || selfHandle->isProxyObject(runtime))) {
+    if (selfHandle->isProxyObject(runtime)) {
       return JSProxy::defineOwnProperty(
           selfHandle,
           runtime,
@@ -2185,7 +2192,7 @@ CallResult<bool> JSObject::defineOwnPropertyInternal(
           valueOrAccessor,
           opFlags);
     }
-    assert(selfHandle->flags_.lazyObject && "descriptor flags are impossible");
+    assert(selfHandle->isLazy(runtime) && "descriptor flags are impossible");
     // if the property was not found and the object is lazy we need to
     // initialize it and try again.
     JSObject::initializeLazyObject(runtime, selfHandle);
@@ -2204,7 +2211,7 @@ ExecutionStatus JSObject::defineNewOwnProperty(
     PropertyFlags propertyFlags,
     Handle<> valueOrAccessor) {
   assert(
-      (!selfHandle->flags_.proxyObject || propertyFlags.privateName) &&
+      (!selfHandle->isProxyObject(runtime) || propertyFlags.privateName) &&
       "cannot define non-private properties on Proxy");
   assert(
       !(propertyFlags.accessor && !valueOrAccessor.get().isPointer()) &&
@@ -2217,7 +2224,7 @@ ExecutionStatus JSObject::defineNewOwnProperty(
           selfHandle->getClass(runtime), runtime, name) &&
       "new property is already defined");
   // Ensure the object is non-lazy before adding the property.
-  if (selfHandle->isLazy())
+  if (selfHandle->isLazy(runtime))
     initializeLazyObject(runtime, selfHandle);
 
   return addOwnPropertyImpl(
@@ -2750,9 +2757,11 @@ HermesValue JSObject::_jitCallImpl(Runtime *runtime, JSObject *self) {
   _sh_throw_current(runtime);
 }
 
-void JSObject::preventExtensions(JSObject *self) {
+void JSObject::preventExtensionsNonProxy(
+    Handle<JSObject> self,
+    PointerBase &pb) {
   assert(
-      !self->flags_.proxyObject &&
+      !self->isProxyObject(pb) &&
       "[[Extensible]] slot cannot be set directly on Proxy objects");
   self->flags_.noExtend = true;
 }
@@ -2761,10 +2770,10 @@ CallResult<bool> JSObject::preventExtensions(
     Handle<JSObject> selfHandle,
     Runtime &runtime,
     PropOpFlags opFlags) {
-  if (LLVM_UNLIKELY(selfHandle->isProxyObject())) {
+  if (LLVM_UNLIKELY(selfHandle->isProxyObject(runtime))) {
     return JSProxy::preventExtensions(selfHandle, runtime, opFlags);
   }
-  JSObject::preventExtensions(*selfHandle);
+  JSObject::preventExtensionsNonProxy(selfHandle, runtime);
   return true;
 }
 
@@ -2834,7 +2843,7 @@ void JSObject::updatePropertyFlagsWithoutTransitions(
 CallResult<bool> JSObject::isExtensible(
     PseudoHandle<JSObject> self,
     Runtime &runtime) {
-  if (LLVM_UNLIKELY(self->isProxyObject())) {
+  if (LLVM_UNLIKELY(self->isProxyObject(runtime))) {
     return JSProxy::isExtensible(runtime.makeHandle(std::move(self)), runtime);
   }
   return self->isExtensible();
@@ -3025,7 +3034,7 @@ ExecutionStatus JSObject::addOwnPropertyImpl(
     WritePropertyCacheEntry *cacheEntry) {
   assert(
       propertyFlags.privateName ||
-      !selfHandle->flags_.proxyObject &&
+      !selfHandle->isProxyObject(runtime) &&
           "Internal non-private properties cannot be added to Proxy objects");
 
   struct : public Locals {
@@ -3606,7 +3615,7 @@ ExecutionStatus setProtoClasses(
       arr->clear(runtime);
       return ExecutionStatus::RETURNED;
     }
-    if (JSObject::Helper::flags(*head).lazyObject) {
+    if (head->isLazy(runtime)) {
       // Ensure all properties have been initialized before caching the hidden
       // class. Not doing this will result in changes to the hidden class
       // when getOwnPropertyKeys is called later.
@@ -3653,7 +3662,7 @@ uint32_t matchesProtoClasses(
   while (head.get()) {
     auto protoCls = arr->at(i++);
     if (protoCls.isNull() || protoCls.getObject() != head->getClassGCPtr() ||
-        head->isProxyObject()) {
+        head->isProxyObject(runtime)) {
       return 0;
     }
     head = head->getParent(runtime);

--- a/lib/VM/JSProxy.cpp
+++ b/lib/VM/JSProxy.cpp
@@ -96,7 +96,7 @@ PseudoHandle<JSProxy> JSProxy::create(Runtime &runtime) {
       // Proxy should not have an observable prototype, so we just set it to
       // null.
       Runtime::makeNullHandle<JSObject>(),
-      runtime.proxyClass);
+      runtime.getHiddenClassForPrototype(nullptr, runtime.classJSProxy));
 
   proxy->flags_.proxyObject = true;
 

--- a/lib/VM/JSProxy.cpp
+++ b/lib/VM/JSProxy.cpp
@@ -98,7 +98,9 @@ PseudoHandle<JSProxy> JSProxy::create(Runtime &runtime) {
       Runtime::makeNullHandle<JSObject>(),
       runtime.getHiddenClassForPrototype(nullptr, runtime.classJSProxy));
 
-  proxy->flags_.proxyObject = true;
+  assert(
+      proxy->isProxyObject(runtime) &&
+      "new Proxy made with the wrong HiddenClass");
 
   return JSObjectInit::initToPseudoHandle(runtime, proxy);
 }

--- a/lib/VM/JSRegExp.cpp
+++ b/lib/VM/JSRegExp.cpp
@@ -217,7 +217,7 @@ ExecutionStatus JSRegExp::initializeGroupNameMappingObj(
   auto objRes = JSObject::create(
       runtime,
       Runtime::makeNullHandle<JSObject>(),
-      runtime.classJSObject,
+      runtime.classJSObjectNullParent,
       parsedMappings.size());
   lv.obj = objRes.get();
 

--- a/lib/VM/JSRegExp.cpp
+++ b/lib/VM/JSRegExp.cpp
@@ -60,14 +60,19 @@ void JSRegExpBuildMeta(const GCCell *cell, Metadata::Builder &mb) {
   mb.addField(&self->groupNameMappings_);
 }
 
+PseudoHandle<JSRegExp> JSRegExp::create(Runtime &runtime) {
+  auto *cell = runtime.makeAFixed<JSRegExp, HasFinalizer::Yes>(
+      runtime, runtime.regExpPrototype, runtime.classJSRegExp);
+  return JSObjectInit::initToPseudoHandle(runtime, cell);
+}
+
 PseudoHandle<JSRegExp> JSRegExp::create(
     Runtime &runtime,
     Handle<JSObject> parentHandle) {
   auto *cell = runtime.makeAFixed<JSRegExp, HasFinalizer::Yes>(
       runtime,
       parentHandle,
-      runtime.getHiddenClassForPrototype(
-          *parentHandle, numOverlapSlots<JSRegExp>()));
+      runtime.getHiddenClassForPrototype(*parentHandle, runtime.classJSRegExp));
   return JSObjectInit::initToPseudoHandle(runtime, cell);
 }
 
@@ -209,7 +214,11 @@ ExecutionStatus JSRegExp::initializeGroupNameMappingObj(
   if (parsedMappings.size() == 0)
     return ExecutionStatus::RETURNED;
 
-  auto objRes = JSObject::create(runtime, parsedMappings.size());
+  auto objRes = JSObject::create(
+      runtime,
+      runtime.objectPrototype,
+      runtime.classJSObject,
+      parsedMappings.size());
   lv.obj = objRes.get();
 
   MutableHandle<HermesValue> numberHandle{runtime};

--- a/lib/VM/JSRegExp.cpp
+++ b/lib/VM/JSRegExp.cpp
@@ -216,7 +216,7 @@ ExecutionStatus JSRegExp::initializeGroupNameMappingObj(
 
   auto objRes = JSObject::create(
       runtime,
-      runtime.objectPrototype,
+      Runtime::makeNullHandle<JSObject>(),
       runtime.classJSObject,
       parsedMappings.size());
   lv.obj = objRes.get();

--- a/lib/VM/JSRegExpStringIterator.cpp
+++ b/lib/VM/JSRegExpStringIterator.cpp
@@ -56,7 +56,7 @@ PseudoHandle<JSRegExpStringIterator> JSRegExpStringIterator::create(
       runtime,
       proto,
       runtime.getHiddenClassForPrototype(
-          *proto, numOverlapSlots<JSRegExpStringIterator>()),
+          *proto, runtime.classJSRegExpStringIterator),
       R,
       S,
       global,

--- a/lib/VM/JSTypedArray.cpp
+++ b/lib/VM/JSTypedArray.cpp
@@ -65,9 +65,9 @@ OptValue<PropertyFlags> JSTypedArrayBase::_getOwnIndexedPropertyFlagsImpl(
   indexedElementFlags.writable = 1;
   indexedElementFlags.configurable = 1;
 
-  if (LLVM_UNLIKELY(self->flags_.sealed)) {
+  if (LLVM_UNLIKELY(self->getClass(runtime)->isSealed())) {
     indexedElementFlags.configurable = 0;
-    if (LLVM_UNLIKELY(self->flags_.frozen))
+    if (LLVM_UNLIKELY(self->getClass(runtime)->isFrozen()))
       indexedElementFlags.writable = 0;
   }
 

--- a/lib/VM/JSTypedArray.cpp
+++ b/lib/VM/JSTypedArray.cpp
@@ -24,8 +24,8 @@ JSTypedArrayBase::JSTypedArrayBase(
       buffer_(nullptr),
       length_(0),
       offset_(0) {
-  flags_.indexedStorage = true;
-  flags_.fastIndexProperties = true;
+  assert(hasIndexedStorage(runtime) && "must have indexed storage");
+  assert(hasFastIndexProperties(runtime) && "must have fast index properties");
 }
 
 void TypedArrayBaseBuildMeta(const GCCell *cell, Metadata::Builder &mb) {

--- a/lib/VM/JSTypedArray.cpp
+++ b/lib/VM/JSTypedArray.cpp
@@ -339,7 +339,9 @@ CallResult<Handle<JSTypedArrayBase>> JSTypedArray<T, C>::allocate(
     size_type length) {
   Handle<JSTypedArrayBase> ta = runtime.makeHandle(
       JSTypedArray<T, C>::create(
-          runtime, JSTypedArray<T, C>::getPrototype(runtime)));
+          runtime,
+          JSTypedArray<T, C>::getPrototype(runtime),
+          JSTypedArray<T, C>::getRootHiddenClass(runtime)));
   if (JSTypedArrayBase::createBuffer(runtime, ta, length) ==
       ExecutionStatus::EXCEPTION) {
     return ExecutionStatus::EXCEPTION;
@@ -376,12 +378,10 @@ CallResult<Handle<JSTypedArrayBase>> JSTypedArray<T, C>::allocateSpecies(
 template <typename T, CellKind C>
 PseudoHandle<JSTypedArray<T, C>> JSTypedArray<T, C>::create(
     Runtime &runtime,
-    Handle<JSObject> parentHandle) {
-  auto *cell = runtime.makeAFixed<JSTypedArray<T, C>>(
-      runtime,
-      parentHandle,
-      runtime.getHiddenClassForPrototype(
-          *parentHandle, numOverlapSlots<JSTypedArray>()));
+    Handle<JSObject> parentHandle,
+    Handle<HiddenClass> clazz) {
+  auto *cell =
+      runtime.makeAFixed<JSTypedArray<T, C>>(runtime, parentHandle, clazz);
   return JSObjectInit::initToPseudoHandle(runtime, cell);
   // NOTE: If any fields are ever added beyond the base class, then the
   // *BuildMeta functions must be updated to call addJSObjectOverlapSlots.
@@ -407,6 +407,15 @@ PseudoHandle<JSTypedArray<T, C>> JSTypedArray<T, C>::create(
   JSTypedArray<type, CellKind::name##ArrayKind>::getPrototype(      \
       const Runtime &runtime) {                                     \
     return Handle<JSObject>::vmcast(&runtime.name##ArrayPrototype); \
+  }
+#include "hermes/VM/TypedArrays.def"
+
+#define TYPED_ARRAY(name, type)                                      \
+  template <>                                                        \
+  Handle<HiddenClass>                                                \
+  JSTypedArray<type, CellKind::name##ArrayKind>::getRootHiddenClass( \
+      const Runtime &runtime) {                                      \
+    return Handle<HiddenClass>::vmcast(&runtime.class##name##Array); \
   }
 #include "hermes/VM/TypedArrays.def"
 

--- a/lib/VM/JSWeakMapImpl.cpp
+++ b/lib/VM/JSWeakMapImpl.cpp
@@ -247,13 +247,37 @@ const ObjectVTable JSWeakMapImpl<C>::vt{
 
 template <CellKind C>
 CallResult<PseudoHandle<JSWeakMapImpl<C>>> JSWeakMapImpl<C>::create(
+    Runtime &runtime) {
+  Handle<JSObject> prototype = runtime.weakMapPrototype;
+  Handle<HiddenClass> clazz = runtime.classJSWeakMap;
+  if constexpr (C == CellKind::JSWeakMapKind) {
+    prototype = Handle<JSObject>::vmcast(&runtime.weakMapPrototype);
+    clazz = Handle<HiddenClass>::vmcast(&runtime.classJSWeakMap);
+  } else {
+    static_assert(C == CellKind::JSWeakSetKind, "Unexpected CellKind");
+    prototype = Handle<JSObject>::vmcast(&runtime.weakSetPrototype);
+    clazz = Handle<HiddenClass>::vmcast(&runtime.classJSWeakSet);
+  }
+  auto *cell = runtime.makeAFixed<JSWeakMapImpl<C>, HasFinalizer::Yes>(
+      runtime, prototype, clazz);
+  return JSObjectInit::initToPseudoHandle(runtime, cell);
+}
+
+template <CellKind C>
+CallResult<PseudoHandle<JSWeakMapImpl<C>>> JSWeakMapImpl<C>::create(
     Runtime &runtime,
     Handle<JSObject> parentHandle) {
+  Handle<HiddenClass> clazz = runtime.classJSWeakMap;
+  if constexpr (C == CellKind::JSWeakMapKind) {
+    clazz = runtime.getHiddenClassForPrototype(
+        *parentHandle, runtime.classJSWeakMap);
+  } else {
+    static_assert(C == CellKind::JSWeakSetKind, "Unexpected CellKind");
+    clazz = runtime.getHiddenClassForPrototype(
+        *parentHandle, runtime.classJSWeakSet);
+  }
   auto *cell = runtime.makeAFixed<JSWeakMapImpl<C>, HasFinalizer::Yes>(
-      runtime,
-      parentHandle,
-      runtime.getHiddenClassForPrototype(
-          *parentHandle, numOverlapSlots<JSWeakMapImpl>()));
+      runtime, parentHandle, clazz);
   return JSObjectInit::initToPseudoHandle(runtime, cell);
 }
 

--- a/lib/VM/JSWeakRef.cpp
+++ b/lib/VM/JSWeakRef.cpp
@@ -65,6 +65,12 @@ void JSWeakRef::_finalizeImpl(GCCell *cell, GC &) {
   self->ref_.releaseSlot();
 }
 
+PseudoHandle<JSWeakRef> JSWeakRef::create(Runtime &runtime) {
+  auto *cell = runtime.makeAFixed<JSWeakRef, HasFinalizer::Yes>(
+      runtime, runtime.weakRefPrototype, runtime.classJSWeakRef);
+  return JSObjectInit::initToPseudoHandle(runtime, cell);
+}
+
 PseudoHandle<JSWeakRef> JSWeakRef::create(
     Runtime &runtime,
     Handle<JSObject> parentHandle) {
@@ -72,7 +78,7 @@ PseudoHandle<JSWeakRef> JSWeakRef::create(
       runtime,
       parentHandle,
       runtime.getHiddenClassForPrototype(
-          *parentHandle, numOverlapSlots<JSWeakRef>()));
+          *parentHandle, runtime.classJSWeakRef));
   return JSObjectInit::initToPseudoHandle(runtime, cell);
 }
 

--- a/lib/VM/Operations.cpp
+++ b/lib/VM/Operations.cpp
@@ -1975,7 +1975,7 @@ ordinaryHasInstance(Runtime &runtime, Handle<> constructor, Handle<> object) {
     if (parentRes->get() == ctorPrototype.get()) {
       return true;
     }
-    if (head->isProxyObject()) {
+    if (head->isProxyObject(runtime)) {
       ++proxyCount;
       if (proxyCount > kMaxProxyCount) {
         return runtime.raiseRangeError(
@@ -2101,7 +2101,7 @@ CallResult<bool> isArray(Runtime &runtime, JSObject *obj) {
     if (vmisa<FastArray>(obj)) {
       return true;
     }
-    if (LLVM_LIKELY(!obj->isProxyObject())) {
+    if (LLVM_LIKELY(!obj->isProxyObject(runtime))) {
       return false;
     }
     if (JSProxy::isRevoked(obj, runtime)) {
@@ -2497,7 +2497,7 @@ ExecutionStatus setTemplateObjectProps(
     return runtime.raiseTypeError(
         "Failed to set 'length' property on the raw object read-only.");
   }
-  JSObject::preventExtensions(rawObj.get());
+  JSObject::preventExtensionsNonProxy(rawObj, runtime);
 
   // Set raw object as a read-only non-enumerable property of the template
   // object.
@@ -2529,7 +2529,7 @@ ExecutionStatus setTemplateObjectProps(
     return runtime.raiseTypeError(
         "Failed to set 'length' property on the raw object read-only.");
   }
-  JSObject::preventExtensions(templateObj.get());
+  JSObject::preventExtensionsNonProxy(templateObj, runtime);
 
   return ExecutionStatus::RETURNED;
 }

--- a/lib/VM/PrimitiveBox.cpp
+++ b/lib/VM/PrimitiveBox.cpp
@@ -39,13 +39,48 @@ void JSStringBuildMeta(const GCCell *cell, Metadata::Builder &mb) {
 
 CallResult<Handle<JSString>> JSString::create(
     Runtime &runtime,
+    Handle<StringPrimitive> value) {
+  auto obj = runtime.makeAFixed<JSString>(
+      runtime, value, runtime.stringPrototype, runtime.classJSString);
+
+  auto selfHandle = JSObjectInit::initToHandle(runtime, obj);
+
+  PropertyFlags pf;
+  pf.writable = 0;
+  pf.enumerable = 0;
+  pf.configurable = 0;
+
+  PinnedHermesValue lengthValue =
+      HermesValue::encodeTrustedNumberValue(value->getStringLength());
+
+  if (LLVM_UNLIKELY(
+          JSObject::defineNewOwnProperty(
+              selfHandle,
+              runtime,
+              Predefined::getSymbolID(Predefined::length),
+              pf,
+              Handle<>{&lengthValue}) == ExecutionStatus::EXCEPTION)) {
+    return ExecutionStatus::EXCEPTION;
+  }
+
+  return selfHandle;
+}
+
+CallResult<Handle<JSString>> JSString::create(
+    Runtime &runtime,
     Handle<StringPrimitive> value,
     Handle<JSObject> parentHandle) {
-  auto clazzHandle = runtime.getHiddenClassForPrototype(
-      *parentHandle, numOverlapSlots<JSString>());
-  auto obj =
-      runtime.makeAFixed<JSString>(runtime, value, parentHandle, clazzHandle);
+  auto clazzHandle =
+      runtime.getHiddenClassForPrototype(*parentHandle, runtime.classJSString);
+  return create(runtime, value, parentHandle, clazzHandle);
+}
 
+CallResult<Handle<JSString>> JSString::create(
+    Runtime &runtime,
+    Handle<StringPrimitive> value,
+    Handle<JSObject> prototype,
+    Handle<HiddenClass> clazz) {
+  auto obj = runtime.makeAFixed<JSString>(runtime, value, prototype, clazz);
   auto selfHandle = JSObjectInit::initToHandle(runtime, obj);
 
   PropertyFlags pf;
@@ -198,8 +233,8 @@ PseudoHandle<JSStringIterator> JSStringIterator::create(
     Runtime &runtime,
     Handle<StringPrimitive> string) {
   auto proto = Handle<JSObject>::vmcast(&runtime.stringIteratorPrototype);
-  auto clazzHandle = runtime.getHiddenClassForPrototype(
-      *proto, numOverlapSlots<JSStringIterator>());
+  auto clazzHandle =
+      runtime.getHiddenClassForPrototype(*proto, runtime.classJSStringIterator);
   auto obj =
       runtime.makeAFixed<JSStringIterator>(runtime, proto, clazzHandle, string);
   return JSObjectInit::initToPseudoHandle(runtime, obj);
@@ -299,8 +334,8 @@ Handle<JSBigInt> JSBigInt::create(
     Runtime &runtime,
     Handle<BigIntPrimitive> value,
     Handle<JSObject> parentHandle) {
-  auto clazzHandle = runtime.getHiddenClassForPrototype(
-      *parentHandle, numOverlapSlots<JSBigInt>());
+  auto clazzHandle =
+      runtime.getHiddenClassForPrototype(*parentHandle, runtime.classJSBigInt);
   auto obj =
       runtime.makeAFixed<JSBigInt>(runtime, value, parentHandle, clazzHandle);
 
@@ -327,12 +362,28 @@ void JSNumberBuildMeta(const GCCell *cell, Metadata::Builder &mb) {
   mb.setVTable(&JSNumber::vt);
 }
 
+PseudoHandle<JSNumber> JSNumber::create(Runtime &runtime, double value) {
+  auto obj = runtime.makeAFixed<JSNumber>(
+      runtime, value, runtime.numberPrototype, runtime.classJSNumber);
+  return JSObjectInit::initToPseudoHandle(runtime, obj);
+}
+
 PseudoHandle<JSNumber> JSNumber::create(
     Runtime &runtime,
     double value,
     Handle<JSObject> parentHandle) {
-  auto clazzHandle = runtime.getHiddenClassForPrototype(
-      *parentHandle, numOverlapSlots<JSNumber>());
+  auto clazzHandle =
+      runtime.getHiddenClassForPrototype(*parentHandle, runtime.classJSNumber);
+  auto obj =
+      runtime.makeAFixed<JSNumber>(runtime, value, parentHandle, clazzHandle);
+  return JSObjectInit::initToPseudoHandle(runtime, obj);
+}
+
+PseudoHandle<JSNumber> JSNumber::create(
+    Runtime &runtime,
+    double value,
+    Handle<JSObject> parentHandle,
+    Handle<HiddenClass> clazzHandle) {
   auto obj =
       runtime.makeAFixed<JSNumber>(runtime, value, parentHandle, clazzHandle);
   return JSObjectInit::initToPseudoHandle(runtime, obj);
@@ -358,10 +409,26 @@ void JSBooleanBuildMeta(const GCCell *cell, Metadata::Builder &mb) {
   mb.setVTable(&JSBoolean::vt);
 }
 
+PseudoHandle<JSBoolean> JSBoolean::create(Runtime &runtime, bool value) {
+  auto obj = runtime.makeAFixed<JSBoolean>(
+      runtime, value, runtime.booleanPrototype, runtime.classJSBoolean);
+  return JSObjectInit::initToPseudoHandle(runtime, obj);
+}
+
 PseudoHandle<JSBoolean>
 JSBoolean::create(Runtime &runtime, bool value, Handle<JSObject> parentHandle) {
-  auto clazzHandle = runtime.getHiddenClassForPrototype(
-      *parentHandle, numOverlapSlots<JSBoolean>());
+  auto clazzHandle =
+      runtime.getHiddenClassForPrototype(*parentHandle, runtime.classJSBoolean);
+  auto obj =
+      runtime.makeAFixed<JSBoolean>(runtime, value, parentHandle, clazzHandle);
+  return JSObjectInit::initToPseudoHandle(runtime, obj);
+}
+
+PseudoHandle<JSBoolean> JSBoolean::create(
+    Runtime &runtime,
+    bool value,
+    Handle<JSObject> parentHandle,
+    Handle<HiddenClass> clazzHandle) {
   auto obj =
       runtime.makeAFixed<JSBoolean>(runtime, value, parentHandle, clazzHandle);
   return JSObjectInit::initToPseudoHandle(runtime, obj);
@@ -393,8 +460,18 @@ PseudoHandle<JSSymbol> JSSymbol::create(
     Runtime &runtime,
     SymbolID value,
     Handle<JSObject> parentHandle) {
-  auto clazzHandle = runtime.getHiddenClassForPrototype(
-      *parentHandle, numOverlapSlots<JSSymbol>());
+  auto clazzHandle =
+      runtime.getHiddenClassForPrototype(*parentHandle, runtime.classJSSymbol);
+  auto *obj =
+      runtime.makeAFixed<JSSymbol>(runtime, value, parentHandle, clazzHandle);
+  return JSObjectInit::initToPseudoHandle(runtime, obj);
+}
+
+PseudoHandle<JSSymbol> JSSymbol::create(
+    Runtime &runtime,
+    SymbolID value,
+    Handle<JSObject> parentHandle,
+    Handle<HiddenClass> clazzHandle) {
   auto *obj =
       runtime.makeAFixed<JSSymbol>(runtime, value, parentHandle, clazzHandle);
   return JSObjectInit::initToPseudoHandle(runtime, obj);

--- a/lib/VM/Runtime.cpp
+++ b/lib/VM/Runtime.cpp
@@ -412,49 +412,7 @@ Runtime::Runtime(
   returnThisCodeBlock_ =
       specialCodeBlockRuntimeModule_->getCodeBlockMayAllocate(1);
 
-  // Initialize the root hidden class and its variants.
-  {
-    MutableHandle<HiddenClass> clazz(*this, HiddenClass::createRoot(*this));
-    rootClazzes_[0] = clazz.getHermesValue();
-    for (unsigned i = 1; i <= InternalProperty::NumAnonymousInternalProperties;
-         ++i) {
-      auto addResult = HiddenClass::reserveSlot(clazz, *this);
-      assert(
-          addResult != ExecutionStatus::EXCEPTION &&
-          "Could not possibly grow larger than the limit");
-      clazz = *addResult->first;
-      rootClazzes_[i] = clazz.getHermesValue();
-    }
-
-    // Create a separate hierarchy of hidden classes for lazy objects, Proxy and
-    // HostObject, for lazy objects so that they never
-    // compare equal to ordinary objects.
-    clazz = HiddenClass::createRoot(*this);
-
-    // For lazy objects, they should just use this empty HiddenClass until they
-    // are actually populated.
-    lazyObjectClass = clazz;
-
-    constexpr unsigned maxNumOverlapSlots = std::max(
-        {JSObject::numOverlapSlots<JSProxy>(),
-         JSObject::numOverlapSlots<JSCallableProxy>(),
-         JSObject::numOverlapSlots<HostObject>()});
-    for (unsigned i = 0;; ++i) {
-      if (i == JSObject::numOverlapSlots<JSProxy>())
-        proxyClass = clazz;
-      if (i == JSObject::numOverlapSlots<JSCallableProxy>())
-        callableProxyClass = clazz;
-      if (i == JSObject::numOverlapSlots<HostObject>())
-        hostObjectClass = clazz;
-      if (i == maxNumOverlapSlots)
-        break;
-      auto addResult = HiddenClass::reserveSlot(clazz, *this);
-      assert(
-          addResult != ExecutionStatus::EXCEPTION &&
-          "Could not possibly grow larger than the limit");
-      clazz = *addResult->first;
-    }
-  }
+  initRootHiddenClasses();
 
   objectPrototype =
       JSObject::create(*this, Runtime::makeNullHandle<JSObject>());
@@ -623,8 +581,6 @@ void Runtime::markRoots(RootAcceptorWithNames &acceptor, bool markLongLived) {
   {
     MarkRootsPhaseTimer timer(*this, RootAcceptor::Section::RuntimeFields);
     acceptor.beginRootSection(RootAcceptor::Section::RuntimeFields);
-    for (auto &clazz : rootClazzes_)
-      acceptor.accept(clazz, "rootClass");
 #define SHRUNTIME_HV_FIELD(name) acceptor.acceptNullable(*toPHV(&name));
 #include "hermes/VM/SHRuntimeHermesValueFields.def"
 #define RUNTIME_HV_FIELD(name, type) acceptor.acceptNullablePV(name);
@@ -1701,6 +1657,41 @@ void Runtime::initCharacterStrings() {
     gc.flushToMarker(marker);
     charStrings_.push_back(allocateCharacterString(ch).getHermesValue());
   }
+}
+
+/// Initialize the root HiddenClasses for all the GCCells.
+void Runtime::initRootHiddenClasses() {
+  struct : public Locals {
+    PinnedValue<HiddenClass> clazz;
+  } lv;
+  LocalsRAII lraii{*this, &lv};
+
+  auto createRoot = [this, &lv](
+                        CellKind kind, PinnedValue<HiddenClass> *result) {
+    size_t baseNumSlots = JSObject::numOverlapSlotsForCellKind(kind);
+    // Create a root HiddenClass
+    lv.clazz = HiddenClass::createRoot(*this);
+    // Get to the base number of slots.
+    for (size_t i = 0; i < baseNumSlots; ++i) {
+      GCScopeMarkerRAII marker{*this};
+      auto addResult = HiddenClass::reserveSlot(lv.clazz, *this);
+      assert(
+          addResult != ExecutionStatus::EXCEPTION &&
+          "Could not possibly grow larger than the limit");
+      lv.clazz = *addResult->first;
+    }
+
+    *result = lv.clazz;
+  };
+
+#define CELL_JSOBJECT_NAME(name, vmClassName) \
+  createRoot(CellKind::name##Kind, &class##name);
+#include "hermes/VM/CellKinds.def"
+
+  // For lazy objects, they should just use this empty HiddenClass until they
+  // are actually populated.
+  lv.clazz = HiddenClass::createRoot(*this);
+  lazyObjectClass_ = lv.clazz;
 }
 
 Handle<StringPrimitive> Runtime::allocateCharacterString(char16_t ch) {

--- a/lib/VM/Runtime.cpp
+++ b/lib/VM/Runtime.cpp
@@ -415,7 +415,7 @@ Runtime::Runtime(
   initRootHiddenClasses();
 
   classJSObjectNullParent =
-      HiddenClass::createRoot(*this, makeNullHandle<JSObject>());
+      HiddenClass::createRoot(*this, makeNullHandle<JSObject>(), ClassFlags{});
 
   objectPrototype = JSObject::create(
       *this, makeNullHandle<JSObject>(), classJSObjectNullParent);
@@ -428,7 +428,7 @@ Runtime::Runtime(
   static_assert(
       JSObject::numOverlapSlots<JSObject>() == 0,
       "must have no overlap slots for classJSObject");
-  classJSObject = HiddenClass::createRoot(*this, objectPrototype);
+  classJSObject = HiddenClass::createRoot(*this, objectPrototype, ClassFlags{});
 
   global_ =
       JSObject::create(*this, objectPrototype, classJSObject).getHermesValue();
@@ -1685,7 +1685,10 @@ void Runtime::initRootHiddenClasses() {
 
   // For lazy objects, they should just use this empty HiddenClass until they
   // are actually populated.
-  lv.clazz = HiddenClass::createRoot(*this, makeNullHandle<JSObject>());
+  ClassFlags lazyFlags{};
+  lazyFlags.lazyObject = 1;
+  lv.clazz =
+      HiddenClass::createRoot(*this, makeNullHandle<JSObject>(), lazyFlags);
   lazyObjectClass_ = lv.clazz;
 }
 

--- a/lib/VM/Runtime.cpp
+++ b/lib/VM/Runtime.cpp
@@ -414,11 +414,28 @@ Runtime::Runtime(
 
   initRootHiddenClasses();
 
-  objectPrototype =
-      JSObject::create(*this, Runtime::makeNullHandle<JSObject>());
+  classJSObjectNullParent =
+      HiddenClass::createRoot(*this, makeNullHandle<JSObject>());
+
+  objectPrototype = JSObject::create(
+      *this, makeNullHandle<JSObject>(), classJSObjectNullParent);
   objectPrototypeRawPtr = *objectPrototype;
 
-  global_ = JSObject::create(*this, objectPrototype).getHermesValue();
+  // We want the prototype of 'global' to be an ordinary object,
+  // with Object.prototype as the parent.
+  // We don't need to use the full createRootHiddenClass in GlobalObject.cpp
+  // because we know that JSObject has no overlap slots, simplifying things.
+  static_assert(
+      JSObject::numOverlapSlots<JSObject>() == 0,
+      "must have no overlap slots for classJSObject");
+  classJSObject = HiddenClass::createRoot(*this, objectPrototype);
+
+  global_ =
+      JSObject::create(*this, objectPrototype, classJSObject).getHermesValue();
+  nullParentTransitionObject =
+      JSObject::create(
+          *this, Runtime::makeNullHandle<JSObject>(), classJSObjectNullParent)
+          .get();
 
   JSLibFlags jsLibFlags{};
   jsLibFlags.enableHermesInternal = runtimeConfig.getEnableHermesInternal();
@@ -1666,31 +1683,9 @@ void Runtime::initRootHiddenClasses() {
   } lv;
   LocalsRAII lraii{*this, &lv};
 
-  auto createRoot = [this, &lv](
-                        CellKind kind, PinnedValue<HiddenClass> *result) {
-    size_t baseNumSlots = JSObject::numOverlapSlotsForCellKind(kind);
-    // Create a root HiddenClass
-    lv.clazz = HiddenClass::createRoot(*this);
-    // Get to the base number of slots.
-    for (size_t i = 0; i < baseNumSlots; ++i) {
-      GCScopeMarkerRAII marker{*this};
-      auto addResult = HiddenClass::reserveSlot(lv.clazz, *this);
-      assert(
-          addResult != ExecutionStatus::EXCEPTION &&
-          "Could not possibly grow larger than the limit");
-      lv.clazz = *addResult->first;
-    }
-
-    *result = lv.clazz;
-  };
-
-#define CELL_JSOBJECT_NAME(name, vmClassName) \
-  createRoot(CellKind::name##Kind, &class##name);
-#include "hermes/VM/CellKinds.def"
-
   // For lazy objects, they should just use this empty HiddenClass until they
   // are actually populated.
-  lv.clazz = HiddenClass::createRoot(*this);
+  lv.clazz = HiddenClass::createRoot(*this, makeNullHandle<JSObject>());
   lazyObjectClass_ = lv.clazz;
 }
 

--- a/lib/VM/RuntimeModule.cpp
+++ b/lib/VM/RuntimeModule.cpp
@@ -395,6 +395,8 @@ void RuntimeModule::setCachedLiteralHiddenClass(
     Runtime &runtime,
     unsigned shapeTableIndex,
     HiddenClass *clazz) {
+  if (shapeTableIndex == hbc::SHAPE_TABLE_CACHING_DISABLED)
+    return;
   assert(
       !findCachedLiteralHiddenClass(runtime, shapeTableIndex) &&
       "Why are we caching an item already cached?");

--- a/lib/VM/RuntimeModule.cpp
+++ b/lib/VM/RuntimeModule.cpp
@@ -11,7 +11,7 @@
 #include "hermes/VM/ArrayStorage.h"
 #include "hermes/VM/CodeBlock.h"
 #include "hermes/VM/Domain.h"
-#include "hermes/VM/HiddenClass.h"
+#include "hermes/VM/HiddenClass-inline.h"
 #include "hermes/VM/ModuleExportsCache.h"
 #include "hermes/VM/Predefined.h"
 #include "hermes/VM/Runtime.h"
@@ -383,12 +383,17 @@ void RuntimeModule::markWeakRoots(
 
 HiddenClass *RuntimeModule::findCachedLiteralHiddenClass(
     Runtime &runtime,
+    JSObject *parent,
     uint32_t shapeTableIndex) const {
   assert(
       shapeTableIndex < objectLiteralHiddenClasses_.size() &&
       "Invalid shape table index");
-  return objectLiteralHiddenClasses_[shapeTableIndex].get(
+  auto *cached = objectLiteralHiddenClasses_[shapeTableIndex].get(
       runtime, runtime.getHeap());
+  if (cached && cached->getObjectParent(runtime) == parent) {
+    return cached;
+  }
+  return nullptr;
 }
 
 void RuntimeModule::setCachedLiteralHiddenClass(
@@ -398,7 +403,8 @@ void RuntimeModule::setCachedLiteralHiddenClass(
   if (shapeTableIndex == hbc::SHAPE_TABLE_CACHING_DISABLED)
     return;
   assert(
-      !findCachedLiteralHiddenClass(runtime, shapeTableIndex) &&
+      !findCachedLiteralHiddenClass(
+          runtime, clazz->getObjectParent(runtime), shapeTableIndex) &&
       "Why are we caching an item already cached?");
   objectLiteralHiddenClasses_[shapeTableIndex].set(runtime, clazz);
 }

--- a/lib/VM/SerializedValue.cpp
+++ b/lib/VM/SerializedValue.cpp
@@ -1458,7 +1458,7 @@ ExecutionStatus serializeImpl(
   /// Use Handle::vmcast here to assert that the value must be an JS object at
   /// this point.
   auto selfObjHandle = Handle<JSObject>::vmcast(value);
-  if (selfObjHandle->isHostObject()) {
+  if (selfObjHandle->isHostObject(runtime)) {
     return runtime.raiseError("Host Objects are not serializable");
   }
 

--- a/lib/VM/SerializedValue.cpp
+++ b/lib/VM/SerializedValue.cpp
@@ -1370,10 +1370,10 @@ CallResult<PseudoHandle<JSTypedArrayBase>> deserializeTypedArray(
   // [[ByteLength]] internal slot value is serialized.[[ByteLength]], whose
   // [[ByteOffset]] internal slot value is serialized.[[ByteOffset]], and whose
   // [[ArrayLength]] internal slot value is serialized.[[ArrayLength]].
-#define TYPED_ARRAY(name, type)                                      \
-  if (typeTag == SerializedValue::Type::name##Array) {               \
-    lv.self = JSTypedArray<type, CellKind::name##ArrayKind>::create( \
-        runtime, runtime.name##ArrayPrototype);                      \
+#define TYPED_ARRAY(name, type)                                             \
+  if (typeTag == SerializedValue::Type::name##Array) {                      \
+    lv.self = JSTypedArray<type, CellKind::name##ArrayKind>::create(        \
+        runtime, runtime.name##ArrayPrototype, runtime.class##name##Array); \
   }
 #include "hermes/VM/TypedArrays.def"
   uint8_t width = lv.self->getByteWidth();

--- a/lib/VM/SerializedValue.cpp
+++ b/lib/VM/SerializedValue.cpp
@@ -899,7 +899,7 @@ ExecutionStatus serializeArrayProperties(
 
     // Let inputValue be ? value.[[Get]](key, value).
     // Fast-path: Access the index element directly.
-    if (LLVM_LIKELY(selfArray->hasFastIndexProperties())) {
+    if (LLVM_LIKELY(selfArray->hasFastIndexProperties(runtime))) {
       SmallHermesValue shv = selfArray->at(runtime, arrayIndex);
       assert(!shv.isEmpty() && "Accessed empty value while serializing Array");
       lv.tmp = shv.unboxToHV(runtime);

--- a/lib/VM/StaticH.cpp
+++ b/lib/VM/StaticH.cpp
@@ -1864,7 +1864,7 @@ static SHLegacyValue createObjectFromBuffer(
 
   if (isTypedAllocKind(AllocKind)) {
     // Freeze the object from the perspective of untyped code.
-    lv.obj->markAsTyped();
+    lv.obj->markAsTyped(runtime);
   }
 
   return lv.obj.getHermesValue();

--- a/lib/VM/StaticH.cpp
+++ b/lib/VM/StaticH.cpp
@@ -10,6 +10,7 @@
 #include "hermes/VM/ArrayStorage.h"
 #include "hermes/VM/Callable.h"
 #include "hermes/VM/FastArray.h"
+#include "hermes/VM/HiddenClass-inline.h"
 #include "hermes/VM/Interpreter.h"
 #include "hermes/VM/JIT/Config.h"
 #include "hermes/VM/JSArray.h"
@@ -1717,7 +1718,9 @@ extern "C" SHLegacyValue _sh_ljs_new_object_with_parent(
   HiddenClass *clazz;
   auto *cacheEntry = reinterpret_cast<WeakRoot<HiddenClass> *>(
       &unit->object_literal_class_cache[shapeTableIndex]);
-  if (*cacheEntry) {
+  if (*cacheEntry &&
+      cacheEntry->getNonNull(runtime, runtime.getHeap())
+              ->getObjectParent(runtime) == *parentHandle) {
     // There is a already a cached entry for this shape, we can just use that.
     clazz = cacheEntry->getNonNull(runtime, runtime.getHeap());
   } else {
@@ -1751,7 +1754,9 @@ static SHLegacyValue createObjectFromBuffer(
   HiddenClass *clazz = nullptr;
   auto *cacheEntry = reinterpret_cast<WeakRoot<HiddenClass> *>(
       &unit->object_literal_class_cache[shapeTableIndex]);
-  if (*cacheEntry) {
+  if (*cacheEntry &&
+      cacheEntry->getNonNull(runtime, runtime.getHeap())
+              ->getObjectParent(runtime) == *parent) {
     // There is a already a cached entry for this shape, we can just use that.
     clazz = cacheEntry->getNonNull(runtime, runtime.getHeap());
   } else {
@@ -1785,8 +1790,8 @@ static SHLegacyValue createObjectFromBuffer(
     if (isTypedAllocKind(AllocKind)) {
       bool propertiesEnumerable =
           AllocKind != ObjectAllocKind::TypedNonEnumerable;
-      lv.clazz =
-          HiddenClass::createForTypedObject(runtime, shapeInfo->num_props);
+      lv.clazz = HiddenClass::createForTypedObject(
+          runtime, parent, shapeInfo->num_props);
       addTypedBufferPropertiesToHiddenClass(
           runtime,
           keyBuffer,

--- a/lib/VM/StaticH.cpp
+++ b/lib/VM/StaticH.cpp
@@ -802,7 +802,7 @@ static inline void putById_RJS(
         LLVM_LIKELY(addCacheEntry.resultClazz) &&
         LLVM_LIKELY(
             addCacheEntry.getParentEpoch() == runtime.getParentCacheEpoch()) &&
-        LLVM_LIKELY(addCacheEntry.parent == obj->getParentGCPtr())) {
+        LLVM_LIKELY(addCacheEntry.parent == obj->getParentGCPtr(runtime))) {
       HiddenClass *resultClazz =
           addCacheEntry.resultClazz.getNonNull(runtime, runtime.getHeap());
       JSObject::addNewOwnPropertyInSlot(
@@ -1052,7 +1052,7 @@ static inline HermesValue getByIdWithReceiver_RJS(
         assert(!obj->getFlags().proxyObject);
         assert(!obj->getFlags().hostObject);
         assert(!obj->getFlags().lazyObject);
-        const GCPointer<JSObject> &parentGCPtr = obj->getParentGCPtr();
+        const GCPointer<JSObject> &parentGCPtr = obj->getParentGCPtr(runtime);
         if (LLVM_LIKELY(parentGCPtr)) {
           JSObject *parent = parentGCPtr.getNonNull(runtime);
           if (LLVM_LIKELY(cacheEntry->clazz == parent->getClassGCPtr())) {

--- a/lib/VM/StaticH.cpp
+++ b/lib/VM/StaticH.cpp
@@ -1703,16 +1703,40 @@ extern "C" SHLegacyValue _sh_ljs_new_object(SHRuntime *shr) {
 LLVM_ATTRIBUTE_NOINLINE
 extern "C" SHLegacyValue _sh_ljs_new_object_with_parent(
     SHRuntime *shr,
-    const SHLegacyValue *parent) {
+    SHUnit *unit,
+    const SHLegacyValue *parent,
+    uint32_t shapeTableIndex) {
+  auto &runtime = getRuntime(shr);
+  auto *parentPHV = toPHV(parent);
+  Handle<JSObject> parentHandle = parentPHV->isObject()
+      ? Handle<JSObject>::vmcast(parentPHV)
+      : parentPHV->isNull()
+      ? Runtime::makeNullHandle<JSObject>()
+      : Handle<JSObject>::vmcast(&runtime.objectPrototype);
+
+  HiddenClass *clazz;
+  auto *cacheEntry = reinterpret_cast<WeakRoot<HiddenClass> *>(
+      &unit->object_literal_class_cache[shapeTableIndex]);
+  if (*cacheEntry) {
+    // There is a already a cached entry for this shape, we can just use that.
+    clazz = cacheEntry->getNonNull(runtime, runtime.getHeap());
+  } else {
+    clazz = *runtime.getHiddenClassForPrototype(
+        *parentHandle, runtime.classJSObject);
+    cacheEntry->set(runtime, clazz);
+  }
+
+  struct : public Locals {
+    PinnedValue<HiddenClass> clazz;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
+
+  lv.clazz = clazz;
+
   PseudoHandle<JSObject> result;
   {
-    NoHandleScope noHandle{getRuntime(shr)};
-    result = JSObject::create(
-        getRuntime(shr),
-        toPHV(parent)->isObject() ? Handle<JSObject>::vmcast(toPHV(parent))
-            : toPHV(parent)->isNull()
-            ? Runtime::makeNullHandle<JSObject>()
-            : Handle<JSObject>::vmcast(&getRuntime(shr).objectPrototype));
+    NoHandleScope noHandle{runtime};
+    result = JSObject::create(runtime, parentHandle, lv.clazz);
   }
   return result.getHermesValue();
 }

--- a/lib/VM/StaticH.cpp
+++ b/lib/VM/StaticH.cpp
@@ -725,7 +725,7 @@ extern "C" void _sh_ljs_declare_global_var(SHRuntime *shr, SHSymbolID name) {
     if (res != ExecutionStatus::EXCEPTION)
       return;
     assert(
-        !runtime.getGlobal()->isProxyObject() &&
+        !runtime.getGlobal()->isProxyObject(runtime) &&
         "global can't be a proxy object");
     // If the property already exists, this should be a noop.
     // Instead of incurring the cost to check every time, do it
@@ -1050,9 +1050,9 @@ static inline HermesValue getByIdWithReceiver_RJS(
       if (LLVM_LIKELY(cacheEntry->negMatchClazz == clazzPtr)) {
         // Proxy, HostObject and lazy objects have special hidden classes, so
         // they should never match the cached class.
-        assert(!obj->getFlags().proxyObject);
-        assert(!obj->getFlags().hostObject);
-        assert(!obj->getFlags().lazyObject);
+        assert(!obj->isProxyObject(runtime));
+        assert(!obj->isHostObject(runtime));
+        assert(!obj->isLazy(runtime));
         const GCPointer<JSObject> &parentGCPtr = obj->getParentGCPtr(runtime);
         if (LLVM_LIKELY(parentGCPtr)) {
           JSObject *parent = parentGCPtr.getNonNull(runtime);
@@ -1090,7 +1090,7 @@ static inline HermesValue getByIdWithReceiver_RJS(
       }
 
       assert(
-          !obj->isProxyObject() &&
+          !obj->isProxyObject(runtime) &&
           "tryGetOwnNamedDescriptorFast returned true on Proxy");
       return JSObject::getNamedSlotValueUnsafe(obj, runtime, desc)
           .unboxToHV(runtime);
@@ -2598,6 +2598,13 @@ _sh_string_concat(SHRuntime *shr, uint32_t argCount, ...) {
     _sh_throw_current(shr);
   }
   return *result;
+}
+
+extern "C" bool _sh_ljs_is_proxy(SHRuntime *shr, SHLegacyValue object) {
+  Runtime &runtime = getRuntime(shr);
+  HermesValue val = *toPHV(&object);
+  JSObject *obj = vmcast<JSObject>(val);
+  return obj->isProxyObject(runtime);
 }
 
 LLVM_ATTRIBUTE_NOINLINE

--- a/lib/VM/StaticH.cpp
+++ b/lib/VM/StaticH.cpp
@@ -1777,8 +1777,7 @@ static SHLegacyValue createObjectFromBuffer(
           runtime,
           keyBuffer,
           shapeInfo->num_props,
-          *runtime.getHiddenClassForPrototype(
-              *parent, JSObject::numOverlapSlots<JSObject>()),
+          *runtime.getHiddenClassForPrototype(*parent, runtime.classJSObject),
           [unit](StringID id) {
             return SymbolID::unsafeCreate(unit->symbols[id]);
           });

--- a/lib/VM/WeakValueObjectMap.cpp
+++ b/lib/VM/WeakValueObjectMap.cpp
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "hermes/VM/WeakValueObjectMap.h"
+
+#include "hermes/VM/BuildMetadata.h"
+#include "hermes/VM/GCCell.h"
+#include "hermes/VM/JSObject.h"
+#include "llvh/ADT/ScopeExit.h"
+
+namespace hermes::vm {
+
+const VTable WeakValueObjectMapImpl::vt{
+    CellKind::WeakValueObjectMapKind,
+    cellSize<WeakValueObjectMapImpl>(),
+    /* allowLargeAlloc */ false,
+    _finalizeImpl,
+    _mallocSizeImpl,
+    /* trimSize */ nullptr};
+
+void WeakValueObjectMapBuildMeta(const GCCell *cell, Metadata::Builder &mb) {
+  const auto *self = static_cast<const WeakValueObjectMapImpl *>(cell);
+  mb.setVTable(&WeakValueObjectMapImpl::vt);
+  mb.addField("keyStorage", &self->keys_);
+}
+
+WeakValueObjectMapImpl::~WeakValueObjectMapImpl() {
+  if (values_) {
+    for (size_type i = 0; i < capacity_; ++i) {
+      if (allocatedWeakRefs_[i]) {
+        values_[i].releaseSlot();
+      }
+    }
+    free(values_);
+  }
+}
+
+WeakValueObjectMapImpl::size_type WeakValueObjectMapImpl::findIndex(
+    Runtime &runtime,
+    JSObject *key) const {
+  NoAllocScope noAlloc{runtime};
+  if (capacity_ == 0) {
+    return capacity_;
+  }
+
+  auto hash = runtime.gcStableHashJSObject(key);
+
+  size_type cap = capacity_;
+  size_type idx = hash & (cap - 1);
+  size_type base = 1;
+
+  // deletedIndex tracks the index of a deleted entry found in the conflict
+  // chain. If we could not find an entry that matches str, we would return
+  // the deleted slot for insertion to be able to reuse deleted space.
+  OptValue<size_type> deletedIndex;
+
+  ArrayStorage *keys = keys_.getNonNull(runtime);
+  for (;;) {
+    if (keys->at(idx).isEmpty()) {
+      // Found an empty entry, meaning that key does not exist in the table.
+      // If deletedIndex is available, return it, otherwise return idx.
+      return deletedIndex ? *deletedIndex : idx;
+    } else if (keys->at(idx).isNull()) {
+      deletedIndex = idx;
+    } else if (keys_.get(runtime)->at(idx).getObject() == key) {
+      return idx;
+    }
+
+    /// Use quadratic probing to find next probe index in the hash table.
+    /// h(k, i) = (h(k) + 1/2 * i + 1/2 * i^2) mod m.
+    /// This guarantees the values of h(k,i) for i in [0,m-1] are all distinct.
+    idx = (idx + base) & (cap - 1);
+    ++base;
+  }
+}
+
+void WeakValueObjectMapImpl::rehash(
+    Handle<WeakValueObjectMapImpl> self,
+    Runtime &runtime,
+    size_type newCapacity) {
+  const size_type oldCapacity = self->capacity_;
+
+  struct : public Locals {
+    PinnedValue<ArrayStorage> oldKeys;
+    PinnedValue<ArrayStorage> newKeys;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
+
+  // Create new key storage.
+  assert(
+      newCapacity < ArrayStorage::maxCapacityNoOverflow() &&
+      "must not overflow");
+  auto keyStorageRes = ArrayStorage::create(runtime, newCapacity, newCapacity);
+  assert(keyStorageRes != ExecutionStatus::EXCEPTION);
+  lv.newKeys = vmcast<ArrayStorage>(*keyStorageRes);
+
+  // Save old storage and values for rehashing.
+  lv.oldKeys = self->keys_.get(runtime);
+  auto *oldValues = self->values_;
+  auto freeOldValues = llvh::make_scope_exit([oldValues] { free(oldValues); });
+
+  // Set up new storage.
+  self->keys_.set(runtime, *lv.newKeys, runtime.getHeap());
+  self->values_ = static_cast<decltype(self->values_)>(
+      checkedCalloc(newCapacity, sizeof(self->values_[0])));
+  self->allocatedWeakRefs_.clear();
+  self->allocatedWeakRefs_.resize(newCapacity, false);
+
+  // Update capacity before rehashing.
+  self->capacity_ = newCapacity;
+  self->size_ = 0;
+
+  // Rehash all valid entries.
+  for (size_type i = 0; i < oldCapacity; ++i) {
+    NoAllocScope noAlloc{runtime};
+    HermesValue oldKey = lv.oldKeys->at(i);
+
+    // Skip empty and tombstone keys.
+    if (oldKey.isEmpty() || oldKey.isNull()) {
+      continue;
+    }
+
+    // Skip invalid weak references.
+    if (!oldValues[i].isValid()) {
+      oldValues[i].releaseSlot();
+      continue;
+    }
+
+    // Find new location for this entry.
+    size_type newIdx = self->findIndex(runtime, vmcast<JSObject>(oldKey));
+
+    // Insert entry at new location.
+    lv.newKeys->set(newIdx, oldKey, runtime.getHeap());
+    self->values_[newIdx] = std::move(oldValues[i]);
+    self->allocatedWeakRefs_[newIdx] = true;
+    ++self->size_;
+  }
+}
+
+bool WeakValueObjectMapImpl::insertNew(
+    Handle<WeakValueObjectMapImpl> self,
+    Runtime &runtime,
+    JSObject *key,
+    GCCell *value) {
+  // Check if we need to grow the table.
+  if (self->shouldGrow(self->capacity_, self->size_ + 1)) {
+    struct : public Locals {
+      PinnedValue<WeakValueObjectMapImpl> self;
+      PinnedValue<JSObject> key;
+      PinnedValue<GCCell> value;
+    } lv;
+    LocalsRAII lraii{runtime, &lv};
+
+    lv.self = *self;
+    lv.key = key;
+    lv.value = value;
+
+    size_type newCapacity = lv.self->capacity_ < kMinCapacity
+        ? kMinCapacity
+        : lv.self->capacity_ * kGrowOrShrinkFactor;
+    if (newCapacity > kMaxCapacity) {
+      return false;
+    }
+    rehash(lv.self, runtime, newCapacity);
+
+    NoAllocScope noAlloc{runtime};
+    size_type idx = lv.self->findIndex(runtime, *lv.key);
+    ArrayStorage *keys = lv.self->keys_.getNonNull(runtime);
+    if (keys->at(idx).isObject()) {
+      if (lv.self->values_[idx].isValid()) {
+        return false;
+      }
+      assert(lv.self->allocatedWeakRefs_[idx]);
+      lv.self->values_[idx].releaseSlot();
+      lv.self->values_[idx] = WeakRef<GCCell>(runtime, lv.value);
+      return true;
+    } else {
+      assert(!self->allocatedWeakRefs_[idx]);
+      keys->set(idx, lv.key.getHermesValue(), runtime.getHeap());
+      lv.self->values_[idx] = WeakRef<GCCell>(runtime, lv.value);
+      lv.self->allocatedWeakRefs_[idx] = true;
+      ++lv.self->size_;
+      return true;
+    }
+  } else {
+    NoAllocScope noAlloc{runtime};
+    size_type idx = self->findIndex(runtime, key);
+    ArrayStorage *keys = self->keys_.getNonNull(runtime);
+    if (keys->at(idx).isObject()) {
+      if (self->values_[idx].isValid()) {
+        return false;
+      }
+      assert(self->allocatedWeakRefs_[idx]);
+      self->values_[idx].releaseSlot();
+      self->values_[idx] = WeakRef<GCCell>(runtime, runtime.getHeap(), value);
+      return true;
+    } else {
+      // Set up the value for new or replaced entries.
+      assert(!self->allocatedWeakRefs_[idx]);
+      keys->set(idx, HermesValue::encodeObjectValue(key), runtime.getHeap());
+      self->values_[idx] = WeakRef<GCCell>(runtime, runtime.getHeap(), value);
+      self->allocatedWeakRefs_[idx] = true;
+      ++self->size_;
+      return true;
+    }
+  }
+  return false;
+}
+
+bool WeakValueObjectMapImpl::erase(
+    Handle<WeakValueObjectMapImpl> self,
+    Runtime &runtime,
+    JSObject *key,
+    GC &gc) {
+  size_type idx = self->findIndex(runtime, key);
+  if (idx == self->capacity())
+    return false;
+
+  ArrayStorage *keys = self->keys_.getNonNull(runtime);
+  HermesValue storedKey = keys->at(idx);
+  if (storedKey.isObject()) {
+    assert(storedKey.getObject() == key && "findIndex wrong");
+    self->keys_.getNonNull(runtime)->set(
+        idx, HermesValue::encodeNullValue(), runtime.getHeap());
+    self->values_[idx].releaseSlot();
+    self->allocatedWeakRefs_[idx] = false;
+    --self->size_;
+    self->recalcPruneLimit();
+    if (self->shouldShrink(self->capacity_, self->size_)) {
+      rehash(self, runtime, self->capacity_ / kGrowOrShrinkFactor);
+    }
+    return true;
+  }
+
+  return false;
+}
+
+void WeakValueObjectMapImpl::pruneInvalid(
+    Handle<WeakValueObjectMapImpl> self,
+    Runtime &runtime,
+    GC &gc) {
+  if (!self->keys_)
+    return;
+
+  NoAllocScope noAlloc{runtime};
+  ArrayStorage *keys = self->keys_.getNonNull(runtime);
+  for (size_type i = 0; i < self->capacity_; ++i) {
+    if (keys->at(i).isObject()) {
+      keys->set(i, HermesValue::encodeNullValue(), runtime.getHeap());
+      self->values_[i].releaseSlot();
+      self->allocatedWeakRefs_[i] = false;
+      --self->size_;
+    }
+  }
+
+  self->recalcPruneLimit();
+
+  if (self->shouldShrink(self->capacity_, self->size_)) {
+    rehash(self, runtime, self->capacity_ / kGrowOrShrinkFactor);
+  }
+}
+
+void WeakValueObjectMapImpl::_finalizeImpl(GCCell *cell, GC &gc) {
+  auto *self = vmcast<WeakValueObjectMapImpl>(cell);
+  self->~WeakValueObjectMapImpl();
+}
+
+size_t WeakValueObjectMapImpl::_mallocSizeImpl(GCCell *cell) {
+  auto *self = vmcast<WeakValueObjectMapImpl>(cell);
+  return self->getMemorySize();
+}
+
+} // namespace hermes::vm

--- a/test/BCGen/HBC/__proto__.js
+++ b/test/BCGen/HBC/__proto__.js
@@ -29,7 +29,7 @@ function dynamicProto(func, getProto) {
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 12
 // CHECK-NEXT:  Value buffer size (bytes): 19
-// CHECK-NEXT:  Shape table count: 2
+// CHECK-NEXT:  Shape table count: 3
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -61,8 +61,9 @@ function dynamicProto(func, getProto) {
 // CHECK-NEXT:[String 2]
 
 // CHECK:Object Shape Table:
-// CHECK-NEXT:0[0, 3]
-// CHECK-NEXT:1[7, 2]
+// CHECK-NEXT:0[0, 0]
+// CHECK-NEXT:1[0, 3]
+// CHECK-NEXT:2[7, 2]
 
 // CHECK:Function<global>(1 params, 3 registers, 0 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000
@@ -78,12 +79,12 @@ function dynamicProto(func, getProto) {
 
 // CHECK:Function<staticProto>(1 params, 2 registers, 0 numbers, 1 non-pointers):
 // CHECK-NEXT:    LoadConstNull     r0
-// CHECK-NEXT:    NewObjectWithBufferAndParent r1, r0, 0, 0
+// CHECK-NEXT:    NewObjectWithBufferAndParent r1, r0, 1, 0
 // CHECK-NEXT:    Ret               r1
 
 // CHECK:Function<dynamicProto>(3 params, 13 registers, 0 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0011
-// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 13
+// CHECK-NEXT:    NewObjectWithBuffer r1, 2, 13
 // CHECK-NEXT:    LoadConstUndefined r0
 // CHECK-NEXT:    LoadParam         r2, 1
 // CHECK-NEXT:    Call1             r2, r2, r0

--- a/test/BCGen/HBC/array.js
+++ b/test/BCGen/HBC/array.js
@@ -24,7 +24,7 @@ var z = [{}];
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 0
 // CHECK-NEXT:  Value buffer size (bytes): 18
-// CHECK-NEXT:  Shape table count: 0
+// CHECK-NEXT:  Shape table count: 1
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -50,6 +50,9 @@ var z = [{}];
 // CHECK-NEXT:[String 1]
 // CHECK-NEXT:[String 1]
 // CHECK-NEXT:[String 0]
+
+// CHECK:Object Shape Table:
+// CHECK-NEXT:0[0, 0]
 
 // CHECK:Function<global>(1 params, 6 registers, 1 numbers, 2 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000

--- a/test/BCGen/HBC/async-function.js
+++ b/test/BCGen/HBC/async-function.js
@@ -34,7 +34,7 @@ var simpleAsyncFE = async function () {
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 5
 // CHECK-NEXT:  Value buffer size (bytes): 16
-// CHECK-NEXT:  Shape table count: 1
+// CHECK-NEXT:  Shape table count: 2
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -71,7 +71,8 @@ var simpleAsyncFE = async function () {
 // CHECK-NEXT:[String 6]
 
 // CHECK:Object Shape Table:
-// CHECK-NEXT:0[0, 2]
+// CHECK-NEXT:0[0, 0]
+// CHECK-NEXT:1[0, 2]
 
 // CHECK:Function Source Table:
 // CHECK-NEXT:  Function ID 7 -> s0
@@ -223,13 +224,13 @@ var simpleAsyncFE = async function () {
 // CHECK-NEXT:    LoadConstUInt8    r1, 3
 // CHECK-NEXT:    StoreNPToEnvironment r2, 2, r1
 // CHECK-NEXT:L9:
-// CHECK-NEXT:    NewObjectWithBuffer r1, 0, 4
+// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 4
 // CHECK-NEXT:    Ret               r1
 // CHECK-NEXT:L4:
 // CHECK-NEXT:    LoadConstUInt8    r1, 3
 // CHECK-NEXT:    StoreNPToEnvironment r2, 2, r1
 // CHECK-NEXT:L10:
-// CHECK-NEXT:    NewObjectWithBuffer r1, 0, 0
+// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 0
 // CHECK-NEXT:    PutOwnBySlotIdx   r1, r5, 0
 // CHECK-NEXT:    Ret               r1
 // CHECK-NEXT:L3:
@@ -251,10 +252,10 @@ var simpleAsyncFE = async function () {
 // CHECK-NEXT:    LoadConstUInt8    r1, 2
 // CHECK-NEXT:    StrictEq          r1, r4, r1
 // CHECK-NEXT:    JmpTrue           L7, r1
-// CHECK-NEXT:    NewObjectWithBuffer r1, 0, 2
+// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 2
 // CHECK-NEXT:    Ret               r1
 // CHECK-NEXT:L7:
-// CHECK-NEXT:    NewObjectWithBuffer r1, 0, 0
+// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 0
 // CHECK-NEXT:    PutOwnBySlotIdx   r1, r3, 0
 // CHECK-NEXT:    Ret               r1
 // CHECK-NEXT:L6:
@@ -312,14 +313,14 @@ var simpleAsyncFE = async function () {
 // CHECK-NEXT:    LoadConstUInt8    r1, 3
 // CHECK-NEXT:    StoreNPToEnvironment r2, 8, r1
 // CHECK-NEXT:L12:
-// CHECK-NEXT:    NewObjectWithBuffer r1, 0, 0
+// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 0
 // CHECK-NEXT:    PutOwnBySlotIdx   r1, r9, 0
 // CHECK-NEXT:    Ret               r1
 // CHECK-NEXT:L5:
 // CHECK-NEXT:    LoadConstUInt8    r1, 3
 // CHECK-NEXT:    StoreNPToEnvironment r2, 8, r1
 // CHECK-NEXT:L13:
-// CHECK-NEXT:    NewObjectWithBuffer r1, 0, 0
+// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 0
 // CHECK-NEXT:    PutOwnBySlotIdx   r1, r8, 0
 // CHECK-NEXT:    Ret               r1
 // CHECK-NEXT:L4:
@@ -351,13 +352,13 @@ var simpleAsyncFE = async function () {
 // CHECK-NEXT:    LoadConstUInt8    r1, 1
 // CHECK-NEXT:    StoreNPToEnvironment r2, 8, r1
 // CHECK-NEXT:L14:
-// CHECK-NEXT:    NewObjectWithBuffer r1, 0, 10
+// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 10
 // CHECK-NEXT:    Ret               r1
 // CHECK-NEXT:L7:
 // CHECK-NEXT:    LoadConstUInt8    r1, 3
 // CHECK-NEXT:    StoreNPToEnvironment r2, 8, r1
 // CHECK-NEXT:L15:
-// CHECK-NEXT:    NewObjectWithBuffer r1, 0, 0
+// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 0
 // CHECK-NEXT:    PutOwnBySlotIdx   r1, r5, 0
 // CHECK-NEXT:    Ret               r1
 // CHECK-NEXT:L6:
@@ -379,10 +380,10 @@ var simpleAsyncFE = async function () {
 // CHECK-NEXT:    LoadConstUInt8    r1, 2
 // CHECK-NEXT:    StrictEq          r1, r4, r1
 // CHECK-NEXT:    JmpTrue           L10, r1
-// CHECK-NEXT:    NewObjectWithBuffer r1, 0, 2
+// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 2
 // CHECK-NEXT:    Ret               r1
 // CHECK-NEXT:L10:
-// CHECK-NEXT:    NewObjectWithBuffer r1, 0, 0
+// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 0
 // CHECK-NEXT:    PutOwnBySlotIdx   r1, r3, 0
 // CHECK-NEXT:    Ret               r1
 // CHECK-NEXT:L9:
@@ -442,14 +443,14 @@ var simpleAsyncFE = async function () {
 // CHECK-NEXT:    LoadConstUInt8    r1, 3
 // CHECK-NEXT:    StoreNPToEnvironment r2, 8, r1
 // CHECK-NEXT:L12:
-// CHECK-NEXT:    NewObjectWithBuffer r1, 0, 0
+// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 0
 // CHECK-NEXT:    PutOwnBySlotIdx   r1, r9, 0
 // CHECK-NEXT:    Ret               r1
 // CHECK-NEXT:L5:
 // CHECK-NEXT:    LoadConstUInt8    r1, 3
 // CHECK-NEXT:    StoreNPToEnvironment r2, 8, r1
 // CHECK-NEXT:L13:
-// CHECK-NEXT:    NewObjectWithBuffer r1, 0, 0
+// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 0
 // CHECK-NEXT:    PutOwnBySlotIdx   r1, r8, 0
 // CHECK-NEXT:    Ret               r1
 // CHECK-NEXT:L4:
@@ -481,13 +482,13 @@ var simpleAsyncFE = async function () {
 // CHECK-NEXT:    LoadConstUInt8    r1, 1
 // CHECK-NEXT:    StoreNPToEnvironment r2, 8, r1
 // CHECK-NEXT:L14:
-// CHECK-NEXT:    NewObjectWithBuffer r1, 0, 10
+// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 10
 // CHECK-NEXT:    Ret               r1
 // CHECK-NEXT:L7:
 // CHECK-NEXT:    LoadConstUInt8    r1, 3
 // CHECK-NEXT:    StoreNPToEnvironment r2, 8, r1
 // CHECK-NEXT:L15:
-// CHECK-NEXT:    NewObjectWithBuffer r1, 0, 0
+// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 0
 // CHECK-NEXT:    PutOwnBySlotIdx   r1, r5, 0
 // CHECK-NEXT:    Ret               r1
 // CHECK-NEXT:L6:
@@ -509,10 +510,10 @@ var simpleAsyncFE = async function () {
 // CHECK-NEXT:    LoadConstUInt8    r1, 2
 // CHECK-NEXT:    StrictEq          r1, r4, r1
 // CHECK-NEXT:    JmpTrue           L10, r1
-// CHECK-NEXT:    NewObjectWithBuffer r1, 0, 2
+// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 2
 // CHECK-NEXT:    Ret               r1
 // CHECK-NEXT:L10:
-// CHECK-NEXT:    NewObjectWithBuffer r1, 0, 0
+// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 0
 // CHECK-NEXT:    PutOwnBySlotIdx   r1, r3, 0
 // CHECK-NEXT:    Ret               r1
 // CHECK-NEXT:L9:

--- a/test/BCGen/HBC/basic_block_profiler.js
+++ b/test/BCGen/HBC/basic_block_profiler.js
@@ -31,7 +31,7 @@ try {
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 0
 // CHECK-NEXT:  Value buffer size (bytes): 0
-// CHECK-NEXT:  Shape table count: 0
+// CHECK-NEXT:  Shape table count: 1
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -48,6 +48,9 @@ try {
 // CHECK-NEXT:i4[ASCII, 15..23] #431898FB: condition
 // CHECK-NEXT:i5[ASCII, 27..31] #834F633C: stack
 // CHECK-NEXT:i6[ASCII, 32..36] #A689F65B: print
+
+// CHECK:Object Shape Table:
+// CHECK-NEXT:0[0, 0]
 
 // CHECK:Function<global>(1 params, 15 registers, 0 numbers, 0 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000

--- a/test/BCGen/HBC/binary.js
+++ b/test/BCGen/HBC/binary.js
@@ -47,7 +47,7 @@ function foo() { return; }
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 0
 // CHECK-NEXT:  Value buffer size (bytes): 0
-// CHECK-NEXT:  Shape table count: 0
+// CHECK-NEXT:  Shape table count: 1
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -60,6 +60,9 @@ function foo() { return; }
 // CHECK-NEXT:s0[ASCII, 0..5]: global
 // CHECK-NEXT:i1[ASCII, 6..11] #A5D4F6F9: binary
 // CHECK-NEXT:i2[ASCII, 12..14] #9290584E: foo
+
+// CHECK:Object Shape Table:
+// CHECK-NEXT:0[0, 0]
 
 // CHECK:Function<global>(1 params, 3 registers, 0 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000

--- a/test/BCGen/HBC/call_function.js
+++ b/test/BCGen/HBC/call_function.js
@@ -24,7 +24,7 @@ foo(0,0,1);
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 0
 // CHECK-NEXT:  Value buffer size (bytes): 0
-// CHECK-NEXT:  Shape table count: 0
+// CHECK-NEXT:  Shape table count: 1
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -36,6 +36,9 @@ foo(0,0,1);
 // CHECK:Global String Table:
 // CHECK-NEXT:s0[ASCII, 0..5]: global
 // CHECK-NEXT:i1[ASCII, 6..8] #9290584E: foo
+
+// CHECK:Object Shape Table:
+// CHECK-NEXT:0[0, 0]
 
 // CHECK:Function<global>(1 params, 16 registers, 2 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000

--- a/test/BCGen/HBC/callbuiltin.js
+++ b/test/BCGen/HBC/callbuiltin.js
@@ -100,7 +100,7 @@ print(foo({a: 10, b: 20, lastKey:30, 5:6}))
 // CHKBC-NEXT:  StringSwitchImm count: 0
 // CHKBC-NEXT:  Key buffer size (bytes): 15
 // CHKBC-NEXT:  Value buffer size (bytes): 18
-// CHKBC-NEXT:  Shape table count: 2
+// CHKBC-NEXT:  Shape table count: 3
 // CHKBC-NEXT:  Segment ID: 0
 // CHKBC-NEXT:  CommonJS module count: 0
 // CHKBC-NEXT:  CommonJS module count (static): 0
@@ -139,8 +139,9 @@ print(foo({a: 10, b: 20, lastKey:30, 5:6}))
 // CHKBC-NEXT:[String 10]
 
 // CHKBC:Object Shape Table:
-// CHKBC-NEXT:0[0, 4]
-// CHKBC-NEXT:1[12, 1]
+// CHKBC-NEXT:0[0, 0]
+// CHKBC-NEXT:1[0, 4]
+// CHKBC-NEXT:2[12, 1]
 
 // CHKBC:Function<global>(1 params, 13 registers, 0 numbers, 1 non-pointers):
 // CHKBC-NEXT:Offset in debug table: source 0x0000
@@ -157,7 +158,7 @@ print(foo({a: 10, b: 20, lastKey:30, 5:6}))
 // CHKBC-NEXT:    PutByIdLoose      r1, r2, 2, "checkNonStaticBui"...
 // CHKBC-NEXT:    TryGetById        r2, r1, 0, "print"
 // CHKBC-NEXT:    GetByIdShort      r3, r1, 1, "foo"
-// CHKBC-NEXT:    NewObjectWithBuffer r1, 0, 0
+// CHKBC-NEXT:    NewObjectWithBuffer r1, 1, 0
 // CHKBC-NEXT:    Call2             r1, r3, r0, r1
 // CHKBC-NEXT:    Call2             r1, r2, r0, r1
 // CHKBC-NEXT:    Ret               r1
@@ -170,7 +171,7 @@ print(foo({a: 10, b: 20, lastKey:30, 5:6}))
 
 // CHKBC:Function<shadows>(1 params, 13 registers, 0 numbers, 1 non-pointers):
 // CHKBC-NEXT:Offset in debug table: source 0x002c
-// CHKBC-NEXT:    NewObjectWithBuffer r3, 1, 17
+// CHKBC-NEXT:    NewObjectWithBuffer r3, 2, 17
 // CHKBC-NEXT:    GetGlobalObject   r1
 // CHKBC-NEXT:    TryGetById        r1, r1, 0, "print"
 // CHKBC-NEXT:    PutOwnBySlotIdx   r3, r1, 0

--- a/test/BCGen/HBC/calln.js
+++ b/test/BCGen/HBC/calln.js
@@ -118,7 +118,7 @@ function foo5(f) { f(1, 2, 3, 4); }
 // BCGEN-NEXT:  StringSwitchImm count: 0
 // BCGEN-NEXT:  Key buffer size (bytes): 0
 // BCGEN-NEXT:  Value buffer size (bytes): 0
-// BCGEN-NEXT:  Shape table count: 0
+// BCGEN-NEXT:  Shape table count: 1
 // BCGEN-NEXT:  Segment ID: 0
 // BCGEN-NEXT:  CommonJS module count: 0
 // BCGEN-NEXT:  CommonJS module count (static): 0
@@ -134,6 +134,9 @@ function foo5(f) { f(1, 2, 3, 4); }
 // BCGEN-NEXT:i3[ASCII, 14..17] #D0BD95F3: foo3
 // BCGEN-NEXT:i4[ASCII, 18..21] #D0BDA900: foo4
 // BCGEN-NEXT:i5[ASCII, 22..25] #D0BDAD11: foo5
+
+// BCGEN:Object Shape Table:
+// BCGEN-NEXT:0[0, 0]
 
 // BCGEN:Function<global>(1 params, 3 registers, 0 numbers, 1 non-pointers):
 // BCGEN-NEXT:Offset in debug table: source 0x0000

--- a/test/BCGen/HBC/construct.js
+++ b/test/BCGen/HBC/construct.js
@@ -28,7 +28,7 @@ function bar() {
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 0
 // CHECK-NEXT:  Value buffer size (bytes): 0
-// CHECK-NEXT:  Shape table count: 0
+// CHECK-NEXT:  Shape table count: 2
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -42,6 +42,10 @@ function bar() {
 // CHECK-NEXT:i1[ASCII, 6..8] #9B85A7ED: bar
 // CHECK-NEXT:i2[ASCII, 9..11] #9290584E: foo
 // CHECK-NEXT:i3[ASCII, 12..12] #0001E7F9: x
+
+// CHECK:Object Shape Table:
+// CHECK-NEXT:0[0, 0]
+// CHECK-NEXT:1[0, 0]
 
 // CHECK:Function<global>(1 params, 3 registers, 0 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000
@@ -67,12 +71,12 @@ function bar() {
 // CHECK-NEXT:Offset in debug table: source 0x0019
 // CHECK-NEXT:[@ 0] GetGlobalObject 1<Reg8>
 // CHECK-NEXT:[@ 2] GetByIdShort 1<Reg8>, 1<Reg8>, 0<UInt8>, 2<UInt8>
-// CHECK-NEXT:[@ 7] CreateThisForNew 2<Reg8>, 1<Reg8>, 1<UInt8>
-// CHECK-NEXT:[@ 11] LoadConstUInt8 3<Reg8>, 1<UInt8>
-// CHECK-NEXT:[@ 14] Mov 4<Reg8>, 2<Reg8>
-// CHECK-NEXT:[@ 17] Construct 1<Reg8>, 1<Reg8>, 2<UInt8>
-// CHECK-NEXT:[@ 21] SelectObject 1<Reg8>, 2<Reg8>, 1<Reg8>
-// CHECK-NEXT:[@ 25] Ret 1<Reg8>
+// CHECK-NEXT:[@ 7] CreateThisForNew 2<Reg8>, 1<Reg8>, 1<UInt8>, 1<UInt16>
+// CHECK-NEXT:[@ 13] LoadConstUInt8 3<Reg8>, 1<UInt8>
+// CHECK-NEXT:[@ 16] Mov 4<Reg8>, 2<Reg8>
+// CHECK-NEXT:[@ 19] Construct 1<Reg8>, 1<Reg8>, 2<UInt8>
+// CHECK-NEXT:[@ 23] SelectObject 1<Reg8>, 2<Reg8>, 1<Reg8>
+// CHECK-NEXT:[@ 27] Ret 1<Reg8>
 
 // CHECK:Debug filename table:
 // CHECK-NEXT:  0: {{.*}}construct.js
@@ -91,5 +95,5 @@ function bar() {
 // CHECK-NEXT:  0x0019  function idx 2, starts at line 14 col 1
 // CHECK-NEXT:    bc 2: line 15 col 14
 // CHECK-NEXT:    bc 7: line 15 col 17
-// CHECK-NEXT:    bc 17: line 15 col 17
+// CHECK-NEXT:    bc 19: line 15 col 17
 // CHECK-NEXT:  0x0027  end of debug source table

--- a/test/BCGen/HBC/debuggercheckbreak.js
+++ b/test/BCGen/HBC/debuggercheckbreak.js
@@ -33,7 +33,7 @@ function test1() {
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 0
 // CHECK-NEXT:  Value buffer size (bytes): 0
-// CHECK-NEXT:  Shape table count: 0
+// CHECK-NEXT:  Shape table count: 1
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -48,6 +48,9 @@ function test1() {
 // CHECK-NEXT:i2[ASCII, 10..14] #A689F65B: print
 // CHECK-NEXT:i3[ASCII, 15..20] #50223B1A: random
 // CHECK-NEXT:i4[ASCII, 21..25] #13935A76: test1
+
+// CHECK:Object Shape Table:
+// CHECK-NEXT:0[0, 0]
 
 // CHECK:Function<global>(1 params, 4 registers, 0 numbers, 0 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000

--- a/test/BCGen/HBC/deltamode/literal-buffers-base.js
+++ b/test/BCGen/HBC/deltamode/literal-buffers-base.js
@@ -71,7 +71,7 @@ function o5() {
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 24
 // CHECK-NEXT:  Value buffer size (bytes): 44
-// CHECK-NEXT:  Shape table count: 4
+// CHECK-NEXT:  Shape table count: 5
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -123,10 +123,11 @@ function o5() {
 // CHECK-NEXT:[String 10]
 
 // CHECK:Object Shape Table:
-// CHECK-NEXT:0[0, 3]
-// CHECK-NEXT:1[7, 3]
-// CHECK-NEXT:2[14, 2]
-// CHECK-NEXT:3[19, 2]
+// CHECK-NEXT:0[0, 0]
+// CHECK-NEXT:1[0, 3]
+// CHECK-NEXT:2[7, 3]
+// CHECK-NEXT:3[14, 2]
+// CHECK-NEXT:4[19, 2]
 
 // CHECK:Function<global>(1 params, 3 registers, 0 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000
@@ -164,23 +165,23 @@ function o5() {
 // CHECK-NEXT:    Ret               r0
 
 // CHECK:Function<o1>(1 params, 1 registers, 0 numbers, 0 non-pointers):
-// CHECK-NEXT:    NewObjectWithBuffer r0, 0, 0
-// CHECK-NEXT:    Ret               r0
-
-// CHECK:Function<o2>(1 params, 1 registers, 0 numbers, 0 non-pointers):
-// CHECK-NEXT:    NewObjectWithBuffer r0, 0, 0
-// CHECK-NEXT:    Ret               r0
-
-// CHECK:Function<o3>(1 params, 1 registers, 0 numbers, 0 non-pointers):
 // CHECK-NEXT:    NewObjectWithBuffer r0, 1, 0
 // CHECK-NEXT:    Ret               r0
 
+// CHECK:Function<o2>(1 params, 1 registers, 0 numbers, 0 non-pointers):
+// CHECK-NEXT:    NewObjectWithBuffer r0, 1, 0
+// CHECK-NEXT:    Ret               r0
+
+// CHECK:Function<o3>(1 params, 1 registers, 0 numbers, 0 non-pointers):
+// CHECK-NEXT:    NewObjectWithBuffer r0, 2, 0
+// CHECK-NEXT:    Ret               r0
+
 // CHECK:Function<o4>(1 params, 1 registers, 0 numbers, 0 non-pointers):
-// CHECK-NEXT:    NewObjectWithBuffer r0, 2, 26
+// CHECK-NEXT:    NewObjectWithBuffer r0, 3, 26
 // CHECK-NEXT:    Ret               r0
 
 // CHECK:Function<o5>(1 params, 1 registers, 0 numbers, 0 non-pointers):
-// CHECK-NEXT:    NewObjectWithBuffer r0, 3, 35
+// CHECK-NEXT:    NewObjectWithBuffer r0, 4, 35
 // CHECK-NEXT:    Ret               r0
 
 // CHECK:Debug filename table:

--- a/test/BCGen/HBC/deltamode/literal-buffers-update.js
+++ b/test/BCGen/HBC/deltamode/literal-buffers-update.js
@@ -90,7 +90,7 @@ function o5() {
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 31
 // CHECK-NEXT:  Value buffer size (bytes): 57
-// CHECK-NEXT:  Shape table count: 5
+// CHECK-NEXT:  Shape table count: 6
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -153,11 +153,12 @@ function o5() {
 // CHECK-NEXT:[String 20]
 
 // CHECK:Object Shape Table:
-// CHECK-NEXT:0[0, 3]
-// CHECK-NEXT:1[7, 3]
-// CHECK-NEXT:2[14, 2]
-// CHECK-NEXT:3[19, 2]
-// CHECK-NEXT:4[24, 3]
+// CHECK-NEXT:0[0, 0]
+// CHECK-NEXT:1[0, 3]
+// CHECK-NEXT:2[7, 3]
+// CHECK-NEXT:3[14, 2]
+// CHECK-NEXT:4[19, 2]
+// CHECK-NEXT:5[24, 3]
 
 // CHECK:Function<global>(1 params, 3 registers, 0 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000
@@ -197,7 +198,7 @@ function o5() {
 // CHECK-NEXT:    Ret               r0
 
 // CHECK:Function<o0>(1 params, 1 registers, 0 numbers, 0 non-pointers):
-// CHECK-NEXT:    NewObjectWithBuffer r0, 4, 44
+// CHECK-NEXT:    NewObjectWithBuffer r0, 5, 44
 // CHECK-NEXT:    Ret               r0
 
 // CHECK:Function<a1>(1 params, 1 registers, 0 numbers, 0 non-pointers):
@@ -209,23 +210,23 @@ function o5() {
 // CHECK-NEXT:    Ret               r0
 
 // CHECK:Function<o1>(1 params, 1 registers, 0 numbers, 0 non-pointers):
-// CHECK-NEXT:    NewObjectWithBuffer r0, 0, 0
-// CHECK-NEXT:    Ret               r0
-
-// CHECK:Function<o2>(1 params, 1 registers, 0 numbers, 0 non-pointers):
-// CHECK-NEXT:    NewObjectWithBuffer r0, 0, 0
-// CHECK-NEXT:    Ret               r0
-
-// CHECK:Function<o3>(1 params, 1 registers, 0 numbers, 0 non-pointers):
 // CHECK-NEXT:    NewObjectWithBuffer r0, 1, 0
 // CHECK-NEXT:    Ret               r0
 
+// CHECK:Function<o2>(1 params, 1 registers, 0 numbers, 0 non-pointers):
+// CHECK-NEXT:    NewObjectWithBuffer r0, 1, 0
+// CHECK-NEXT:    Ret               r0
+
+// CHECK:Function<o3>(1 params, 1 registers, 0 numbers, 0 non-pointers):
+// CHECK-NEXT:    NewObjectWithBuffer r0, 2, 0
+// CHECK-NEXT:    Ret               r0
+
 // CHECK:Function<o4>(1 params, 1 registers, 0 numbers, 0 non-pointers):
-// CHECK-NEXT:    NewObjectWithBuffer r0, 2, 26
+// CHECK-NEXT:    NewObjectWithBuffer r0, 3, 26
 // CHECK-NEXT:    Ret               r0
 
 // CHECK:Function<o5>(1 params, 1 registers, 0 numbers, 0 non-pointers):
-// CHECK-NEXT:    NewObjectWithBuffer r0, 3, 35
+// CHECK-NEXT:    NewObjectWithBuffer r0, 4, 35
 // CHECK-NEXT:    Ret               r0
 
 // CHECK:Debug filename table:

--- a/test/BCGen/HBC/dis-string-operands.js
+++ b/test/BCGen/HBC/dis-string-operands.js
@@ -16,7 +16,7 @@ bazz = "const-string";
 
 //CHECK:    DeclareGlobalVar  "glob"
 //CHECK:    DeclareGlobalVar  "re"
-//CHECK:    NewObjectWithBuffer {{r[0-9]+}}, 0, 0
+//CHECK:    NewObjectWithBuffer {{r[0-9]+}}, 1, 0
 //CHECK:    GetGlobalObject   {{r[0-9]+}}
 //CHECK:    TryGetById        {{r[0-9]+}}, {{r[0-9]+}}, 0, "bar"
 //CHECK:    LoadConstUndefined {{r[0-9]+}}

--- a/test/BCGen/HBC/disasm-objdump.js
+++ b/test/BCGen/HBC/disasm-objdump.js
@@ -11,10 +11,10 @@ print("hello");
 
 //CHECK-LABEL:{{.*}}: file format HBC-{{.*}}
 //CHECK-LABEL:Disassembly of section .text:
-//CHECK-LABEL:00000000000000b4 <_0>:
-//CHECK-NEXT:000000b4:{{.*}}GetGlobalObject {{.*}}%r1
-//CHECK-NEXT:000000b6:{{.*}}TryGetById {{.*}}%r2, %r1, $0x0, $0x02
-//CHECK-NEXT:000000bc:{{.*}}LoadConstString {{.*}}%r1, $0x01
-//CHECK-NEXT:000000c0:{{.*}}LoadConstUndefined {{.*}}%r0
-//CHECK-NEXT:000000c2:{{.*}}Call2 {{.*}}%r1, %r2, %r0, %r1
-//CHECK-NEXT:000000c7:{{.*}}Ret {{.*}}%r1
+//CHECK-LABEL:00000000000000bc <_0>:
+//CHECK-NEXT:000000bc:{{.*}}GetGlobalObject {{.*}}%r1
+//CHECK-NEXT:000000be:{{.*}}TryGetById {{.*}}%r2, %r1, $0x0, $0x02
+//CHECK-NEXT:000000c4:{{.*}}LoadConstString {{.*}}%r1, $0x01
+//CHECK-NEXT:000000c8:{{.*}}LoadConstUndefined {{.*}}%r0
+//CHECK-NEXT:000000ca:{{.*}}Call2 {{.*}}%r1, %r2, %r0, %r1
+//CHECK-NEXT:000000cf:{{.*}}Ret {{.*}}%r1

--- a/test/BCGen/HBC/es6/generator.js
+++ b/test/BCGen/HBC/es6/generator.js
@@ -32,7 +32,7 @@ function *args() {
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 5
 // CHECK-NEXT:  Value buffer size (bytes): 10
-// CHECK-NEXT:  Shape table count: 1
+// CHECK-NEXT:  Shape table count: 2
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -67,7 +67,8 @@ function *args() {
 // CHECK-NEXT:[String 5]
 
 // CHECK:Object Shape Table:
-// CHECK-NEXT:0[0, 2]
+// CHECK-NEXT:0[0, 0]
+// CHECK-NEXT:1[0, 2]
 
 // CHECK:Function Source Table:
 // CHECK-NEXT:  Function ID 3 -> s0
@@ -166,7 +167,7 @@ function *args() {
 // CHECK-NEXT:    LoadConstUInt8    r8, 3
 // CHECK-NEXT:    StoreNPToEnvironment r2, 9, r8
 // CHECK-NEXT:L14:
-// CHECK-NEXT:    NewObjectWithBuffer r8, 0, 0
+// CHECK-NEXT:    NewObjectWithBuffer r8, 1, 0
 // CHECK-NEXT:    PutOwnBySlotIdx   r8, r11, 0
 // CHECK-NEXT:    Ret               r8
 // CHECK-NEXT:L4:
@@ -204,7 +205,7 @@ function *args() {
 // CHECK-NEXT:    LoadConstUInt8    r8, 3
 // CHECK-NEXT:    StoreNPToEnvironment r2, 9, r8
 // CHECK-NEXT:L15:
-// CHECK-NEXT:    NewObjectWithBuffer r8, 0, 6
+// CHECK-NEXT:    NewObjectWithBuffer r8, 1, 6
 // CHECK-NEXT:    Ret               r8
 // CHECK-NEXT:L6:
 // CHECK-NEXT:    LoadFromEnvironment r8, r2, 4
@@ -219,14 +220,14 @@ function *args() {
 // CHECK-NEXT:    LoadConstUInt8    r1, 1
 // CHECK-NEXT:    StoreNPToEnvironment r2, 9, r1
 // CHECK-NEXT:L16:
-// CHECK-NEXT:    NewObjectWithBuffer r1, 0, 4
+// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 4
 // CHECK-NEXT:    PutOwnBySlotIdx   r1, r6, 0
 // CHECK-NEXT:    Ret               r1
 // CHECK-NEXT:L9:
 // CHECK-NEXT:    LoadConstUInt8    r1, 3
 // CHECK-NEXT:    StoreNPToEnvironment r2, 9, r1
 // CHECK-NEXT:L17:
-// CHECK-NEXT:    NewObjectWithBuffer r1, 0, 0
+// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 0
 // CHECK-NEXT:    PutOwnBySlotIdx   r1, r5, 0
 // CHECK-NEXT:    Ret               r1
 // CHECK-NEXT:L8:
@@ -248,10 +249,10 @@ function *args() {
 // CHECK-NEXT:    LoadConstUInt8    r1, 2
 // CHECK-NEXT:    StrictEq          r1, r4, r1
 // CHECK-NEXT:    JmpTrue           L12, r1
-// CHECK-NEXT:    NewObjectWithBuffer r1, 0, 2
+// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 2
 // CHECK-NEXT:    Ret               r1
 // CHECK-NEXT:L12:
-// CHECK-NEXT:    NewObjectWithBuffer r1, 0, 0
+// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 0
 // CHECK-NEXT:    PutOwnBySlotIdx   r1, r3, 0
 // CHECK-NEXT:    Ret               r1
 // CHECK-NEXT:L11:
@@ -308,13 +309,13 @@ function *args() {
 // CHECK-NEXT:    LoadConstUInt8    r1, 3
 // CHECK-NEXT:    StoreNPToEnvironment r2, 4, r1
 // CHECK-NEXT:L12:
-// CHECK-NEXT:    NewObjectWithBuffer r1, 0, 2
+// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 2
 // CHECK-NEXT:    Ret               r1
 // CHECK-NEXT:L5:
 // CHECK-NEXT:    LoadConstUInt8    r1, 3
 // CHECK-NEXT:    StoreNPToEnvironment r2, 4, r1
 // CHECK-NEXT:L13:
-// CHECK-NEXT:    NewObjectWithBuffer r1, 0, 0
+// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 0
 // CHECK-NEXT:    PutOwnBySlotIdx   r1, r9, 0
 // CHECK-NEXT:    Ret               r1
 // CHECK-NEXT:L4:
@@ -345,14 +346,14 @@ function *args() {
 // CHECK-NEXT:    LoadConstUInt8    r1, 1
 // CHECK-NEXT:    StoreNPToEnvironment r2, 4, r1
 // CHECK-NEXT:L14:
-// CHECK-NEXT:    NewObjectWithBuffer r1, 0, 4
+// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 4
 // CHECK-NEXT:    PutOwnBySlotIdx   r1, r6, 0
 // CHECK-NEXT:    Ret               r1
 // CHECK-NEXT:L7:
 // CHECK-NEXT:    LoadConstUInt8    r1, 3
 // CHECK-NEXT:    StoreNPToEnvironment r2, 4, r1
 // CHECK-NEXT:L15:
-// CHECK-NEXT:    NewObjectWithBuffer r1, 0, 0
+// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 0
 // CHECK-NEXT:    PutOwnBySlotIdx   r1, r5, 0
 // CHECK-NEXT:    Ret               r1
 // CHECK-NEXT:L6:
@@ -374,10 +375,10 @@ function *args() {
 // CHECK-NEXT:    LoadConstUInt8    r1, 2
 // CHECK-NEXT:    StrictEq          r1, r4, r1
 // CHECK-NEXT:    JmpTrue           L10, r1
-// CHECK-NEXT:    NewObjectWithBuffer r1, 0, 2
+// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 2
 // CHECK-NEXT:    Ret               r1
 // CHECK-NEXT:L10:
-// CHECK-NEXT:    NewObjectWithBuffer r1, 0, 0
+// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 0
 // CHECK-NEXT:    PutOwnBySlotIdx   r1, r3, 0
 // CHECK-NEXT:    Ret               r1
 // CHECK-NEXT:L9:

--- a/test/BCGen/HBC/es6/spread-arguments.js
+++ b/test/BCGen/HBC/es6/spread-arguments.js
@@ -25,7 +25,7 @@ function foo(fn, x) {
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 0
 // CHECK-NEXT:  Value buffer size (bytes): 0
-// CHECK-NEXT:  Shape table count: 0
+// CHECK-NEXT:  Shape table count: 1
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -37,6 +37,9 @@ function foo(fn, x) {
 // CHECK:Global String Table:
 // CHECK-NEXT:s0[ASCII, 0..5]: global
 // CHECK-NEXT:i1[ASCII, 6..8] #9290584E: foo
+
+// CHECK:Object Shape Table:
+// CHECK-NEXT:0[0, 0]
 
 // CHECK:Function<global>(1 params, 3 registers, 0 numbers, 0 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000

--- a/test/BCGen/HBC/es6/tdz-check.js
+++ b/test/BCGen/HBC/es6/tdz-check.js
@@ -25,7 +25,7 @@ function foo() {
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 0
 // CHECK-NEXT:  Value buffer size (bytes): 0
-// CHECK-NEXT:  Shape table count: 0
+// CHECK-NEXT:  Shape table count: 1
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -37,6 +37,9 @@ function foo() {
 // CHECK:Global String Table:
 // CHECK-NEXT:s0[ASCII, 0..5]: global
 // CHECK-NEXT:i1[ASCII, 6..8] #9290584E: foo
+
+// CHECK:Object Shape Table:
+// CHECK-NEXT:0[0, 0]
 
 // CHECK:Function<global>(1 params, 3 registers, 0 numbers, 0 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000

--- a/test/BCGen/HBC/exceptions.js
+++ b/test/BCGen/HBC/exceptions.js
@@ -38,7 +38,7 @@ function foo(a) {
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 0
 // CHECK-NEXT:  Value buffer size (bytes): 0
-// CHECK-NEXT:  Shape table count: 0
+// CHECK-NEXT:  Shape table count: 1
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -50,6 +50,9 @@ function foo(a) {
 // CHECK:Global String Table:
 // CHECK-NEXT:s0[ASCII, 0..5]: global
 // CHECK-NEXT:i1[ASCII, 6..8] #9290584E: foo
+
+// CHECK:Object Shape Table:
+// CHECK-NEXT:0[0, 0]
 
 // CHECK:Function<global>(1 params, 3 registers, 0 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000

--- a/test/BCGen/HBC/fibonacci.js
+++ b/test/BCGen/HBC/fibonacci.js
@@ -26,7 +26,7 @@ function fibonacci(num) {
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 0
 // CHECK-NEXT:  Value buffer size (bytes): 0
-// CHECK-NEXT:  Shape table count: 0
+// CHECK-NEXT:  Shape table count: 1
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -38,6 +38,9 @@ function fibonacci(num) {
 // CHECK:Global String Table:
 // CHECK-NEXT:s0[ASCII, 0..5]: global
 // CHECK-NEXT:i1[ASCII, 6..14] #85794EA3: fibonacci
+
+// CHECK:Object Shape Table:
+// CHECK-NEXT:0[0, 0]
 
 // CHECK:Function<global>(1 params, 3 registers, 0 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000

--- a/test/BCGen/HBC/float-constant.js
+++ b/test/BCGen/HBC/float-constant.js
@@ -25,7 +25,7 @@ var z = 0.0;
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 0
 // CHECK-NEXT:  Value buffer size (bytes): 0
-// CHECK-NEXT:  Shape table count: 0
+// CHECK-NEXT:  Shape table count: 1
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -40,6 +40,9 @@ var z = 0.0;
 // CHECK-NEXT:i2[ASCII, 7..7] #0001E7F9: x
 // CHECK-NEXT:i3[ASCII, 8..8] #0001E3E8: y
 // CHECK-NEXT:i4[ASCII, 9..9] #0001EFDB: z
+
+// CHECK:Object Shape Table:
+// CHECK-NEXT:0[0, 0]
 
 // CHECK:Function<global>(1 params, 3 registers, 1 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000

--- a/test/BCGen/HBC/flow/class-shape-table.js
+++ b/test/BCGen/HBC/flow/class-shape-table.js
@@ -29,7 +29,7 @@ globalThis.b = ({x:1} as any);
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 3
 // CHECK-NEXT:  Value buffer size (bytes): 10
-// CHECK-NEXT:  Shape table count: 2
+// CHECK-NEXT:  Shape table count: 3
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -55,22 +55,23 @@ globalThis.b = ({x:1} as any);
 // CHECK-NEXT:[String 6]
 
 // CHECK:Object Shape Table:
-// CHECK-NEXT:0[0, 1]
+// CHECK-NEXT:0[0, 0]
 // CHECK-NEXT:1[0, 1]
+// CHECK-NEXT:2[0, 1]
 
 // CHECK:Function<global>(1 params, 4 registers, 0 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000
 // CHECK-NEXT:    LoadConstNull     r0
-// CHECK-NEXT:    NewObjectWithParent r2, r0
+// CHECK-NEXT:    NewObjectWithParent r2, r0, 0
 // CHECK-NEXT:    LoadConstUndefined r0
 // CHECK-NEXT:    CreateClosure     r1, r0, Function<A>
 // CHECK-NEXT:    PutByIdStrict     r1, r2, 0, "prototype"
 // CHECK-NEXT:    GetGlobalObject   r1
 // CHECK-NEXT:    TryGetById        r3, r1, 0, "globalThis"
-// CHECK-NEXT:    NewTypedObjectWithBuffer r2, r2, 0, 0, 0
+// CHECK-NEXT:    NewTypedObjectWithBuffer r2, r2, 1, 0, 0
 // CHECK-NEXT:    PutByIdStrict     r3, r2, 1, "a"
 // CHECK-NEXT:    TryGetById        r2, r1, 0, "globalThis"
-// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 5
+// CHECK-NEXT:    NewObjectWithBuffer r1, 2, 5
 // CHECK-NEXT:    PutByIdStrict     r2, r1, 2, "b"
 // CHECK-NEXT:    Ret               r0
 
@@ -86,9 +87,9 @@ globalThis.b = ({x:1} as any);
 
 // CHECK:Debug source table:
 // CHECK-NEXT:  0x0000  function idx 0, starts at line 10 col 1
-// CHECK-NEXT:    bc 12: line 10 col 1
-// CHECK-NEXT:    bc 20: line 16 col 1
-// CHECK-NEXT:    bc 38: line 16 col 14
-// CHECK-NEXT:    bc 44: line 17 col 1
-// CHECK-NEXT:    bc 56: line 17 col 14
+// CHECK-NEXT:    bc 16: line 10 col 1
+// CHECK-NEXT:    bc 24: line 16 col 1
+// CHECK-NEXT:    bc 42: line 16 col 14
+// CHECK-NEXT:    bc 48: line 17 col 1
+// CHECK-NEXT:    bc 60: line 17 col 14
 // CHECK-NEXT:  0x0014  end of debug source table

--- a/test/BCGen/HBC/flow/class-shape-table.js
+++ b/test/BCGen/HBC/flow/class-shape-table.js
@@ -29,7 +29,7 @@ globalThis.b = ({x:1} as any);
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 3
 // CHECK-NEXT:  Value buffer size (bytes): 10
-// CHECK-NEXT:  Shape table count: 3
+// CHECK-NEXT:  Shape table count: 4
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -56,22 +56,23 @@ globalThis.b = ({x:1} as any);
 
 // CHECK:Object Shape Table:
 // CHECK-NEXT:0[0, 0]
-// CHECK-NEXT:1[0, 1]
+// CHECK-NEXT:1[0, 0]
 // CHECK-NEXT:2[0, 1]
+// CHECK-NEXT:3[0, 1]
 
 // CHECK:Function<global>(1 params, 4 registers, 0 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000
 // CHECK-NEXT:    LoadConstNull     r0
-// CHECK-NEXT:    NewObjectWithParent r2, r0, 0
+// CHECK-NEXT:    NewObjectWithParent r2, r0, 1
 // CHECK-NEXT:    LoadConstUndefined r0
 // CHECK-NEXT:    CreateClosure     r1, r0, Function<A>
 // CHECK-NEXT:    PutByIdStrict     r1, r2, 0, "prototype"
 // CHECK-NEXT:    GetGlobalObject   r1
 // CHECK-NEXT:    TryGetById        r3, r1, 0, "globalThis"
-// CHECK-NEXT:    NewTypedObjectWithBuffer r2, r2, 1, 0, 0
+// CHECK-NEXT:    NewTypedObjectWithBuffer r2, r2, 2, 0, 0
 // CHECK-NEXT:    PutByIdStrict     r3, r2, 1, "a"
 // CHECK-NEXT:    TryGetById        r2, r1, 0, "globalThis"
-// CHECK-NEXT:    NewObjectWithBuffer r1, 2, 5
+// CHECK-NEXT:    NewObjectWithBuffer r1, 3, 5
 // CHECK-NEXT:    PutByIdStrict     r2, r1, 2, "b"
 // CHECK-NEXT:    Ret               r0
 

--- a/test/BCGen/HBC/for_in.js
+++ b/test/BCGen/HBC/for_in.js
@@ -32,7 +32,7 @@ test_one(1,2,3)
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 0
 // CHECK-NEXT:  Value buffer size (bytes): 0
-// CHECK-NEXT:  Shape table count: 0
+// CHECK-NEXT:  Shape table count: 1
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -44,6 +44,9 @@ test_one(1,2,3)
 // CHECK:Global String Table:
 // CHECK-NEXT:s0[ASCII, 0..5]: global
 // CHECK-NEXT:i1[ASCII, 6..13] #33D4E32D: test_one
+
+// CHECK:Object Shape Table:
+// CHECK-NEXT:0[0, 0]
 
 // CHECK:Function<global>(1 params, 17 registers, 3 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000

--- a/test/BCGen/HBC/get-by-int-const.js
+++ b/test/BCGen/HBC/get-by-int-const.js
@@ -26,7 +26,7 @@ function foo(a) {
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 0
 // CHECK-NEXT:  Value buffer size (bytes): 0
-// CHECK-NEXT:  Shape table count: 0
+// CHECK-NEXT:  Shape table count: 1
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -38,6 +38,9 @@ function foo(a) {
 // CHECK:Global String Table:
 // CHECK-NEXT:s0[ASCII, 0..5]: global
 // CHECK-NEXT:i1[ASCII, 6..8] #9290584E: foo
+
+// CHECK:Object Shape Table:
+// CHECK-NEXT:0[0, 0]
 
 // CHECK:Function<global>(1 params, 3 registers, 0 numbers, 0 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000

--- a/test/BCGen/HBC/gettersetter.js
+++ b/test/BCGen/HBC/gettersetter.js
@@ -27,7 +27,7 @@ var obj = {
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 0
 // CHECK-NEXT:  Value buffer size (bytes): 0
-// CHECK-NEXT:  Shape table count: 0
+// CHECK-NEXT:  Shape table count: 1
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -46,6 +46,9 @@ var obj = {
 // CHECK-NEXT:s6[ASCII, 15..20]: global
 // CHECK-NEXT:s7[ASCII, 21..25]: set b
 // CHECK-NEXT:i8[ASCII, 26..28] #DC53DBCF: obj
+
+// CHECK:Object Shape Table:
+// CHECK-NEXT:0[0, 0]
 
 // CHECK:Function<global>(1 params, 5 registers, 0 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000

--- a/test/BCGen/HBC/globals.js
+++ b/test/BCGen/HBC/globals.js
@@ -25,7 +25,7 @@ y = x;
 // STRICT-NEXT:  StringSwitchImm count: 0
 // STRICT-NEXT:  Key buffer size (bytes): 0
 // STRICT-NEXT:  Value buffer size (bytes): 0
-// STRICT-NEXT:  Shape table count: 0
+// STRICT-NEXT:  Shape table count: 1
 // STRICT-NEXT:  Segment ID: 0
 // STRICT-NEXT:  CommonJS module count: 0
 // STRICT-NEXT:  CommonJS module count (static): 0
@@ -39,6 +39,9 @@ y = x;
 // STRICT-NEXT:i1[ASCII, 6..8] #9290584E: foo
 // STRICT-NEXT:i2[ASCII, 9..9] #0001E7F9: x
 // STRICT-NEXT:i3[ASCII, 10..10] #0001E3E8: y
+
+// STRICT:Object Shape Table:
+// STRICT-NEXT:0[0, 0]
 
 // STRICT:Function<global>(1 params, 14 registers, 1 numbers, 1 non-pointers):
 // STRICT-NEXT:Offset in debug table: source 0x0000
@@ -82,7 +85,7 @@ y = x;
 // NONSTRICT-NEXT:  StringSwitchImm count: 0
 // NONSTRICT-NEXT:  Key buffer size (bytes): 0
 // NONSTRICT-NEXT:  Value buffer size (bytes): 0
-// NONSTRICT-NEXT:  Shape table count: 0
+// NONSTRICT-NEXT:  Shape table count: 1
 // NONSTRICT-NEXT:  Segment ID: 0
 // NONSTRICT-NEXT:  CommonJS module count: 0
 // NONSTRICT-NEXT:  CommonJS module count (static): 0
@@ -96,6 +99,9 @@ y = x;
 // NONSTRICT-NEXT:i1[ASCII, 6..8] #9290584E: foo
 // NONSTRICT-NEXT:i2[ASCII, 9..9] #0001E7F9: x
 // NONSTRICT-NEXT:i3[ASCII, 10..10] #0001E3E8: y
+
+// NONSTRICT:Object Shape Table:
+// NONSTRICT-NEXT:0[0, 0]
 
 // NONSTRICT:Function<global>(1 params, 14 registers, 1 numbers, 1 non-pointers):
 // NONSTRICT-NEXT:Offset in debug table: source 0x0000

--- a/test/BCGen/HBC/hbc_object_literals.js
+++ b/test/BCGen/HBC/hbc_object_literals.js
@@ -201,7 +201,7 @@ function obj7() {
 // BCGEN-NEXT:  StringSwitchImm count: 0
 // BCGEN-NEXT:  Key buffer size (bytes): 107
 // BCGEN-NEXT:  Value buffer size (bytes): 160
-// BCGEN-NEXT:  Shape table count: 4
+// BCGEN-NEXT:  Shape table count: 5
 // BCGEN-NEXT:  Segment ID: 0
 // BCGEN-NEXT:  CommonJS module count: 0
 // BCGEN-NEXT:  CommonJS module count (static): 0
@@ -338,10 +338,11 @@ function obj7() {
 // BCGEN-NEXT:[String 10]
 
 // BCGEN:Object Shape Table:
-// BCGEN-NEXT:0[0, 7]
-// BCGEN-NEXT:1[15, 18]
-// BCGEN-NEXT:2[53, 13]
-// BCGEN-NEXT:3[83, 6]
+// BCGEN-NEXT:0[0, 0]
+// BCGEN-NEXT:1[0, 7]
+// BCGEN-NEXT:2[15, 18]
+// BCGEN-NEXT:3[53, 13]
+// BCGEN-NEXT:4[83, 6]
 
 // BCGEN:Function<global>(1 params, 3 registers, 0 numbers, 1 non-pointers):
 // BCGEN-NEXT:Offset in debug table: source 0x0000
@@ -371,34 +372,34 @@ function obj7() {
 // BCGEN-NEXT:    Ret               r0
 
 // BCGEN:Function<obj1>(1 params, 3 registers, 0 numbers, 1 non-pointers):
-// BCGEN-NEXT:    NewObjectWithBuffer r1, 0, 0
+// BCGEN-NEXT:    NewObjectWithBuffer r1, 1, 0
 // BCGEN-NEXT:    LoadConstUndefined r0
 // BCGEN-NEXT:    CreateClosure     r2, r0, Function<f>
 // BCGEN-NEXT:    PutOwnBySlotIdx   r1, r2, 5
 // BCGEN-NEXT:    Ret               r1
 
 // BCGEN:Function<obj2>(1 params, 1 registers, 0 numbers, 0 non-pointers):
-// BCGEN-NEXT:    NewObjectWithBuffer r0, 1, 17
+// BCGEN-NEXT:    NewObjectWithBuffer r0, 2, 17
 // BCGEN-NEXT:    Ret               r0
 
 // BCGEN:Function<obj3>(1 params, 1 registers, 0 numbers, 0 non-pointers):
-// BCGEN-NEXT:    NewObjectWithBuffer r0, 2, 85
+// BCGEN-NEXT:    NewObjectWithBuffer r0, 3, 85
 // BCGEN-NEXT:    Ret               r0
 
 // BCGEN:Function<obj4>(1 params, 1 registers, 0 numbers, 0 non-pointers):
-// BCGEN-NEXT:    NewObjectWithBuffer r0, 2, 85
+// BCGEN-NEXT:    NewObjectWithBuffer r0, 3, 85
 // BCGEN-NEXT:    Ret               r0
 
 // BCGEN:Function<obj5>(1 params, 1 registers, 0 numbers, 0 non-pointers):
-// BCGEN-NEXT:    NewObjectWithBuffer r0, 3, 135
+// BCGEN-NEXT:    NewObjectWithBuffer r0, 4, 135
 // BCGEN-NEXT:    Ret               r0
 
 // BCGEN:Function<obj6>(1 params, 1 registers, 0 numbers, 0 non-pointers):
-// BCGEN-NEXT:    NewObjectWithBuffer r0, 3, 67
+// BCGEN-NEXT:    NewObjectWithBuffer r0, 4, 67
 // BCGEN-NEXT:    Ret               r0
 
 // BCGEN:Function<obj7>(1 params, 1 registers, 0 numbers, 0 non-pointers):
-// BCGEN-NEXT:    NewObjectWithBuffer r0, 3, 68
+// BCGEN-NEXT:    NewObjectWithBuffer r0, 4, 68
 // BCGEN-NEXT:    Ret               r0
 
 // BCGEN:Function<f>(1 params, 1 registers, 0 numbers, 1 non-pointers):

--- a/test/BCGen/HBC/inline-cache-ids.js
+++ b/test/BCGen/HBC/inline-cache-ids.js
@@ -139,7 +139,7 @@ function manyPutByIds(o, o2, val) {
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 0
 // CHECK-NEXT:  Value buffer size (bytes): 0
-// CHECK-NEXT:  Shape table count: 0
+// CHECK-NEXT:  Shape table count: 1
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -410,6 +410,9 @@ function manyPutByIds(o, o2, val) {
 // CHECK-NEXT:i258[ASCII, 874..877] #8540FCA9: p255
 // CHECK-NEXT:i259[ASCII, 878..881] #8540F8BE: p256
 // CHECK-NEXT:i260[ASCII, 882..885] #8540E4CF: p257
+
+// CHECK:Object Shape Table:
+// CHECK-NEXT:0[0, 0]
 
 // CHECK:Function<global>(1 params, 3 registers, 0 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000

--- a/test/BCGen/HBC/int-strict-equality.js
+++ b/test/BCGen/HBC/int-strict-equality.js
@@ -146,7 +146,7 @@ function test_could_be_int(func) {
 // CHKBC-NEXT:  StringSwitchImm count: 0
 // CHKBC-NEXT:  Key buffer size (bytes): 0
 // CHKBC-NEXT:  Value buffer size (bytes): 0
-// CHKBC-NEXT:  Shape table count: 0
+// CHKBC-NEXT:  Shape table count: 1
 // CHKBC-NEXT:  Segment ID: 0
 // CHKBC-NEXT:  CommonJS module count: 0
 // CHKBC-NEXT:  CommonJS module count (static): 0
@@ -161,6 +161,9 @@ function test_could_be_int(func) {
 // CHKBC-NEXT:i2[ASCII, 19..31] #738B3606: test_int_uint
 // CHKBC-NEXT:i3[ASCII, 31..42] #B424DF91: test_int_int
 // CHKBC-NEXT:i4[ASCII, 42..58] #7CF5E44C: test_could_be_int
+
+// CHKBC:Object Shape Table:
+// CHKBC-NEXT:0[0, 0]
 
 // CHKBC:Function<global>(1 params, 3 registers, 0 numbers, 1 non-pointers):
 // CHKBC-NEXT:Offset in debug table: source 0x0000

--- a/test/BCGen/HBC/interp-dispatch.js
+++ b/test/BCGen/HBC/interp-dispatch.js
@@ -40,7 +40,7 @@ print(bench(4e6, 100))
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 0
 // CHECK-NEXT:  Value buffer size (bytes): 0
-// CHECK-NEXT:  Shape table count: 0
+// CHECK-NEXT:  Shape table count: 1
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -53,6 +53,9 @@ print(bench(4e6, 100))
 // CHECK-NEXT:s0[ASCII, 0..5]: global
 // CHECK-NEXT:i1[ASCII, 6..10] #20300996: bench
 // CHECK-NEXT:i2[ASCII, 11..15] #A689F65B: print
+
+// CHECK:Object Shape Table:
+// CHECK-NEXT:0[0, 0]
 
 // CHECK:Function<global>(1 params, 15 registers, 2 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000

--- a/test/BCGen/HBC/jumps.js
+++ b/test/BCGen/HBC/jumps.js
@@ -63,7 +63,7 @@ function foo(a) {
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 0
 // CHECK-NEXT:  Value buffer size (bytes): 0
-// CHECK-NEXT:  Shape table count: 0
+// CHECK-NEXT:  Shape table count: 1
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -75,6 +75,9 @@ function foo(a) {
 // CHECK:Global String Table:
 // CHECK-NEXT:s0[ASCII, 0..5]: global
 // CHECK-NEXT:i1[ASCII, 6..8] #9290584E: foo
+
+// CHECK:Object Shape Table:
+// CHECK-NEXT:0[0, 0]
 
 // CHECK:Function<global>(1 params, 3 registers, 0 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000

--- a/test/BCGen/HBC/lower-globalobject.js
+++ b/test/BCGen/HBC/lower-globalobject.js
@@ -45,7 +45,7 @@ function foo() {
 // CHKBC-NEXT:  StringSwitchImm count: 0
 // CHKBC-NEXT:  Key buffer size (bytes): 0
 // CHKBC-NEXT:  Value buffer size (bytes): 0
-// CHKBC-NEXT:  Shape table count: 0
+// CHKBC-NEXT:  Shape table count: 1
 // CHKBC-NEXT:  Segment ID: 0
 // CHKBC-NEXT:  CommonJS module count: 0
 // CHKBC-NEXT:  CommonJS module count (static): 0
@@ -58,6 +58,9 @@ function foo() {
 // CHKBC-NEXT:s0[ASCII, 0..5]: global
 // CHKBC-NEXT:i1[ASCII, 6..8] #9290584E: foo
 // CHKBC-NEXT:i2[ASCII, 9..9] #0001E7F9: x
+
+// CHKBC:Object Shape Table:
+// CHKBC-NEXT:0[0, 0]
 
 // CHKBC:Function<global>(1 params, 3 registers, 0 numbers, 1 non-pointers):
 // CHKBC-NEXT:Offset in debug table: source 0x0000

--- a/test/BCGen/HBC/new-array-debug.js
+++ b/test/BCGen/HBC/new-array-debug.js
@@ -25,7 +25,7 @@ function foo() {
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 0
 // CHECK-NEXT:  Value buffer size (bytes): 0
-// CHECK-NEXT:  Shape table count: 0
+// CHECK-NEXT:  Shape table count: 1
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -37,6 +37,9 @@ function foo() {
 // CHECK:Global String Table:
 // CHECK-NEXT:s0[ASCII, 0..5]: global
 // CHECK-NEXT:i1[ASCII, 6..8] #9290584E: foo
+
+// CHECK:Object Shape Table:
+// CHECK-NEXT:0[0, 0]
 
 // CHECK:Function<global>(1 params, 3 registers, 0 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000

--- a/test/BCGen/HBC/new-object-with-parent-shape-table.js
+++ b/test/BCGen/HBC/new-object-with-parent-shape-table.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermesc -dump-bytecode %s | %FileCheckOrRegen --match-full-lines %s
+
+// Show that the shape table is used correctly for NewObjectWithParent.
+var a = {__proto__: Math};
+var b = {__proto__: JSON};
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:Bytecode File Information:
+// CHECK-NEXT:  Bytecode version number: {{.*}}
+// CHECK-NEXT:  Source hash: {{.*}}
+// CHECK-NEXT:  Function count: 1
+// CHECK-NEXT:  String count: 5
+// CHECK-NEXT:  BigInt count: 0
+// CHECK-NEXT:  String Kind Entry count: 2
+// CHECK-NEXT:  RegExp count: 0
+// CHECK-NEXT:  StringSwitchImm count: 0
+// CHECK-NEXT:  Key buffer size (bytes): 0
+// CHECK-NEXT:  Value buffer size (bytes): 0
+// CHECK-NEXT:  Shape table count: 1
+// CHECK-NEXT:  Segment ID: 0
+// CHECK-NEXT:  CommonJS module count: 0
+// CHECK-NEXT:  CommonJS module count (static): 0
+// CHECK-NEXT:  Function source count: 0
+// CHECK-NEXT:  Bytecode options:
+// CHECK-NEXT:    staticBuiltins: 0
+// CHECK-NEXT:    cjsModulesStaticallyResolved: 0
+
+// CHECK:Global String Table:
+// CHECK-NEXT:s0[ASCII, 0..5]: global
+// CHECK-NEXT:i1[ASCII, 4..4] #00018270: a
+// CHECK-NEXT:i2[ASCII, 6..9] #971CE5C7: JSON
+// CHECK-NEXT:i3[ASCII, 10..13] #1C182460: Math
+// CHECK-NEXT:i4[ASCII, 14..14] #00018E43: b
+
+// CHECK:Object Shape Table:
+// CHECK-NEXT:0[0, 0]
+
+// CHECK:Function<global>(1 params, 3 registers, 0 numbers, 1 non-pointers):
+// CHECK-NEXT:Offset in debug table: source 0x0000
+// CHECK-NEXT:    DeclareGlobalVar  "a"
+// CHECK-NEXT:    DeclareGlobalVar  "b"
+// CHECK-NEXT:    GetGlobalObject   r2
+// CHECK-NEXT:    TryGetById        r1, r2, 0, "Math"
+// CHECK-NEXT:    NewObjectWithParent r1, r1, 0
+// CHECK-NEXT:    PutByIdLoose      r2, r1, 0, "a"
+// CHECK-NEXT:    TryGetById        r1, r2, 1, "JSON"
+// CHECK-NEXT:    NewObjectWithParent r1, r1, 0
+// CHECK-NEXT:    PutByIdLoose      r2, r1, 1, "b"
+// CHECK-NEXT:    LoadConstUndefined r0
+// CHECK-NEXT:    Ret               r0
+
+// CHECK:Debug filename table:
+// CHECK-NEXT:  0: {{.*}}new-object-with-parent-shape-table.js
+
+// CHECK:Debug file table:
+// CHECK-NEXT:  source table offset 0x0000: filename id 0
+
+// CHECK:Debug source table:
+// CHECK-NEXT:  0x0000  function idx 0, starts at line 11 col 1
+// CHECK-NEXT:    bc 0: line 11 col 1
+// CHECK-NEXT:    bc 5: line 11 col 1
+// CHECK-NEXT:    bc 12: line 11 col 21
+// CHECK-NEXT:    bc 25: line 11 col 7
+// CHECK-NEXT:    bc 31: line 12 col 21
+// CHECK-NEXT:    bc 44: line 12 col 7
+// CHECK-NEXT:  0x0017  end of debug source table

--- a/test/BCGen/HBC/new-object-with-parent-shape-table.js
+++ b/test/BCGen/HBC/new-object-with-parent-shape-table.js
@@ -24,7 +24,7 @@ var b = {__proto__: JSON};
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 0
 // CHECK-NEXT:  Value buffer size (bytes): 0
-// CHECK-NEXT:  Shape table count: 2
+// CHECK-NEXT:  Shape table count: 3
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -43,6 +43,7 @@ var b = {__proto__: JSON};
 // CHECK:Object Shape Table:
 // CHECK-NEXT:0[0, 0]
 // CHECK-NEXT:1[0, 0]
+// CHECK-NEXT:2[0, 0]
 
 // CHECK:Function<global>(1 params, 3 registers, 0 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000
@@ -50,10 +51,10 @@ var b = {__proto__: JSON};
 // CHECK-NEXT:    DeclareGlobalVar  "b"
 // CHECK-NEXT:    GetGlobalObject   r2
 // CHECK-NEXT:    TryGetById        r1, r2, 0, "Math"
-// CHECK-NEXT:    NewObjectWithParent r1, r1, 0
+// CHECK-NEXT:    NewObjectWithParent r1, r1, 1
 // CHECK-NEXT:    PutByIdLoose      r2, r1, 0, "a"
 // CHECK-NEXT:    TryGetById        r1, r2, 1, "JSON"
-// CHECK-NEXT:    NewObjectWithParent r1, r1, 1
+// CHECK-NEXT:    NewObjectWithParent r1, r1, 2
 // CHECK-NEXT:    PutByIdLoose      r2, r1, 1, "b"
 // CHECK-NEXT:    LoadConstUndefined r0
 // CHECK-NEXT:    Ret               r0

--- a/test/BCGen/HBC/object_literal_opt.js
+++ b/test/BCGen/HBC/object_literal_opt.js
@@ -37,7 +37,7 @@ function foo(p) {
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 12
 // CHECK-NEXT:  Value buffer size (bytes): 18
-// CHECK-NEXT:  Shape table count: 2
+// CHECK-NEXT:  Shape table count: 3
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -71,8 +71,9 @@ function foo(p) {
 // CHECK-NEXT:[String 7]
 
 // CHECK:Object Shape Table:
-// CHECK-NEXT:0[0, 2]
-// CHECK-NEXT:1[5, 3]
+// CHECK-NEXT:0[0, 0]
+// CHECK-NEXT:1[0, 2]
+// CHECK-NEXT:2[5, 3]
 
 // CHECK:Function<global>(1 params, 11 registers, 0 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000
@@ -86,11 +87,11 @@ function foo(p) {
 // CHECK-NEXT:[@ 29] Ret 1<Reg8>
 
 // CHECK:Function<foo>(2 params, 1 registers, 0 numbers, 0 non-pointers):
-// CHECK-NEXT:[@ 0] NewObjectWithBuffer 0<Reg8>, 0<UInt16>, 0<UInt16>
+// CHECK-NEXT:[@ 0] NewObjectWithBuffer 0<Reg8>, 1<UInt16>, 0<UInt16>
 // CHECK-NEXT:[@ 6] Ret 0<Reg8>
 
 // CHECK:Function<>(1 params, 2 registers, 0 numbers, 0 non-pointers):
-// CHECK-NEXT:[@ 0] NewObjectWithBuffer 0<Reg8>, 1<UInt16>, 9<UInt16>
+// CHECK-NEXT:[@ 0] NewObjectWithBuffer 0<Reg8>, 2<UInt16>, 9<UInt16>
 // CHECK-NEXT:[@ 6] LoadThisNS 1<Reg8>
 // CHECK-NEXT:[@ 8] PutOwnBySlotIdx 0<Reg8>, 1<Reg8>, 1<UInt8>
 // CHECK-NEXT:[@ 12] Ret 0<Reg8>

--- a/test/BCGen/HBC/objects.js
+++ b/test/BCGen/HBC/objects.js
@@ -30,7 +30,7 @@ function foo(p) {
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 3
 // CHECK-NEXT:  Value buffer size (bytes): 5
-// CHECK-NEXT:  Shape table count: 1
+// CHECK-NEXT:  Shape table count: 2
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -52,7 +52,8 @@ function foo(p) {
 // CHECK-NEXT:[String 1]
 
 // CHECK:Object Shape Table:
-// CHECK-NEXT:0[0, 1]
+// CHECK-NEXT:0[0, 0]
+// CHECK-NEXT:1[0, 1]
 
 // CHECK:Function<global>(1 params, 3 registers, 0 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000
@@ -66,7 +67,7 @@ function foo(p) {
 // CHECK:Function<foo>(2 params, 5 registers, 1 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x000b
 // CHECK-NEXT:[@ 0] LoadParam 3<Reg8>, 1<UInt8>
-// CHECK-NEXT:[@ 3] NewObjectWithBuffer 2<Reg8>, 0<UInt16>, 0<UInt16>
+// CHECK-NEXT:[@ 3] NewObjectWithBuffer 2<Reg8>, 1<UInt16>, 0<UInt16>
 // CHECK-NEXT:[@ 9] LoadConstUInt8 0<Reg8>, 1<UInt8>
 // CHECK-NEXT:[@ 12] PutByIdLoose 2<Reg8>, 0<Reg8>, 0<UInt8>, 1<UInt16>
 // CHECK-NEXT:[@ 18] PutByValLoose 2<Reg8>, 3<Reg8>, 0<Reg8>

--- a/test/BCGen/HBC/pretty.js
+++ b/test/BCGen/HBC/pretty.js
@@ -27,7 +27,7 @@ function foo (a) {
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 0
 // CHECK-NEXT:  Value buffer size (bytes): 0
-// CHECK-NEXT:  Shape table count: 0
+// CHECK-NEXT:  Shape table count: 1
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -41,6 +41,9 @@ function foo (a) {
 // CHECK-NEXT:s1[UTF-16, 14..79]: \x54\x00\x68\x00\x69\x00\x73\x00\x0A\x00\x69\x00\x73\x00\x20\x00\x35\x04\x34\x04\x38\x04\x3D\x04\x20\x00\x6C\x00\x6F\x00\x6E\x00\x67\x00\x20\x00\x55\x00\x6E\x00\x69\x00\x63\x00\x6F\x00\x64\x00\x65\x00\x20\x00\x73\x00\x74\x00\x72\x00\x69\x00\x6E\x00\x67\x00\x3D\x00
 // CHECK-NEXT:i2[ASCII, 6..8] #9290584E: foo
 // CHECK-NEXT:i3[ASCII, 9..13] #A689F65B: print
+
+// CHECK:Object Shape Table:
+// CHECK-NEXT:0[0, 0]
 
 // CHECK:Function<global>(1 params, 3 registers, 0 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000

--- a/test/BCGen/HBC/private-property-cache-ids.js
+++ b/test/BCGen/HBC/private-property-cache-ids.js
@@ -146,7 +146,7 @@
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 0
 // CHECK-NEXT:  Value buffer size (bytes): 0
-// CHECK-NEXT:  Shape table count: 0
+// CHECK-NEXT:  Shape table count: 1
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -420,6 +420,9 @@
 // CHECK-NEXT:i261[ASCII, 1151..1155] #F27082CD: #f257
 // CHECK-NEXT:i262[ASCII, 1156..1160] #A689F65B: print
 // CHECK-NEXT:i263[ASCII, 1161..1169] #807C5F3D: prototype
+
+// CHECK:Object Shape Table:
+// CHECK-NEXT:0[0, 0]
 
 // CHECK:Function<global>(1 params, 14 registers, 0 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000
@@ -960,7 +963,7 @@
 // CHECK-NEXT:    GetParentEnvironment r3, 0
 // CHECK-NEXT:    GetNewTarget      r2
 // CHECK-NEXT:    GetById           r2, r2, 0, "prototype"
-// CHECK-NEXT:    NewObjectWithParent r2, r2
+// CHECK-NEXT:    NewObjectWithParent r2, r2, 0
 // CHECK-NEXT:    LoadFromEnvironment r4, r3, 0
 // CHECK-NEXT:    PrivateIsIn       r1, r4, r2, r0
 // CHECK-NEXT:    JmpTrueLong       L1, r1

--- a/test/BCGen/HBC/private-property-cache-ids.js
+++ b/test/BCGen/HBC/private-property-cache-ids.js
@@ -146,7 +146,7 @@
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 0
 // CHECK-NEXT:  Value buffer size (bytes): 0
-// CHECK-NEXT:  Shape table count: 1
+// CHECK-NEXT:  Shape table count: 2
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -423,6 +423,7 @@
 
 // CHECK:Object Shape Table:
 // CHECK-NEXT:0[0, 0]
+// CHECK-NEXT:1[0, 0]
 
 // CHECK:Function<global>(1 params, 14 registers, 0 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000
@@ -963,7 +964,7 @@
 // CHECK-NEXT:    GetParentEnvironment r3, 0
 // CHECK-NEXT:    GetNewTarget      r2
 // CHECK-NEXT:    GetById           r2, r2, 0, "prototype"
-// CHECK-NEXT:    NewObjectWithParent r2, r2, 0
+// CHECK-NEXT:    NewObjectWithParent r2, r2, 1
 // CHECK-NEXT:    LoadFromEnvironment r4, r3, 0
 // CHECK-NEXT:    PrivateIsIn       r1, r4, r2, r0
 // CHECK-NEXT:    JmpTrueLong       L1, r1

--- a/test/BCGen/HBC/return.js
+++ b/test/BCGen/HBC/return.js
@@ -24,7 +24,7 @@ function foo() {
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 0
 // CHECK-NEXT:  Value buffer size (bytes): 0
-// CHECK-NEXT:  Shape table count: 0
+// CHECK-NEXT:  Shape table count: 1
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -36,6 +36,9 @@ function foo() {
 // CHECK:Global String Table:
 // CHECK-NEXT:s0[ASCII, 0..5]: global
 // CHECK-NEXT:i1[ASCII, 6..8] #9290584E: foo
+
+// CHECK:Object Shape Table:
+// CHECK-NEXT:0[0, 0]
 
 // CHECK:Function<global>(1 params, 3 registers, 0 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000

--- a/test/BCGen/HBC/shape-table-proto.js
+++ b/test/BCGen/HBC/shape-table-proto.js
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// RUN: %hermesc -dump-bytecode %s | %FileCheckOrRegen --match-full-lines %s
+// RUN: %hermes -target=HBC -dump-bytecode %s | %FileCheckOrRegen --match-full-lines %s
 
-// Show that the shape table is used correctly for NewObjectWithParent.
-var a = {__proto__: Math};
-var b = {__proto__: JSON};
+// Ensure the shape table has two separate entries.
+var a = {x: 1, __proto__: null};
+var b = {x: 1, __proto__: Math};
 
 // Auto-generated content below. Please do not modify manually.
 
@@ -22,8 +22,8 @@ var b = {__proto__: JSON};
 // CHECK-NEXT:  String Kind Entry count: 2
 // CHECK-NEXT:  RegExp count: 0
 // CHECK-NEXT:  StringSwitchImm count: 0
-// CHECK-NEXT:  Key buffer size (bytes): 0
-// CHECK-NEXT:  Value buffer size (bytes): 0
+// CHECK-NEXT:  Key buffer size (bytes): 3
+// CHECK-NEXT:  Value buffer size (bytes): 5
 // CHECK-NEXT:  Shape table count: 2
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
@@ -36,30 +36,38 @@ var b = {__proto__: JSON};
 // CHECK:Global String Table:
 // CHECK-NEXT:s0[ASCII, 0..5]: global
 // CHECK-NEXT:i1[ASCII, 4..4] #00018270: a
-// CHECK-NEXT:i2[ASCII, 6..9] #971CE5C7: JSON
-// CHECK-NEXT:i3[ASCII, 10..13] #1C182460: Math
-// CHECK-NEXT:i4[ASCII, 14..14] #00018E43: b
+// CHECK-NEXT:i2[ASCII, 6..9] #1C182460: Math
+// CHECK-NEXT:i3[ASCII, 10..10] #00018E43: b
+// CHECK-NEXT:i4[ASCII, 11..11] #0001E7F9: x
+
+// CHECK:Literal Value Buffer:
+// CHECK-NEXT:[int 1]
+
+// CHECK:Object Key Buffer:
+// CHECK-NEXT:[String 4]
 
 // CHECK:Object Shape Table:
-// CHECK-NEXT:0[0, 0]
-// CHECK-NEXT:1[0, 0]
+// CHECK-NEXT:0[0, 1]
+// CHECK-NEXT:1[0, 1]
 
-// CHECK:Function<global>(1 params, 3 registers, 0 numbers, 1 non-pointers):
+// CHECK:Function<global>(1 params, 14 registers, 0 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000
 // CHECK-NEXT:    DeclareGlobalVar  "a"
 // CHECK-NEXT:    DeclareGlobalVar  "b"
 // CHECK-NEXT:    GetGlobalObject   r2
-// CHECK-NEXT:    TryGetById        r1, r2, 0, "Math"
-// CHECK-NEXT:    NewObjectWithParent r1, r1, 0
+// CHECK-NEXT:    LoadConstNull     r0
+// CHECK-NEXT:    NewObjectWithBufferAndParent r1, r0, 0, 0
 // CHECK-NEXT:    PutByIdLoose      r2, r1, 0, "a"
-// CHECK-NEXT:    TryGetById        r1, r2, 1, "JSON"
-// CHECK-NEXT:    NewObjectWithParent r1, r1, 1
+// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 0
+// CHECK-NEXT:    TryGetById        r4, r2, 0, "Math"
+// CHECK-NEXT:    Mov               r5, r1
+// CHECK-NEXT:    CallBuiltin       r3, "HermesBuiltin.silentSetPrototypeOf", 3
 // CHECK-NEXT:    PutByIdLoose      r2, r1, 1, "b"
 // CHECK-NEXT:    LoadConstUndefined r0
 // CHECK-NEXT:    Ret               r0
 
 // CHECK:Debug filename table:
-// CHECK-NEXT:  0: {{.*}}new-object-with-parent-shape-table.js
+// CHECK-NEXT:  0: {{.*}}shape-table-proto.js
 
 // CHECK:Debug file table:
 // CHECK-NEXT:  source table offset 0x0000: filename id 0
@@ -68,8 +76,8 @@ var b = {__proto__: JSON};
 // CHECK-NEXT:  0x0000  function idx 0, starts at line 11 col 1
 // CHECK-NEXT:    bc 0: line 11 col 1
 // CHECK-NEXT:    bc 5: line 11 col 1
-// CHECK-NEXT:    bc 12: line 11 col 21
 // CHECK-NEXT:    bc 25: line 11 col 7
-// CHECK-NEXT:    bc 31: line 12 col 21
-// CHECK-NEXT:    bc 44: line 12 col 7
+// CHECK-NEXT:    bc 37: line 12 col 27
+// CHECK-NEXT:    bc 46: line 12 col 16
+// CHECK-NEXT:    bc 50: line 12 col 7
 // CHECK-NEXT:  0x0017  end of debug source table

--- a/test/BCGen/HBC/shape-table-proto.js
+++ b/test/BCGen/HBC/shape-table-proto.js
@@ -24,7 +24,7 @@ var b = {x: 1, __proto__: Math};
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 3
 // CHECK-NEXT:  Value buffer size (bytes): 5
-// CHECK-NEXT:  Shape table count: 2
+// CHECK-NEXT:  Shape table count: 3
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -47,8 +47,9 @@ var b = {x: 1, __proto__: Math};
 // CHECK-NEXT:[String 4]
 
 // CHECK:Object Shape Table:
-// CHECK-NEXT:0[0, 1]
+// CHECK-NEXT:0[0, 0]
 // CHECK-NEXT:1[0, 1]
+// CHECK-NEXT:2[0, 1]
 
 // CHECK:Function<global>(1 params, 14 registers, 0 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000
@@ -56,9 +57,9 @@ var b = {x: 1, __proto__: Math};
 // CHECK-NEXT:    DeclareGlobalVar  "b"
 // CHECK-NEXT:    GetGlobalObject   r2
 // CHECK-NEXT:    LoadConstNull     r0
-// CHECK-NEXT:    NewObjectWithBufferAndParent r1, r0, 0, 0
+// CHECK-NEXT:    NewObjectWithBufferAndParent r1, r0, 1, 0
 // CHECK-NEXT:    PutByIdLoose      r2, r1, 0, "a"
-// CHECK-NEXT:    NewObjectWithBuffer r1, 1, 0
+// CHECK-NEXT:    NewObjectWithBuffer r1, 2, 0
 // CHECK-NEXT:    TryGetById        r4, r2, 0, "Math"
 // CHECK-NEXT:    Mov               r5, r1
 // CHECK-NEXT:    CallBuiltin       r3, "HermesBuiltin.silentSetPrototypeOf", 3

--- a/test/BCGen/HBC/store_to_env.js
+++ b/test/BCGen/HBC/store_to_env.js
@@ -38,7 +38,7 @@ function foo() {
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 0
 // CHECK-NEXT:  Value buffer size (bytes): 0
-// CHECK-NEXT:  Shape table count: 0
+// CHECK-NEXT:  Shape table count: 2
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -56,6 +56,10 @@ function foo() {
 // CHECK-NEXT:i5[ASCII, 22..24] #9290584E: foo
 // CHECK-NEXT:i6[ASCII, 25..29] #A689F65B: print
 
+// CHECK:Object Shape Table:
+// CHECK-NEXT:0[0, 0]
+// CHECK-NEXT:1[0, 0]
+
 // CHECK:Function<global>(1 params, 3 registers, 0 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000
 // CHECK-NEXT:    DeclareGlobalVar  "foo"
@@ -72,7 +76,7 @@ function foo() {
 // CHECK-NEXT:    StoreNPToEnvironment r1, 0, r0
 // CHECK-NEXT:    GetGlobalObject   r2
 // CHECK-NEXT:    TryGetById        r2, r2, 0, "Object"
-// CHECK-NEXT:    CreateThisForNew  r3, r2, 1
+// CHECK-NEXT:    CreateThisForNew  r3, r2, 1, 1
 // CHECK-NEXT:    Mov               r4, r3
 // CHECK-NEXT:    Construct         r2, r2, 1
 // CHECK-NEXT:    SelectObject      r2, r3, r2
@@ -118,7 +122,7 @@ function foo() {
 // CHECK-NEXT:  0x000b  function idx 1, starts at line 10 col 1
 // CHECK-NEXT:    bc 15: line 14 col 21
 // CHECK-NEXT:    bc 21: line 14 col 27
-// CHECK-NEXT:    bc 28: line 14 col 27
+// CHECK-NEXT:    bc 30: line 14 col 27
 // CHECK-NEXT:  0x0019  function idx 2, starts at line 17 col 18
 // CHECK-NEXT:    bc 20: line 21 col 9
 // CHECK-NEXT:    bc 32: line 21 col 14

--- a/test/BCGen/HBC/strip_func_name_id.js
+++ b/test/BCGen/HBC/strip_func_name_id.js
@@ -22,7 +22,7 @@ Math['function-name-stripped'] = 123;
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 0
 // CHECK-NEXT:  Value buffer size (bytes): 0
-// CHECK-NEXT:  Shape table count: 0
+// CHECK-NEXT:  Shape table count: 1
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -34,6 +34,9 @@ Math['function-name-stripped'] = 123;
 // CHECK:Global String Table:
 // CHECK-NEXT:i0[ASCII, 0..3] #1C182460: Math
 // CHECK-NEXT:i1[ASCII, 4..25] #D7615A1F: function-name-stripped
+
+// CHECK:Object Shape Table:
+// CHECK-NEXT:0[0, 0]
 
 // CHECK:Function<function-name-stripped>(1 params, 2 registers, 1 numbers, 0 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000

--- a/test/BCGen/HBC/switch-2.js
+++ b/test/BCGen/HBC/switch-2.js
@@ -90,7 +90,7 @@ function f(x) {
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 0
 // CHECK-NEXT:  Value buffer size (bytes): 0
-// CHECK-NEXT:  Shape table count: 0
+// CHECK-NEXT:  Shape table count: 1
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -103,6 +103,9 @@ function f(x) {
 // CHECK-NEXT:s0[ASCII, 0..5]: global
 // CHECK-NEXT:i1[ASCII, 0..0] #00019A16: g
 // CHECK-NEXT:i2[ASCII, 6..6] #00019E07: f
+
+// CHECK:Object Shape Table:
+// CHECK-NEXT:0[0, 0]
 
 // CHECK:Function<global>(1 params, 3 registers, 0 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000

--- a/test/BCGen/HBC/switch-pretty.js
+++ b/test/BCGen/HBC/switch-pretty.js
@@ -90,7 +90,7 @@ function f(x) {
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 0
 // CHECK-NEXT:  Value buffer size (bytes): 0
-// CHECK-NEXT:  Shape table count: 0
+// CHECK-NEXT:  Shape table count: 1
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -103,6 +103,9 @@ function f(x) {
 // CHECK-NEXT:s0[ASCII, 0..5]: global
 // CHECK-NEXT:i1[ASCII, 0..0] #00019A16: g
 // CHECK-NEXT:i2[ASCII, 6..6] #00019E07: f
+
+// CHECK:Object Shape Table:
+// CHECK-NEXT:0[0, 0]
 
 // CHECK:Function<global>(1 params, 3 registers, 0 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000

--- a/test/BCGen/HBC/xmod-requires-opt.js
+++ b/test/BCGen/HBC/xmod-requires-opt.js
@@ -52,7 +52,7 @@ function require(modIdx) {
 // CHECK-NEXT:  StringSwitchImm count: 0
 // CHECK-NEXT:  Key buffer size (bytes): 0
 // CHECK-NEXT:  Value buffer size (bytes): 0
-// CHECK-NEXT:  Shape table count: 0
+// CHECK-NEXT:  Shape table count: 1
 // CHECK-NEXT:  Segment ID: 0
 // CHECK-NEXT:  CommonJS module count: 0
 // CHECK-NEXT:  CommonJS module count (static): 0
@@ -70,6 +70,9 @@ function require(modIdx) {
 // CHECK-NEXT:i5[ASCII, 24..30] #EB75CA32: require
 // CHECK-NEXT:i6[ASCII, 30..36] #C765D706: exports
 // CHECK-NEXT:i7[ASCII, 37..37] #0001E7F9: x
+
+// CHECK:Object Shape Table:
+// CHECK-NEXT:0[0, 0]
 
 // CHECK:Function<global>(1 params, 3 registers, 0 numbers, 1 non-pointers):
 // CHECK-NEXT:Offset in debug table: source 0x0000

--- a/test/Optimizer/object-with-object-field-alloc.js
+++ b/test/Optimizer/object-with-object-field-alloc.js
@@ -35,11 +35,11 @@ new Foo();
 // CHECK-NEXT:%BB0:
 // CHECK-NEXT:  %0 = CreateScopeInst (:environment) %VS0: any, empty: any
 // CHECK-NEXT:  %1 = LIRLoadConstInst (:null) null: null
-// CHECK-NEXT:  %2 = AllocTypedNonEnumObjectInst (:object) %1: null
+// CHECK-NEXT:  %2 = LIRAllocTypedNonEnumObjectFromBufferInst (:object) %1: null
 // CHECK-NEXT:       StoreFrameInst %0: environment, %2: object, [%VS0.?O.prototype]: object
 // CHECK-NEXT:  %4 = CreateFunctionInst (:object) empty: any, empty: any, %O(): functionCode
 // CHECK-NEXT:       StorePropertyStrictInst %2: object, %4: object, "prototype": string
-// CHECK-NEXT:  %6 = AllocTypedNonEnumObjectInst (:object) %1: null
+// CHECK-NEXT:  %6 = LIRAllocTypedNonEnumObjectFromBufferInst (:object) %1: null
 // CHECK-NEXT:  %7 = CreateFunctionInst (:object) %0: environment, %VS0: any, %Foo(): functionCode
 // CHECK-NEXT:       StorePropertyStrictInst %6: object, %7: object, "prototype": string
 // CHECK-NEXT:  %9 = LIRLoadConstInst (:undefined) undefined: undefined

--- a/test/Optimizer/switch-of-strings-back-branch.js
+++ b/test/Optimizer/switch-of-strings-back-branch.js
@@ -67,7 +67,7 @@ function stringSwitch(x) {
 // HBC-NEXT:  StringSwitchImm count: 1
 // HBC-NEXT:  Key buffer size (bytes): 0
 // HBC-NEXT:  Value buffer size (bytes): 0
-// HBC-NEXT:  Shape table count: 0
+// HBC-NEXT:  Shape table count: 1
 // HBC-NEXT:  Segment ID: 0
 // HBC-NEXT:  CommonJS module count: 0
 // HBC-NEXT:  CommonJS module count (static): 0
@@ -98,6 +98,9 @@ function stringSwitch(x) {
 // HBC-NEXT:s18[ASCII, 33..34]: hi
 // HBC-NEXT:i19[ASCII, 22..33] #646CA4B1: stringSwitch
 // HBC-NEXT:i20[ASCII, 35..39] #A689F65B: print
+
+// HBC:Object Shape Table:
+// HBC-NEXT:0[0, 0]
 
 // HBC:Function<global>(1 params, 3 registers, 0 numbers, 1 non-pointers):
 // HBC-NEXT:Offset in debug table: source 0x0000
@@ -213,7 +216,7 @@ function stringSwitch(x) {
 // HBCRAW-NEXT:  StringSwitchImm count: 1
 // HBCRAW-NEXT:  Key buffer size (bytes): 0
 // HBCRAW-NEXT:  Value buffer size (bytes): 0
-// HBCRAW-NEXT:  Shape table count: 0
+// HBCRAW-NEXT:  Shape table count: 1
 // HBCRAW-NEXT:  Segment ID: 0
 // HBCRAW-NEXT:  CommonJS module count: 0
 // HBCRAW-NEXT:  CommonJS module count (static): 0
@@ -244,6 +247,9 @@ function stringSwitch(x) {
 // HBCRAW-NEXT:s18[ASCII, 33..34]: hi
 // HBCRAW-NEXT:i19[ASCII, 22..33] #646CA4B1: stringSwitch
 // HBCRAW-NEXT:i20[ASCII, 35..39] #A689F65B: print
+
+// HBCRAW:Object Shape Table:
+// HBCRAW-NEXT:0[0, 0]
 
 // HBCRAW:Function<global>(1 params, 3 registers, 0 numbers, 1 non-pointers):
 // HBCRAW-NEXT:Offset in debug table: source 0x0000

--- a/test/Optimizer/switch-of-strings-multiple-switches.js
+++ b/test/Optimizer/switch-of-strings-multiple-switches.js
@@ -268,7 +268,7 @@ function stringSwitchSeveralSwitches(b, s, i) {
 // HBC-NEXT:  StringSwitchImm count: 2
 // HBC-NEXT:  Key buffer size (bytes): 0
 // HBC-NEXT:  Value buffer size (bytes): 0
-// HBC-NEXT:  Shape table count: 0
+// HBC-NEXT:  Shape table count: 1
 // HBC-NEXT:  Segment ID: 0
 // HBC-NEXT:  CommonJS module count: 0
 // HBC-NEXT:  CommonJS module count (static): 0
@@ -300,6 +300,9 @@ function stringSwitchSeveralSwitches(b, s, i) {
 // HBC-NEXT:s19[ASCII, 69..70]: l8
 // HBC-NEXT:s20[ASCII, 71..72]: l9
 // HBC-NEXT:i21[ASCII, 73..99] #88138FB1: stringSwitchSeveralSwitches
+
+// HBC:Object Shape Table:
+// HBC-NEXT:0[0, 0]
 
 // HBC:Function<global>(1 params, 3 registers, 0 numbers, 1 non-pointers):
 // HBC-NEXT:Offset in debug table: source 0x0000

--- a/test/Optimizer/switch-of-strings.js
+++ b/test/Optimizer/switch-of-strings.js
@@ -103,7 +103,7 @@
 // HBC-NEXT:  StringSwitchImm count: 1
 // HBC-NEXT:  Key buffer size (bytes): 0
 // HBC-NEXT:  Value buffer size (bytes): 0
-// HBC-NEXT:  Shape table count: 0
+// HBC-NEXT:  Shape table count: 1
 // HBC-NEXT:  Segment ID: 0
 // HBC-NEXT:  CommonJS module count: 0
 // HBC-NEXT:  CommonJS module count (static): 0
@@ -125,6 +125,9 @@
 // HBC-NEXT:s9[ASCII, 21..22]: l8
 // HBC-NEXT:s10[ASCII, 23..24]: l9
 // HBC-NEXT:s11[ASCII, 25..36]: stringSwitch
+
+// HBC:Object Shape Table:
+// HBC-NEXT:0[0, 0]
 
 // HBC:Function<global>(1 params, 13 registers, 1 numbers, 1 non-pointers):
 // HBC-NEXT:Offset in debug table: source 0x0000

--- a/test/RA/implicit-env-operand.js
+++ b/test/RA/implicit-env-operand.js
@@ -152,7 +152,7 @@
 // CHECK-NEXT:  {r2}      %2 = CreateScopeInst (:environment) %VS0: any, {r2} %1: environment
 // CHECK-NEXT:  {r1}      %3 = GetNewTargetInst (:object) %new.target: object
 // CHECK-NEXT:  {r1}      %4 = LoadPropertyInst (:any) {r1} %3: object, "prototype": string
-// CHECK-NEXT:  {r1}      %5 = AllocObjectLiteralInst (:object) {r1} %4: any
+// CHECK-NEXT:  {r1}      %5 = LIRAllocObjectFromBufferInst (:object) {r1} %4: any
 // CHECK-NEXT:  {r0}      %6 = StoreFrameInst {r2} %2: environment, {r1} %5: object, [%VS0.this]: object
 // CHECK-NEXT:  {r1}      %7 = LoadFrameInst (:object) {r2} %2: environment, [%VS0.this]: object
 // CHECK-NEXT:  {r0}      %8 = ReturnInst {r1} %7: object

--- a/unittests/VMRuntime/AdditionalSlots.h
+++ b/unittests/VMRuntime/AdditionalSlots.h
@@ -18,7 +18,9 @@ namespace vm {
 template <typename T>
 size_t numAdditionalSlotsForTest() {
   // Allocate the maximum possible number of anonymous property slots, this
-  // ensures that we use both direct and indirect storage.
+  // ensures that we use both direct and indirect storage when possible.
+  // For NativeFunctions, there may not be enough internal anonymous properties
+  // to do this.
   static_assert(
       InternalProperty::NumAnonymousInternalProperties >
           JSObject::DIRECT_PROPERTY_SLOTS,
@@ -27,7 +29,7 @@ size_t numAdditionalSlotsForTest() {
       InternalProperty::NumAnonymousInternalProperties -
       JSObject::numOverlapSlots<T>();
   static_assert(
-      numAdditionalSlots > 1, "At least 2 properties needed for this test");
+      numAdditionalSlots > 0, "At least 1 property needed for this test");
   return numAdditionalSlots;
 }
 

--- a/unittests/VMRuntime/CMakeLists.txt
+++ b/unittests/VMRuntime/CMakeLists.txt
@@ -72,6 +72,7 @@ set(RTSources
   TestHelpers1.cpp TestHelpers1.h
   TwineChar16Test.cpp
   WeakValueMapTest.cpp
+  WeakValueObjectMapTest.cpp
   MetadataTest.cpp
   FinalizationRegistryTest.cpp
   )

--- a/unittests/VMRuntime/DecoratedObjectTest.cpp
+++ b/unittests/VMRuntime/DecoratedObjectTest.cpp
@@ -36,6 +36,7 @@ TEST_F(DecoratedObjectTest, DecoratedObjectFinalizerRunsOnce) {
         DecoratedObject::create(
             runtime,
             Handle<JSObject>::vmcast(&runtime.objectPrototype),
+            runtime.classDecoratedObject,
             std::make_unique<TestDecoration>(counter)));
     runtime.collect("test");
     // should not have been finalized yet
@@ -58,6 +59,7 @@ TEST_F(DecoratedObjectTest, ChangeDecoration) {
         DecoratedObject::create(
             runtime,
             Handle<JSObject>::vmcast(&runtime.objectPrototype),
+            runtime.classDecoratedObject,
             std::make_unique<TestDecoration>(counter)));
     EXPECT_EQ(0, *counter);
     handle->setDecoration(std::make_unique<TestDecoration>(counter));
@@ -77,22 +79,11 @@ TEST_F(DecoratedObjectTest, NullDecoration) {
         DecoratedObject::create(
             runtime,
             Handle<JSObject>::vmcast(&runtime.objectPrototype),
+            runtime.classDecoratedObject,
             nullptr));
     EXPECT_EQ(nullptr, handle->getDecoration());
   }
   runtime.collect("test");
-}
-
-TEST_F(DecoratedObjectTest, AdditionalSlots) {
-  auto counter = std::make_shared<int>(0);
-  GCScope scope{runtime, "DecoratedObjectTest"};
-  auto handle = runtime.makeHandle(
-      DecoratedObject::create(
-          runtime,
-          Handle<JSObject>::vmcast(&runtime.objectPrototype),
-          std::make_unique<TestDecoration>(counter),
-          numAdditionalSlotsForTest<DecoratedObject>()));
-  testAdditionalSlots(runtime, handle);
 }
 
 } // namespace

--- a/unittests/VMRuntime/FinalizationRegistryTest.cpp
+++ b/unittests/VMRuntime/FinalizationRegistryTest.cpp
@@ -45,13 +45,10 @@ TEST_F(FinalizationRegistryTest, RegisterAndUnregisterTest) {
 
   lv.callable = *NativeFunction::create(
       runtime,
-      Handle<JSObject>::vmcast(&runtime.functionPrototype),
-      Runtime::makeNullHandle<Environment>(),
       nullptr,
       noopCallback,
       Predefined::getSymbolID(Predefined::emptyString),
-      0,
-      Runtime::makeNullHandle<JSObject>());
+      0);
 
   auto frRes = JSFinalizationRegistry::create(
       runtime, runtime.arrayPrototype, lv.callable);

--- a/unittests/VMRuntime/HeapSnapshotTest.cpp
+++ b/unittests/VMRuntime/HeapSnapshotTest.cpp
@@ -823,8 +823,8 @@ using HeapSnapshotRuntimeTest = RuntimeTestFixture;
 
 template <typename T>
 size_t firstNamedPropertyEdge() {
-  // parent, __proto__, class, directProp$i
-  return JSObject::DIRECT_PROPERTY_SLOTS - JSObject::numOverlapSlots<T>() + 3;
+  // __proto__, class, directProp$i
+  return JSObject::DIRECT_PROPERTY_SLOTS - JSObject::numOverlapSlots<T>() + 2;
 }
 
 TEST_F(HeapSnapshotRuntimeTest, FunctionLocationForLazyCode) {

--- a/unittests/VMRuntime/HiddenClassTest.cpp
+++ b/unittests/VMRuntime/HiddenClassTest.cpp
@@ -52,8 +52,8 @@ TEST_F(HiddenClassTest, SmokeTest) {
   MutableHandle<HiddenClass> y{runtime};
   MutableHandle<HiddenClass> z{runtime};
 
-  auto rootHnd = runtime.makeHandle<HiddenClass>(
-      HiddenClass::createRoot(runtime, Runtime::makeNullHandle<JSObject>()));
+  auto rootHnd = runtime.makeHandle<HiddenClass>(HiddenClass::createRoot(
+      runtime, Runtime::makeNullHandle<JSObject>(), ClassFlags{}));
 
   ASSERT_EQ(0u, rootHnd->getNumProperties());
   ASSERT_FALSE(rootHnd->isDictionary());
@@ -266,8 +266,8 @@ TEST_F(HiddenClassTest, AccessorsTest) {
   MutableHandle<HiddenClass> x{runtime};
   MutableHandle<HiddenClass> y{runtime};
 
-  auto rootCls = runtime.makeHandle<HiddenClass>(
-      HiddenClass::createRoot(runtime, Runtime::makeNullHandle<JSObject>()));
+  auto rootCls = runtime.makeHandle<HiddenClass>(HiddenClass::createRoot(
+      runtime, Runtime::makeNullHandle<JSObject>(), ClassFlags{}));
 
   ASSERT_FALSE(rootCls->getMayHaveAccessor());
 
@@ -351,7 +351,8 @@ TEST_F(HiddenClassTest, UpdatePropertyFlagsWithoutTransitionsTest) {
   // Add y.a, y.b, y.c
   MutableHandle<HiddenClass> y{
       runtime,
-      HiddenClass::createRoot(runtime, Runtime::makeNullHandle<JSObject>())};
+      HiddenClass::createRoot(
+          runtime, Runtime::makeNullHandle<JSObject>(), ClassFlags{})};
   {
     // y.a
     auto addRes = HiddenClass::addProperty(
@@ -478,7 +479,8 @@ TEST_F(HiddenClassTest, UpdatePropertyFlagsWithoutTransitionsTest) {
 TEST_F(HiddenClassTest, ForEachProperty) {
   MutableHandle<HiddenClass> clazz{
       runtime,
-      HiddenClass::createRoot(runtime, Runtime::makeNullHandle<JSObject>())};
+      HiddenClass::createRoot(
+          runtime, Runtime::makeNullHandle<JSObject>(), ClassFlags{})};
 
   auto aHnd = *runtime.getIdentifierTable().getSymbolHandle(
       runtime, createUTF16Ref(u"a"));
@@ -593,8 +595,8 @@ TEST_F(HiddenClassTest, ObjectParentTest) {
   } lv;
   LocalsRAII lraii{runtime, &lv};
 
-  lv.clazz =
-      HiddenClass::createRoot(runtime, Runtime::makeNullHandle<JSObject>());
+  lv.clazz = HiddenClass::createRoot(
+      runtime, Runtime::makeNullHandle<JSObject>(), ClassFlags{});
   EXPECT_TRUE(lv.clazz->getObjectParent(runtime) == nullptr);
 
   lv.clazz = HiddenClass::updateObjectParent(

--- a/unittests/VMRuntime/HiddenClassTest.cpp
+++ b/unittests/VMRuntime/HiddenClassTest.cpp
@@ -7,6 +7,7 @@
 
 #include "hermes/VM/HiddenClass.h"
 
+#include "hermes/VM/HiddenClass-inline.h"
 #include "hermes/VM/HostModel.h"
 #include "hermes/VM/JSCallableProxy.h"
 #include "hermes/VM/JSProxy.h"
@@ -51,12 +52,13 @@ TEST_F(HiddenClassTest, SmokeTest) {
   MutableHandle<HiddenClass> y{runtime};
   MutableHandle<HiddenClass> z{runtime};
 
-  auto rootHnd =
-      runtime.makeHandle<HiddenClass>(HiddenClass::createRoot(runtime));
+  auto rootHnd = runtime.makeHandle<HiddenClass>(
+      HiddenClass::createRoot(runtime, Runtime::makeNullHandle<JSObject>()));
 
   ASSERT_EQ(0u, rootHnd->getNumProperties());
   ASSERT_FALSE(rootHnd->isDictionary());
   ASSERT_TRUE(rootHnd->isKnownLeaf());
+  ASSERT_FALSE(rootHnd->getObjectParentGCPtr());
 
   // x = {}
   x = *rootHnd;
@@ -264,8 +266,8 @@ TEST_F(HiddenClassTest, AccessorsTest) {
   MutableHandle<HiddenClass> x{runtime};
   MutableHandle<HiddenClass> y{runtime};
 
-  auto rootCls =
-      runtime.makeHandle<HiddenClass>(HiddenClass::createRoot(runtime));
+  auto rootCls = runtime.makeHandle<HiddenClass>(
+      HiddenClass::createRoot(runtime, Runtime::makeNullHandle<JSObject>()));
 
   ASSERT_FALSE(rootCls->getMayHaveAccessor());
 
@@ -347,7 +349,9 @@ TEST_F(HiddenClassTest, UpdatePropertyFlagsWithoutTransitionsTest) {
       runtime, createUTF16Ref(u"d"));
 
   // Add y.a, y.b, y.c
-  MutableHandle<HiddenClass> y{runtime, HiddenClass::createRoot(runtime)};
+  MutableHandle<HiddenClass> y{
+      runtime,
+      HiddenClass::createRoot(runtime, Runtime::makeNullHandle<JSObject>())};
   {
     // y.a
     auto addRes = HiddenClass::addProperty(
@@ -472,7 +476,9 @@ TEST_F(HiddenClassTest, UpdatePropertyFlagsWithoutTransitionsTest) {
 }
 
 TEST_F(HiddenClassTest, ForEachProperty) {
-  MutableHandle<HiddenClass> clazz{runtime, HiddenClass::createRoot(runtime)};
+  MutableHandle<HiddenClass> clazz{
+      runtime,
+      HiddenClass::createRoot(runtime, Runtime::makeNullHandle<JSObject>())};
 
   auto aHnd = *runtime.getIdentifierTable().getSymbolHandle(
       runtime, createUTF16Ref(u"a"));
@@ -530,7 +536,8 @@ TEST_F(HiddenClassTest, TypedObjectTest) {
   Handle<SymbolID> aHnd = *runtime.getIdentifierTable().getSymbolHandle(
       runtime, createASCIIRef("a"));
 
-  lv.hc = vmcast<HiddenClass>(HiddenClass::createForTypedObject(runtime, 2));
+  lv.hc = vmcast<HiddenClass>(HiddenClass::createForTypedObject(
+      runtime, Runtime::makeNullHandle<JSObject>(), 2));
   // Shouldn't do anything, the rest of the test should run.
   lv.hc->clearPropertyMap(runtime.getHeap());
 
@@ -576,6 +583,35 @@ TEST_F(HiddenClassTest, TypedObjectTest) {
         createPseudoHandle(*lv.hc), runtime, *aHnd, desc);
     EXPECT_TRUE(pos.hasValue());
   }
+}
+
+TEST_F(HiddenClassTest, ObjectParentTest) {
+  struct : public Locals {
+    PinnedValue<HiddenClass> clazz;
+    PinnedValue<JSObject> obj1;
+    PinnedValue<JSObject> tmp;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
+
+  lv.clazz =
+      HiddenClass::createRoot(runtime, Runtime::makeNullHandle<JSObject>());
+  EXPECT_TRUE(lv.clazz->getObjectParent(runtime) == nullptr);
+
+  lv.clazz = HiddenClass::updateObjectParent(
+      lv.clazz, runtime, createPseudoHandle(*lv.obj1));
+  EXPECT_TRUE(lv.clazz->getObjectParent(runtime) == *lv.obj1);
+
+  lv.clazz = HiddenClass::updateObjectParent(
+      lv.clazz, runtime, createPseudoHandle<JSObject>(nullptr));
+  EXPECT_TRUE(lv.clazz->getObjectParent(runtime) == nullptr);
+
+  for (size_t i = 0; i < 10; ++i) {
+    lv.tmp = JSObject::create(runtime);
+    lv.clazz = HiddenClass::updateObjectParent(
+        lv.clazz, runtime, createPseudoHandle(*lv.tmp));
+  }
+
+  EXPECT_TRUE(lv.clazz->isDictionary());
 }
 
 } // namespace

--- a/unittests/VMRuntime/HiddenClassTest.cpp
+++ b/unittests/VMRuntime/HiddenClassTest.cpp
@@ -50,6 +50,9 @@ TEST_F(HiddenClassTest, SmokeTest) {
 
   MutableHandle<HiddenClass> x{runtime};
   MutableHandle<HiddenClass> y{runtime};
+  MutableHandle<HiddenClass> y1{runtime};
+  MutableHandle<HiddenClass> y2{runtime};
+  MutableHandle<HiddenClass> y3{runtime};
   MutableHandle<HiddenClass> z{runtime};
 
   auto rootHnd = runtime.makeHandle<HiddenClass>(HiddenClass::createRoot(
@@ -207,10 +210,10 @@ TEST_F(HiddenClassTest, SmokeTest) {
     ASSERT_EQ(*x, *z);
   }
 
-  auto y1 = HiddenClass::makeAllReadOnly(y, runtime);
-  auto y2 = HiddenClass::makeAllReadOnly(y, runtime);
+  y1 = HiddenClass::freeze(y, runtime);
+  y2 = HiddenClass::freeze(y, runtime);
   ASSERT_EQ(*y1, *y2);
-  auto y3 = HiddenClass::makeAllReadOnly(y1, runtime);
+  y3 = HiddenClass::freeze(y1, runtime);
   ASSERT_EQ(*y1, *y3);
 
   // Turn x into a dictionary by erasing x.a

--- a/unittests/VMRuntime/HiddenClassTest.cpp
+++ b/unittests/VMRuntime/HiddenClassTest.cpp
@@ -521,37 +521,6 @@ TEST_F(HiddenClassTest, ForEachProperty) {
   EXPECT_EQ(expectedProperties, propertiesNoAlloc);
 }
 
-TEST_F(HiddenClassTest, ReservedSlots) {
-  auto aHnd = *runtime.getIdentifierTable().getSymbolHandle(
-      runtime, createUTF16Ref(u"a"));
-  for (unsigned i = 0; i <= InternalProperty::NumAnonymousInternalProperties;
-       ++i) {
-    Handle<HiddenClass> clazz =
-        runtime.getHiddenClassForPrototype(*runtime.getGlobal(), i);
-    EXPECT_FALSE(clazz->isDictionary());
-    auto addRes = HiddenClass::addProperty(
-        clazz, runtime, *aHnd, PropertyFlags::defaultNewNamedPropertyFlags());
-    ASSERT_RETURNED(addRes);
-    EXPECT_EQ(i, addRes->second);
-  }
-
-  // Verify that the saved HiddenClasses for Proxies and HostObjects are
-  // different from the equivalent "normal" HiddenClasses.
-  EXPECT_NE(
-      *runtime.proxyClass,
-      *runtime.getHiddenClassForPrototype(
-          nullptr, JSObject::numOverlapSlots<JSProxy>()));
-  EXPECT_NE(
-      *runtime.callableProxyClass,
-      *runtime.getHiddenClassForPrototype(
-          nullptr, JSObject::numOverlapSlots<JSCallableProxy>()));
-  EXPECT_NE(
-      *runtime.hostObjectClass,
-      *runtime.getHiddenClassForPrototype(
-          runtime.objectPrototypeRawPtr,
-          JSObject::numOverlapSlots<HostObject>()));
-}
-
 TEST_F(HiddenClassTest, TypedObjectTest) {
   struct : public Locals {
     PinnedValue<HiddenClass> hc;

--- a/unittests/VMRuntime/InterpreterTest.cpp
+++ b/unittests/VMRuntime/InterpreterTest.cpp
@@ -202,13 +202,10 @@ TEST_F(InterpreterTest, SimpleSmokeTest) {
 
   auto printFn = runtime.makeHandle<NativeFunction>(*NativeFunction::create(
       runtime,
-      runtime.functionPrototype,
-      Runtime::makeNullHandle<Environment>(),
       nullptr,
       print,
       Predefined::getSymbolID(Predefined::emptyString),
-      0,
-      Runtime::makeNullHandle<JSObject>()));
+      0));
 
   // Define the 'print' function.
   (void)JSObject::putNamed_RJS(
@@ -591,13 +588,10 @@ TEST_F(InterpreterTest, FrameSizeTest) {
 
   auto getSPFn = runtime.makeHandle<NativeFunction>(*NativeFunction::create(
       runtime,
-      runtime.functionPrototype,
-      Runtime::makeNullHandle<Environment>(),
       nullptr,
       getSP,
       Predefined::getSymbolID(Predefined::emptyString),
-      0,
-      Runtime::makeNullHandle<JSObject>()));
+      0));
 
   // Define the 'getSP' function.
   (void)JSObject::putNamed_RJS(

--- a/unittests/VMRuntime/NativeFunctionTest.cpp
+++ b/unittests/VMRuntime/NativeFunctionTest.cpp
@@ -19,21 +19,6 @@ namespace {
 
 using NativeFunctionTest = RuntimeTestFixture;
 
-TEST_F(NativeFunctionTest, AdditionalSlots) {
-  GCScope scope{runtime, "NativeFunctionTest"};
-  auto handle = NativeFunction::create(
-      runtime,
-      runtime.functionPrototype,
-      Runtime::makeNullHandle<Environment>(),
-      nullptr,
-      nullptr,
-      Predefined::getSymbolID(Predefined::emptyString),
-      0,
-      Runtime::makeNullHandle<JSObject>(),
-      numAdditionalSlotsForTest<NativeFunction>());
-  testAdditionalSlots(runtime, handle);
-}
-
 TEST(NativeFunctionNameTest, SmokeTest) {
   EXPECT_STREQ("print", getFunctionName(print));
   EXPECT_STREQ(

--- a/unittests/VMRuntime/ObjectModelTest.cpp
+++ b/unittests/VMRuntime/ObjectModelTest.cpp
@@ -902,7 +902,7 @@ TEST_F(ObjectModelTest, ParentCacheEpochTest) {
   lv.obj = JSObject::create(runtime, lv.parent);
   uint32_t idx = *runtimeModule->allocateAddCacheEntry();
   AddPropertyCacheEntry &entry = runtimeModule->getAddCacheEntry(idx);
-  entry.parent = lv.obj->getParentGCPtr();
+  entry.parent = lv.obj->getParentGCPtr(runtime);
   entry.startClazz = lv.obj->getClassGCPtr();
   entry.setParentEpochAndSlot(runtime.getParentCacheEpoch(), 5);
 

--- a/unittests/VMRuntime/ObjectModelTest.cpp
+++ b/unittests/VMRuntime/ObjectModelTest.cpp
@@ -194,7 +194,7 @@ TEST_F(ObjectModelTest, DefineOwnPropertyTest) {
     EXPECT_PROPERTY_FLAG(FALSE, obj, *prop1ID, enumerable);
     EXPECT_PROPERTY_FLAG(FALSE, obj, *prop1ID, configurable);
     EXPECT_PROPERTY_FLAG(FALSE, obj, *prop1ID, accessor);
-    JSObject::preventExtensions(obj.get());
+    JSObject::preventExtensionsNonProxy(obj, runtime);
     ASSERT_TRUE(*JSObject::defineOwnProperty(
         obj,
         runtime,

--- a/unittests/VMRuntime/StackTracesTreeTest.cpp
+++ b/unittests/VMRuntime/StackTracesTreeTest.cpp
@@ -204,13 +204,10 @@ struct StackTracesTreeParameterizedTest
             enableAllocationLocationTrackerSym,
             runtime.makeHandle<NativeFunction>(*NativeFunction::create(
                 runtime,
-                runtime.functionPrototype,
-                Runtime::makeNullHandle<Environment>(),
                 nullptr,
                 trackerOnByDefault() ? noop : enableAllocationLocationTracker,
                 enableAllocationLocationTrackerSym,
-                0,
-                Runtime::makeNullHandle<JSObject>())))));
+                0)))));
   }
 
   // No need for a tear-down, because the runtime destructor will clear all

--- a/unittests/VMRuntime/WeakValueObjectMapTest.cpp
+++ b/unittests/VMRuntime/WeakValueObjectMapTest.cpp
@@ -1,0 +1,463 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "hermes/VM/WeakValueObjectMap.h"
+
+#include "hermes/VM/DummyObject.h"
+#include "hermes/VM/PrimitiveBox.h"
+#include "hermes/VM/Runtime.h"
+
+#include "VMRuntimeTestHelpers.h"
+
+#include "gtest/gtest.h"
+
+using namespace hermes::vm;
+
+namespace {
+
+using WeakValueObjectMapTest = LargeHeapRuntimeTestFixture;
+using DummyObject = testhelpers::DummyObject;
+
+TEST_F(WeakValueObjectMapTest, InsertNewTest) {
+  struct : public Locals {
+    PinnedValue<WeakValueObjectMap<DummyObject>> map;
+    PinnedValue<JSObject> key;
+    PinnedValue<DummyObject> value1;
+    PinnedValue<DummyObject> value2;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
+
+  lv.map = WeakValueObjectMap<DummyObject>::create(runtime);
+
+  lv.key = JSObject::create(runtime);
+  lv.value1 = DummyObject::create(runtime.getHeap(), runtime);
+  lv.value2 = DummyObject::create(runtime.getHeap(), runtime);
+
+  EXPECT_TRUE(
+      WeakValueObjectMap<DummyObject>::insertNew(
+          lv.map, runtime, *lv.key, *lv.value1));
+
+  EXPECT_FALSE(
+      WeakValueObjectMap<DummyObject>::insertNew(
+          lv.map, runtime, *lv.key, *lv.value2));
+
+  // Free the value1 and trigger GC to invalidate the old WeakRef.
+  lv.value1 = nullptr;
+  runtime.collect("test");
+
+  EXPECT_FALSE(lv.map->containsKey(runtime, *lv.key));
+
+  EXPECT_TRUE(
+      WeakValueObjectMap<DummyObject>::insertNew(
+          lv.map, runtime, *lv.key, *lv.value2));
+}
+
+TEST_F(WeakValueObjectMapTest, RehashTest) {
+  struct : public Locals {
+    PinnedValue<WeakValueObjectMap<DummyObject>> map;
+    PinnedValue<ArrayStorage> keys;
+    PinnedValue<ArrayStorage> values;
+    PinnedValue<JSObject> tempKey;
+    PinnedValue<DummyObject> tempValue;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
+
+  lv.map = WeakValueObjectMap<DummyObject>::create(runtime);
+
+  lv.keys.castAndSetHermesValue<ArrayStorage>(
+      *ArrayStorage::create(runtime, 32, 32));
+  lv.values.castAndSetHermesValue<ArrayStorage>(
+      *ArrayStorage::create(runtime, 32, 32));
+
+  for (uint32_t i = 0; i < 10; ++i) {
+    lv.tempKey = JSObject::create(runtime);
+    lv.tempValue = DummyObject::create(runtime.getHeap(), runtime);
+
+    // Store them to prevent GC.
+    lv.keys->set(
+        i, HermesValue::encodeObjectValue(*lv.tempKey), runtime.getHeap());
+    lv.values->set(
+        i, HermesValue::encodeObjectValue(*lv.tempValue), runtime.getHeap());
+  }
+
+  for (uint32_t i = 0; i < 2; ++i) {
+    JSObject *key = vmcast<JSObject>(lv.keys->at(i));
+    DummyObject *expectedValue = vmcast<DummyObject>(lv.values->at(i));
+    EXPECT_TRUE(
+        WeakValueObjectMap<DummyObject>::insertNew(
+            lv.map, runtime, key, expectedValue));
+  }
+
+  for (uint32_t i = 0; i < 2; ++i) {
+    JSObject *key = vmcast<JSObject>(lv.keys->at(i));
+    DummyObject *expectedValue = vmcast<DummyObject>(lv.values->at(i));
+    EXPECT_EQ(expectedValue, lv.map->lookup(runtime, key));
+  }
+
+  lv.values->set(1, HermesValue::encodeUndefinedValue(), runtime.getHeap());
+  runtime.collect("test");
+  ASSERT_FALSE(lv.map->containsKey(runtime, vmcast<JSObject>(lv.keys->at(1))));
+
+  // Force the rehash with an invalid WeakRef.
+  for (uint32_t i = 3; i < 10; ++i) {
+    JSObject *key = vmcast<JSObject>(lv.keys->at(i));
+    DummyObject *expectedValue = vmcast<DummyObject>(lv.values->at(i));
+    EXPECT_TRUE(
+        WeakValueObjectMap<DummyObject>::insertNew(
+            lv.map, runtime, key, expectedValue));
+  }
+}
+
+TEST_F(WeakValueObjectMapTest, GrowTest) {
+  struct : public Locals {
+    PinnedValue<WeakValueObjectMap<DummyObject>> map;
+    PinnedValue<ArrayStorage> keys;
+    PinnedValue<ArrayStorage> values;
+    PinnedValue<JSObject> tempKey;
+    PinnedValue<DummyObject> tempValue;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
+
+  lv.map = WeakValueObjectMap<DummyObject>::create(runtime);
+
+  // Create storage for keys and values to prevent GC.
+  lv.keys.castAndSetHermesValue<ArrayStorage>(
+      *ArrayStorage::create(runtime, 32, 32));
+  lv.values.castAndSetHermesValue<ArrayStorage>(
+      *ArrayStorage::create(runtime, 32, 32));
+
+  // Initially map should be empty with 0 capacity.
+  EXPECT_TRUE(lv.map->isKnownEmpty());
+  EXPECT_EQ(lv.map->capacity(), 0);
+
+  // Insert enough items to trigger multiple grows.
+  // Initial capacity will be 8, so insert 20 items to grow to 16, then 32.
+  const uint32_t numItems = 20;
+
+  for (uint32_t i = 0; i < numItems; ++i) {
+    // Create key and value using safe pattern.
+    lv.tempKey = JSObject::create(runtime);
+    lv.tempValue = DummyObject::create(runtime.getHeap(), runtime);
+
+    // Store them to prevent GC.
+    lv.keys->set(
+        i, HermesValue::encodeObjectValue(*lv.tempKey), runtime.getHeap());
+    lv.values->set(
+        i, HermesValue::encodeObjectValue(*lv.tempValue), runtime.getHeap());
+
+    // Insert into map.
+    bool insertRes = WeakValueObjectMap<DummyObject>::insertNew(
+        lv.map, runtime, *lv.tempKey, *lv.tempValue);
+    EXPECT_TRUE(insertRes); // Should be inserted successfully.
+  }
+
+  // After inserting 20 items, capacity should have grown.
+  // Started at 8 (first grow), then 16 (second grow), then 32.
+  EXPECT_GE(lv.map->capacity(), 32);
+  EXPECT_FALSE(lv.map->isKnownEmpty());
+
+  // Verify all items are still accessible after rehashing.
+  for (uint32_t i = 0; i < numItems; ++i) {
+    JSObject *key = vmcast<JSObject>(lv.keys->at(i));
+    DummyObject *expectedValue = vmcast<DummyObject>(lv.values->at(i));
+
+    // Test containsKey.
+    EXPECT_TRUE(lv.map->containsKey(runtime, key));
+
+    // Test lookup.
+    DummyObject *foundValue = lv.map->lookup(runtime, key);
+    ASSERT_NE(foundValue, nullptr);
+    EXPECT_EQ(foundValue, expectedValue);
+  }
+
+  // Test that non-existent keys return null.
+  lv.tempKey = JSObject::create(runtime);
+  EXPECT_FALSE(lv.map->containsKey(runtime, *lv.tempKey));
+  EXPECT_EQ(lv.map->lookup(runtime, *lv.tempKey), nullptr);
+}
+
+TEST_F(WeakValueObjectMapTest, ShrinkTest) {
+  struct : public Locals {
+    PinnedValue<WeakValueObjectMap<DummyObject>> map;
+    PinnedValue<ArrayStorage> keys;
+    PinnedValue<ArrayStorage> values;
+    PinnedValue<JSObject> tempKey;
+    PinnedValue<DummyObject> tempValue;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
+
+  lv.map = WeakValueObjectMap<DummyObject>::create(runtime);
+
+  // Create storage for keys and values.
+  lv.keys.castAndSetHermesValue<ArrayStorage>(
+      *ArrayStorage::create(runtime, 64, 64));
+  lv.values.castAndSetHermesValue<ArrayStorage>(
+      *ArrayStorage::create(runtime, 64, 64));
+
+  // Insert enough items to get a large capacity (64).
+  const uint32_t numItems = 40;
+
+  for (uint32_t i = 0; i < numItems; ++i) {
+    lv.tempKey = JSObject::create(runtime);
+    lv.tempValue = DummyObject::create(runtime.getHeap(), runtime);
+
+    lv.keys->set(
+        i, HermesValue::encodeObjectValue(*lv.tempKey), runtime.getHeap());
+    lv.values->set(
+        i, HermesValue::encodeObjectValue(*lv.tempValue), runtime.getHeap());
+
+    bool insertRes = WeakValueObjectMap<DummyObject>::insertNew(
+        lv.map, runtime, *lv.tempKey, *lv.tempValue);
+    EXPECT_TRUE(insertRes);
+  }
+
+  // Should have grown to capacity of 64.
+  EXPECT_GE(lv.map->capacity(), 64);
+
+  // Now erase most items, keeping only a few (below 1/8 of capacity).
+  // With capacity 64, keeping 3 items should trigger shrinking (3 < 64/8 = 8).
+  const uint32_t itemsToKeep = 3;
+
+  for (uint32_t i = itemsToKeep; i < numItems; ++i) {
+    JSObject *key = vmcast<JSObject>(lv.keys->at(i));
+    bool erased = WeakValueObjectMap<DummyObject>::erase(
+        lv.map, runtime, key, runtime.getHeap());
+    EXPECT_TRUE(erased);
+    key = vmcast<JSObject>(lv.keys->at(i));
+    EXPECT_FALSE(lv.map->containsKey(runtime, key));
+
+    {
+      JSObject *key = vmcast<JSObject>(lv.keys->at(i));
+      EXPECT_FALSE(lv.map->containsKey(runtime, key)) << "i = " << i << "\n";
+      EXPECT_EQ(lv.map->lookup(runtime, key), nullptr);
+    }
+
+    if (i >= 27) {
+      JSObject *key = vmcast<JSObject>(lv.keys->at(27));
+      EXPECT_FALSE(lv.map->containsKey(runtime, key)) << "i = " << 27 << "\n";
+    }
+  }
+
+  // Capacity should've shrunk below 64.
+  EXPECT_LT(lv.map->capacity(), 64);
+
+  JSObject *key = vmcast<JSObject>(lv.keys->at(27));
+  EXPECT_FALSE(lv.map->containsKey(runtime, key)) << "i = " << 27 << "\n";
+
+  // Verify erased items are no longer accessible.
+  for (uint32_t i = itemsToKeep; i < numItems; ++i) {
+    JSObject *key = vmcast<JSObject>(lv.keys->at(i));
+    EXPECT_FALSE(lv.map->containsKey(runtime, key)) << "i = " << i << "\n";
+    EXPECT_EQ(lv.map->lookup(runtime, key), nullptr);
+  }
+
+  // Verify the remaining items are still accessible.
+  for (uint32_t i = 0; i < itemsToKeep; ++i) {
+    JSObject *key = vmcast<JSObject>(lv.keys->at(i));
+    DummyObject *expectedValue = vmcast<DummyObject>(lv.values->at(i));
+
+    EXPECT_TRUE(lv.map->containsKey(runtime, key));
+    DummyObject *foundValue = lv.map->lookup(runtime, key);
+    ASSERT_NE(foundValue, nullptr);
+    EXPECT_EQ(foundValue, expectedValue);
+  }
+}
+
+TEST_F(WeakValueObjectMapTest, WeaknessWithGCTest) {
+  struct : public Locals {
+    PinnedValue<WeakValueObjectMap<DummyObject>> map;
+    PinnedValue<DummyObject> value1;
+    PinnedValue<DummyObject> value2;
+    PinnedValue<DummyObject> value3;
+    PinnedValue<JSObject> key1;
+    PinnedValue<JSObject> key2;
+    PinnedValue<JSObject> key3;
+    PinnedValue<JSObject> key4;
+    PinnedValue<DummyObject> value4;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
+
+  lv.map = WeakValueObjectMap<DummyObject>::create(runtime);
+
+  // Create keys and values using safe allocation pattern.
+  lv.key1 = JSObject::create(runtime);
+  lv.key2 = JSObject::create(runtime);
+  lv.key3 = JSObject::create(runtime);
+  lv.key4 = JSObject::create(runtime);
+
+  lv.value1 = DummyObject::create(runtime.getHeap(), runtime);
+  lv.value2 = DummyObject::create(runtime.getHeap(), runtime);
+  lv.value3 = DummyObject::create(runtime.getHeap(), runtime);
+  lv.value4 = DummyObject::create(runtime.getHeap(), runtime);
+
+  // Insert all values into the map.
+  bool insertRes1 = WeakValueObjectMap<DummyObject>::insertNew(
+      lv.map, runtime, *lv.key1, *lv.value1);
+  EXPECT_TRUE(insertRes1);
+
+  bool insertRes2 = WeakValueObjectMap<DummyObject>::insertNew(
+      lv.map, runtime, *lv.key2, *lv.value2);
+  EXPECT_TRUE(insertRes2);
+
+  bool insertRes3 = WeakValueObjectMap<DummyObject>::insertNew(
+      lv.map, runtime, *lv.key3, *lv.value3);
+  EXPECT_TRUE(insertRes3);
+
+  bool insertRes4 = WeakValueObjectMap<DummyObject>::insertNew(
+      lv.map, runtime, *lv.key4, *lv.value4);
+  EXPECT_TRUE(insertRes4);
+
+  // All items should be accessible before GC.
+  EXPECT_TRUE(lv.map->containsKey(runtime, *lv.key1));
+  EXPECT_TRUE(lv.map->containsKey(runtime, *lv.key2));
+  EXPECT_TRUE(lv.map->containsKey(runtime, *lv.key3));
+  EXPECT_TRUE(lv.map->containsKey(runtime, *lv.key4));
+
+  // Clear value4 and trigger GC.
+  // value4 should be collected.
+  lv.value4 = nullptr;
+  runtime.collect("test");
+
+  // After GC, values 1, 2, 3 should still be accessible (strong references).
+  EXPECT_TRUE(lv.map->containsKey(runtime, *lv.key1));
+  EXPECT_TRUE(lv.map->containsKey(runtime, *lv.key2));
+  EXPECT_TRUE(lv.map->containsKey(runtime, *lv.key3));
+
+  // value4 should no longer be accessible (weak reference was broken).
+  EXPECT_FALSE(lv.map->containsKey(runtime, *lv.key4));
+  EXPECT_EQ(lv.map->lookup(runtime, *lv.key4), nullptr);
+
+  // Clear more references and test shrinking after pruning.
+  lv.value1 = nullptr;
+  lv.value2 = nullptr;
+  runtime.collect("test");
+
+  // Now only value3 should be accessible.
+  EXPECT_FALSE(lv.map->containsKey(runtime, *lv.key1));
+  EXPECT_FALSE(lv.map->containsKey(runtime, *lv.key2));
+  EXPECT_TRUE(lv.map->containsKey(runtime, *lv.key3));
+  EXPECT_FALSE(lv.map->containsKey(runtime, *lv.key4));
+}
+
+TEST_F(WeakValueObjectMapTest, RepeatedGrowShrinkTest) {
+  struct : public Locals {
+    PinnedValue<WeakValueObjectMap<DummyObject>> map;
+    PinnedValue<ArrayStorage> keys;
+    PinnedValue<ArrayStorage> values;
+    PinnedValue<JSObject> tempKey;
+    PinnedValue<DummyObject> tempValue;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
+
+  lv.map = WeakValueObjectMap<DummyObject>::create(runtime);
+
+  // Create large storage for keys and values.
+  lv.keys.castAndSetHermesValue<ArrayStorage>(
+      *ArrayStorage::create(runtime, 100, 100));
+  lv.values.castAndSetHermesValue<ArrayStorage>(
+      *ArrayStorage::create(runtime, 100, 100));
+
+  // Perform multiple cycles of grow and shrink.
+  for (int cycle = 0; cycle < 3; ++cycle) {
+    // Grow phase: insert many items.
+    const uint32_t itemsToAdd = 30;
+
+    for (uint32_t i = 0; i < itemsToAdd; ++i) {
+      lv.tempKey = JSObject::create(runtime);
+      lv.tempValue = DummyObject::create(runtime.getHeap(), runtime);
+
+      lv.keys->set(
+          i, HermesValue::encodeObjectValue(*lv.tempKey), runtime.getHeap());
+      lv.values->set(
+          i, HermesValue::encodeObjectValue(*lv.tempValue), runtime.getHeap());
+
+      bool insertRes = WeakValueObjectMap<DummyObject>::insertNew(
+          lv.map, runtime, *lv.tempKey, *lv.tempValue);
+      EXPECT_TRUE(insertRes);
+    }
+
+    // Verify capacity has grown.
+    // Should be at least 32 after adding 30 items.
+    auto grownCapacity = lv.map->capacity();
+    EXPECT_GE(grownCapacity, 32);
+
+    // Verify all items are accessible.
+    for (uint32_t i = 0; i < itemsToAdd; ++i) {
+      JSObject *key = vmcast<JSObject>(lv.keys->at(i));
+      EXPECT_TRUE(lv.map->containsKey(runtime, key));
+      EXPECT_NE(lv.map->lookup(runtime, key), nullptr);
+    }
+
+    // Shrink phase: remove most items.
+    const uint32_t itemsToKeep = 2;
+
+    for (uint32_t i = itemsToKeep; i < itemsToAdd; ++i) {
+      JSObject *key = vmcast<JSObject>(lv.keys->at(i));
+      bool erased = WeakValueObjectMap<DummyObject>::erase(
+          lv.map, runtime, key, runtime.getHeap());
+      EXPECT_TRUE(erased);
+    }
+
+    // Verify capacity has shrunk or at least not grown further.
+    auto shrunkCapacity = lv.map->capacity();
+    EXPECT_LE(shrunkCapacity, grownCapacity);
+
+    // Verify remaining items are still accessible.
+    for (uint32_t i = 0; i < itemsToKeep; ++i) {
+      JSObject *key = vmcast<JSObject>(lv.keys->at(i));
+      EXPECT_TRUE(lv.map->containsKey(runtime, key));
+      EXPECT_NE(lv.map->lookup(runtime, key), nullptr);
+    }
+
+    // Verify removed items are no longer accessible.
+    for (uint32_t i = itemsToKeep; i < itemsToAdd; ++i) {
+      JSObject *key = vmcast<JSObject>(lv.keys->at(i));
+      EXPECT_FALSE(lv.map->containsKey(runtime, key));
+      EXPECT_EQ(lv.map->lookup(runtime, key), nullptr);
+    }
+
+    // Clean up remaining items for next cycle.
+    for (uint32_t i = 0; i < itemsToKeep; ++i) {
+      JSObject *key = vmcast<JSObject>(lv.keys->at(i));
+      WeakValueObjectMap<DummyObject>::erase(
+          lv.map, runtime, key, runtime.getHeap());
+    }
+  }
+
+  // After all cycles, map should be empty or very small.
+  EXPECT_TRUE(lv.map->isKnownEmpty() || lv.map->capacity() <= 16);
+}
+
+TEST_F(WeakValueObjectMapTest, EmptyMapOperationsTest) {
+  struct : public Locals {
+    PinnedValue<WeakValueObjectMap<DummyObject>> map;
+    PinnedValue<JSObject> tempKey;
+    PinnedValue<DummyObject> tempValue;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
+
+  lv.map = WeakValueObjectMap<DummyObject>::create(runtime);
+
+  EXPECT_TRUE(lv.map->isKnownEmpty());
+  EXPECT_EQ(lv.map->capacity(), 0);
+
+  lv.tempKey = JSObject::create(runtime);
+  EXPECT_FALSE(lv.map->containsKey(runtime, *lv.tempKey));
+  EXPECT_EQ(lv.map->lookup(runtime, *lv.tempKey), nullptr);
+
+  bool erased = WeakValueObjectMap<DummyObject>::erase(
+      lv.map, runtime, *lv.tempKey, runtime.getHeap());
+  EXPECT_FALSE(erased);
+
+  lv.tempValue = DummyObject::create(runtime.getHeap(), runtime);
+  bool insertRes = WeakValueObjectMap<DummyObject>::insertNew(
+      lv.map, runtime, *lv.tempKey, *lv.tempValue);
+  EXPECT_TRUE(insertRes);
+
+  EXPECT_FALSE(lv.map->isKnownEmpty());
+}
+} // namespace


### PR DESCRIPTION
Summary:
Marking an object as cached using the epoch may now allocate a new
`HiddenClass`, so some care has to be taken due to the various
NoAllocScope uses around this flag.

Differential Revision: D84654981
