### PR TITLE
Fix Number.prototype.toFixed comment for fraction digit range

### DIFF
--- a/lib/VM/JSLib/Number.cpp
+++ b/lib/VM/JSLib/Number.cpp
@@ -410,7 +410,7 @@ CallResult<HermesValue> numberPrototypeToFixed(void *, Runtime &runtime) {
         "toFixed argument must be between 0 and 100");
   }
   /// Number of digits after the decimal point.
-  /// Because we checked, 0 <= f <= 20.
+  /// Because we checked, 0 <= f <= 100.
   /// In particular, we know that f is non-negative.
   int32_t f = static_cast<int32_t>(fDouble);
 


### PR DESCRIPTION
## Summary
Align the inline comment above `numberPrototypeToFixed` with the actual validation: fraction digits are constrained to 0–100 (per spec step 3 and the RangeError message), not 0–20.

## Test plan
- Comment-only change; no runtime behavior change.