### PR TITLE
Guard gtest build on HERMES_ENABLE_TEST_SUITE

### DIFF
--- a/external/llvh/CMakeLists.txt
+++ b/external/llvh/CMakeLists.txt
@@ -32,7 +32,9 @@ add_subdirectory(utils/FileCheck)
 add_subdirectory(utils/TableGen)
 add_subdirectory(utils/not)
 add_subdirectory(utils/count)
-add_subdirectory(utils/unittest)
+if(HERMES_ENABLE_TEST_SUITE)
+  add_subdirectory(utils/unittest)
+endif()
 
 set(LLVH_LIT_ARGS "-sv")
 set(LLVH_LIT_TEST_PARAMS


### PR DESCRIPTION
## Summary

The gtest and gtest_main targets in external/llvh/utils/unittest were built unconditionally, even when HERMES_ENABLE_TEST_SUITE was set to OFF. This adds a conditional guard so the unittest subdirectory is only included when the test suite is enabled, matching the existing guard on the unittests/ directory in the top-level CMakeLists.txt.

