### PR TITLE
SIMD-accelerate JSON string scanning in JSONLexer (#1984)

### DIFF
--- a/benchmarks/bench-runner/resource/test-suites/micros/jsonStringify.js
+++ b/benchmarks/bench-runner/resource/test-suites/micros/jsonStringify.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+// Benchmark for JSON.stringify and JSON.parse with string values.
+// Exercises the string quoting/scanning hot paths where SIMD can
+// skip over long runs of non-escape characters in bulk.
+
+var start = Date.now();
+(function () {
+  var numIter = 200000;
+
+  // Build strings with long runs of normal characters and occasional
+  // escape characters to exercise both the SIMD bulk skip and the
+  // scalar escape handling.
+  var shortStr = 'hello world';
+  var base = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  var longStr = '';
+  for (var i = 0; i < 8; i++) {
+    longStr += base;
+  }
+  // 296 chars, no escapes.
+
+  var longStrWithEscapes = '';
+  for (var i = 0; i < 8; i++) {
+    // 35 normal chars then a quote and a backslash.
+    longStrWithEscapes += 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789' + '"\\';
+  }
+  longStrWithEscapes = longStrWithEscapes.substring(0, 256);
+
+  // An object with multiple string fields, typical of real payloads.
+  var obj = {
+    name: 'John Doe',
+    address: '123 Main St, Anytown, USA 12345',
+    bio: longStr.substring(0, 64),
+    notes: longStrWithEscapes.substring(0, 64),
+  };
+
+  var sum = 0;
+  for (var i = 0; i < numIter; i++) {
+    // Stringify exercises quoteStringForJSON.
+    var s1 = JSON.stringify(shortStr);
+    var s2 = JSON.stringify(longStr);
+    var s3 = JSON.stringify(longStrWithEscapes);
+    var s4 = JSON.stringify(obj);
+    sum += s1.length + s2.length + s3.length + s4.length;
+
+    // Parse exercises JSONLexer::scanString.
+    var p1 = JSON.parse(s1);
+    var p2 = JSON.parse(s2);
+    var p3 = JSON.parse(s3);
+    var p4 = JSON.parse(s4);
+    sum += p1.length + p2.length + p3.length + p4.notes.length;
+  }
+
+  print('done, sum =', sum);
+})();
+var end = Date.now();
+print('Time: ' + (end - start));

--- a/include/hermes/Support/FastArraySearch.h
+++ b/include/hermes/Support/FastArraySearch.h
@@ -83,4 +83,16 @@ int64_t searchReverseU64(
     size_t end,
     uint64_t target);
 
+/// Scan [start, end) for the first byte that requires escaping in a JSON
+/// string per ECMA-404: '"' (0x22), '\\' (0x5C), or any control character
+/// (<= 0x1F).
+/// \return pointer to the first such character, or \p end if none found.
+const char *scanJsonEscapeU8(const char *start, const char *end);
+
+/// Scan [start, end) for the first char16_t that requires escaping in a JSON
+/// string per ECMA-404: '"' (0x22), '\\' (0x5C), or any control character
+/// (<= 0x1F).
+/// \return pointer to the first such character, or \p end if none found.
+const char16_t *scanJsonEscapeU16(const char16_t *start, const char16_t *end);
+
 } // namespace hermes

--- a/lib/Support/FastArraySearch.cpp
+++ b/lib/Support/FastArraySearch.cpp
@@ -470,4 +470,122 @@ int64_t searchReverseU64(
   return searchU64Impl<true>(arr, start, end, target);
 }
 
