### PR TITLE
Implement `Promise.withResolvers()` and `Promise.try(func, arg1, arg2, /* …, */ argN)`

### DIFF
--- a/utils/promise/Promise.try.js
+++ b/utils/promise/Promise.try.js
@@ -1,0 +1,6 @@
+Promise.try = function promiseTry(callbackFn) {
+  var args = arguments;
+  return new Promise(function (resolve) {
+    resolve(callbackFn.apply(undefined, iterableToArray(args).slice(1)));
+  });
+};

--- a/utils/promise/Promise.withResolvers.js
+++ b/utils/promise/Promise.withResolvers.js
@@ -1,0 +1,11 @@
+Promise.withResolvers = function () {
+  var resolve;
+  var reject;
+
+  var promise = new Promise(function (res, rej) {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise: promise, resolve: resolve, reject: reject };
+}

--- a/utils/promise/index.js
+++ b/utils/promise/index.js
@@ -5,6 +5,8 @@
 const Promise = require('promise/setimmediate/es6-extensions');
 
 require('promise/setimmediate/finally');
+require('./Promise.withResolvers.js'); // Specification: https://tc39.es/ecma262/#sec-promise.withResolvers
+require('./Promise.try.js');  // Specification: https://tc39.es/ecma262/#sec-promise.try
 
 // expose Promise to global.
 globalThis.Promise = Promise;


### PR DESCRIPTION

## Summary

To be honest, contributing to open-source can be quite demotivating. I want to bring something useful to the community, but nobody seems interested in reviewing my pull requests: [PR1](https://github.com/then/promise/pull/179) and [PR2](https://github.com/then/promise/pull/180). The maintainers are unreachable, providing zero feedback on GitHub and ignore me in other social networks.

I’m fed up with trying to reach out to the promise maintainers for months, so I’ve decided to implement it directly in the Hermes engine.

---


`Promise.try(fn, ...args)` :
- Specification: https://tc39.es/ecma262/#sec-promise.try
- Docs: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/try
- TS: [TypeScript/src/lib/esnext.promise.d.ts](https://github.com/microsoft/TypeScript/blob/66edca11c98ade9a5e2a2b019fdad7d58ee9d4ac/src/lib/esnext.promise.d.ts#L15)




The `Promise.try()` static method takes a callback of any kind (returns or throws, synchronously or asynchronously) and wraps its result in a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).

```tsx
Promise.try(() => func(arg1, arg2));
// or you can do this 
Promise.try(func, arg1, arg2);
```




----


`Promise.withResolvers()` :
- Specification: https://tc39.es/ecma262/#sec-promise.withResolvers
- Docs: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers
- TS: [TypeScript/src/lib/es2024.promise.d.ts](https://github.com/microsoft/TypeScript/blob/66edca11c98ade9a5e2a2b019fdad7d58ee9d4ac/src/lib/es2024.promise.d.ts#L16)




`Promise.withResolvers()` is exactly equivalent to the following code:

```tsx
let resolve, reject;
const promise = new Promise((res, rej) => {
  resolve = res;
  reject = rej;
});
```




## Test Plan


you run examples from MDN