### PR TITLE
Fix 'occured' -> 'occurred' typos in CompilerDriver enum doc comments

### DIFF
--- a/include/hermes/CompilerDriver/CompilerDriver.h
+++ b/include/hermes/CompilerDriver/CompilerDriver.h
@@ -31,9 +31,9 @@ enum CompileStatus {
   InputFileError,
   /// An output file could not be written.
   OutputFileError,
-  /// An error occured during optimization.
+  /// An error occurred during optimization.
   OptimizationFailed,
-  /// An error occured in the backend during/after IR lowering.
+  /// An error occurred in the backend during/after IR lowering.
   BackendError,
 };
 


### PR DESCRIPTION
Two doxygen comments on the CompilerDriver result enum members in `include/hermes/CompilerDriver/CompilerDriver.h` used `An error occured`:

- line 34: `/// An error occured during optimization.`
- line 36: `/// An error occured in the backend during/after IR lowering.`

Doc-only change inside a header file.