### PR TITLE
Cherrypick `Promise.try` and `Promise.withResolvers` to the Hermes V1 branch (250829098.0.0-stable)

### DIFF
--- a/lib/InternalJavaScript/01-Promise.js
+++ b/lib/InternalJavaScript/01-Promise.js
@@ -396,6 +396,22 @@
     });
   };
 
+  core.withResolvers = function () {
+    var resolve, reject;
+    var promise = new this(function (res, rej) {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise: promise, resolve: resolve, reject: reject };
+  };
+
+  core.try = function (callback) {
+    var args = arguments;
+    return new this(function (res) {
+      res(callback.apply(undefined, iterableToArray(args).slice(1)))
+    });
+  };
+
   core.prototype.finally = function (f) {
     return this.then(function (value) {
       return core.resolve(f()).then(function () {

--- a/test/hermes/promise-try.js
+++ b/test/hermes/promise-try.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes %s | %FileCheck --match-full-lines %s
+// RUN: %hermes -Xmicrotask-queue %s | %FileCheck --match-full-lines %s
+
+print('promise-try');
+// CHECK-LABEL: promise-try
+
+// try exists and is a function
+print(typeof Promise.try);
+// CHECK-NEXT: function
+// CHECK-NEXT: true
+
+// Basic resolve
+var r1 = Promise.try(function () { return 30; });
+print(r1 instanceof Promise);
+r1.then(function(v) { print('resolved:', v); });
+
+// Basic reject
+var r2 = Promise.try(function () { throw 'oops...'; });
+r2.then(null, function(e) { print('rejected:', e); });
+
+// Arguments passing down
+var r3 = Promise.try(function (a,b,c) { return a + b + c; }, 1, 2, 3);
+r3.then(function(v) { print('arguments:', v); });
+
+// No callback
+var r4 = Promise.try();
+r4.then(null, function(e) { print('no_callback:', e.message); });
+
+// Async callback
+var r5 = Promise.try(function () { return Promise.resolve(31) })
+r5.then(function(v) { print('async resolved:', v); });
+
+// Microtask callbacks run after all synchronous code
+// CHECK-NEXT: resolved: 30
+// CHECK-NEXT: rejected: oops...
+// CHECK-NEXT: arguments: 6
+// CHECK-NEXT: no_callback: Cannot read property 'apply' of undefined
+// CHECK-NEXT: async resolved: 31

--- a/test/hermes/promise-withResolvers.js
+++ b/test/hermes/promise-withResolvers.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes %s | %FileCheck --match-full-lines %s
+// RUN: %hermes -Xmicrotask-queue %s | %FileCheck --match-full-lines %s
+
+print('promise-withResolvers');
+// CHECK-LABEL: promise-withResolvers
+
+// withResolvers exists and is a function
+print(typeof Promise.withResolvers);
+// CHECK-NEXT: function
+
+// Basic resolve
+var r1 = Promise.withResolvers();
+print(r1.promise instanceof Promise);
+// CHECK-NEXT: true
+print(typeof r1.resolve);
+// CHECK-NEXT: function
+print(typeof r1.reject);
+// CHECK-NEXT: function
+r1.resolve(42);
+r1.promise.then(function(v) { print('resolved:', v); });
+
+// Basic reject
+var r2 = Promise.withResolvers();
+r2.reject('oops');
+r2.promise.then(null, function(e) { print('rejected:', e); });
+
+// Subclass support (uses 'this' as constructor)
+class MyPromise extends Promise {}
+var r3 = Promise.withResolvers.call(MyPromise);
+print(r3.promise instanceof MyPromise);
+// CHECK-NEXT: true
+r3.resolve('sub');
+r3.promise.then(function(v) { print('subclass:', v); });
+
+// Microtask callbacks run after all synchronous code
+// CHECK-NEXT: resolved: 42
+// CHECK-NEXT: rejected: oops
+// CHECK-NEXT: subclass: sub


### PR DESCRIPTION
## Summary

Based on this conversations: https://github.com/facebook/hermes/pull/2018#issuecomment-4443759708


## Test Plan


```
LIT_OPTS="-j1" LIT_FILTER="promise-try.js" cmake --build build --target check-hermes
LIT_OPTS="-j1" LIT_FILTER="promise-withResolvers.js" cmake --build build --target check-hermes
```



