### PR TITLE
FlowChecker: Index constraint per arrow parameter in contextual typing

### DIFF
--- a/lib/Sema/FlowChecker-expr.cpp
+++ b/lib/Sema/FlowChecker-expr.cpp
@@ -300,6 +300,7 @@ class FlowChecker::ExprVisitor {
         }
 
         params.push_back(typedFnParam);
+        ++i;
       }
 
       Type *returnType;

--- a/test/hermes/flow/arrow-multi-param-contextual.js
+++ b/test/hermes/flow/arrow-multi-param-contextual.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+// RUN: %hermes -typed %s | %FileCheck --match-full-lines %s
+// RUN: %shermes -typed -exec %s | %FileCheck --match-full-lines %s
+
+/// Test that contextual typing for arrow function parameters indexes the
+/// constraint function type per parameter, so that the Nth arrow parameter
+/// receives the Nth parameter type from the expected callback signature.
+/// Previously every parameter was inferred as the type of the first
+/// constraint parameter.
+
+'use strict';
+
+(function () {
+
+type Entry = {name: string};
+type Counter = {value: number};
+
+function combine(
+  callback: (left: Entry, right: Counter) => string,
+): string {
+  return callback(({name: 'left'}: any), ({value: 7}: any));
+}
+
+print(
+  combine((left, right) => {
+    // 'right' must be inferred as Counter, not Entry.
+    let v: number = right.value;
+    return left.name + ':' + String(v);
+  }),
+);
+// CHECK: left:7
+
+})();


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `main`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/HEAD/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.

  Note: We kindly request that pull requests address more than just a single typo.
  While we sincerely appreciate your attention to detail, we would be most grateful
  if typo fixes were batched together to include several corrections. This helps our
  maintainers focus on substantive contributions to the codebase. Thank you for your
  understanding and cooperation!
-->

## Summary

The contextual-typing loop in `FlowChecker::ExprVisitor::visit(ArrowFunctionExpressionNode *, ..., Type *constraint)` walks arrow parameters and assigns types from `constraintFnType->getParams()[i]`, but the index `i` was never incremented inside the range-based loop.

As a result, every arrow parameter was typed as the first constraint parameter, so property access on the second and later parameters of a multi-parameter callback failed to type-check:

```ts
type Entry   = {name: string};
type Counter = {value: number};

function combine(cb: (l: Entry, r: Counter) => string): string {
  return cb(({name: 'left'}: any), ({value: 7}: any));
}

combine((l, r) => l.name + r.value);
// Before this PR: `r` is typed as Entry (the first constraint param),
// so `r.value` fails with `property 'value' not defined in object`.
```

This PR increments `i` after pushing each parameter so the Nth arrow parameter receives the Nth constraint parameter type. The existing `i < constraintFnType->getParams().size()` bounds guard keeps the fallback to `any` when the arrow parameter count exceeds the constraint arity, so mismatched-arity cases are unchanged.

A focused lit test is added that fails before the fix (`property 'value' not defined in object`) and passes after.


## Test Plan

- `ninja -C build check-hermes` — full suite passes; 2897 expected passes, no regressions.
- The new test `test/hermes/flow/arrow-multi-param-contextual.js` fails on `static_h` without the fix and passes with the fix applied.
- Reproduces the original symptom on a minimal multi-parameter callback (`(left: Entry, right: Counter) => string`) and asserts that property access on the second parameter type-checks.
