### PR TITLE
Pass the rejected Promise to rejection-tracker callbacks

### DIFF
--- a/lib/InternalJavaScript/01-Promise.js
+++ b/lib/InternalJavaScript/01-Promise.js
@@ -449,6 +449,7 @@
         rejections[promise._E] = {
           displayId: null,
           error: err,
+          promise: promise,
           timeout: setTimeout(
             onUnhandled.bind(null, promise._E),
             // For reference errors and type errors, this almost always
@@ -476,7 +477,8 @@
           rejections[id].logged = true;
           options.onUnhandled(
             rejections[id].displayId,
-            rejections[id].error
+            rejections[id].error,
+            rejections[id].promise
           );
         } else {
           rejections[id].logged = true;
@@ -490,7 +492,11 @@
     function onHandled(id) {
       if (rejections[id].logged) {
         if (options.onHandled) {
-          options.onHandled(rejections[id].displayId, rejections[id].error);
+          options.onHandled(
+            rejections[id].displayId,
+            rejections[id].error,
+            rejections[id].promise
+          );
         } else if (!rejections[id].onUnhandled) {
           console.warn(
             'Promise Rejection Handled (id: ' + rejections[id].displayId + '):'

--- a/test/hermes/promise.js
+++ b/test/hermes/promise.js
@@ -33,18 +33,23 @@ promise.then(function(message) {
 });
 // CHECK-NEXT: Resolved: success!
 
+var deferred;
 HermesInternal.enablePromiseRejectionTracker({
   allRejections: true,
-  onUnhandled: function(id, error) {
-    print("Unhandled:", error);
+  onUnhandled: function(id, error, p) {
+    print("Unhandled:", error, "samePromise:", p === deferred);
   },
 });
 
-var promise = new Promise(function(res, rej) {
+var rejectedPromise = new Promise(function(res, rej) {
   rej("failure!");
 });
 
-promise.then(function() {
+// `.then()` attaches a handler to `rejectedPromise`, which fires `_B` and
+// clears its rejection entry. The rejection then propagates to the deferred
+// promise that `.then()` returns; that's the promise the tracker eventually
+// reports as unhandled.
+deferred = rejectedPromise.then(function() {
   print('resolved');
 });
-// CHECK-NEXT: Unhandled: failure!
+// CHECK-NEXT: Unhandled: failure! samePromise: true


### PR DESCRIPTION
## Summary

Cherry-pick of upstream `static_h` commit `988db9411a6d7cd3f3c47fe6fcc8725eb9bd20a3` onto `250829098.0.0-stable`.

Threads the rejected `Promise` instance through as a 3rd positional argument to `options.onUnhandled` / `options.onHandled` in `lib/InternalJavaScript/01-Promise.js`, and updates the LIT `test/hermes/promise.js` test to assert the new arg.

Backwards compatible: existing 2-arg consumers continue to work because the extra positional argument is ignored.

## Test plan

- CI runs the LIT test suite, which includes the updated `test/hermes/promise.js`.