### PR TITLE
Validate NPM token before building Static Hermes

### DIFF
--- a/.github/workflows/rn-build-hermes.yml
+++ b/.github/workflows/rn-build-hermes.yml
@@ -36,6 +36,21 @@ jobs:
         uses: ./.github/actions/setup-node
       - name: Install node dependencies
         uses: ./.github/actions/yarn-install
+      - name: Verify NPM token
+        run: |
+          if [[ -z "$GHA_NPM_TOKEN" ]]; then
+            echo "⚠️ No NPM token found. Skipping validation."
+            exit 0
+          fi
+          echo "//registry.npmjs.org/:_authToken=$GHA_NPM_TOKEN" > ~/.npmrc
+          if ! npm whoami > /dev/null 2>&1; then
+            echo "❌ NPM token is invalid or expired. Aborting release."
+            exit 1
+          fi
+          echo "✅ NPM token is valid ($(npm whoami))"
+          rm -f ~/.npmrc
+        env:
+          GHA_NPM_TOKEN: ${{ secrets.GHA_NPM_TOKEN }}
       - id: set_release_type
         run: |
           # Guard: never allow release mode on static_h branch


### PR DESCRIPTION
Summary:
Add an early NPM token validation step to the rn-build-hermes workflow.
This runs `npm whoami` right after yarn install to fail fast if the token
is expired or invalid, avoiding hours of wasted build time on a release
that would fail at the publish step.

The step gracefully skips when no token is present (e.g. PRs or pushes).

Reviewed By: lavenzg

Differential Revision: D101377186