+//===----------------------------------------------------------------------===//
+// Special character scanning for JSON strings
+//===----------------------------------------------------------------------===//
+
+/// Scalar helper: scan for first byte that is '"', '\\', or <= 0x1F.
+static const char *scalarScanU8(const char *p, const char *end) {
+  while (p < end) {
+    unsigned char ch = static_cast<unsigned char>(*p);
+    if (ch <= 0x1F || ch == '"' || ch == '\\')
+      return p;
+    ++p;
+  }
+  return end;
+}
+
+/// Scalar helper: scan for first char16_t that is '"', '\\', or <= 0x1F.
+static const char16_t *scalarScanU16(const char16_t *p, const char16_t *end) {
+  while (p < end) {
+    char16_t ch = *p;
+    if (ch <= 0x1F || ch == u'"' || ch == u'\\')
+      return p;
+    ++p;
+  }
+  return end;
+}
+
+const char *scanJsonEscapeU8(const char *start, const char *end) {
+  assert(start <= end && "start must be <= end");
+  const char *p = start;
+
+#ifdef HERMES_SIMD_NEON
+  // Broadcast each special character/threshold into 128-bit vectors.
+  uint8x16_t vQuote = vdupq_n_u8('"');
+  uint8x16_t vBackslash = vdupq_n_u8('\\');
+  uint8x16_t vCtrlLimit = vdupq_n_u8(0x20);
+  while (p + 16 <= end) {
+    uint8x16_t data = vld1q_u8(reinterpret_cast<const uint8_t *>(p));
+    // Check three conditions in parallel:
+    // cmp1: byte == '"', cmp2: byte == '\\', cmp3: byte < 0x20 (control).
+    uint8x16_t cmp1 = vceqq_u8(data, vQuote);
+    uint8x16_t cmp2 = vceqq_u8(data, vBackslash);
+    uint8x16_t cmp3 = vcltq_u8(data, vCtrlLimit);
+    // OR all three results; any non-zero lane means a special char exists.
+    uint8x16_t match = vorrq_u8(vorrq_u8(cmp1, cmp2), cmp3);
+    if (vmaxvq_u8(match))
+      // Fall back to scalar to find the exact byte within this chunk.
+      return scalarScanU8(p, p + 16);
+    p += 16;
+  }
+#elif defined(HERMES_SIMD_SSE2)
+  __m128i vQuote = _mm_set1_epi8('"');
+  __m128i vBackslash = _mm_set1_epi8('\\');
+  __m128i vCtrlLimit = _mm_set1_epi8(0x20);
+  while (p + 16 <= end) {
+    __m128i data = _mm_loadu_si128(reinterpret_cast<const __m128i *>(p));
+    __m128i cmp1 = _mm_cmpeq_epi8(data, vQuote);
+    __m128i cmp2 = _mm_cmpeq_epi8(data, vBackslash);
+    // _mm_cmplt_epi8 is signed comparison; this works for JSON because
+    // all valid JSON string bytes are < 0x80 (high bit clear), so
+    // signed < 0x20 is equivalent to unsigned < 0x20.
+    __m128i cmp3 = _mm_cmplt_epi8(data, vCtrlLimit);
+    __m128i match = _mm_or_si128(_mm_or_si128(cmp1, cmp2), cmp3);
+    // 1 mask bit per byte; countTrailingZeros gives exact byte offset.
+    unsigned mask = static_cast<unsigned>(_mm_movemask_epi8(match));
+    if (mask)
+      return p + llvh::countTrailingZeros(mask);
+    p += 16;
+  }
+#endif
+
+  return scalarScanU8(p, end);
+}
+
+const char16_t *scanJsonEscapeU16(const char16_t *start, const char16_t *end) {
+  assert(start <= end && "start must be <= end");
+  const char16_t *p = start;
+
+#ifdef HERMES_SIMD_NEON
+  // Same approach as scanJsonEscapeU8 but with 16-bit lanes (8 per chunk).
+  uint16x8_t vQuote = vdupq_n_u16(u'"');
+  uint16x8_t vBackslash = vdupq_n_u16(u'\\');
+  uint16x8_t vCtrlLimit = vdupq_n_u16(0x20);
+  while (p + 8 <= end) {
+    uint16x8_t data = vld1q_u16(reinterpret_cast<const uint16_t *>(p));
+    uint16x8_t cmp1 = vceqq_u16(data, vQuote);
+    uint16x8_t cmp2 = vceqq_u16(data, vBackslash);
+    uint16x8_t cmp3 = vcltq_u16(data, vCtrlLimit);
+    uint16x8_t match = vorrq_u16(vorrq_u16(cmp1, cmp2), cmp3);
+    if (vmaxvq_u16(match))
+      return scalarScanU16(p, p + 8);
+    p += 8;
+  }
+#elif defined(HERMES_SIMD_SSE2)
+  __m128i vQuote = _mm_set1_epi16(u'"');
+  __m128i vBackslash = _mm_set1_epi16(u'\\');
+  // Bias for unsigned comparison: XOR with 0x8000 converts signed
+  // _mm_cmplt_epi16 into an unsigned less-than, avoiding false positives
+  // for char16_t values >= 0x8000 (e.g. CJK, surrogates).
+  __m128i bias = _mm_set1_epi16(static_cast<short>(0x8000));
+  __m128i vCtrlLimitBiased = _mm_xor_si128(_mm_set1_epi16(0x20), bias);
+  while (p + 8 <= end) {
+    __m128i data = _mm_loadu_si128(reinterpret_cast<const __m128i *>(p));
+    __m128i cmp1 = _mm_cmpeq_epi16(data, vQuote);
+    __m128i cmp2 = _mm_cmpeq_epi16(data, vBackslash);
+    __m128i cmp3 = _mm_cmplt_epi16(_mm_xor_si128(data, bias), vCtrlLimitBiased);
+    __m128i match = _mm_or_si128(_mm_or_si128(cmp1, cmp2), cmp3);
+    // Each 16-bit lane produces 2 mask bits; divide by 2 for the
+    // element index.
+    unsigned mask = static_cast<unsigned>(_mm_movemask_epi8(match));
+    if (mask)
+      return p + llvh::countTrailingZeros(mask) / 2;
+    p += 8;
+  }
+#endif
+
+  return scalarScanU16(p, end);
+}
+
 } // namespace hermes

