### PR TITLE
Rename gtest/gtest_main targets to llvh-gtest/llvh-gtest_main

### DIFF
--- a/cmake/modules/Lit.cmake
+++ b/cmake/modules/Lit.cmake
@@ -86,7 +86,7 @@ function(add_unittest test_suite test_name)
 
   add_hermes_executable(${test_name} ${ARGN})
 
-  target_link_libraries(${test_name} gtest_main)
+  target_link_libraries(${test_name} llvh-gtest_main)
 
   add_dependencies(${test_suite} ${test_name})
   get_target_property(test_suite_folder ${test_suite} FOLDER)

--- a/external/llvh/utils/unittest/CMakeLists.txt
+++ b/external/llvh/utils/unittest/CMakeLists.txt
@@ -50,7 +50,7 @@ if (LLVM_PTHREAD_LIBRARY_PATH)
   list(APPEND LIBS pthread)
 endif()
 
-add_hermes_library(gtest STATIC
+add_hermes_library(llvh-gtest STATIC
   googletest/src/gtest-all.cc
   googlemock/src/gmock-all.cc
 

--- a/external/llvh/utils/unittest/UnitTestMain/CMakeLists.txt
+++ b/external/llvh/utils/unittest/UnitTestMain/CMakeLists.txt
@@ -1,8 +1,8 @@
-add_hermes_library(gtest_main
+add_hermes_library(llvh-gtest_main
   TestMain.cpp
 
   LINK_LIBS
-  gtest
+  llvh-gtest
 
   LINK_OBJLIBS
   LLVHSupport # Depends on llvh::cl


### PR DESCRIPTION
Avoid CMake target name conflicts when Hermes is embedded via
add_subdirectory() in a project that also uses gtest.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>