### PR TITLE
Update prettier-plugin-hermes-parser in fbsource to 0.35.0

### DIFF
--- a/benchmarks/build-helpers/flow-bundler/package.json
+++ b/benchmarks/build-helpers/flow-bundler/package.json
@@ -19,7 +19,7 @@
     "hermes-transform": "0.35.0",
     "metro-react-native-babel-preset": "^0.77.0",
     "prettier": "2.8.8",
-    "prettier-plugin-hermes-parser": "0.34.1",
+    "prettier-plugin-hermes-parser": "0.35.0",
     "string-width": "4.2.3",
     "yargs": "^17.7.2"
   }

--- a/benchmarks/build-helpers/flow-bundler/yarn.lock
+++ b/benchmarks/build-helpers/flow-bundler/yarn.lock
@@ -1738,10 +1738,10 @@ pkg-dir@^3.0.0:
   dependencies:
     find-up "^3.0.0"
 
-prettier-plugin-hermes-parser@0.34.1:
-  version "0.34.1"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-hermes-parser/-/prettier-plugin-hermes-parser-0.34.1.tgz#75fc7abe0435ab45ee4431b1b1ce1a7baba6903c"
-  integrity sha512-cdA3tlvvFZkr8CuzaRJ28EVl7ep2zbfxKBBiS1t1w2Kud+Gsv/aQeU2a6rmMBnMJn510xPrIy0aZ9AG0uQHcRQ==
+prettier-plugin-hermes-parser@0.35.0:
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-hermes-parser/-/prettier-plugin-hermes-parser-0.35.0.tgz#f037f76b50669aa9fd9dcbe78ceec7b891239646"
+  integrity sha512-+qAxEwdNI6sWw/g/+OxbUp5Tt5WaiuufQpDyE95M13S+P+IO8UDmErSBUwN+QvxakcT0bGTd8sfSLJNZrfV4eg==
 
 prettier@2.8.8:
   version "2.8.8"


### PR DESCRIPTION
Summary:
Bump prettier-plugin-hermes-parser to 0.35.0.

Changelog: [internal]

Reviewed By: SamChou19815

Differential Revision: D100850992