--- a/lib/VM/JSLib/JSONLexer.cpp
+++ b/lib/VM/JSLib/JSONLexer.cpp
@@ -7,6 +7,7 @@
 
 #include "JSONLexer.h"
 
+#include "hermes/Support/FastArraySearch.h"
 #include "hermes/VM/StringPrimitive.h"
 
 #include "hermes/Support/BuildTable256.h"
@@ -264,6 +265,26 @@ ExecutionStatus JSONLexer<Kind>::scanString() {
     if (LLVM_UNLIKELY(!hasChar())) {
       return error("Unexpected end of input");
     }
+
+    // SIMD fast scan: skip over runs of normal characters in bulk.
+    if constexpr (Traits::UsesRawPtr) {
+      const CharT *scanEnd;
+      if constexpr (sizeof(CharT) == 1)
+        scanEnd = scanJsonEscapeU8(iter_.cur, iter_.end);
+      else
+        scanEnd = scanJsonEscapeU16(iter_.cur, iter_.end);
+
+      if (scanEnd > iter_.cur) {
+        if constexpr (ForKey::value) {
+          for (const CharT *p = iter_.cur; p < scanEnd; ++p)
+            hash = hermes::updateJenkinsHash(hash, *p);
+        }
+        iter_.cur = scanEnd;
+        if (!hasChar())
+          return error("Unexpected end of input");
+      }
+    }
+
     CharT curVal = *iter_.cur;
     if (curVal == '"') {
       // Reached the end of string.

--- a/lib/VM/JSLib/RuntimeJSONStringify.cpp
+++ b/lib/VM/JSLib/RuntimeJSONStringify.cpp
@@ -10,6 +10,7 @@
 #include "Object.h"
 
 #include "hermes/Support/BuildTable256.h"
+#include "hermes/Support/FastArraySearch.h"
 #include "hermes/VM/ArrayLike.h"
 #include "hermes/VM/ArrayStorage.h"
 #include "hermes/VM/Callable.h"
@@ -619,6 +620,15 @@ void quoteStringForJSON(Output &output, llvh::ArrayRef<CharT> view) {
   const CharT *beginUnescPtr = begin;
   // Quote.2.
   while (cursor < end) {
+    // SIMD fast skip: advance cursor past normal characters in bulk.
+    // Only for ASCII — UTF-16 needs surrogate handling that scanJsonEscapeU16
+    // does not cover.
+    if constexpr (sizeof(CharT) == 1) {
+      const CharT *scanEnd = scanJsonEscapeU8(cursor, end);
+      cursor = scanEnd;
+      if (cursor >= end)
+        break;
+    }
     CharT ch = *cursor;
     if constexpr (sizeof(CharT) > 1) {
       if (ch >= UNICODE_SURROGATE_FIRST && ch <= UNICODE_SURROGATE_LAST) {

--- a/unittests/Support/FastArraySearchTest.cpp
+++ b/unittests/Support/FastArraySearchTest.cpp
@@ -679,4 +679,123 @@ TEST(SIMD, ReverseU64VariousOffsets) {
   EXPECT_EQ(searchReverseU64(arr, 0, 5, 42), -1);
 }
 
+//===----------------------------------------------------------------------===//
+// scanJsonEscapeU8
+//===----------------------------------------------------------------------===//
+
+TEST(SIMD, ScanU8Empty) {
+  const char *p = "";
+  EXPECT_EQ(scanJsonEscapeU8(p, p), p);
+}
+
+TEST(SIMD, ScanU8NoSpecial) {
+  const char *s = "hello world 123";
+  EXPECT_EQ(scanJsonEscapeU8(s, s + 15), s + 15);
+}
+
+TEST(SIMD, ScanU8Quote) {
+  const char *s = "hello\"world";
+  EXPECT_EQ(scanJsonEscapeU8(s, s + 11), s + 5);
+}
+
+TEST(SIMD, ScanU8Backslash) {
+  const char *s = "hello\\world";
+  EXPECT_EQ(scanJsonEscapeU8(s, s + 11), s + 5);
+}
+
+TEST(SIMD, ScanU8ControlChar) {
+  std::string s = "hello";
+  s += '\x0A'; // newline
+  s += "world";
+  EXPECT_EQ(scanJsonEscapeU8(s.data(), s.data() + s.size()), s.data() + 5);
+}
+
+TEST(SIMD, ScanU8AtStart) {
+  const char *s = "\"hello";
+  EXPECT_EQ(scanJsonEscapeU8(s, s + 6), s);
+}
+
+TEST(SIMD, ScanU8AtEnd) {
+  std::string s(30, 'a');
+  s += '"';
+  EXPECT_EQ(scanJsonEscapeU8(s.data(), s.data() + s.size()), s.data() + 30);
+}
+
+TEST(SIMD, ScanU8Large) {
+  // Test across SIMD boundaries (>16 bytes).
+  std::string s(200, 'x');
+  s[150] = '"';
+  EXPECT_EQ(scanJsonEscapeU8(s.data(), s.data() + s.size()), s.data() + 150);
+}
+
+TEST(SIMD, ScanU8LargeNoSpecial) {
+  std::string s(200, 'x');
+  EXPECT_EQ(
+      scanJsonEscapeU8(s.data(), s.data() + s.size()), s.data() + s.size());
+}
+
+TEST(SIMD, ScanU8ControlZero) {
+  std::string s = "abc";
+  s += '\0';
+  s += "def";
+  EXPECT_EQ(scanJsonEscapeU8(s.data(), s.data() + s.size()), s.data() + 3);
+}
+
+//===----------------------------------------------------------------------===//
+// scanJsonEscapeU16
+//===----------------------------------------------------------------------===//
+
+TEST(SIMD, ScanU16Empty) {
+  const char16_t *p = u"";
+  EXPECT_EQ(scanJsonEscapeU16(p, p), p);
+}
+
+TEST(SIMD, ScanU16NoSpecial) {
+  const char16_t *s = u"hello world 123";
+  EXPECT_EQ(scanJsonEscapeU16(s, s + 15), s + 15);
+}
+
+TEST(SIMD, ScanU16Quote) {
+  const char16_t *s = u"hello\"world";
+  EXPECT_EQ(scanJsonEscapeU16(s, s + 11), s + 5);
+}
+
+TEST(SIMD, ScanU16Backslash) {
+  const char16_t *s = u"hello\\world";
+  EXPECT_EQ(scanJsonEscapeU16(s, s + 11), s + 5);
+}
+
+TEST(SIMD, ScanU16ControlChar) {
+  std::u16string s = u"hello";
+  s += u'\x0A';
+  s += u"world";
+  EXPECT_EQ(scanJsonEscapeU16(s.data(), s.data() + s.size()), s.data() + 5);
+}
+
+TEST(SIMD, ScanU16Large) {
+  std::u16string s(200, u'x');
+  s[150] = u'"';
+  EXPECT_EQ(scanJsonEscapeU16(s.data(), s.data() + s.size()), s.data() + 150);
+}
+
+TEST(SIMD, ScanU16LargeNoSpecial) {
+  std::u16string s(200, u'x');
+  EXPECT_EQ(
+      scanJsonEscapeU16(s.data(), s.data() + s.size()), s.data() + s.size());
+}
+
+TEST(SIMD, ScanU16HighUnicode) {
+  // Characters above 0x1F but not quote/backslash should be skipped.
+  std::u16string s(20, u'\u4e2d'); // Chinese character
+  s += u'"';
+  EXPECT_EQ(scanJsonEscapeU16(s.data(), s.data() + s.size()), s.data() + 20);
+}
+
+TEST(SIMD, ScanU16HighBit) {
+  // Values >= 0x8000 must not false-positive as control chars.
+  std::u16string s(20, u'\uFFFF');
+  s += u'"';
+  EXPECT_EQ(scanJsonEscapeU16(s.data(), s.data() + s.size()), s.data() + 20);
+}
+
 } // namespace


### PR DESCRIPTION
Summary:

Add SIMD-optimized character scanning functions (scanSpecialCharU8, scanSpecialCharU16) that find the first byte/char16_t that is '"', '\\', or <= 0x1F. Use these in JSONLexer::scanString() to skip over runs of normal characters in bulk during the escape-free hot loop.

The SIMD scan applies only to ASCII and UTF16 encodings (where UsesRawPtr is true and we have a contiguous buffer with known bounds). UTF8 uses UTF16Stream which is not a raw pointer and is unaffected.

Jenkins hash is handled separately: after SIMD skips a range of normal characters, the hash is computed over that range in a scalar loop, keeping the SIMD scan free of data dependencies.

Implementation tiers:
- NEON (aarch64): 16 bytes / 8 char16_t per iteration
- SSE2 (x86-64): 16 bytes / 8 char16_t per iteration
- Scalar fallback for all other platforms

Reviewed By: tmikov

Differential Revision: D93549305


