### PR TITLE
fix: include macOS slice in universal Hermes xcframework

### DIFF
--- a/.github/workflows/build-hermes-macos.yml
+++ b/.github/workflows/build-hermes-macos.yml
@@ -57,7 +57,7 @@ jobs:
           chmod +x ./utils/build-apple-framework-rn.sh
           source ./utils/build-apple-framework-rn.sh
           prepare_dest_root_for_ci
-      - name: Create fat framework for iOS
+      - name: Create universal framework
         shell: bash
         run: |
           echo "[HERMES] Creating the universal framework"
@@ -72,8 +72,6 @@ jobs:
           echo "Packaging Hermes Apple frameworks for $BUILD_TYPE build type"
 
           TARBALL_OUTPUT_DIR=$(mktemp -d /tmp/hermes-tarball-output-XXXXXXXX)
-
-          echo "Packaging Hermes Apple frameworks for $BUILD_TYPE build type"
 
           TARBALL_OUTPUT_PATH=$(node ./utils/scripts/hermes/create-tarball.js \
             --inputDir . \

--- a/utils/build-apple-framework-rn.sh
+++ b/utils/build-apple-framework-rn.sh
@@ -231,10 +231,12 @@ function create_universal_framework {
   # shellcheck disable=SC2086
   if xcodebuild -create-xcframework $args -output "universal/hermesvm.xcframework"
   then
-    # # Remove the thin iOS hermesvm.frameworks that are now part of the universal
-    # XCFramework
+    # Remove the thin hermesvm.frameworks that are now part of the universal
+    # XCFramework, but keep macosx since it's expected as a standalone framework.
     for platform in "${platforms[@]}"; do
-      rm -r "$platform"
+      if [[ "$platform" != "macosx" ]]; then
+        rm -r "$platform"
+      fi
     done
   fi
 

--- a/utils/build-ios-framework-rn.sh
+++ b/utils/build-ios-framework-rn.sh
@@ -12,15 +12,9 @@ set -e
 # Given a specific target, retrieve the right architecture for it
 # $1 the target you want to build. Allowed values: iphoneos, iphonesimulator, catalyst, xros, xrsimulator
 function get_architecture {
-    if [[ $1 == "iphoneos" || $1 == "xros" ]]; then
+    if [[ $1 == "iphoneos" || $1 == "appletvos" || $1 == "xros" ]]; then
       echo "arm64"
-    elif [[ $1 == "iphonesimulator" || $1 == "xrsimulator" ]]; then
-      echo "x86_64;arm64"
-    elif [[ $1 == "appletvos" ]]; then
-      echo "arm64"
-    elif [[ $1 == "appletvsimulator" ]]; then
-      echo "x86_64;arm64"
-    elif [[ $1 == "catalyst" ]]; then
+    elif [[ $1 == "iphonesimulator" || $1 == "appletvsimulator" || $1 == "catalyst" || $1 == "macosx" || $1 == "xrsimulator" ]]; then
       echo "x86_64;arm64"
     else
       echo "Error: unknown architecture passed $1"
@@ -29,7 +23,9 @@ function get_architecture {
 }
 
 function get_deployment_target {
-    if [[ $1 == "xros" || $1 == "xrsimulator" ]]; then
+    if [[ $1 == "macosx" ]]; then
+      echo "$(get_mac_deployment_target)"
+    elif [[ $1 == "xros" || $1 == "xrsimulator" ]]; then
       echo "$(get_visionos_deployment_target)"
     else # tvOS and iOS use the same deployment target
       echo "$(get_ios_deployment_target)"
@@ -53,7 +49,7 @@ function build_framework {
 # group the frameworks together to create a universal framework
 function build_universal_framework {
     if [ ! -d destroot/Library/Frameworks/universal/hermesvm.xcframework ]; then
-        create_universal_framework "iphoneos" "iphonesimulator" "catalyst" "xros" "xrsimulator" "appletvos" "appletvsimulator"
+        create_universal_framework "macosx" "iphoneos" "iphonesimulator" "catalyst" "xros" "xrsimulator" "appletvos" "appletvsimulator"
     else
         echo "Skipping; Clean \"destroot\" to rebuild".
     fi
@@ -63,6 +59,7 @@ function build_universal_framework {
 # this is used to preserve backward compatibility
 function create_framework {
     if [ ! -d destroot/Library/Frameworks/universal/hermesvm.xcframework ]; then
+        build_framework "macosx"
         build_framework "iphoneos"
         build_framework "iphonesimulator"
         build_framework "appletvos"

--- a/utils/build-ios-framework.sh
+++ b/utils/build-ios-framework.sh
@@ -7,10 +7,12 @@
 . ./utils/build-apple-framework.sh
 
 if [ ! -d destroot/Library/Frameworks/universal/hermes.xcframework ]; then
+    mac_deployment_target=$(get_mac_deployment_target)
     ios_deployment_target=$(get_ios_deployment_target)
     visionos_deployment_target=$(get_visionos_deployment_target)
     tvos_deployment_target=$(get_tvos_deployment_target)
 
+    build_apple_framework "macosx" "x86_64;arm64" "$mac_deployment_target"
     build_apple_framework "iphoneos" "arm64" "$ios_deployment_target"
     build_apple_framework "iphonesimulator" "x86_64;arm64" "$ios_deployment_target"
     build_apple_framework "catalyst" "x86_64;arm64" "$ios_deployment_target"
@@ -19,7 +21,7 @@ if [ ! -d destroot/Library/Frameworks/universal/hermes.xcframework ]; then
     build_apple_framework "appletvos" "arm64" "$tvos_deployment_target"
     build_apple_framework "appletvsimulator" "x86_64;arm64" "$tvos_deployment_target"
 
-    create_universal_framework "iphoneos" "iphonesimulator" "catalyst" "xros" "xrsimulator" "appletvos" "appletvsimulator"
+    create_universal_framework "macosx" "iphoneos" "iphonesimulator" "catalyst" "xros" "xrsimulator" "appletvos" "appletvsimulator"
 else
     echo "Skipping; Clean \"destroot\" to rebuild".
 fi


### PR DESCRIPTION
## Summary

Mirror of https://github.com/facebook/hermes/pull/1958 (targeting `static_h`), adapted for the `250829098.0.0-stable` release branch.

Unlike the `static_h` PR which consolidates all Apple build scripts and removes `build-mac-framework.sh`, this PR takes a minimal approach: it adds `build_apple_framework "macosx"` and includes `"macosx"` in the `create_universal_framework` call so the macOS slice is part of the universal xcframework.

`build-mac-framework.sh` is left in place for backward compatibility on this release branch.

### Motivation

The context of this change is https://github.com/microsoft/react-native-macos/pull/2815, where we are adding SPM / prebuild support to React Native macOS.

Including the macOS slice in the universal xcframework allows [react-native-macos](https://github.com/microsoft/react-native-macos) to use the same prebuilt Hermes artifacts as react-native for iOS, visionOS, and tvOS — without platform-specific patching.

## Test plan

CI should pass. The `build_apple_framework "macosx"` call is already exercised by `build-mac-framework.sh` — this PR just routes it through the same path as every other platform.