### PR TITLE
Fix dict HiddenClass sharing in RegExp .groups

### DIFF
--- a/lib/VM/JSLib/RegExp.cpp
+++ b/lib/VM/JSLib/RegExp.cpp
@@ -477,16 +477,84 @@ static ExecutionStatus regExpConstructorFastCopy(
   return ExecutionStatus::RETURNED;
 }
 
-static void createGroupsObject(
+/// Build an object whose property keys are identical to \p mappingObj. Each
+/// value for a given property key `k` in this object is
+/// `source[mappingObj[k]]`. The result has a null prototype.
+static CallResult<PseudoHandle<JSObject>> buildGroupsObject(
     Runtime &runtime,
-    Handle<JSArray> matchObj,
-    Handle<JSObject> mappingObj) {
+    Handle<JSObject> mappingObj,
+    Handle<JSArray> source) {
   struct : public Locals {
-    PinnedValue<HiddenClass> clazzHandle;
+    PinnedValue<HiddenClass> clazz;
     PinnedValue<JSObject> groupsObj;
+    PinnedValue<> tmpVal;
   } lv;
   LocalsRAII lraii(runtime, &lv);
 
+  lv.clazz = mappingObj->getClass(runtime);
+
+  if (LLVM_LIKELY(!lv.clazz->isDictionary())) {
+    // Fast path: non-dictionary class is safe to share between groupsObj and
+    // mappingObj.
+    lv.groupsObj =
+        JSObject::create(runtime, Runtime::makeNullHandle<JSObject>(), lv.clazz)
+            .get();
+    HiddenClass::forEachProperty(
+        lv.clazz, runtime, [&](SymbolID, NamedPropertyDescriptor desc) {
+          assert(
+              !desc.flags.privateName &&
+              "private name not expected in regex mapping object");
+          auto idx =
+              JSObject::getNamedSlotValueUnsafe(*mappingObj, runtime, desc.slot)
+                  .getNumber(runtime);
+          JSObject::setNamedSlotValueUnsafe(
+              lv.groupsObj.get(), runtime, desc.slot, source->at(runtime, idx));
+        });
+    return PseudoHandle<JSObject>::create(lv.groupsObj.get());
+  }
+
+  // Slow path: mappingObj's class is in dictionary mode. Dictionary classes
+  // are owned by a single object and mutated in place; sharing one with
+  // groupsObj would let a later mutation on this `groups` grow the shared
+  // class past the underlying propStorage of any sibling (out-of-bounds
+  // read/write). Build groupsObj with its own fresh class instead.
+  //
+  // Calling defineNewOwnProperty inside HiddenClass::forEachPropertyWhile is
+  // safe: it only touches groupsObj's class chain (independent from
+  // lv.clazz), and forEachPropertyWhile flushes the GCScope after each
+  // callback so handle counts stay bounded.
+  lv.groupsObj =
+      JSObject::create(runtime, Runtime::makeNullHandle<JSObject>()).get();
+  ExecutionStatus status = ExecutionStatus::RETURNED;
+  HiddenClass::forEachPropertyWhile(
+      lv.clazz,
+      runtime,
+      [&](Runtime &, SymbolID id, NamedPropertyDescriptor desc) -> bool {
+        auto idx =
+            JSObject::getNamedSlotValueUnsafe(*mappingObj, runtime, desc.slot)
+                .getNumber(runtime);
+        lv.tmpVal = source->at(runtime, idx).unboxToHV(runtime);
+        if (LLVM_UNLIKELY(
+                JSObject::defineNewOwnProperty(
+                    lv.groupsObj,
+                    runtime,
+                    id,
+                    PropertyFlags::defaultNewNamedPropertyFlags(),
+                    lv.tmpVal) == ExecutionStatus::EXCEPTION)) {
+          status = ExecutionStatus::EXCEPTION;
+          return false;
+        }
+        return true;
+      });
+  if (LLVM_UNLIKELY(status == ExecutionStatus::EXCEPTION))
+    return ExecutionStatus::EXCEPTION;
+  return PseudoHandle<JSObject>::create(lv.groupsObj.get());
+}
+
+static ExecutionStatus setMatchGroups(
+    Runtime &runtime,
+    Handle<JSArray> matchObj,
+    Handle<JSObject> mappingObj) {
   // matchObj is created with a HiddenClass that already has the groups
   // property.
   NamedPropertyDescriptor groupsDesc;
@@ -502,34 +570,19 @@ static void createGroupsObject(
   if (!mappingObj) {
     auto shv = SmallHermesValue::encodeUndefinedValue();
     JSObject::setNamedSlotValueUnsafe(matchObj.get(), runtime, groupsDesc, shv);
-    return;
+    return ExecutionStatus::RETURNED;
   }
 
   // The `__proto__` property on the groups object is not special,
   // and does not affect the [[Prototype]] of the resulting groups object.
   // This means that the prototype of the resulting groups object is null.
-  lv.clazzHandle = mappingObj->getClass(runtime);
-  auto groupsObjRes = JSObject::create(
-      runtime, Runtime::makeNullHandle<JSObject>(), lv.clazzHandle);
-  lv.groupsObj = groupsObjRes.get();
+  auto groupsRes = buildGroupsObject(runtime, mappingObj, matchObj);
+  if (LLVM_UNLIKELY(groupsRes == ExecutionStatus::EXCEPTION))
+    return ExecutionStatus::EXCEPTION;
 
-  HiddenClass::forEachProperty(
-      lv.clazzHandle, runtime, [&](SymbolID id, NamedPropertyDescriptor desc) {
-        assert(
-            !desc.flags.privateName &&
-            "private name not expected in regex mapping object");
-        auto groupIdx =
-            JSObject::getNamedSlotValueUnsafe(*mappingObj, runtime, desc.slot)
-                .getNumber(runtime);
-        JSObject::setNamedSlotValueUnsafe(
-            lv.groupsObj.get(),
-            runtime,
-            desc.slot,
-            matchObj->at(runtime, groupIdx));
-      });
-
-  auto shv = SmallHermesValue::encodeObjectValue(lv.groupsObj.get(), runtime);
+  auto shv = SmallHermesValue::encodeObjectValue(groupsRes->get(), runtime);
   JSObject::setNamedSlotValueUnsafe(matchObj.get(), runtime, groupsDesc, shv);
+  return ExecutionStatus::RETURNED;
 }
 
 /// ES2022 22.2.7.8 MakeMatchIndicesIndexPairArray
@@ -545,7 +598,6 @@ static ExecutionStatus makeMatchIndicesIndexPairArray(
     PinnedValue<> groups;
     PinnedValue<JSArray> A;
     PinnedValue<JSArray> pair;
-    PinnedValue<HiddenClass> mappingObjClazz;
     PinnedValue<JSObject> groupsObj;
   } lv;
   LocalsRAII lraii(runtime, &lv);
@@ -602,29 +654,13 @@ static ExecutionStatus makeMatchIndicesIndexPairArray(
   // 6. If hasGroups is true, then
   if (hasGroups) {
     // a. Let groups be OrdinaryObjectCreate(null).
-    lv.mappingObjClazz = mappingObj->getClass(runtime);
-    auto groupsRes = JSObject::create(
-        runtime, Runtime::makeNullHandle<JSObject>(), lv.mappingObjClazz);
-    lv.groupsObj = groupsRes.get();
-    HiddenClass::forEachProperty(
-        lv.mappingObjClazz,
-        runtime,
-        [&](SymbolID id, NamedPropertyDescriptor desc) {
-          assert(
-              !desc.flags.privateName &&
-              "private name not expected in regex mapping object");
-          auto groupIdx =
-              JSObject::getNamedSlotValueUnsafe(*mappingObj, runtime, desc.slot)
-                  .getNumber(runtime);
-          // 9.e. If i > 0 and groupNames[i - 1] is not undefined, then
-          // ii. Perform ! CreateDataPropertyOrThrow(groups, groupNames[i-1],
-          // matchIndexPair).
-          JSObject::setNamedSlotValueUnsafe(
-              lv.groupsObj.get(),
-              runtime,
-              desc.slot,
-              lv.A.get()->at(runtime, groupIdx));
-        });
+    // 9.e. If i > 0 and groupNames[i - 1] is not undefined, then
+    // ii. Perform ! CreateDataPropertyOrThrow(groups, groupNames[i-1],
+    // matchIndexPair).
+    auto groupsRes = buildGroupsObject(runtime, mappingObj, lv.A);
+    if (LLVM_UNLIKELY(groupsRes == ExecutionStatus::EXCEPTION))
+      return ExecutionStatus::EXCEPTION;
+    lv.groupsObj = groupsRes->get();
     lv.groups = lv.groupsObj.getHermesValue();
   } else {
     // 7. Else,
@@ -855,7 +891,10 @@ ExecutionStatus directRegExpExec(
     }
   }
 
-  createGroupsObject(runtime, lv.A, groupNames);
+  if (LLVM_UNLIKELY(
+          setMatchGroups(runtime, lv.A, groupNames) ==
+          ExecutionStatus::EXCEPTION))
+    return ExecutionStatus::EXCEPTION;
   resultOut.castAndSetHermesValue<JSArray>(lv.A.getHermesValue());
   return ExecutionStatus::RETURNED;
 }

--- a/test/hermes/regress-shared-dictionary-hc-regexp.js
+++ b/test/hermes/regress-shared-dictionary-hc-regexp.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -O %s | %FileCheck --match-full-lines %s
+// RUN: %shermes -exec %s | %FileCheck --match-full-lines %s
+
+// Regression: RegExp must not reuse the per-regexp groupNameMappings_
+// HiddenClass for the .groups (or .indices.groups) object. With at least
+// kDictionaryThreshold + 1 named groups that class is in dictionary mode,
+// and dictionary classes are owned by exactly one object and mutated in
+// place; sharing one lets a mutation on one match's .groups corrupt
+// another (out-of-bounds property storage access).
+
+// kDictionaryThreshold + 1: the slow-path object transitions to a dictionary.
+var N = 65;
+
+var src = '', input = '';
+for (var i = 0; i < N; i++) { src += '(?<g' + i + '>.)'; input += 'x'; }
+var re = new RegExp(src, 'd');
+var m1 = re.exec(input), m2 = re.exec(input);
+delete m1.groups.g1;
+print(Object.keys(m2.groups).length, m2.groups.g1);
+// CHECK: 65 x
+m1.groups.EXTRA = 'BAD';
+print(m2.groups.EXTRA);
+// CHECK-NEXT: undefined
+
+// Same for the .indices.groups path.
+print(Object.keys(m1.indices.groups).length);
+// CHECK-NEXT: 65
+delete m1.indices.groups.g1;
+print(Object.keys(m2.indices.groups).length, m2.indices.groups.g1[0]);
+// CHECK-NEXT: 65 1


### PR DESCRIPTION
Summary:
createGroupsObject and makeMatchIndicesIndexPairArray pass mappingObj->getClass() (the per-regexp groupNameMappings_ class) directly to JSObject::create, so every match's .groups and .indices.groups shares that class. With at least
kDictionaryThreshold + 1 = 65 named capture groups, the class is in dictionary mode. Dictionary classes are documented as single-owner and mutated in place (HiddenClass.h:99-105): adding a property via one .groups appends to the shared DictPropertyMap and grows that object's propStorage_; the sibling .groups objects' storage is not grown, so subsequent reads/writes via the new name address slots past their propStorage_ and corrupt the GC heap. A regex with 65+ named groups whose matches are reused and mutated will silently crash or misbehave; this is a robustness defect, not a security boundary (Hermes treats JS source as trusted).

Extract a buildGroupsObject helper. Fast path (LLVM_LIKELY, non-dictionary) is byte-equivalent to the previous code: share the class, setNamedSlotValueUnsafe per slot. Slow path builds groupsObj with its own fresh class, defining each property with defineNewOwnProperty under per-iteration GCScopeMarkerRAII (otherwise 65+ handles accumulate into the caller's GCScope and overflow). Both call sites now invoke the helper. createGroupsObject and directRegExpExec propagate the new ExecutionStatus.

Reviewed By: micleo2

Differential Revision: D103232951

fbshipit-source-id: e0d10417eda51074658af1fab012a73d84546de4