### PR TITLE
[Legacy] Bump `hermes-compiler` on `main` to 0.18.0

### DIFF
--- a/npm/hermes-compiler/package.json
+++ b/npm/hermes-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-compiler",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "private": false,
   "description": "The hermes compiler CLI used during the React Native build process",
   "license": "MIT",


### PR DESCRIPTION
As part of branch cutting for React Native OSS (which still supports legacy Hermes), React Native 0.86 will [track](https://github.com/facebook/react-native/commit/89a2a20739ceda065cdc605397bfe9c178403b4a) [`release-v0.17`](https://github.com/facebook/hermes/tree/release-v0.17) of (legacy) Hermes, which I cut yesterday.

This bumps the version on `main` to `0.18.0` ready for the next branch cut (per [release process](https://github.com/reactwg/react-native-releases/blob/main/docs/guide-hermes-release.md#step-5-bump-version-on-main-and-hermes-v1-release-branch), see also #1871, #1923).