### PR TITLE
Implement `Promise.try(func, arg1, arg2, /* …, */ argN)`

### DIFF
--- a/lib/InternalJavaScript/01-Promise.js
+++ b/lib/InternalJavaScript/01-Promise.js
@@ -417,6 +417,13 @@
     return { promise: promise, resolve: resolve, reject: reject };
   };
 
+  core.try = function (callback) {
+    var args = arguments;
+    return new this(function (res) {
+      res(callback.apply(undefined, iterableToArray(args).slice(1)))
+    });
+  };
+
   core.prototype.finally = function (f) {
     return this.then(function (value) {
       return core.resolve(f()).then(function () {

--- a/test/hermes/promise-try.js
+++ b/test/hermes/promise-try.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes %s | %FileCheck --match-full-lines %s
+// RUN: %hermes -Xmicrotask-queue %s | %FileCheck --match-full-lines %s
+
+print('promise-try');
+// CHECK-LABEL: promise-try
+
+// try exists and is a function
+print(typeof Promise.try);
+// CHECK-NEXT: function
+// CHECK-NEXT: true
+
+// Basic resolve
+var r1 = Promise.try(function () { return 30; });
+print(r1 instanceof Promise);
+r1.then(function(v) { print('resolved:', v); });
+
+// Basic reject
+var r2 = Promise.try(function () { throw 'oops...'; });
+r2.then(null, function(e) { print('rejected:', e); });
+
+// Arguments passing down
+var r3 = Promise.try(function (a,b,c) { return a + b + c; }, 1, 2, 3);
+r3.then(function(v) { print('arguments:', v); });
+
+// No callback
+var r4 = Promise.try();
+r4.then(null, function(e) { print('no_callback:', e.message); });
+
+// Async callback
+var r5 = Promise.try(function () { return Promise.resolve(31) })
+r5.then(function(v) { print('async resolved:', v); });
+
+// Microtask callbacks run after all synchronous code
+// CHECK-NEXT: resolved: 30
+// CHECK-NEXT: rejected: oops...
+// CHECK-NEXT: arguments: 6
+// CHECK-NEXT: no_callback: Cannot read property 'apply' of undefined
+// CHECK-NEXT: async resolved: 31

--- a/utils/testsuite/skiplist.json
+++ b/utils/testsuite/skiplist.json
@@ -392,9 +392,6 @@
         "test262/test/built-ins/Promise/race/invoke-resolve-on-promises-every-iteration-of-custom.js",
         "test262/test/built-ins/Promise/race/resolve-non-callable.js",
         "test262/test/built-ins/Promise/resolve/resolve-self.js",
-        "test262/test/built-ins/Promise/try/args.js",
-        "test262/test/built-ins/Promise/try/return-value.js",
-        "test262/test/built-ins/Promise/try/throws.js",
         "test262/test/language/statements/for-await-of/iterator-close-throw-get-method-abrupt.js",
         "test262/test/language/statements/for-await-of/iterator-close-throw-get-method-non-callable.js"
       ],
@@ -604,14 +601,10 @@
       "comment": "These are rest failing tests in mjsunit that we may support soon."
     },
     {
-      "comment": "Promise.try is not implemented. All Promise.try tests fail with 'undefined is not a function'.",
+      "comment": "Promise.try is implemented but a 'try' prop defined no by spec.",
       "paths": [
-        "test262/test/built-ins/Promise/try/ctx-ctor-throws.js",
-        "test262/test/built-ins/Promise/try/ctx-ctor.js",
-        "test262/test/built-ins/Promise/try/length.js",
         "test262/test/built-ins/Promise/try/name.js",
         "test262/test/built-ins/Promise/try/not-a-constructor.js",
-        "test262/test/built-ins/Promise/try/promise.js",
         "test262/test/built-ins/Promise/try/prop-desc.js"
       ]
     },


### PR DESCRIPTION


## Summary

`Promise.try(fn, ...args)` :
- Specification: https://tc39.es/ecma262/#sec-promise.try
- Docs: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/try
- TS: [TypeScript/src/lib/esnext.promise.d.ts](https://github.com/microsoft/TypeScript/blob/66edca11c98ade9a5e2a2b019fdad7d58ee9d4ac/src/lib/esnext.promise.d.ts#L15)




The `Promise.try()` static method takes a callback of any kind (returns or throws, synchronously or asynchronously) and wraps its result in a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).

```tsx
Promise.try(() => func(arg1, arg2));
// or you can do this 
Promise.try(func, arg1, arg2);
```




## Test Plan

```bash
LIT_OPTS="-j1" LIT_FILTER="promise-try.js" cmake --build build --target check-hermes
```
