### PR TITLE
FlowLib: Add typed Set wrapper (#1940)

### DIFF
--- a/benchmarks/widgets/simple-classes/widgets.js
+++ b/benchmarks/widgets/simple-classes/widgets.js
@@ -12,9 +12,6 @@
 
 (function() {
 
-const mapPrototypeGet: any = Map.prototype.get;
-const mapPrototypeSet: any = Map.prototype.set;
-
 // ==> widget.js <==
 
 class Widget {
@@ -158,13 +155,13 @@ function reconcileChildren(
   oldChildren: RenderNode[],
 ): RenderNode[] {
   const outChildren: RenderNode[] = [];
-  const oldChildrenByKey: any = new Map();
-  oldChildren.forEach(child => { $SHBuiltin.call(mapPrototypeSet, oldChildrenByKey, child.key, child); });
+  const oldChildrenByKey = new Map<string, RenderNode>();
+  oldChildren.forEach(child => { oldChildrenByKey.set(child.key, child); });
 
   newChildren.forEach(child => {
     const newKey = child.key;
     const oldChild: RenderNode | void =
-      $SHBuiltin.call(mapPrototypeGet, oldChildrenByKey, newKey);
+      oldChildrenByKey.get(newKey);
     if (oldChild !== undefined) {
       outChildren.push(reconcileRenderNode(child, oldChild));
     } else {
@@ -177,16 +174,16 @@ function reconcileChildren(
 
 function mapEntitiesToComponents(
   entities: VirtualEntity[],
-): any {
-  const map: any = new Map();
+): Map<number, Component[]> {
+  const map = new Map<number, Component[]>();
   entities.forEach(entity => {
     const key: number = entity.key;
     const value: Component[] = entity.value;
-    if ($SHBuiltin.call(mapPrototypeGet, map, key) == undefined) {
-      $SHBuiltin.call(mapPrototypeSet, map, key, ([]: Component[]));
+    if (map.get(key) == undefined) {
+      map.set(key, ([]: Component[]));
     }
 
-    const components: Component[] = $SHBuiltin.call(mapPrototypeGet, map, key);
+    const components: Component[] = map.get(key);
     if (components !== undefined) {
       components.push(...value);
     } else {
@@ -214,12 +211,12 @@ function diffTrees(
     entityId => !newEntityIds.includes(entityId),
   );
 
-  const oldComponents: any = mapEntitiesToComponents(oldEntities);
-  const newComponents: any = mapEntitiesToComponents(newEntities);
+  const oldComponents = mapEntitiesToComponents(oldEntities);
+  const newComponents = mapEntitiesToComponents(newEntities);
 
   createdEntities.forEach(entityId => {
     const comps: Component[] =
-      $SHBuiltin.call(mapPrototypeGet, newComponents, entityId) || ([]: Component[]);
+      newComponents.get(entityId) || ([]: Component[]);
     const components = comps.map(
       it => new ComponentPair(entityId, it),
     );
@@ -227,11 +224,11 @@ function diffTrees(
   });
 
   newComponents.forEach((value: Component[], key: number) => {
-    if ($SHBuiltin.call(mapPrototypeGet, oldComponents, key) == undefined) {
+    if (oldComponents.get(key) == undefined) {
       return;
     }
 
-    const oldComponentsForKey: Component[] = $SHBuiltin.call(mapPrototypeGet, oldComponents, key) || ([]: Component[]);
+    const oldComponentsForKey: Component[] = oldComponents.get(key) || ([]: Component[]);
     const newComponentsForKey: Component[] = value;
 
     const deleted: Component[] = oldComponentsForKey.filter(

--- a/lib/FlowLib/01-array.js
+++ b/lib/FlowLib/01-array.js
@@ -290,7 +290,25 @@ class Array<T> {
     return result;
   }
 
-  // TODO: with.
+  @Hermes.final
+  with(index: number, value: T): Array<T> {
+    "inline";
+    var len: number = this.length;
+    var idx: number = __ToIntegerOrInfinity(index);
+    if (idx < 0) {
+      idx += len;
+      if (idx < 0)
+        throw new RangeError("Invalid index");
+    } else if (idx >= len) {
+      throw new RangeError("Invalid index");
+    }
+    // Spread the whole array and then overwrite.
+    // Avoids branching every iteration.
+    var result: T[] = [...this];
+    result[idx] = value;
+    return result;
+  }
+
   // TODO: fill.
   // TODO: reverse.
   // TODO: copyWithin.

--- a/lib/FlowLib/01-array.js
+++ b/lib/FlowLib/01-array.js
@@ -98,18 +98,7 @@ class Array<T> {
 
   @Hermes.final
   toString(): string {
-    var len: number = this.length;
-    if (len === 0)
-      return "";
-    var el0: T = this[0];
-    var result: string = (el0 === undefined || el0 === null) ? "" : String(el0);
-    for (var i: number = 1; i < len; ++i) {
-      result += ",";
-      var el: T = this[i];
-      if (el !== undefined && el !== null)
-        result += String(el);
-    }
-    return result;
+    return this.join();
   }
 
   @Hermes.final
@@ -252,7 +241,24 @@ class Array<T> {
     return -1;
   }
 
-  // TODO: join.
+  @Hermes.final
+  join(separator?: string): string {
+    "inline";
+    var len: number = this.length;
+    if (len === 0)
+      return "";
+    var sep: string = separator !== undefined ? separator : ",";
+    var el0: T = this[0];
+    var result: string = (el0 === undefined || el0 === null) ? "" : String(el0);
+    for (var i: number = 1; i < len; ++i) {
+      result += sep;
+      var el: T = this[i];
+      if (el !== undefined && el !== null)
+        result += String(el);
+    }
+    return result;
+  }
+
   // TODO: slice.
   // TODO: toReversed.
   // TODO: with.

--- a/lib/FlowLib/01-array.js
+++ b/lib/FlowLib/01-array.js
@@ -196,7 +196,34 @@ class Array<T> {
     return false;
   }
 
-  // TODO: find / findIndex.
+  @Hermes.final
+  find<This>(
+    callback: (this: This, t: T, i: number, array: Array<T>) => boolean,
+    thisArg?: This,
+  ): T | void {
+    "inline";
+    for (var i: number = 0, e = this.length; i < e; ++i) {
+      var t: T = this[i];
+      if ($SHBuiltin.call(callback, thisArg, t, i, this))
+        return t;
+    }
+    return undefined;
+  }
+
+  @Hermes.final
+  findIndex<This>(
+    callback: (this: This, t: T, i: number, array: Array<T>) => boolean,
+    thisArg?: This,
+  ): number {
+    "inline";
+    for (var i: number = 0, e = this.length; i < e; ++i) {
+      var t: T = this[i];
+      if ($SHBuiltin.call(callback, thisArg, t, i, this))
+        return i;
+    }
+    return -1;
+  }
+
   // TODO: findLast / findLastIndex.
   // TODO: join.
   // TODO: slice.

--- a/lib/FlowLib/01-array.js
+++ b/lib/FlowLib/01-array.js
@@ -259,7 +259,27 @@ class Array<T> {
     return result;
   }
 
-  // TODO: slice.
+  @Hermes.final
+  slice(start?: number, end?: number): Array<T> {
+    var len: number = this.length;
+    var s: number = start !== undefined ? __ToIntegerOrInfinity(start) : 0;
+    if (s < 0) {
+      s += len;
+      if (s < 0)
+        s = 0;
+    }
+    var e: number = end !== undefined ? __ToIntegerOrInfinity(end) : len;
+    if (e < 0)
+      e += len;
+    if (e > len)
+      e = len;
+    var result: T[] = [];
+    for (var i: number = s; i < e; ++i) {
+      result.push(this[i]);
+    }
+    return result;
+  }
+
   // TODO: toReversed.
   // TODO: with.
   // TODO: fill.

--- a/lib/FlowLib/01-array.js
+++ b/lib/FlowLib/01-array.js
@@ -155,7 +155,19 @@ class Array<T> {
     return -1;
   }
 
-  // TODO: at.
+  @Hermes.final
+  at(index: number): T | void {
+    "inline";
+    var len: number = this.length;
+    index = __ToIntegerOrInfinity(index);
+    if (index >= 0) {
+      return index < len ? this[index] : undefined;
+    } else {
+      index += len;
+      return index >= 0 ? this[index] : undefined;
+    }
+  }
+
   // TODO: every / some.
   // TODO: find / findIndex.
   // TODO: findLast / findLastIndex.

--- a/lib/FlowLib/01-array.js
+++ b/lib/FlowLib/01-array.js
@@ -112,7 +112,49 @@ class Array<T> {
     return result;
   }
 
-  // TODO: indexOf / lastIndexOf.
+  @Hermes.final
+  indexOf(searchElement: T, fromIndex?: number): number {
+    "inline";
+    var len: number = this.length;
+    var start: number;
+    if (fromIndex !== undefined) {
+      start = __ToIntegerOrInfinity(fromIndex);
+      if (start < 0) {
+        start = len + start;
+        if (start < 0)
+          start = 0;
+      }
+    } else {
+      start = 0;
+    }
+    for (var i: number = start; i < len; ++i) {
+      if (this[i] === searchElement)
+        return i;
+    }
+    return -1;
+  }
+
+  @Hermes.final
+  lastIndexOf(searchElement: T, fromIndex?: number): number {
+    "inline";
+    var len: number = this.length;
+    var start: number;
+    if (fromIndex !== undefined) {
+      start = __ToIntegerOrInfinity(fromIndex);
+      if (start < 0)
+        start = len + start;
+      if (start >= len)
+        start = len - 1;
+    } else {
+      start = len - 1;
+    }
+    for (var i: number = start; i >= 0; --i) {
+      if (this[i] === searchElement)
+        return i;
+    }
+    return -1;
+  }
+
   // TODO: at.
   // TODO: every / some.
   // TODO: find / findIndex.

--- a/lib/FlowLib/01-array.js
+++ b/lib/FlowLib/01-array.js
@@ -280,7 +280,16 @@ class Array<T> {
     return result;
   }
 
-  // TODO: toReversed.
+  @Hermes.final
+  toReversed(): Array<T> {
+    "inline";
+    var result: Array<T> = [];
+    for (var i: number = this.length - 1; i >= 0; --i) {
+      result.push(this[i]);
+    }
+    return result;
+  }
+
   // TODO: with.
   // TODO: fill.
   // TODO: reverse.

--- a/lib/FlowLib/01-array.js
+++ b/lib/FlowLib/01-array.js
@@ -224,7 +224,34 @@ class Array<T> {
     return -1;
   }
 
-  // TODO: findLast / findLastIndex.
+  @Hermes.final
+  findLast<This>(
+    callback: (this: This, t: T, i: number, array: Array<T>) => boolean,
+    thisArg?: This,
+  ): T | void {
+    "inline";
+    for (var i: number = this.length - 1; i >= 0; --i) {
+      var t: T = this[i];
+      if ($SHBuiltin.call(callback, thisArg, t, i, this))
+        return t;
+    }
+    return undefined;
+  }
+
+  @Hermes.final
+  findLastIndex<This>(
+    callback: (this: This, t: T, i: number, array: Array<T>) => boolean,
+    thisArg?: This,
+  ): number {
+    "inline";
+    for (var i: number = this.length - 1; i >= 0; --i) {
+      var t: T = this[i];
+      if ($SHBuiltin.call(callback, thisArg, t, i, this))
+        return i;
+    }
+    return -1;
+  }
+
   // TODO: join.
   // TODO: slice.
   // TODO: toReversed.

--- a/lib/FlowLib/01-array.js
+++ b/lib/FlowLib/01-array.js
@@ -168,7 +168,34 @@ class Array<T> {
     }
   }
 
-  // TODO: every / some.
+  @Hermes.final
+  every<This>(
+    callback: (this: This, t: T, i: number, array: Array<T>) => boolean,
+    thisArg?: This,
+  ): boolean {
+    "inline";
+    for (var i: number = 0, e = this.length; i < e; ++i) {
+      var t: T = this[i];
+      if (!$SHBuiltin.call(callback, thisArg, t, i, this))
+        return false;
+    }
+    return true;
+  }
+
+  @Hermes.final
+  some<This>(
+    callback: (this: This, t: T, i: number, array: Array<T>) => boolean,
+    thisArg?: This,
+  ): boolean {
+    "inline";
+    for (var i: number = 0, e = this.length; i < e; ++i) {
+      var t: T = this[i];
+      if ($SHBuiltin.call(callback, thisArg, t, i, this))
+        return true;
+    }
+    return false;
+  }
+
   // TODO: find / findIndex.
   // TODO: findLast / findLastIndex.
   // TODO: join.

--- a/lib/FlowLib/01-array.js
+++ b/lib/FlowLib/01-array.js
@@ -309,7 +309,27 @@ class Array<T> {
     return result;
   }
 
-  // TODO: fill.
+  @Hermes.final
+  fill(value: T, start?: number, end?: number): Array<T> {
+    "inline";
+    var len: number = this.length;
+    var s: number = start !== undefined ? __ToIntegerOrInfinity(start) : 0;
+    if (s < 0) {
+      s += len;
+      if (s < 0)
+        s = 0;
+    }
+    var e: number = end !== undefined ? __ToIntegerOrInfinity(end) : len;
+    if (e < 0)
+      e += len;
+    if (e > len)
+      e = len;
+    for (var i: number = s; i < e; ++i) {
+      this[i] = value;
+    }
+    return this;
+  }
+
   // TODO: reverse.
   // TODO: copyWithin.
   // TODO: reduce / reduceRight.

--- a/lib/FlowLib/01-array.js
+++ b/lib/FlowLib/01-array.js
@@ -330,7 +330,21 @@ class Array<T> {
     return this;
   }
 
-  // TODO: reverse.
+  @Hermes.final
+  reverse(): Array<T> {
+    "inline";
+    var lo: number = 0;
+    var hi: number = this.length - 1;
+    while (lo < hi) {
+      var tmp: T = this[lo];
+      this[lo] = this[hi];
+      this[hi] = tmp;
+      ++lo;
+      --hi;
+    }
+    return this;
+  }
+
   // TODO: copyWithin.
   // TODO: reduce / reduceRight.
   // TODO: flat — needs recursive type flattening.

--- a/lib/FlowLib/01-array.js
+++ b/lib/FlowLib/01-array.js
@@ -8,28 +8,30 @@
 @Hermes.array
 class Array<T> {
   @Hermes.final
-  map<U>(
-    callback: (t: T, i?: number, array?: Array<T>) => U,
+  map<U, This>(
+    callback: (this: This, t: T, i: number, array: Array<T>) => U,
+    thisArg?: This,
   ): Array<U> {
     "inline";
     var result: U[] = [];
     for (var i: number = 0, e = this.length; i < e; ++i) {
       var t: T = this[i];
-      var u: U = callback(t, i, this);
+      var u: U = $SHBuiltin.call(callback, thisArg, t, i, this);
       result.push(u);
     }
     return result;
   }
 
   @Hermes.final
-  filter(
-    callback: (t: T, i?: number, array?: Array<T>) => any,
+  filter<This>(
+    callback: (this: This, t: T, i: number, array: Array<T>) => any,
+    thisArg?: This,
   ): Array<T> {
     "inline";
     var result: T[] = [];
     for (var i: number = 0, e = this.length; i < e; ++i) {
       var t: T = this[i];
-      if (callback(t, i, this))
+      if ($SHBuiltin.call(callback, thisArg, t, i, this))
         result.push(t);
     }
     return result;
@@ -59,19 +61,21 @@ class Array<T> {
   }
 
   @Hermes.final
-  forEach(
-    callback: (t: T, i?: number, array?: Array<T>) => void,
+  forEach<This>(
+    callback: (this: This, t: T, i: number, array: Array<T>) => void,
+    thisArg?: This,
   ): void {
     "inline";
     for (var i: number = 0, e = this.length; i < e; ++i) {
       var t: T = this[i];
-      callback(t, i, this);
+      $SHBuiltin.call(callback, thisArg, t, i, this);
     }
   }
 
   @Hermes.final
-  flatMap<U>(
-    callback: (t: T, i?: number, array?: Array<T>) => Array<U>,
+  flatMap<U, This>(
+    callback: (this: This, t: T, i: number, array: Array<T>) => Array<U>,
+    thisArg?: This,
   ): Array<U> {
     "inline";
     var result: Array<U> = [];
@@ -80,7 +84,7 @@ class Array<T> {
       // TODO: callback return type should be U | Array<U> per spec (non-array
       // values are kept as-is, arrays are flattened one level).
       // Needs runtime Array.isArray() or instanceof check in typed mode.
-      var arr: Array<U> = callback(t, i, this);
+      var arr: Array<U> = $SHBuiltin.call(callback, thisArg, t, i, this);
       result.push(...arr);
     }
     return result;

--- a/lib/FlowLib/01-array.js
+++ b/lib/FlowLib/01-array.js
@@ -345,7 +345,50 @@ class Array<T> {
     return this;
   }
 
-  // TODO: copyWithin.
+  @Hermes.final
+  copyWithin(target: number, start: number, end?: number): Array<T> {
+    var len: number = this.length;
+    var to: number = __ToIntegerOrInfinity(target);
+    if (to < 0) {
+      to = len + to;
+      if (to < 0)
+        to = 0;
+    }
+    var from: number = __ToIntegerOrInfinity(start);
+    if (from < 0) {
+      from = len + from;
+      if (from < 0)
+        from = 0;
+    }
+    var fin: number;
+    if (end !== undefined) {
+      fin = __ToIntegerOrInfinity(end);
+      if (fin < 0)
+        fin = len + fin;
+      if (fin > len)
+        fin = len;
+    } else {
+      fin = len;
+    }
+    var count: number = fin - from;
+    if (count <= 0)
+      return this;
+    if (to + count > len)
+      count = len - to;
+    if (from < to) {
+      var i: number = count - 1;
+      while (i >= 0) {
+        this[to + i] = this[from + i];
+        --i;
+      }
+    } else {
+      for (var j: number = 0; j < count; ++j) {
+        this[to + j] = this[from + j];
+      }
+    }
+    return this;
+  }
+
   // TODO: reduce / reduceRight.
   // TODO: flat — needs recursive type flattening.
   // TODO: splice / toSpliced — no varargs support.

--- a/lib/FlowLib/03-map.js
+++ b/lib/FlowLib/03-map.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+class Map<K, V> {
+  /// Native implementation of this Map.
+  #impl: any;
+
+  constructor() {
+    "inline";
+    this.#impl = new globalThis.Map();
+  }
+
+  @Hermes.final
+  get(k: K): V | void {
+    "inline";
+    return this.#impl.get(k) as (V | void);
+  }
+
+  @Hermes.final
+  set(k: K, v: V): Map<K, V> {
+    "inline";
+    this.#impl.set(k, v);
+    return this;
+  }
+
+  @Hermes.final
+  has(k: K): bool {
+    "inline";
+    return this.#impl.has(k) as bool;
+  }
+
+  @Hermes.final
+  delete(k: K): bool {
+    "inline";
+    return this.#impl.delete(k) as bool;
+  }
+
+  @Hermes.final
+  clear(): void {
+    "inline";
+    this.#impl.clear();
+  }
+
+  @Hermes.final
+  forEach(cb: (v: V, k?: K, m?: Map<K, V>) => any): void {
+    "inline";
+    this.#impl.forEach((v, k, m) => {
+      return cb(v, k, this);
+    });
+  }
+}

--- a/lib/FlowLib/04-set.js
+++ b/lib/FlowLib/04-set.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+class Set<T> {
+  /// Native implementation of this Set.
+  #impl: any;
+
+  constructor() {
+    "inline";
+    this.#impl = new globalThis.Set();
+  }
+
+  @Hermes.final
+  add(v: T): Set<T> {
+    "inline";
+    this.#impl.add(v);
+    return this;
+  }
+
+  @Hermes.final
+  has(v: T): bool {
+    "inline";
+    return this.#impl.has(v) as bool;
+  }
+
+  @Hermes.final
+  delete(v: T): bool {
+    "inline";
+    return this.#impl.delete(v) as bool;
+  }
+
+  @Hermes.final
+  clear(): void {
+    "inline";
+    this.#impl.clear();
+  }
+
+  @Hermes.final
+  forEach(cb: (v: T, k?: T, s?: Set<T>) => any): void {
+    "inline";
+    this.#impl.forEach((v, k, s) => {
+      return cb(v, k, this);
+    });
+  }
+}

--- a/lib/FlowLib/CMakeLists.txt
+++ b/lib/FlowLib/CMakeLists.txt
@@ -15,6 +15,7 @@ set(flowlib_sources
   "00-prelude.js"
   "01-array.js"
   "02-string.js"
+  "03-map.js"
 )
 list(SORT flowlib_sources)
 

--- a/lib/FlowLib/CMakeLists.txt
+++ b/lib/FlowLib/CMakeLists.txt
@@ -16,6 +16,7 @@ set(flowlib_sources
   "01-array.js"
   "02-string.js"
   "03-map.js"
+  "04-set.js"
 )
 list(SORT flowlib_sources)
 

--- a/lib/Sema/FlowChecker-expr.cpp
+++ b/lib/Sema/FlowChecker-expr.cpp
@@ -172,25 +172,12 @@ void FlowChecker::matchConstraintToType(
       case TypeKind::TypedFunction: {
         auto *constraintFn = llvh::cast<TypedFunctionType>(constraint->info);
         auto *typeFn = llvh::cast<TypedFunctionType>(type->info);
-        // Allow mismatched param counts when trailing params are optional.
+        // Match the common params and return type to resolve placeholders.
+        // Param count mismatches are allowed here because inference only
+        // needs to extract placeholder bindings; flowing compatibility is
+        // checked separately.
         size_t minParams = std::min(
             constraintFn->getParams().size(), typeFn->getParams().size());
-        if (constraintFn->getParams().size() != typeFn->getParams().size()) {
-          // Verify the extra params are optional.
-          bool ok = true;
-          auto &longer =
-              constraintFn->getParams().size() > typeFn->getParams().size()
-              ? constraintFn->getParams()
-              : typeFn->getParams();
-          for (size_t i = minParams, e = longer.size(); i < e; ++i) {
-            if (!longer[i].optional) {
-              ok = false;
-              break;
-            }
-          }
-          if (!ok)
-            continue;
-        }
 
         worklist.insert({constraintFn->getThisParam(), typeFn->getThisParam()});
         for (size_t i = 0; i < minParams; ++i) {

--- a/lib/Sema/FlowChecker.cpp
+++ b/lib/Sema/FlowChecker.cpp
@@ -2674,12 +2674,8 @@ FlowChecker::CanFlowResult FlowChecker::canAFlowIntoB(
 
   {
     if (aType->getParams().size() < bType->getParams().size()) {
-      // It's valid to flow from a function that has no optional parameters to a
-      // function that adds them.
-      const auto &extraParam = bType->getParams()[aType->getParams().size()];
-      if (!extraParam.optional) {
-        return {};
-      }
+      // It's valid to flow from a function with fewer parameters to one with
+      // more, but we need a checked cast.
       needCheckedCast = true;
     } else if (aType->getParams().size() > bType->getParams().size()) {
       // Removing optional parameters is always valid.

--- a/lib/Sema/FlowChecker.cpp
+++ b/lib/Sema/FlowChecker.cpp
@@ -96,6 +96,7 @@
 #include "hermes/AST/ASTUtils.h"
 #include "hermes/Support/Conversions.h"
 
+#include "llvh/ADT/BitVector.h"
 #include "llvh/ADT/MapVector.h"
 #include "llvh/ADT/ScopeExit.h"
 #include "llvh/ADT/SetVector.h"
@@ -3096,14 +3097,46 @@ bool FlowChecker::inferPlaceholdersFromCallArgs(
     bindingTable_.activateScope(savedScope);
   }
 
-  // Visit arguments with constraints to infer remaining type params.
-  size_t argIdx = 0;
-  for (ESTree::Node &arg : callArgs) {
-    Type *constraint = argIdx < callArgConstraints.size()
-        ? callArgConstraints[argIdx]
-        : nullptr;
-    visitExpression(&arg, callNode, constraint);
-    ++argIdx;
+  // Snapshot which constraints are simple (direct InferencePlaceholder),
+  // since pass 1 will mutate them.
+  size_t numCallArgs = callArgs.size();
+  llvh::BitVector isSimple(std::max(numCallArgs, callArgConstraints.size()));
+  for (size_t i = 0, e = callArgConstraints.size(); i < e; ++i) {
+    if (callArgConstraints[i] &&
+        llvh::isa<InferencePlaceholderType>(callArgConstraints[i]->info))
+      isSimple.set(i);
+  }
+
+  // Pass 1: visit arguments with simple placeholder constraints (bare T).
+  // Resolving these first allows complex constraints referencing the same
+  // type params (e.g., T => string) to use the resolved type in pass 2,
+  // even if the simple placeholder comes after the complex constraint.
+  {
+    size_t argIdx = 0;
+    for (ESTree::Node &arg : callArgs) {
+      if (isSimple[argIdx])
+        visitExpression(&arg, callNode, callArgConstraints[argIdx]);
+      ++argIdx;
+    }
+    // Infer void for simple placeholder params with no corresponding arg.
+    for (size_t i = numCallArgs, e = callArgConstraints.size(); i < e; ++i) {
+      if (isSimple[i])
+        callArgConstraints[i]->info = flowContext_.getVoidInfo();
+    }
+  }
+
+  // Pass 2: visit remaining arguments with complex constraints.
+  {
+    size_t argIdx = 0;
+    for (ESTree::Node &arg : callArgs) {
+      if (!isSimple[argIdx]) {
+        Type *constraint = argIdx < callArgConstraints.size()
+            ? callArgConstraints[argIdx]
+            : nullptr;
+        visitExpression(&arg, callNode, constraint);
+      }
+      ++argIdx;
+    }
   }
 
   // Inference succeeded iff none of the typeArgs are still

--- a/test/Sema/flow/builtin-argument-error.js
+++ b/test/Sema/flow/builtin-argument-error.js
@@ -25,7 +25,4 @@ function testMap(arr: number[]): number[] {
 // CHECK-NEXT:{{.*}}builtin-argument-error.js:17:3: error: ft: return value incompatible with return type: cannot return class Array<string> as class Array<number>
 // CHECK-NEXT:  return arr.map((n: number): string => 'x', undefined);
 // CHECK-NEXT:  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// CHECK-NEXT:{{.*}}builtin-argument-error.js:17:10: error: ft: function expects at most 1 arguments, but 2 supplied
-// CHECK-NEXT:  return arr.map((n: number): string => 'x', undefined);
-// CHECK-NEXT:         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// CHECK-NEXT:Emitted 3 errors. exiting.
+// CHECK-NEXT:Emitted 2 errors. exiting.

--- a/test/Sema/flow/builtin-array-map.js
+++ b/test/Sema/flow/builtin-array-map.js
@@ -19,7 +19,8 @@ function test(arr: number[]): number[] {
 // CHECK-NEXT:%class.2 = class(Array<number>)
 // CHECK-NEXT:%function.3 = function(arr: %class.2): %class.2
 // CHECK-NEXT:%function.4 = function(n: number, i: number, a: %class.2): number
-// CHECK-NEXT:%function.5 = function(this: %class.2, callback: %function.4): %class.2
+// CHECK-NEXT:%function.5 = function(this: %class.2, callback: %function.6, thisArg: void): %class.2
+// CHECK-NEXT:%function.6 = function(this: void, t: number, i: number, array: %class.2): number
 
 // CHECK:SemContext
 // CHECK-NEXT:Func strict

--- a/test/Sema/flow/infer-generic-call-simple-placeholder.js
+++ b/test/Sema/flow/infer-generic-call-simple-placeholder.js
@@ -1,0 +1,177 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %shermes -typed -dump-sema %s | %FileCheckOrRegen %s --match-full-lines
+
+// Simple placeholder (bare T) should be resolved before complex constraints,
+// so that complex constraints referencing T can use the resolved type.
+
+// T inferred as string from 2nd arg, arrow param x gets type string.
+function foo<T>(f: (x: T) => T, x: T): void {
+  f(x);
+}
+foo(x => x, 'hello');
+
+// T inferred as void when no argument is passed for optional param.
+function bar<T>(x?: T): T {
+  return x;
+}
+let v1: void = bar();
+
+// T inferred from simple arg, used in complex constraint with one param.
+function baz<T>(x: T, f: (a: T) => string): void {
+  f(x);
+}
+baz('hello', a => '');
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:%untyped_function.1 = untyped_function()
+// CHECK-NEXT:%function.2 = function(x: string): string
+// CHECK-NEXT:%function.3 = function(f: %function.2, x: string): void
+// CHECK-NEXT:%function.4 = function(x: void): void
+// CHECK-NEXT:%function.5 = function(x: string, f: %function.2): void
+
+// CHECK:SemContext
+// CHECK-NEXT:Func strict
+// CHECK-NEXT:    Scope %s.1
+// CHECK-NEXT:        Decl %d.1 'exports' Parameter : any
+// CHECK-NEXT:        Decl %d.2 'foo' Var
+// CHECK-NEXT:        Decl %d.3 'bar' Var
+// CHECK-NEXT:        Decl %d.4 'v1' Let : void
+// CHECK-NEXT:        Decl %d.5 'baz' Var
+// CHECK-NEXT:        Decl %d.6 'arguments' Var Arguments
+// CHECK-NEXT:        Decl %d.7 'foo' Var : %function.3
+// CHECK-NEXT:        Decl %d.8 'bar' Var : %function.4
+// CHECK-NEXT:        Decl %d.9 'baz' Var : %function.5
+// CHECK-NEXT:        hoistedFunction foo
+// CHECK-NEXT:        hoistedFunction bar
+// CHECK-NEXT:        hoistedFunction baz
+// CHECK-NEXT:        hoistedFunction foo
+// CHECK-NEXT:        hoistedFunction bar
+// CHECK-NEXT:        hoistedFunction baz
+// CHECK-NEXT:    Func strict
+// CHECK-NEXT:        Scope %s.2
+// CHECK-NEXT:            Decl %d.10 'f' Parameter
+// CHECK-NEXT:            Decl %d.11 'x' Parameter
+// CHECK-NEXT:            Decl %d.12 'arguments' Var Arguments
+// CHECK-NEXT:    Func strict
+// CHECK-NEXT:        Scope %s.3
+// CHECK-NEXT:            Decl %d.13 'x' Parameter : string
+// CHECK-NEXT:    Func strict
+// CHECK-NEXT:        Scope %s.4
+// CHECK-NEXT:            Decl %d.14 'x' Parameter
+// CHECK-NEXT:            Decl %d.15 'arguments' Var Arguments
+// CHECK-NEXT:    Func strict
+// CHECK-NEXT:        Scope %s.5
+// CHECK-NEXT:            Decl %d.16 'x' Parameter
+// CHECK-NEXT:            Decl %d.17 'f' Parameter
+// CHECK-NEXT:            Decl %d.18 'arguments' Var Arguments
+// CHECK-NEXT:    Func strict
+// CHECK-NEXT:        Scope %s.6
+// CHECK-NEXT:            Decl %d.19 'a' Parameter : string
+// CHECK-NEXT:    Func strict
+// CHECK-NEXT:        Scope %s.7
+// CHECK-NEXT:            Decl %d.20 'f' Parameter : %function.2
+// CHECK-NEXT:            Decl %d.21 'x' Parameter : string
+// CHECK-NEXT:            Decl %d.22 'arguments' Var Arguments
+// CHECK-NEXT:    Func strict
+// CHECK-NEXT:        Scope %s.8
+// CHECK-NEXT:            Decl %d.23 'x' Parameter : void
+// CHECK-NEXT:            Decl %d.24 'arguments' Var Arguments
+// CHECK-NEXT:    Func strict
+// CHECK-NEXT:        Scope %s.9
+// CHECK-NEXT:            Decl %d.25 'x' Parameter : string
+// CHECK-NEXT:            Decl %d.26 'f' Parameter : %function.2
+// CHECK-NEXT:            Decl %d.27 'arguments' Var Arguments
+
+// CHECK:FunctionExpression : %untyped_function.1
+// CHECK-NEXT:    Id 'exports' [D:E:%d.1 'exports']
+// CHECK-NEXT:    BlockStatement
+// CHECK-NEXT:        FunctionDeclaration : %function.3
+// CHECK-NEXT:            Id 'foo' [D:E:%d.7 'foo']
+// CHECK-NEXT:            Id 'f' [D:E:%d.20 'f']
+// CHECK-NEXT:            Id 'x' [D:E:%d.21 'x']
+// CHECK-NEXT:            BlockStatement
+// CHECK-NEXT:                ExpressionStatement
+// CHECK-NEXT:                    CallExpression : string
+// CHECK-NEXT:                        Id 'f' [D:E:%d.20 'f'] : %function.2
+// CHECK-NEXT:                        Id 'x' [D:E:%d.21 'x'] : string
+// CHECK-NEXT:            TypeParameterDeclaration
+// CHECK-NEXT:                TypeParameter
+// CHECK-NEXT:        FunctionDeclaration
+// CHECK-NEXT:            Id 'foo' [D:E:%d.2 'foo']
+// CHECK-NEXT:            Id 'f' [D:E:%d.10 'f']
+// CHECK-NEXT:            Id 'x' [D:E:%d.11 'x']
+// CHECK-NEXT:            BlockStatement
+// CHECK-NEXT:                ExpressionStatement
+// CHECK-NEXT:                    CallExpression
+// CHECK-NEXT:                        Id 'f' [D:E:%d.10 'f']
+// CHECK-NEXT:                        Id 'x' [D:E:%d.11 'x']
+// CHECK-NEXT:            TypeParameterDeclaration
+// CHECK-NEXT:                TypeParameter
+// CHECK-NEXT:        ExpressionStatement
+// CHECK-NEXT:            CallExpression : void
+// CHECK-NEXT:                Id 'foo' [D:E:%d.7 'foo'] : %function.3
+// CHECK-NEXT:                ArrowFunctionExpression : %function.2
+// CHECK-NEXT:                    Id 'x' [D:E:%d.13 'x']
+// CHECK-NEXT:                    BlockStatement
+// CHECK-NEXT:                        ReturnStatement
+// CHECK-NEXT:                            Id 'x' [D:E:%d.13 'x'] : string
+// CHECK-NEXT:                StringLiteral : string
+// CHECK-NEXT:        FunctionDeclaration : %function.4
+// CHECK-NEXT:            Id 'bar' [D:E:%d.8 'bar']
+// CHECK-NEXT:            Id 'x' [D:E:%d.23 'x']
+// CHECK-NEXT:            BlockStatement
+// CHECK-NEXT:                ReturnStatement
+// CHECK-NEXT:                    Id 'x' [D:E:%d.23 'x'] : void
+// CHECK-NEXT:            TypeParameterDeclaration
+// CHECK-NEXT:                TypeParameter
+// CHECK-NEXT:        FunctionDeclaration
+// CHECK-NEXT:            Id 'bar' [D:E:%d.3 'bar']
+// CHECK-NEXT:            Id 'x' [D:E:%d.14 'x']
+// CHECK-NEXT:            BlockStatement
+// CHECK-NEXT:                ReturnStatement
+// CHECK-NEXT:                    Id 'x' [D:E:%d.14 'x']
+// CHECK-NEXT:            TypeParameterDeclaration
+// CHECK-NEXT:                TypeParameter
+// CHECK-NEXT:        VariableDeclaration
+// CHECK-NEXT:            VariableDeclarator
+// CHECK-NEXT:                CallExpression : void
+// CHECK-NEXT:                    Id 'bar' [D:E:%d.8 'bar'] : %function.4
+// CHECK-NEXT:                Id 'v1' [D:E:%d.4 'v1']
+// CHECK-NEXT:        FunctionDeclaration : %function.5
+// CHECK-NEXT:            Id 'baz' [D:E:%d.9 'baz']
+// CHECK-NEXT:            Id 'x' [D:E:%d.25 'x']
+// CHECK-NEXT:            Id 'f' [D:E:%d.26 'f']
+// CHECK-NEXT:            BlockStatement
+// CHECK-NEXT:                ExpressionStatement
+// CHECK-NEXT:                    CallExpression : string
+// CHECK-NEXT:                        Id 'f' [D:E:%d.26 'f'] : %function.2
+// CHECK-NEXT:                        Id 'x' [D:E:%d.25 'x'] : string
+// CHECK-NEXT:            TypeParameterDeclaration
+// CHECK-NEXT:                TypeParameter
+// CHECK-NEXT:        FunctionDeclaration
+// CHECK-NEXT:            Id 'baz' [D:E:%d.5 'baz']
+// CHECK-NEXT:            Id 'x' [D:E:%d.16 'x']
+// CHECK-NEXT:            Id 'f' [D:E:%d.17 'f']
+// CHECK-NEXT:            BlockStatement
+// CHECK-NEXT:                ExpressionStatement
+// CHECK-NEXT:                    CallExpression
+// CHECK-NEXT:                        Id 'f' [D:E:%d.17 'f']
+// CHECK-NEXT:                        Id 'x' [D:E:%d.16 'x']
+// CHECK-NEXT:            TypeParameterDeclaration
+// CHECK-NEXT:                TypeParameter
+// CHECK-NEXT:        ExpressionStatement
+// CHECK-NEXT:            CallExpression : void
+// CHECK-NEXT:                Id 'baz' [D:E:%d.9 'baz'] : %function.5
+// CHECK-NEXT:                StringLiteral : string
+// CHECK-NEXT:                ArrowFunctionExpression : %function.2
+// CHECK-NEXT:                    Id 'a' [D:E:%d.19 'a']
+// CHECK-NEXT:                    BlockStatement
+// CHECK-NEXT:                        ReturnStatement
+// CHECK-NEXT:                            StringLiteral : string

--- a/test/Sema/flow/optional-param.js
+++ b/test/Sema/flow/optional-param.js
@@ -24,13 +24,28 @@ function removeOptional(): void {
   let c: (x: number) => void = b;
 }
 
+// Flow: fewer params into more non-optional params (checked cast).
+function fewerToMore(cb: (x: number) => void): void {
+  cb(1);
+}
+function testFewerToMore(): void {
+  fewerToMore(() => {});
+}
+
+// Flow: fewer params into more non-optional params via assignment.
+function assignFewerToMore(): void {
+  let f: (x: number, y: string) => void = (x: number) => {};
+}
+
 // Auto-generated content below. Please do not modify manually.
 
 // CHECK:%untyped_function.1 = untyped_function()
 // CHECK-NEXT:%function.2 = function(x: number, y: number): void
 // CHECK-NEXT:%function.3 = function(): void
-// CHECK-NEXT:%union.4 = union(void | number)
-// CHECK-NEXT:%function.5 = function(x: number): void
+// CHECK-NEXT:%function.4 = function(x: number): void
+// CHECK-NEXT:%function.5 = function(cb: %function.4): void
+// CHECK-NEXT:%union.6 = union(void | number)
+// CHECK-NEXT:%function.7 = function(x: number, y: string): void
 
 // CHECK:SemContext
 // CHECK-NEXT:Func strict
@@ -39,32 +54,54 @@ function removeOptional(): void {
 // CHECK-NEXT:        Decl %d.2 'decl' Var : %function.2
 // CHECK-NEXT:        Decl %d.3 'addOptional' Var : %function.3
 // CHECK-NEXT:        Decl %d.4 'removeOptional' Var : %function.3
-// CHECK-NEXT:        Decl %d.5 'arguments' Var Arguments
+// CHECK-NEXT:        Decl %d.5 'fewerToMore' Var : %function.5
+// CHECK-NEXT:        Decl %d.6 'testFewerToMore' Var : %function.3
+// CHECK-NEXT:        Decl %d.7 'assignFewerToMore' Var : %function.3
+// CHECK-NEXT:        Decl %d.8 'arguments' Var Arguments
 // CHECK-NEXT:        hoistedFunction decl
 // CHECK-NEXT:        hoistedFunction addOptional
 // CHECK-NEXT:        hoistedFunction removeOptional
+// CHECK-NEXT:        hoistedFunction fewerToMore
+// CHECK-NEXT:        hoistedFunction testFewerToMore
+// CHECK-NEXT:        hoistedFunction assignFewerToMore
 // CHECK-NEXT:    Func strict
 // CHECK-NEXT:        Scope %s.2
-// CHECK-NEXT:            Decl %d.6 'x' Parameter : number
-// CHECK-NEXT:            Decl %d.7 'y' Parameter : %union.4
-// CHECK-NEXT:            Decl %d.8 'arguments' Var Arguments
+// CHECK-NEXT:            Decl %d.9 'x' Parameter : number
+// CHECK-NEXT:            Decl %d.10 'y' Parameter : %union.6
+// CHECK-NEXT:            Decl %d.11 'arguments' Var Arguments
 // CHECK-NEXT:    Func strict
 // CHECK-NEXT:        Scope %s.3
-// CHECK-NEXT:            Decl %d.9 'a' Let : %function.5
-// CHECK-NEXT:            Decl %d.10 'arguments' Var Arguments
+// CHECK-NEXT:            Decl %d.12 'a' Let : %function.4
+// CHECK-NEXT:            Decl %d.13 'arguments' Var Arguments
 // CHECK-NEXT:    Func strict
 // CHECK-NEXT:        Scope %s.4
-// CHECK-NEXT:            Decl %d.11 'b' Let : %function.2
-// CHECK-NEXT:            Decl %d.12 'c' Let : %function.5
-// CHECK-NEXT:            Decl %d.13 'arguments' Var Arguments
+// CHECK-NEXT:            Decl %d.14 'b' Let : %function.2
+// CHECK-NEXT:            Decl %d.15 'c' Let : %function.4
+// CHECK-NEXT:            Decl %d.16 'arguments' Var Arguments
+// CHECK-NEXT:    Func strict
+// CHECK-NEXT:        Scope %s.5
+// CHECK-NEXT:            Decl %d.17 'cb' Parameter : %function.4
+// CHECK-NEXT:            Decl %d.18 'arguments' Var Arguments
+// CHECK-NEXT:    Func strict
+// CHECK-NEXT:        Scope %s.6
+// CHECK-NEXT:            Decl %d.19 'arguments' Var Arguments
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.7
+// CHECK-NEXT:    Func strict
+// CHECK-NEXT:        Scope %s.8
+// CHECK-NEXT:            Decl %d.20 'f' Let : %function.7
+// CHECK-NEXT:            Decl %d.21 'arguments' Var Arguments
+// CHECK-NEXT:        Func strict
+// CHECK-NEXT:            Scope %s.9
+// CHECK-NEXT:                Decl %d.22 'x' Parameter : number
 
 // CHECK:FunctionExpression : %untyped_function.1
 // CHECK-NEXT:    Id 'exports' [D:E:%d.1 'exports']
 // CHECK-NEXT:    BlockStatement
 // CHECK-NEXT:        FunctionDeclaration : %function.2
 // CHECK-NEXT:            Id 'decl' [D:E:%d.2 'decl']
-// CHECK-NEXT:            Id 'x' [D:E:%d.6 'x']
-// CHECK-NEXT:            Id 'y' [D:E:%d.7 'y']
+// CHECK-NEXT:            Id 'x' [D:E:%d.9 'x']
+// CHECK-NEXT:            Id 'y' [D:E:%d.10 'y']
 // CHECK-NEXT:            BlockStatement
 // CHECK-NEXT:        TypeAlias
 // CHECK-NEXT:            Id 'F'
@@ -81,18 +118,45 @@ function removeOptional(): void {
 // CHECK-NEXT:            BlockStatement
 // CHECK-NEXT:                VariableDeclaration
 // CHECK-NEXT:                    VariableDeclarator
-// CHECK-NEXT:                        ImplicitCheckedCast : %function.5
+// CHECK-NEXT:                        ImplicitCheckedCast : %function.4
 // CHECK-NEXT:                            Id 'decl' [D:E:%d.2 'decl'] : %function.2
-// CHECK-NEXT:                        Id 'a' [D:E:%d.9 'a']
+// CHECK-NEXT:                        Id 'a' [D:E:%d.12 'a']
 // CHECK-NEXT:        FunctionDeclaration : %function.3
 // CHECK-NEXT:            Id 'removeOptional' [D:E:%d.4 'removeOptional']
 // CHECK-NEXT:            BlockStatement
 // CHECK-NEXT:                VariableDeclaration
 // CHECK-NEXT:                    VariableDeclarator
 // CHECK-NEXT:                        Id 'decl' [D:E:%d.2 'decl'] : %function.2
-// CHECK-NEXT:                        Id 'b' [D:E:%d.11 'b']
+// CHECK-NEXT:                        Id 'b' [D:E:%d.14 'b']
 // CHECK-NEXT:                VariableDeclaration
 // CHECK-NEXT:                    VariableDeclarator
-// CHECK-NEXT:                        ImplicitCheckedCast : %function.5
-// CHECK-NEXT:                            Id 'b' [D:E:%d.11 'b'] : %function.2
-// CHECK-NEXT:                        Id 'c' [D:E:%d.12 'c']
+// CHECK-NEXT:                        ImplicitCheckedCast : %function.4
+// CHECK-NEXT:                            Id 'b' [D:E:%d.14 'b'] : %function.2
+// CHECK-NEXT:                        Id 'c' [D:E:%d.15 'c']
+// CHECK-NEXT:        FunctionDeclaration : %function.5
+// CHECK-NEXT:            Id 'fewerToMore' [D:E:%d.5 'fewerToMore']
+// CHECK-NEXT:            Id 'cb' [D:E:%d.17 'cb']
+// CHECK-NEXT:            BlockStatement
+// CHECK-NEXT:                ExpressionStatement
+// CHECK-NEXT:                    CallExpression : void
+// CHECK-NEXT:                        Id 'cb' [D:E:%d.17 'cb'] : %function.4
+// CHECK-NEXT:                        NumericLiteral : number
+// CHECK-NEXT:        FunctionDeclaration : %function.3
+// CHECK-NEXT:            Id 'testFewerToMore' [D:E:%d.6 'testFewerToMore']
+// CHECK-NEXT:            BlockStatement
+// CHECK-NEXT:                ExpressionStatement
+// CHECK-NEXT:                    CallExpression : void
+// CHECK-NEXT:                        Id 'fewerToMore' [D:E:%d.5 'fewerToMore'] : %function.5
+// CHECK-NEXT:                        ImplicitCheckedCast : %function.4
+// CHECK-NEXT:                            ArrowFunctionExpression : %function.3
+// CHECK-NEXT:                                BlockStatement
+// CHECK-NEXT:        FunctionDeclaration : %function.3
+// CHECK-NEXT:            Id 'assignFewerToMore' [D:E:%d.7 'assignFewerToMore']
+// CHECK-NEXT:            BlockStatement
+// CHECK-NEXT:                VariableDeclaration
+// CHECK-NEXT:                    VariableDeclarator
+// CHECK-NEXT:                        ImplicitCheckedCast : %function.7
+// CHECK-NEXT:                            ArrowFunctionExpression : %function.4
+// CHECK-NEXT:                                Id 'x' [D:E:%d.22 'x']
+// CHECK-NEXT:                                BlockStatement
+// CHECK-NEXT:                        Id 'f' [D:E:%d.20 'f']

--- a/test/hermes/flow/builtin-array-at.js
+++ b/test/hermes/flow/builtin-array-at.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+// RUN: %hermes -typed %s | %FileCheck --match-full-lines %s
+// RUN: %shermes -typed -exec %s | %FileCheck --match-full-lines %s
+
+/// Test Array.prototype.at with typed arrays.
+
+'use strict';
+
+(function () {
+
+const nums: number[] = [10, 20, 30, 40, 50];
+
+// Positive index.
+print(nums.at(0));
+// CHECK: 10
+print(nums.at(2));
+// CHECK-NEXT: 30
+
+// Negative index.
+print(nums.at(-1));
+// CHECK-NEXT: 50
+print(nums.at(-3));
+// CHECK-NEXT: 30
+
+// Out of bounds.
+print(nums.at(5));
+// CHECK-NEXT: undefined
+print(nums.at(-6));
+// CHECK-NEXT: undefined
+
+// Empty array.
+const empty: number[] = [];
+print(empty.at(0));
+// CHECK-NEXT: undefined
+
+})();

--- a/test/hermes/flow/builtin-array-copyWithin.js
+++ b/test/hermes/flow/builtin-array-copyWithin.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+// RUN: %hermes -typed %s | %FileCheck --match-full-lines %s
+// RUN: %shermes -typed -exec %s | %FileCheck --match-full-lines %s
+
+/// Test Array.prototype.copyWithin with typed arrays.
+
+'use strict';
+
+(function () {
+
+// Copy forward (no overlap).
+var a: number[] = [1, 2, 3, 4, 5];
+a.copyWithin(0, 3, 5);
+print(a[0], a[1], a[2], a[3], a[4]);
+// CHECK: 4 5 3 4 5
+
+// Copy backward (overlap, target > start).
+var b: number[] = [1, 2, 3, 4, 5];
+b.copyWithin(2, 0, 3);
+print(b[0], b[1], b[2], b[3], b[4]);
+// CHECK-NEXT: 1 2 1 2 3
+
+// Negative target.
+var c: number[] = [1, 2, 3, 4, 5];
+c.copyWithin(-2, 0, 2);
+print(c[0], c[1], c[2], c[3], c[4]);
+// CHECK-NEXT: 1 2 3 1 2
+
+// Negative start and end.
+var d: number[] = [1, 2, 3, 4, 5];
+d.copyWithin(0, -3, -1);
+print(d[0], d[1], d[2], d[3], d[4]);
+// CHECK-NEXT: 3 4 3 4 5
+
+// Count clamped to not exceed array length.
+var e: number[] = [1, 2, 3];
+e.copyWithin(1, 0, 3);
+print(e[0], e[1], e[2]);
+// CHECK-NEXT: 1 1 2
+
+// Returns the array.
+var f: number[] = [1, 2, 3];
+var result: number[] = f.copyWithin(0, 1, 3);
+print(result[0], result[1], result[2]);
+// CHECK-NEXT: 2 3 3
+
+// End parameter omitted defaults to length.
+var g: number[] = [1, 2, 3, 4, 5];
+g.copyWithin(0, 3);
+print(g[0], g[1], g[2], g[3], g[4]);
+// CHECK-NEXT: 4 5 3 4 5
+
+// End omitted with negative start.
+var h: number[] = [1, 2, 3, 4, 5];
+h.copyWithin(0, -2);
+print(h[0], h[1], h[2], h[3], h[4]);
+// CHECK-NEXT: 4 5 3 4 5
+
+})();

--- a/test/hermes/flow/builtin-array-every.js
+++ b/test/hermes/flow/builtin-array-every.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+// RUN: %hermes -typed %s | %FileCheck --match-full-lines %s
+// RUN: %shermes -typed -exec %s | %FileCheck --match-full-lines %s
+
+/// Test Array.prototype.every and some with typed arrays.
+
+'use strict';
+
+(function () {
+
+const nums: number[] = [2, 4, 6, 8];
+
+// every: all even.
+print(nums.every((n: number): boolean => n % 2 === 0));
+// CHECK: true
+
+// every: not all > 5.
+print(nums.every((n: number): boolean => n > 5));
+// CHECK-NEXT: false
+
+// every on empty array is true.
+const empty: number[] = [];
+print(empty.every((n: number): boolean => n > 0));
+// CHECK-NEXT: true
+
+// some: has element > 5.
+print(nums.some((n: number): boolean => n > 5));
+// CHECK-NEXT: true
+
+// some: no element > 100.
+print(nums.some((n: number): boolean => n > 100));
+// CHECK-NEXT: false
+
+// some on empty array is false.
+print(empty.some((n: number): boolean => n > 0));
+// CHECK-NEXT: false
+
+// every with index parameter.
+const arr: number[] = [0, 1, 2, 3];
+print(arr.every((n: number, i: number): boolean => n === i));
+// CHECK-NEXT: true
+
+// every with thisArg.
+const threshold: number[] = [5];
+print(nums.every(function(this: number[], n: number): boolean {
+  return n <= this[0] * 2;
+}, threshold));
+// CHECK-NEXT: true
+
+// some with thisArg.
+print(nums.some(function(this: number[], n: number): boolean {
+  return n > this[0];
+}, threshold));
+// CHECK-NEXT: true
+
+})();

--- a/test/hermes/flow/builtin-array-fill.js
+++ b/test/hermes/flow/builtin-array-fill.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+// RUN: %hermes -typed %s | %FileCheck --match-full-lines %s
+// RUN: %shermes -typed -exec %s | %FileCheck --match-full-lines %s
+
+/// Test Array.prototype.fill with typed arrays.
+
+'use strict';
+
+(function () {
+
+// Fill entire array.
+var nums: number[] = [1, 2, 3, 4, 5];
+nums.fill(0);
+print(nums[0], nums[1], nums[2], nums[3], nums[4]);
+// CHECK: 0 0 0 0 0
+
+// Fill returns the array.
+var arr: number[] = [1, 2, 3];
+var result: number[] = arr.fill(7);
+print(result[0], result[1], result[2]);
+// CHECK-NEXT: 7 7 7
+
+// Fill single element.
+var single: number[] = [1];
+single.fill(42);
+print(single[0]);
+// CHECK-NEXT: 42
+
+// Fill empty array (no-op).
+var empty: number[] = [];
+empty.fill(99);
+print(empty.length);
+// CHECK-NEXT: 0
+
+// Fill string array.
+var strs: string[] = ['a', 'b', 'c'];
+strs.fill('x');
+print(strs[0], strs[1], strs[2]);
+// CHECK-NEXT: x x x
+
+// Fill with start only.
+var a: number[] = [1, 2, 3, 4, 5];
+a.fill(9, 2);
+print(a[0], a[1], a[2], a[3], a[4]);
+// CHECK-NEXT: 1 2 9 9 9
+
+// Fill with start and end.
+var b: number[] = [1, 2, 3, 4, 5];
+b.fill(7, 1, 3);
+print(b[0], b[1], b[2], b[3], b[4]);
+// CHECK-NEXT: 1 7 7 4 5
+
+// Fill with negative start and end.
+var c: number[] = [1, 2, 3, 4, 5];
+c.fill(8, -3, -1);
+print(c[0], c[1], c[2], c[3], c[4]);
+// CHECK-NEXT: 1 2 8 8 5
+
+})();

--- a/test/hermes/flow/builtin-array-filter.js
+++ b/test/hermes/flow/builtin-array-filter.js
@@ -35,4 +35,15 @@ const none: number[] = nums.filter((n: number): boolean => n > 100);
 print(none.length);
 // CHECK-NEXT: 0
 
+// Filter with thisArg.
+const threshold: number[] = [3];
+const above: number[] = nums.filter(function(
+  this: number[],
+  n: number,
+): boolean {
+  return n > this[0];
+}, threshold);
+print(above.length, above[0], above[1], above[2]);
+// CHECK-NEXT: 3 4 5 6
+
 })();

--- a/test/hermes/flow/builtin-array-find.js
+++ b/test/hermes/flow/builtin-array-find.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+// RUN: %hermes -typed %s | %FileCheck --match-full-lines %s
+// RUN: %shermes -typed -exec %s | %FileCheck --match-full-lines %s
+
+/// Test Array.prototype.find and findIndex with typed arrays.
+
+'use strict';
+
+(function () {
+
+const nums: number[] = [1, 2, 3, 4, 5];
+
+// find: first even.
+print(nums.find((n: number): boolean => n % 2 === 0));
+// CHECK: 2
+
+// find: not found.
+print(nums.find((n: number): boolean => n > 100));
+// CHECK-NEXT: undefined
+
+// findIndex: first even.
+print(nums.findIndex((n: number): boolean => n % 2 === 0));
+// CHECK-NEXT: 1
+
+// findIndex: not found.
+print(nums.findIndex((n: number): boolean => n > 100));
+// CHECK-NEXT: -1
+
+// Empty array.
+const empty: number[] = [];
+print(empty.find((n: number): boolean => true));
+// CHECK-NEXT: undefined
+print(empty.findIndex((n: number): boolean => true));
+// CHECK-NEXT: -1
+
+// find with index parameter.
+print(nums.find((n: number, i: number): boolean => i === 3));
+// CHECK-NEXT: 4
+
+// find with thisArg.
+const threshold: number[] = [3];
+print(nums.find(function(this: number[], n: number): boolean {
+  return n > this[0];
+}, threshold));
+// CHECK-NEXT: 4
+
+// findIndex with thisArg.
+print(nums.findIndex(function(this: number[], n: number): boolean {
+  return n > this[0];
+}, threshold));
+// CHECK-NEXT: 3
+
+})();

--- a/test/hermes/flow/builtin-array-findLast.js
+++ b/test/hermes/flow/builtin-array-findLast.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+// RUN: %hermes -typed %s | %FileCheck --match-full-lines %s
+// RUN: %shermes -typed -exec %s | %FileCheck --match-full-lines %s
+
+/// Test Array.prototype.findLast and findLastIndex with typed arrays.
+
+'use strict';
+
+(function () {
+
+const nums: number[] = [1, 2, 3, 4, 5, 6];
+
+// findLast: last even.
+print(nums.findLast((n: number): boolean => n % 2 === 0));
+// CHECK: 6
+
+// findLast: not found.
+print(nums.findLast((n: number): boolean => n > 100));
+// CHECK-NEXT: undefined
+
+// findLastIndex: last even.
+print(nums.findLastIndex((n: number): boolean => n % 2 === 0));
+// CHECK-NEXT: 5
+
+// findLastIndex: not found.
+print(nums.findLastIndex((n: number): boolean => n > 100));
+// CHECK-NEXT: -1
+
+// Empty array.
+const empty: number[] = [];
+print(empty.findLast((n: number): boolean => true));
+// CHECK-NEXT: undefined
+print(empty.findLastIndex((n: number): boolean => true));
+// CHECK-NEXT: -1
+
+// findLast with thisArg.
+const threshold: number[] = [3];
+print(nums.findLast(function(this: number[], n: number): boolean {
+  return n < this[0];
+}, threshold));
+// CHECK-NEXT: 2
+
+// findLastIndex with thisArg.
+print(nums.findLastIndex(function(this: number[], n: number): boolean {
+  return n < this[0];
+}, threshold));
+// CHECK-NEXT: 1
+
+})();

--- a/test/hermes/flow/builtin-array-flatMap.js
+++ b/test/hermes/flow/builtin-array-flatMap.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+// RUN: %hermes -typed %s | %FileCheck --match-full-lines %s
+// RUN: %shermes -typed -exec %s | %FileCheck --match-full-lines %s
+
+/// Test Array.prototype.flatMap with typed arrays.
+
+'use strict';
+
+(function () {
+
+const nums: number[] = [1, 2, 3];
+
+// Basic flatMap: duplicate each element.
+const doubled: number[] = nums.flatMap(
+  (n: number): number[] => [n, n],
+);
+print(doubled.length, doubled[0], doubled[1], doubled[2], doubled[3], doubled[4], doubled[5]);
+// CHECK: 6 1 1 2 2 3 3
+
+// flatMap on empty array.
+const empty: number[] = [];
+const result: number[] = empty.flatMap(
+  (n: number): number[] => [n, n],
+);
+print(result.length);
+// CHECK-NEXT: 0
+
+// flatMap with thisArg.
+const offset: number[] = [10];
+const shifted: number[] = nums.flatMap(function(
+  this: number[],
+  n: number,
+): number[] {
+  return [n + this[0]];
+}, offset);
+print(shifted.length, shifted[0], shifted[1], shifted[2]);
+// CHECK-NEXT: 3 11 12 13
+
+})();

--- a/test/hermes/flow/builtin-array-forEach.js
+++ b/test/hermes/flow/builtin-array-forEach.js
@@ -37,4 +37,13 @@ empty.forEach((n: number): void => { called = true; });
 print(called);
 // CHECK-NEXT: false
 
+// forEach with thisArg.
+var ctx: number[] = [100];
+var result: number = 0;
+nums.forEach(function(this: number[], n: number): void {
+  result += this[0] + n;
+}, ctx);
+print(result);
+// CHECK-NEXT: 360
+
 })();

--- a/test/hermes/flow/builtin-array-indexOf.js
+++ b/test/hermes/flow/builtin-array-indexOf.js
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+// RUN: %hermes -typed %s | %FileCheck --match-full-lines %s
+// RUN: %shermes -typed -exec %s | %FileCheck --match-full-lines %s
+
+/// Test Array.prototype.indexOf and lastIndexOf with typed arrays.
+
+'use strict';
+
+(function () {
+
+const nums: number[] = [1, 2, 3, 2, 1];
+
+// Basic indexOf.
+print(nums.indexOf(2));
+// CHECK: 1
+
+// indexOf not found.
+print(nums.indexOf(9));
+// CHECK-NEXT: -1
+
+// Basic lastIndexOf.
+print(nums.lastIndexOf(2));
+// CHECK-NEXT: 3
+
+// lastIndexOf not found.
+print(nums.lastIndexOf(9));
+// CHECK-NEXT: -1
+
+// Empty array.
+const empty: number[] = [];
+print(empty.indexOf(1));
+// CHECK-NEXT: -1
+print(empty.lastIndexOf(1));
+// CHECK-NEXT: -1
+
+// String array.
+const strs: string[] = ['a', 'b', 'c', 'b'];
+print(strs.indexOf('b'));
+// CHECK-NEXT: 1
+print(strs.lastIndexOf('b'));
+// CHECK-NEXT: 3
+
+// indexOf with fromIndex.
+print(nums.indexOf(2, 2));
+// CHECK-NEXT: 3
+print(nums.indexOf(2, -2));
+// CHECK-NEXT: 3
+print(nums.indexOf(2, -1));
+// CHECK-NEXT: -1
+// Negative fromIndex that normalizes below 0 starts from 0.
+print(nums.indexOf(1, -100));
+// CHECK-NEXT: 0
+
+// lastIndexOf with fromIndex.
+print(nums.lastIndexOf(2, 2));
+// CHECK-NEXT: 1
+print(nums.lastIndexOf(2, 0));
+// CHECK-NEXT: -1
+print(nums.lastIndexOf(2, -2));
+// CHECK-NEXT: 3
+print(nums.lastIndexOf(2, -4));
+// CHECK-NEXT: 1
+// fromIndex >= length clamps to length - 1.
+print(nums.lastIndexOf(1, 100));
+// CHECK-NEXT: 4
+
+// NaN is not found by indexOf (uses strict equality, not SameValueZero).
+var withNaN: number[] = [1, NaN, 3];
+print(withNaN.indexOf(NaN));
+// CHECK-NEXT: -1
+
+// NaN is not found by lastIndexOf.
+print(withNaN.lastIndexOf(NaN));
+// CHECK-NEXT: -1
+
+})();

--- a/test/hermes/flow/builtin-array-join.js
+++ b/test/hermes/flow/builtin-array-join.js
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+// RUN: %hermes -typed %s | %FileCheck --match-full-lines %s
+// RUN: %shermes -typed -exec %s | %FileCheck --match-full-lines %s
+
+/// Test Array.prototype.join with typed arrays.
+
+'use strict';
+
+(function () {
+
+const nums: number[] = [1, 2, 3];
+
+// Join with comma.
+print(nums.join(','));
+// CHECK: 1,2,3
+
+// Join with space.
+print(nums.join(' '));
+// CHECK-NEXT: 1 2 3
+
+// Join with empty string.
+print(nums.join(''));
+// CHECK-NEXT: 123
+
+// Join with multi-char separator.
+print(nums.join(' - '));
+// CHECK-NEXT: 1 - 2 - 3
+
+// Single element.
+const single: number[] = [42];
+print(single.join(','));
+// CHECK-NEXT: 42
+
+// Empty array.
+const empty: number[] = [];
+print(empty.join(','));
+// CHECK-EMPTY:
+
+// String array.
+const strs: string[] = ['a', 'b', 'c'];
+print(strs.join('|'));
+// CHECK-NEXT: a|b|c
+
+// Default separator is comma.
+print(nums.join());
+// CHECK-NEXT: 1,2,3
+
+// Default separator on empty array.
+print(empty.join());
+// CHECK-EMPTY:
+
+// Undefined and null elements produce empty strings.
+var mixed: (number | void | null)[] = [1, undefined, null, 3];
+print(mixed.join(','));
+// CHECK-NEXT: 1,,,3
+
+print(mixed.join());
+// CHECK-NEXT: 1,,,3
+
+print(mixed.join('-'));
+// CHECK-NEXT: 1---3
+
+// All undefined/null.
+var allEmpty: (void | null)[] = [undefined, null, undefined];
+print(allEmpty.join(','));
+// CHECK-NEXT: ,,
+
+// Single undefined.
+var singleUndef: (number | void)[] = [undefined];
+print(singleUndef.join(','));
+// CHECK-EMPTY:
+
+// toString also handles undefined/null as empty strings.
+print(mixed.toString());
+// CHECK-NEXT: 1,,,3
+
+})();

--- a/test/hermes/flow/builtin-array-map-infer.js
+++ b/test/hermes/flow/builtin-array-map-infer.js
@@ -40,4 +40,12 @@ const b: Foo[] = nums.map((n: number): Foo => new Foo(n * 10));
 print(b.length, b[0].x, b[1].x, b[2].x);
 // CHECK-NEXT: 3 10 20 30
 
+// Map with thisArg.
+const offset: number[] = [100];
+const c: number[] = nums.map(function(this: number[], n: number): number {
+  return n + this[0];
+}, offset);
+print(c.length, c[0], c[1], c[2]);
+// CHECK-NEXT: 3 101 102 103
+
 })();

--- a/test/hermes/flow/builtin-array-reverse.js
+++ b/test/hermes/flow/builtin-array-reverse.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+// RUN: %hermes -typed %s | %FileCheck --match-full-lines %s
+// RUN: %shermes -typed -exec %s | %FileCheck --match-full-lines %s
+
+/// Test Array.prototype.reverse with typed arrays.
+
+'use strict';
+
+(function () {
+
+// Reverse odd-length array.
+var nums: number[] = [1, 2, 3, 4, 5];
+nums.reverse();
+print(nums[0], nums[1], nums[2], nums[3], nums[4]);
+// CHECK: 5 4 3 2 1
+
+// Reverse even-length array.
+var even: number[] = [1, 2, 3, 4];
+even.reverse();
+print(even[0], even[1], even[2], even[3]);
+// CHECK-NEXT: 4 3 2 1
+
+// Reverse returns the array.
+var arr: number[] = [10, 20];
+var result: number[] = arr.reverse();
+print(result[0], result[1]);
+// CHECK-NEXT: 20 10
+
+// Single element.
+var single: number[] = [42];
+single.reverse();
+print(single[0]);
+// CHECK-NEXT: 42
+
+// Empty array.
+var empty: number[] = [];
+empty.reverse();
+print(empty.length);
+// CHECK-NEXT: 0
+
+})();

--- a/test/hermes/flow/builtin-array-slice.js
+++ b/test/hermes/flow/builtin-array-slice.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+// RUN: %hermes -typed %s | %FileCheck --match-full-lines %s
+// RUN: %shermes -typed -exec %s | %FileCheck --match-full-lines %s
+
+/// Test Array.prototype.slice with typed arrays.
+
+'use strict';
+
+(function () {
+
+const nums: number[] = [1, 2, 3, 4, 5];
+
+// Basic slice.
+var s: number[] = nums.slice(1, 4);
+print(s.length, s[0], s[1], s[2]);
+// CHECK: 3 2 3 4
+
+// Slice from start.
+s = nums.slice(0, 2);
+print(s.length, s[0], s[1]);
+// CHECK-NEXT: 2 1 2
+
+// Slice entire array.
+s = nums.slice(0, 5);
+print(s.length);
+// CHECK-NEXT: 5
+
+// Negative start.
+s = nums.slice(-2, 5);
+print(s.length, s[0], s[1]);
+// CHECK-NEXT: 2 4 5
+
+// Negative end.
+s = nums.slice(1, -1);
+print(s.length, s[0], s[1], s[2]);
+// CHECK-NEXT: 3 2 3 4
+
+// Empty result when start >= end.
+s = nums.slice(3, 2);
+print(s.length);
+// CHECK-NEXT: 0
+
+// Empty array.
+const empty: number[] = [];
+s = empty.slice(0, 0);
+print(s.length);
+// CHECK-NEXT: 0
+
+// No arguments copies entire array.
+s = nums.slice();
+print(s.length, s[0], s[1], s[2], s[3], s[4]);
+// CHECK-NEXT: 5 1 2 3 4 5
+
+// Only start argument.
+s = nums.slice(2);
+print(s.length, s[0], s[1], s[2]);
+// CHECK-NEXT: 3 3 4 5
+
+// Negative start, no end.
+s = nums.slice(-2);
+print(s.length, s[0], s[1]);
+// CHECK-NEXT: 2 4 5
+
+})();

--- a/test/hermes/flow/builtin-array-toReversed.js
+++ b/test/hermes/flow/builtin-array-toReversed.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+// RUN: %hermes -typed %s | %FileCheck --match-full-lines %s
+// RUN: %shermes -typed -exec %s | %FileCheck --match-full-lines %s
+
+/// Test Array.prototype.toReversed with typed arrays.
+
+'use strict';
+
+(function () {
+
+const nums: number[] = [1, 2, 3, 4, 5];
+
+// Basic toReversed.
+var r: number[] = nums.toReversed();
+print(r.length, r[0], r[1], r[2], r[3], r[4]);
+// CHECK: 5 5 4 3 2 1
+
+// Original unchanged.
+print(nums[0], nums[4]);
+// CHECK-NEXT: 1 5
+
+// Single element.
+const single: number[] = [42];
+r = single.toReversed();
+print(r.length, r[0]);
+// CHECK-NEXT: 1 42
+
+// Empty array.
+const empty: number[] = [];
+r = empty.toReversed();
+print(r.length);
+// CHECK-NEXT: 0
+
+})();

--- a/test/hermes/flow/builtin-array-with.js
+++ b/test/hermes/flow/builtin-array-with.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+// RUN: %hermes -typed %s | %FileCheck --match-full-lines %s
+// RUN: %shermes -typed -exec %s | %FileCheck --match-full-lines %s
+
+/// Test Array.prototype.with with typed arrays.
+
+'use strict';
+
+(function () {
+
+const nums: number[] = [1, 2, 3, 4, 5];
+
+// Replace at index 2.
+var w: number[] = nums.with(2, 99);
+print(w.length, w[0], w[1], w[2], w[3], w[4]);
+// CHECK: 5 1 2 99 4 5
+
+// Original unchanged.
+print(nums[2]);
+// CHECK-NEXT: 3
+
+// Replace at index 0.
+w = nums.with(0, 10);
+print(w[0], w[1]);
+// CHECK-NEXT: 10 2
+
+// Negative index.
+w = nums.with(-1, 50);
+print(w[4]);
+// CHECK-NEXT: 50
+
+// Replace last element.
+w = nums.with(-2, 40);
+print(w[3], w[4]);
+// CHECK-NEXT: 40 5
+
+// Out-of-bounds throws RangeError.
+try { nums.with(5, 0); } catch (e) { print(e.constructor.name); }
+// CHECK-NEXT: RangeError
+try { nums.with(-6, 0); } catch (e) { print(e.constructor.name); }
+// CHECK-NEXT: RangeError
+
+})();

--- a/test/hermes/flow/map.js
+++ b/test/hermes/flow/map.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+// RUN: %hermes -O0 -typed %s | %FileCheck --match-full-lines %s
+// RUN: %hermes -typed %s | %FileCheck --match-full-lines %s
+// RUN: %shermes -typed -exec %s | %FileCheck --match-full-lines %s
+
+// Basic get/set with string keys and number values.
+let m = new Map<string, number>();
+m.set('a', 1);
+m.set('b', 2);
+print(m.get('a'));
+// CHECK: 1
+print(m.get('b'));
+// CHECK-NEXT: 2
+print(m.get('c'));
+// CHECK-NEXT: undefined
+
+// Overwrite existing key.
+m.set('a', 42);
+print(m.get('a'));
+// CHECK-NEXT: 42
+
+// Number keys with string values.
+let m2 = new Map<number, string>();
+m2.set(1, 'hello');
+m2.set(2, 'world');
+print(m2.get(1));
+// CHECK-NEXT: hello
+print(m2.get(2));
+// CHECK-NEXT: world
+print(m2.get(3));
+// CHECK-NEXT: undefined
+
+// Chained set calls.
+let m3 = new Map<string, number>();
+m3.set('x', 10).set('y', 20).set('z', 30);
+print(m3.get('x'));
+// CHECK-NEXT: 10
+print(m3.get('y'));
+// CHECK-NEXT: 20
+print(m3.get('z'));
+// CHECK-NEXT: 30
+
+// has().
+print(m.has('a'));
+// CHECK-NEXT: true
+print(m.has('nonexistent'));
+// CHECK-NEXT: false
+
+// delete().
+print(m.delete('a'));
+// CHECK-NEXT: true
+print(m.has('a'));
+// CHECK-NEXT: false
+print(m.get('a'));
+// CHECK-NEXT: undefined
+print(m.delete('a'));
+// CHECK-NEXT: false
+
+// clear().
+m.set('x', 1);
+m.set('y', 2);
+print(m.has('x'));
+// CHECK-NEXT: true
+m.clear();
+print(m.has('x'));
+// CHECK-NEXT: false
+print(m.has('b'));
+// CHECK-NEXT: false

--- a/test/hermes/flow/set.js
+++ b/test/hermes/flow/set.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+// RUN: %hermes -O0 -typed %s | %FileCheck --match-full-lines %s
+// RUN: %hermes -typed %s | %FileCheck --match-full-lines %s
+// RUN: %shermes -typed -exec %s | %FileCheck --match-full-lines %s
+
+// Basic add/has.
+let s = new Set<string>();
+s.add('a');
+s.add('b');
+print(s.has('a'));
+// CHECK: true
+print(s.has('b'));
+// CHECK-NEXT: true
+print(s.has('c'));
+// CHECK-NEXT: false
+
+// Chained add.
+let s2 = new Set<number>();
+s2.add(1).add(2).add(3);
+print(s2.has(1));
+// CHECK-NEXT: true
+print(s2.has(3));
+// CHECK-NEXT: true
+
+// delete().
+print(s.delete('a'));
+// CHECK-NEXT: true
+print(s.has('a'));
+// CHECK-NEXT: false
+print(s.delete('a'));
+// CHECK-NEXT: false
+
+// clear().
+s.add('x');
+s.add('y');
+print(s.has('x'));
+// CHECK-NEXT: true
+s.clear();
+print(s.has('x'));
+// CHECK-NEXT: false
+print(s.has('b'));
+// CHECK-NEXT: false
+
+// forEach().
+let s3 = new Set<number>();
+s3.add(10).add(20).add(30);
+s3.forEach(v => { print(v); });
+// CHECK-NEXT: 10
+// CHECK-NEXT: 20
+// CHECK-NEXT: 30

--- a/test/hermes/flow/widgets.js
+++ b/test/hermes/flow/widgets.js
@@ -16,9 +16,6 @@
 
 (function() {
 
-const mapPrototypeGet: any = Map.prototype.get;
-const mapPrototypeSet: any = Map.prototype.set;
-
 // ==> widget.js <==
 
 class Widget {
@@ -162,13 +159,13 @@ function reconcileChildren(
   oldChildren: RenderNode[],
 ): RenderNode[] {
   const outChildren: RenderNode[] = [];
-  const oldChildrenByKey: any = new Map();
-  oldChildren.forEach(child => { $SHBuiltin.call(mapPrototypeSet, oldChildrenByKey, child.key, child); });
+  const oldChildrenByKey = new Map<string, RenderNode>();
+  oldChildren.forEach(child => { oldChildrenByKey.set(child.key, child); });
 
   newChildren.forEach(child => {
     const newKey = child.key;
     const oldChild: RenderNode | void =
-      $SHBuiltin.call(mapPrototypeGet, oldChildrenByKey, newKey);
+      oldChildrenByKey.get(newKey);
     if (oldChild !== undefined) {
       outChildren.push(reconcileRenderNode(child, oldChild));
     } else {
@@ -181,16 +178,16 @@ function reconcileChildren(
 
 function mapEntitiesToComponents(
   entities: VirtualEntity[],
-): any {
-  const map: any = new Map();
+): Map<number, Component[]> {
+  const map = new Map<number, Component[]>();
   entities.forEach(entity => {
     const key: number = entity.key;
     const value: Component[] = entity.value;
-    if ($SHBuiltin.call(mapPrototypeGet, map, key) == undefined) {
-      $SHBuiltin.call(mapPrototypeSet, map, key, ([]: Component[]));
+    if (map.get(key) == undefined) {
+      map.set(key, ([]: Component[]));
     }
 
-    const components: Component[] = $SHBuiltin.call(mapPrototypeGet, map, key);
+    const components: Component[] = map.get(key);
     if (components !== undefined) {
       components.push(...value);
     } else {
@@ -218,12 +215,12 @@ function diffTrees(
     entityId => !newEntityIds.includes(entityId),
   );
 
-  const oldComponents: any = mapEntitiesToComponents(oldEntities);
-  const newComponents: any = mapEntitiesToComponents(newEntities);
+  const oldComponents = mapEntitiesToComponents(oldEntities);
+  const newComponents = mapEntitiesToComponents(newEntities);
 
   createdEntities.forEach(entityId => {
     const comps: Component[] =
-      $SHBuiltin.call(mapPrototypeGet, newComponents, entityId) || ([]: Component[]);
+      newComponents.get(entityId) || ([]: Component[]);
     const components = comps.map(
       it => new ComponentPair(entityId, it),
     );
@@ -231,11 +228,11 @@ function diffTrees(
   });
 
   newComponents.forEach((value: Component[], key: number) => {
-    if ($SHBuiltin.call(mapPrototypeGet, oldComponents, key) == undefined) {
+    if (oldComponents.get(key) == undefined) {
       return;
     }
 
-    const oldComponentsForKey: Component[] = $SHBuiltin.call(mapPrototypeGet, oldComponents, key) || ([]: Component[]);
+    const oldComponentsForKey: Component[] = oldComponents.get(key) || ([]: Component[]);
     const newComponentsForKey: Component[] = value;
 
     const deleted: Component[] = oldComponentsForKey.filter(


### PR DESCRIPTION
Summary:

Add a generic `Set<T>` to FlowLib that wraps the native Set
with typed add/has/delete/clear/forEach methods, allowing
typed code to use Set methods directly.

Reviewed By: micleo2

Differential Revision: D96520014
