### PR TITLE
Directly encode Object/Symbol in WeakRefObjOrSym::getNoBarrierUnsafe()

### DIFF
--- a/include/hermes/VM/SmallHermesValue-inline.h
+++ b/include/hermes/VM/SmallHermesValue-inline.h
@@ -25,11 +25,66 @@ void SmallHermesValueAdaptor::setInGC(SmallHermesValueAdaptor hv, GC &gc) {
   HermesValue::setInGC(hv, gc);
 }
 
+HermesValue SmallHermesValueAdaptor::unboxToHVWithReadBarrier(
+    PointerBase &pb,
+    GC &gc) const {
+  if (isPointer()) {
+    gc.weakRefReadBarrier(getPointer(pb));
+  } else if (isSymbol()) {
+    gc.weakRefReadBarrier(getSymbol());
+  }
+  return *this;
+}
+
 #else // #ifndef HERMESVM_BOXED_DOUBLES
 
 void HermesValue32::setInGC(HermesValue32 hv, GC &gc) {
   setNoBarrier(hv);
   assert(gc.calledByGC());
+}
+
+HermesValue HermesValue32::unboxToHVWithReadBarrier(PointerBase &pb, GC &gc)
+    const {
+  // Since we need to perform read barrier with gc, we can't use the same
+  // unified inline path `_sh_shv_unbox_inline` as used by unboxToHV.
+
+  auto tag = getTag();
+  // We check for CompressedHV64 and pointers first, because we know that they
+  // comprise the overwhelming majority of values.
+  if (tag == Tag::CompressedHV64)
+    return HermesValue::fromRaw(compressedHV64ToBits());
+  if (tag <= Tag::Object) {
+    // This must be a pointer tag, since the only tag before the first pointer
+    // tag is CompressedHV64, which we have already checked for.
+    assert(tag == Tag::Object || tag == Tag::BigInt || tag == Tag::String);
+    auto toHV64Tag = [](Tag tag) {
+      // Compute the HV64 tag by applying an offset to the HV32 tag.
+      auto offs = (uint32_t)HermesValue::Tag::Str - (uint32_t)Tag::String;
+      // Note that we can use | here instead of + here because we know that the
+      // HV32 pointer tags are only 2 bits, and the two low bits of offs are 0.
+      // At least on arm64, this meaningfully improves the generated code.
+      return (HermesValue::Tag)(offs | (uint32_t)tag);
+    };
+    // Check that the calculation is correct.
+    static_assert(toHV64Tag(Tag::Object) == HermesValue::Tag::Object);
+    static_assert(toHV64Tag(Tag::BigInt) == HermesValue::Tag::BigInt);
+    static_assert(toHV64Tag(Tag::String) == HermesValue::Tag::Str);
+    auto *ptr = getPointer(pb);
+    // Perform a read barrier on the pointer.
+    gc.weakRefReadBarrier(ptr);
+    return HermesValue::fromTagAndValue(toHV64Tag(tag), (uint64_t)ptr);
+  }
+  if (tag == Tag::Symbol) {
+    auto symbol = getSymbol();
+    // Perform a read barrier on the symbol.
+    gc.weakRefReadBarrier(symbol);
+    return HermesValue::encodeSymbolValue(symbol);
+  }
+
+  assert(tag == Tag::BoxedDouble);
+  // Read barrier is not needed for boxed double since we are unboxing it now.
+  return HermesValue::encodeTrustedNumberValue(
+      vmcast<BoxedDouble>(getPointer(pb))->get());
 }
 
 HermesValue HermesValue32::unboxToHV(PointerBase &pb) const {

--- a/include/hermes/VM/SmallHermesValue.h
+++ b/include/hermes/VM/SmallHermesValue.h
@@ -217,6 +217,11 @@ class SmallHermesValueAdaptor : protected HermesValue {
   static bool canInlineDouble(double d) {
     return true;
   }
+
+ protected:
+  /// Perform read barrier when the value is Pointer or Symbol, then unbox. This
+  /// is only used by WeakSmallHermesValue.
+  inline HermesValue unboxToHVWithReadBarrier(PointerBase &pb, GC &gc) const;
 };
 using SmallHermesValue = SmallHermesValueAdaptor;
 
@@ -601,6 +606,12 @@ class HermesValue32 {
   inline void setNoBarrier(HermesValue32 other) {
     raw_ = other.raw_;
   }
+
+  /// Convert this to a full HermesValue, and unbox it if it is currently boxed.
+  /// The conversion is the same as unboxToHV, but it also performs a read
+  /// barrier if the value is pointer or symbol. This is only used by
+  /// WeakSmallHermesValue, where we need to hold the read pointer/symbol alive.
+  inline HermesValue unboxToHVWithReadBarrier(PointerBase &pb, GC &gc) const;
 };
 using SmallHermesValue = HermesValue32;
 

--- a/include/hermes/VM/WeakRef.h
+++ b/include/hermes/VM/WeakRef.h
@@ -132,7 +132,11 @@ class WeakRefObjOrSym : public WeakRefBase {
   explicit WeakRefObjOrSym(WeakRefSlot *slot) : WeakRefBase(slot) {}
 
   HermesValue getNoBarrierUnsafe(PointerBase &base) const {
-    return slot_->getValueNoBarrierUnsafe(base);
+    if (slot_->isObject()) {
+      return HermesValue::encodeObjectValue(
+          slot_->getObjectNoBarrierUnsafe(base));
+    }
+    return HermesValue::encodeSymbolValue(slot_->getSymbolNoBarrierUnsafe());
   }
 
   /// \return the HeapSnapshot node id for the underlying Object or Symbol.

--- a/include/hermes/VM/WeakRefSlot-inline.h
+++ b/include/hermes/VM/WeakRefSlot-inline.h
@@ -26,11 +26,8 @@ GCCell *WeakRefSlot::getObject(PointerBase &base, GC &gc) const {
 }
 
 HermesValue WeakRefSlot::getValueNoBarrierUnsafe(PointerBase &base) const {
-  // We don't use unboxToHV here because we know the exact possible types.
-  if (value_.root.isObject())
-    return HermesValue::encodeObjectValue(
-        value_.root.getObjectNoBarrierUnsafe(base));
-  return HermesValue::encodeSymbolValue(value_.root.getSymbolNoBarrierUnsafe());
+  assert(hasValue() && "tried to access collected referent");
+  return value_.root.unboxToHV(base);
 }
 
 } // namespace vm

--- a/include/hermes/VM/WeakRefSlot-inline.h
+++ b/include/hermes/VM/WeakRefSlot-inline.h
@@ -25,6 +25,11 @@ GCCell *WeakRefSlot::getObject(PointerBase &base, GC &gc) const {
   return value_.root.getObject(base, gc);
 }
 
+HermesValue WeakRefSlot::getValue(PointerBase &base, GC &gc) const {
+  assert(hasValue() && "tried to access collected referent");
+  return value_.root.unboxToHVWithReadBarrier(base, gc);
+}
+
 HermesValue WeakRefSlot::getValueNoBarrierUnsafe(PointerBase &base) const {
   assert(hasValue() && "tried to access collected referent");
   return value_.root.unboxToHV(base);

--- a/include/hermes/VM/WeakRefSlot.h
+++ b/include/hermes/VM/WeakRefSlot.h
@@ -10,16 +10,19 @@
 
 #include "hermes/VM/CompressedPointer.h"
 #include "hermes/VM/GCCell.h"
-#include "hermes/VM/GCConcurrency.h"
 #include "hermes/VM/HermesValue.h"
+#include "hermes/VM/RootAcceptor.h"
 #include "hermes/VM/WeakRoot.h"
 
 namespace hermes {
 namespace vm {
 
-/// This is a single slot in the weak reference table. It contains a pointer to
-/// a GC managed object. The GC will make sure it is updated when the object is
-/// moved; if the object is garbage-collected, the pointer will be cleared.
+/// This is a single slot in the weak reference table. It manages a
+/// WeakSmallHermesValue that can weakly hold Pointer (i.e., String, Object,
+/// BoxedDouble, BigInt) and Symbol values, or any other primitive values that a
+/// SmallHermesValue can hold (e.g., Bool, small integer, etc.). The GC will
+/// make sure it is updated when the object is moved; if the object/symbol is
+/// garbage-collected, it will be invalidated.
 class WeakRefSlot {
  public:
   // Mutator methods.
@@ -37,8 +40,9 @@ class WeakRefSlot {
     return value_.root.isSymbol();
   }
 
-  /// Return the underlying value, which is either an Object or Symbol, without
-  /// a read barrier.
+  /// Return the underlying value, without a read barrier. This should only be
+  /// used in cases where it is known that no read barrier is necessary (e.g.,
+  /// in the GC itself).
   inline HermesValue getValueNoBarrierUnsafe(PointerBase &base) const;
 
   /// Return the object as a GCCell *, with a read barrier

--- a/include/hermes/VM/WeakRefSlot.h
+++ b/include/hermes/VM/WeakRefSlot.h
@@ -40,6 +40,10 @@ class WeakRefSlot {
     return value_.root.isSymbol();
   }
 
+  /// Return the underlying value, with a read barrier if it's a pointer or
+  /// symbol.
+  inline HermesValue getValue(PointerBase &base, GC &gc) const;
+
   /// Return the underlying value, without a read barrier. This should only be
   /// used in cases where it is known that no read barrier is necessary (e.g.,
   /// in the GC itself).

--- a/include/hermes/VM/WeakRoot.h
+++ b/include/hermes/VM/WeakRoot.h
@@ -149,6 +149,7 @@ class WeakSmallHermesValue final : protected SmallHermesValue {
   using SmallHermesValue::isSymbol;
   using SmallHermesValue::operator=;
   using SmallHermesValue::getRaw;
+  using SmallHermesValue::unboxToHV;
 
   inline SymbolID getSymbol(GC &gc) const;
   SymbolID getSymbolNoBarrierUnsafe() const {

--- a/include/hermes/VM/WeakRoot.h
+++ b/include/hermes/VM/WeakRoot.h
@@ -134,7 +134,7 @@ class WeakRootSymbolID final : protected SymbolID {
 /// value if the pointed object has been evacuated, or invalidate it if it's
 /// dead. During old gen collection, we invalidate it if the pointed object is
 /// dead or the symbol is invalid.
-class WeakSmallHermesValue final : protected SmallHermesValue {
+class WeakSmallHermesValue final : private SmallHermesValue {
  public:
   WeakSmallHermesValue() : SmallHermesValue(encodeEmptyValue()) {}
 
@@ -150,6 +150,7 @@ class WeakSmallHermesValue final : protected SmallHermesValue {
   using SmallHermesValue::operator=;
   using SmallHermesValue::getRaw;
   using SmallHermesValue::unboxToHV;
+  using SmallHermesValue::unboxToHVWithReadBarrier;
 
   inline SymbolID getSymbol(GC &gc) const;
   SymbolID getSymbolNoBarrierUnsafe() const {


### PR DESCRIPTION
Summary:
`WeakRefSlot::getValueNoBarrierUnsafe` now always to a full unbox to
HV, which is unncessary for `WeakRefObjOrSym` since we know the exact
tags. So encode to HermesValue on its own instead.

Reviewed By: tmikov

Differential Revision: D95595472


