### PR TITLE
Fix Date.prototype.toLocaleString() TypeError message for non-Date this

### DIFF
--- a/lib/VM/JSLib/Date.cpp
+++ b/lib/VM/JSLib/Date.cpp
@@ -619,7 +619,7 @@ CallResult<HermesValue> datePrototypeToLocaleStringHelper(
   auto *date = dyn_vmcast<JSDate>(args.getThisArg());
   if (!date) {
     return runtime.raiseTypeError(
-        "Date.prototype.toString() called on non-Date object");
+        "Date.prototype.toLocaleString() called on non-Date object");
   }
   double t = date->getPrimitiveValue();
   if (!std::isfinite(t)) {


### PR DESCRIPTION
## Summary
`datePrototypeToLocaleStringHelper` raised a TypeError with the wrong method name in the message (`toString()` instead of `toLocaleString()`). This updates the string to match the actual API.

## Test plan
- Build Hermes; run any existing Date/locale tests if present.