### PR TITLE
fix: include macOS slice in universal Hermes xcframework

### DIFF
--- a/utils/build-apple-framework.sh
+++ b/utils/build-apple-framework.sh
@@ -232,10 +232,12 @@ function create_universal_framework {
   # shellcheck disable=SC2086
   if xcodebuild -create-xcframework $args -output "universal/hermesvm.xcframework"
   then
-    # # Remove the thin iOS hermesvm.frameworks that are now part of the universal
-    # XCFramework
+    # Remove the thin hermesvm.frameworks that are now part of the universal
+    # XCFramework, but keep macosx since it's expected as a standalone framework.
     for platform in "${platforms[@]}"; do
-      rm -r "$platform"
+      if [[ "$platform" != "macosx" ]]; then
+        rm -r "$platform"
+      fi
     done
   fi
 

--- a/utils/build-ios-framework.sh
+++ b/utils/build-ios-framework.sh
@@ -12,15 +12,9 @@ set -e
 # Given a specific target, retrieve the right architecture for it
 # $1 the target you want to build. Allowed values: iphoneos, iphonesimulator, catalyst, xros, xrsimulator
 function get_architecture {
-    if [[ $1 == "iphoneos" || $1 == "xros" ]]; then
+    if [[ $1 == "iphoneos" || $1 == "appletvos" || $1 == "xros" ]]; then
       echo "arm64"
-    elif [[ $1 == "iphonesimulator" || $1 == "xrsimulator" ]]; then
-      echo "x86_64;arm64"
-    elif [[ $1 == "appletvos" ]]; then
-      echo "arm64"
-    elif [[ $1 == "appletvsimulator" ]]; then
-      echo "x86_64;arm64"
-    elif [[ $1 == "catalyst" ]]; then
+    elif [[ $1 == "iphonesimulator" || $1 == "appletvsimulator" || $1 == "catalyst" || $1 == "macosx" || $1 == "xrsimulator" ]]; then
       echo "x86_64;arm64"
     else
       echo "Error: unknown architecture passed $1"
@@ -29,7 +23,9 @@ function get_architecture {
 }
 
 function get_deployment_target {
-    if [[ $1 == "xros" || $1 == "xrsimulator" ]]; then
+    if [[ $1 == "macosx" ]]; then
+      echo "$(get_mac_deployment_target)"
+    elif [[ $1 == "xros" || $1 == "xrsimulator" ]]; then
       echo "$(get_visionos_deployment_target)"
     else # tvOS and iOS use the same deployment target
       echo "$(get_ios_deployment_target)"
@@ -51,7 +47,7 @@ function build_framework {
 # group the frameworks together to create a universal framework
 function build_universal_framework {
     if [ ! -d destroot/Library/Frameworks/universal/hermesvm.xcframework ]; then
-        create_universal_framework "iphoneos" "iphonesimulator" "catalyst" "xros" "xrsimulator" "appletvos" "appletvsimulator"
+        create_universal_framework "macosx" "iphoneos" "iphonesimulator" "catalyst" "xros" "xrsimulator" "appletvos" "appletvsimulator"
     else
         echo "Skipping; Clean \"destroot\" to rebuild".
     fi
@@ -61,6 +57,7 @@ function build_universal_framework {
 # this is used to preserve backward compatibility
 function create_framework {
     if [ ! -d destroot/Library/Frameworks/universal/hermesvm.xcframework ]; then
+        build_framework "macosx"
         build_framework "iphoneos"
         build_framework "iphonesimulator"
         build_framework "appletvos"


### PR DESCRIPTION
## Summary

Mirror of https://github.com/facebook/hermes/pull/1958 (targeting `static_h`), adapted for the legacy `main` branch.

Unlike the `static_h` PR which consolidates all Apple build scripts and removes `build-mac-framework.sh`, this PR takes a minimal approach: it adds macOS support to the existing `build-ios-framework.sh` functions (`get_architecture`, `get_deployment_target`, `create_framework`, `build_universal_framework`) so the macOS slice is included in the universal xcframework.

`build-mac-framework.sh` is left in place for backward compatibility on this legacy branch.

### Motivation

The context of this change is https://github.com/microsoft/react-native-macos/pull/2815, where we are adding SPM / prebuild support to React Native macOS.

Including the macOS slice in the universal xcframework allows [react-native-macos](https://github.com/microsoft/react-native-macos) to use the same prebuilt Hermes artifacts as react-native for iOS, visionOS, and tvOS — without platform-specific patching.

## Test plan

CI should pass. The `build_apple_framework "macosx"` call is already exercised by `build-mac-framework.sh` — this PR just routes it through the same path as every other platform.