### PR TITLE
Skip breakpoints on read-only bytecode pages instead of aborting

### DIFF
--- a/API/hermes/hermes.cpp
+++ b/API/hermes/hermes.cpp
@@ -254,7 +254,8 @@ class HermesRuntimeImpl final : public HermesRuntime,
                                 private IHermesTestHelpers,
                                 private InstallHermesFatalErrorHandler,
                                 private jsi::Instrumentation,
-                                public ISetEventLoopControl
+                                public ISetEventLoopControl,
+                                public ICancelAsyncTimeout
 #ifdef JSI_UNSTABLE
     ,
                                 public jsi::ISerialization,
@@ -1323,6 +1324,7 @@ class HermesRuntimeImpl final : public HermesRuntime,
   void registerForProfiling() override;
   void unregisterForProfiling() override;
   void asyncTriggerTimeout() override;
+  bool asyncCancelTimeout() override;
   void watchTimeLimit(uint32_t timeoutInMs) override;
   void unwatchTimeLimit() override;
   jsi::Value evaluateJavaScriptWithSourceMap(
@@ -1622,6 +1624,8 @@ jsi::ICast *HermesRuntimeImpl::castInterface(const jsi::UUID &interfaceUUID) {
     return static_cast<IHermes *>(this);
   } else if (interfaceUUID == IHermesSHUnit::uuid) {
     return static_cast<IHermesSHUnit *>(this);
+  } else if (interfaceUUID == ICancelAsyncTimeout::uuid) {
+    return static_cast<ICancelAsyncTimeout *>(this);
   }
 #ifdef JSI_UNSTABLE
   else if (interfaceUUID == ISerialization::uuid) {
@@ -1900,6 +1904,17 @@ void HermesRuntimeImpl::asyncTriggerTimeout() {
   // and NoMutatorScope uses non-atomic counters that would race with the
   // main thread. triggerTimeoutAsyncBreak() is already thread-safe.
   runtime_.triggerTimeoutAsyncBreak();
+}
+
+bool HermesRuntimeImpl::asyncCancelTimeout() {
+  // Unlike asyncTriggerTimeout(), this may only be called on the JS thread
+  // (see the IHermes contract), so NoMutatorScope is safe here. That
+  // contract is also what makes the clear below correct: on this thread the
+  // interpreter is either not running or suspended in the native frame that
+  // called us, so it cannot concurrently consume the request in an async
+  // break check.
+  vm::NoMutatorScope noMutatorScope{runtime_};
+  return runtime_.cancelTimeoutAsyncBreak();
 }
 
 void HermesRuntimeImpl::watchTimeLimit(uint32_t timeoutInMs) {

--- a/API/hermes_sandbox/HermesSandboxRuntime.cpp
+++ b/API/hermes_sandbox/HermesSandboxRuntime.cpp
@@ -9,6 +9,7 @@
 
 #include "external/hermes_sandbox_impl_compiled.h"
 #include "hermes/ADT/ManagedChunkedList.h"
+#include "jsi/hermes-interfaces.h"
 #include "jsi/jsilib.h"
 
 #include <atomic>
@@ -897,6 +898,7 @@ class NativeTable {
 #define THROW_UNIMPLEMENTED() throwUnimplementedImpl(__func__)
 
 class HermesSandboxRuntimeImpl : public facebook::hermes::HermesSandboxRuntime,
+                                 public facebook::hermes::ICancelAsyncTimeout,
                                  public W2CHermesRAII {
   class ManagedPointerHolder;
 
@@ -1741,6 +1743,20 @@ class HermesSandboxRuntimeImpl : public facebook::hermes::HermesSandboxRuntime,
 
   void asyncTriggerTimeout() override {
     asyncTimeout_.store(true, std::memory_order_relaxed);
+  }
+
+  bool asyncCancelTimeout() override {
+    // The flag lives on the host side and the sandboxed interpreter polls it
+    // through a host callback (see the testAndClearAsyncTimeout vtable use),
+    // so clearing it here fully cancels a not-yet-observed request.
+    return testAndClearAsyncTimeout();
+  }
+
+  ICast *castInterface(const UUID &interfaceUUID) override {
+    if (interfaceUUID == facebook::hermes::ICancelAsyncTimeout::uuid) {
+      return static_cast<facebook::hermes::ICancelAsyncTimeout *>(this);
+    }
+    return Runtime::castInterface(interfaceUUID);
   }
 
   /// Return true if an asynchronous timeout has been triggered.

--- a/API/hermes_sandbox/HermesSandboxRuntime.h
+++ b/API/hermes_sandbox/HermesSandboxRuntime.h
@@ -28,7 +28,9 @@ class HERMES_EXPORT HermesSandboxRuntime : public jsi::Runtime {
       const std::string &sourceURL) = 0;
 
   /// Asynchronously terminates the current execution. This can be called on
-  /// any thread.
+  /// any thread. A pending, not-yet-observed termination request can be
+  /// cancelled via the ICancelAsyncTimeout interface (obtained with
+  /// castInterface).
   virtual void asyncTriggerTimeout() = 0;
 };
 

--- a/API/jsi/jsi/hermes-interfaces.h
+++ b/API/jsi/jsi/hermes-interfaces.h
@@ -182,7 +182,8 @@ class JSI_EXPORT IHermes : public jsi::ICast {
   /// the emitted code contains async break checks).
 
   /// Asynchronously terminates the current execution. This can be called on
-  /// any thread.
+  /// any thread. A pending, not-yet-observed termination request can be
+  /// cancelled via the ICancelAsyncTimeout interface, where supported.
   virtual void asyncTriggerTimeout() = 0;
 
   /// Register this runtime for execution time limit monitoring, with a time
@@ -219,6 +220,35 @@ class JSI_EXPORT IHermes : public jsi::ICast {
 
  protected:
   ~IHermes() = default;
+};
+
+/// Cancellation counterpart to IHermes::asyncTriggerTimeout(), for runtimes
+/// that support it. Obtained via castInterface; a null result means the
+/// runtime does not support cancellation.
+class ICancelAsyncTimeout : public jsi::ICast {
+ public:
+  static constexpr jsi::UUID uuid{
+      0x46e249ba,
+      0xd059,
+      0x4900,
+      0x9f22,
+      0xbbbc43b52e0b};
+
+  /// Cancel a pending timeout previously requested with
+  /// IHermes::asyncTriggerTimeout() that has not yet been observed by
+  /// executing JS. \return true if a pending timeout was cancelled, false if
+  /// there was none (either none was triggered, or it already terminated an
+  /// execution). Unlike asyncTriggerTimeout(), this may only be called on
+  /// the thread that executes JS on this runtime -- either between
+  /// executions or from a native frame invoked by executing JS. Calling it
+  /// from another thread would race the interpreter's consumption of the
+  /// request. This is the analog of V8's Isolate::CancelTerminateExecution:
+  /// without it, a timeout that fires after the targeted execution completed
+  /// remains pending and terminates the next, unrelated execution.
+  virtual bool asyncCancelTimeout() = 0;
+
+ protected:
+  ~ICancelAsyncTimeout() = default;
 };
 
 /// Interface for provide Hermes backend specific methods.

--- a/include/hermes/VM/CodeBlock.h
+++ b/include/hermes/VM/CodeBlock.h
@@ -371,7 +371,11 @@ class CodeBlock final : private llvh::TrailingObjects<
   /// at location \p offset.
   /// Requires that there's a breakpoint registered at \p offset.
   /// Increments the user count of the associated runtime module.
-  void installBreakpointAtOffset(uint32_t offset);
+  /// \return true on success; false if the bytecode page cannot be made
+  ///   writable (e.g. statically embedded bytecode in a read-only segment
+  ///   that the OS refuses to remap, such as macOS __DATA_CONST under
+  ///   hardened runtime). On failure, no state is modified.
+  LLVM_NODISCARD bool installBreakpointAtOffset(uint32_t offset);
 
   /// Uninstalls the debugger instruction from the opcode stream
   /// at location \p offset, replacing it with \p opCode.

--- a/include/hermes/VM/Debugger/Debugger.h
+++ b/include/hermes/VM/Debugger/Debugger.h
@@ -473,8 +473,13 @@ class Debugger {
   /// for the given codeBlock and offset, else creates one.
   /// Used by other functions which should be called to set breakpoints.
   /// Installs a breakpoint at that location, doesn't modify it.
-  /// \return the location at which the breakpoint was installed.
-  BreakpointLocation &installBreakpoint(CodeBlock *codeBlock, uint32_t offset);
+  /// \return a pointer to the location at which the breakpoint was installed,
+  ///   or nullptr if the bytecode page cannot be made writable (e.g.
+  ///   statically embedded bytecode in a read-only segment that the OS
+  ///   refuses to remap). On failure, no state is modified.
+  LLVM_NODISCARD BreakpointLocation *installBreakpoint(
+      CodeBlock *codeBlock,
+      uint32_t offset);
 
   /// Helper function to uninstall a breakpoint. Always use this function to
   /// uninstall breakpoints. This takes care of the case when we purposely keep
@@ -489,7 +494,11 @@ class Debugger {
   /// If the physical breakpoint isn't enabled yet, patches the debugger
   /// instruction in.
   /// Sets the breakpoint ID to \p id.
-  void
+  /// \return true on success; false if the bytecode page cannot be made
+  ///   writable. On failure, no state is modified and the breakpoint is not
+  ///   physically installed (the caller may still keep it in
+  ///   userBreakpoints_ as a record).
+  bool
   setUserBreakpoint(CodeBlock *codeBlock, uint32_t offset, BreakpointID id);
 
   /// Should not be called directly except from \p setStepBreakpoint() or \p

--- a/include/hermes/VM/Runtime.h
+++ b/include/hermes/VM/Runtime.h
@@ -745,6 +745,16 @@ class Runtime : public RuntimeBase, public HandleRootOwner {
     triggerAsyncBreak(AsyncBreakReasonBits::Timeout);
   }
 
+  /// Cancel a timeout async break requested via triggerTimeoutAsyncBreak()
+  /// that has not yet been observed by the interpreter. Unlike
+  /// triggerTimeoutAsyncBreak(), this may only be called on the thread that
+  /// executes JS -- either between executions or from a native frame invoked
+  /// by executing JS; see testAndClearAsyncBreakRequest(). \return whether a
+  /// request was pending.
+  bool cancelTimeoutAsyncBreak() {
+    return testAndClearTimeoutAsyncBreakRequest();
+  }
+
 #ifdef HERMES_ENABLE_DEBUGGER
   /// Encapsulates useful information about a stack frame, needed by the
   /// debugger. It requres extra context and cannot be extracted from a
@@ -1511,8 +1521,11 @@ class Runtime : public RuntimeBase, public HandleRootOwner {
   /// \p reasonBit request bit afterward.
   uint8_t testAndClearAsyncBreakRequest(uint8_t reasonBits) {
     /// Note that while the triggerTimeoutAsyncBreak() function may be called
-    /// from any thread, this one may only be called from within the Interpreter
-    /// loop.
+    /// from any thread, this one may only be called on the thread that
+    /// executes JS: either from within the Interpreter loop, or from a host
+    /// API while no JS is executing (e.g. HermesRuntime::asyncCancelTimeout).
+    /// Concurrent calls could both pass the fast path and then race the
+    /// fetch_and, making the loser observe oldFlag == 0.
     uint8_t flag = asyncBreakRequestFlag_.load(std::memory_order_relaxed);
     if (LLVM_LIKELY((flag & (uint8_t)reasonBits) == 0)) {
       // Fast path.

--- a/lib/VM/CodeBlock.cpp
+++ b/lib/VM/CodeBlock.cpp
@@ -324,8 +324,10 @@ uint32_t CodeBlock::getVirtualOffset() const {
 #ifdef HERMES_ENABLE_DEBUGGER
 
 /// Makes the page that \p address is in writable.
-/// If it fails, aborts execution.
-static void makeWritable(void *address, size_t length) {
+/// \return true on success, false if the page cannot be made writable (e.g.
+///   the bytecode lives in a read-only segment of the binary that the OS
+///   refuses to remap, such as macOS __DATA_CONST under hardened runtime).
+static bool makeWritable(void *address, size_t length) {
   void *endAddress = static_cast<void *>(static_cast<char *>(address) + length);
 
   // Align the address to page size before setting the pagesize.
@@ -335,14 +337,11 @@ static void makeWritable(void *address, size_t length) {
   size_t totalLength =
       static_cast<char *>(endAddress) - static_cast<char *>(alignedAddress);
 
-  bool success = oscompat::vm_protect(
+  return oscompat::vm_protect(
       alignedAddress, totalLength, oscompat::ProtectMode::ReadWrite);
-  if (!success) {
-    hermes_fatal("mprotect failed before modifying breakpoint");
-  }
 }
 
-void CodeBlock::installBreakpointAtOffset(uint32_t offset) {
+bool CodeBlock::installBreakpointAtOffset(uint32_t offset) {
   auto opcodes = getOpcodeArray();
   assert(offset < opcodes.size() && "patch offset out of bounds");
   hbc::opcode_atom_t *address =
@@ -354,9 +353,12 @@ void CodeBlock::installBreakpointAtOffset(uint32_t offset) {
       sizeof(inst::DebuggerInst) == 1,
       "debugger instruction can only be a single opcode atom");
 
-  makeWritable(address, sizeof(inst::DebuggerInst));
+  if (!makeWritable(address, sizeof(inst::DebuggerInst))) {
+    return false;
+  }
   *address = debuggerOpcode;
   ++numInstalledBreakpoints_;
+  return true;
 }
 
 void CodeBlock::uninstallBreakpointAtOffset(

--- a/lib/VM/Debugger/Debugger.cpp
+++ b/lib/VM/Debugger/Debugger.cpp
@@ -421,7 +421,12 @@ ExecutionStatus Debugger::debuggerLoop(
             }
             breakAtPossibleNextInstructions(state);
             if (breakpointOpt) {
-              state.codeBlock->installBreakpointAtOffset(state.offset);
+              // Re-installing a previously-installed breakpoint: the page is
+              // already known writable.
+              bool ok =
+                  state.codeBlock->installBreakpointAtOffset(state.offset);
+              (void)ok;
+              assert(ok && "re-installing existing breakpoint cannot fail");
             }
             if (stepMode == StepMode::Into) {
               // Stepping in could enter another code block,
@@ -767,18 +772,26 @@ Debugger::getBreakpointLocation(CodeBlock *codeBlock, uint32_t offset) const {
 }
 
 auto Debugger::installBreakpoint(CodeBlock *codeBlock, uint32_t offset)
-    -> BreakpointLocation & {
+    -> BreakpointLocation * {
   auto opcodes = codeBlock->getOpcodeArray();
   assert(offset < opcodes.size() && "invalid offset to set breakpoint");
-  auto &location =
-      breakpointLocations_
-          .try_emplace(codeBlock->getOffsetPtr(offset), opcodes[offset])
-          .first->second;
+  auto *opcodePtr = codeBlock->getOffsetPtr(offset);
+  auto emplaceResult =
+      breakpointLocations_.try_emplace(opcodePtr, opcodes[offset]);
+  auto &location = emplaceResult.first->second;
   if (location.count() == 0) {
     // count used to be 0, so patch this in now that the count > 0.
-    codeBlock->installBreakpointAtOffset(offset);
+    if (!codeBlock->installBreakpointAtOffset(offset)) {
+      // Patching failed (e.g. statically embedded bytecode in a read-only
+      // segment that the OS refuses to remap). Roll back the entry we just
+      // inserted so state stays consistent, and signal failure to caller.
+      if (emplaceResult.second) {
+        breakpointLocations_.erase(emplaceResult.first);
+      }
+      return nullptr;
+    }
   }
-  return location;
+  return &location;
 }
 
 void Debugger::uninstallBreakpoint(
@@ -796,12 +809,16 @@ void Debugger::uninstallBreakpoint(
   }
 }
 
-void Debugger::setUserBreakpoint(
+bool Debugger::setUserBreakpoint(
     CodeBlock *codeBlock,
     uint32_t offset,
     BreakpointID id) {
-  BreakpointLocation &location = installBreakpoint(codeBlock, offset);
-  location.userBreakpointIDs.insert(id);
+  BreakpointLocation *location = installBreakpoint(codeBlock, offset);
+  if (!location) {
+    return false;
+  }
+  location->userBreakpointIDs.insert(id);
+  return true;
 }
 
 void Debugger::doSetNonUserBreakpoint(
@@ -809,15 +826,22 @@ void Debugger::doSetNonUserBreakpoint(
     uint32_t offset,
     uint32_t callStackDepth,
     bool isStepBreakpoint) {
-  BreakpointLocation &location = installBreakpoint(codeBlock, offset);
+  BreakpointLocation *location = installBreakpoint(codeBlock, offset);
+  if (!location) {
+    // Best-effort: step/restoration breakpoints are an optimization for
+    // pause-on-entry while stepping. If the target lives in a read-only
+    // bytecode segment we cannot patch, just skip it -- stepping will simply
+    // not pause at the entry of that code block.
+    return;
+  }
   std::vector<Breakpoint> &breakpoints =
       isStepBreakpoint ? tempBreakpoints_ : restorationBreakpoints_;
-  if (location.callStackDepths.count(callStackDepth) == 0) {
-    location.callStackDepths.insert(callStackDepth);
+  if (location->callStackDepths.count(callStackDepth) == 0) {
+    location->callStackDepths.insert(callStackDepth);
   }
 
-  if ((isStepBreakpoint && !location.hasStepBreakpoint) ||
-      (!isStepBreakpoint && !location.hasRestorationBreakpoint)) {
+  if ((isStepBreakpoint && !location->hasStepBreakpoint) ||
+      (!isStepBreakpoint && !location->hasRestorationBreakpoint)) {
     // Leave the resolved location empty for now,
     // let the caller fill it in lazily.
     Breakpoint breakpoint{};
@@ -828,9 +852,9 @@ void Debugger::doSetNonUserBreakpoint(
   }
 
   if (isStepBreakpoint) {
-    location.hasStepBreakpoint = true;
+    location->hasStepBreakpoint = true;
   } else {
-    location.hasRestorationBreakpoint = true;
+    location->hasRestorationBreakpoint = true;
   }
 }
 
@@ -843,17 +867,22 @@ void Debugger::setStepBreakpoint(
 }
 
 void Debugger::setOnLoadBreakpoint(CodeBlock *codeBlock, uint32_t offset) {
-  BreakpointLocation &location = installBreakpoint(codeBlock, offset);
+  BreakpointLocation *location = installBreakpoint(codeBlock, offset);
+  if (!location) {
+    // Best-effort: pauseOnScriptLoad cannot pause inside a code block whose
+    // bytecode page is not writable. Skip.
+    return;
+  }
   // Leave the resolved location empty for now,
   // let the caller fill it in lazily.
   Breakpoint breakpoint{};
   breakpoint.codeBlock = codeBlock;
   breakpoint.offset = offset;
   breakpoint.enabled = true;
-  assert(!location.onLoad && "can't set duplicate on-load breakpoint");
-  location.onLoad = true;
+  assert(!location->onLoad && "can't set duplicate on-load breakpoint");
+  location->onLoad = true;
   tempBreakpoints_.push_back(breakpoint);
-  assert(location.count() && "invalid count following set breakpoint");
+  assert(location->count() && "invalid count following set breakpoint");
 }
 
 void Debugger::unsetUserBreakpoint(
@@ -1017,8 +1046,12 @@ void Debugger::setRestorationBreakpoint(
 
 bool Debugger::restoreBreakpointIfAny() {
   if (breakpointToRestore_.first != nullptr) {
-    breakpointToRestore_.first->installBreakpointAtOffset(
+    // Re-installing a previously-installed breakpoint: the page is already
+    // known writable.
+    bool ok = breakpointToRestore_.first->installBreakpointAtOffset(
         breakpointToRestore_.second);
+    (void)ok;
+    assert(ok && "re-installing existing breakpoint cannot fail");
     breakpointToRestore_ = {nullptr, 0};
     return true;
   }
@@ -1046,7 +1079,10 @@ ExecutionStatus Debugger::stepInstruction(InterpreterState &state) {
     // Temporarily uninstall the breakpoint so we can run the real instruction.
     uninstallBreakpoint(codeBlock, offset, locationOpt->opCode);
     status = runtime_.stepFunction(newState);
-    codeBlock->installBreakpointAtOffset(offset);
+    // Re-install: page already known writable.
+    bool ok = codeBlock->installBreakpointAtOffset(offset);
+    (void)ok;
+    assert(ok && "re-installing existing breakpoint cannot fail");
   } else {
     status = runtime_.stepFunction(newState);
   }
@@ -1092,7 +1128,10 @@ ExecutionStatus Debugger::processInstUnderDebuggerOpCode(
       runtime_.setCurrentIP(ip);
       ExecutionStatus status = runtime_.stepFunction(newState);
       runtime_.invalidateCurrentIP();
-      codeBlock->installBreakpointAtOffset(offset);
+      // Re-install: page already known writable.
+      bool ok = codeBlock->installBreakpointAtOffset(offset);
+      (void)ok;
+      assert(ok && "re-installing existing breakpoint cannot fail");
       if (status == ExecutionStatus::EXCEPTION) {
         return status;
       }

--- a/unittests/API/APITest.cpp
+++ b/unittests/API/APITest.cpp
@@ -540,6 +540,42 @@ TEST_P(HermesRuntimeTest, TriggerAsyncTimeout) {
     runTest(hsrt);
 }
 
+TEST_P(HermesRuntimeTest, CancelAsyncTimeout) {
+  auto runTest = [](auto *rt) {
+    // Cancellation lives on its own castInterface-obtained interface rather
+    // than on the runtime class, so that adding it does not change any
+    // existing vtable; null would mean the runtime does not support it.
+    auto *cancel = castInterface<ICancelAsyncTimeout>(rt);
+    ASSERT_NE(cancel, nullptr);
+
+    // Nothing pending: there is nothing to cancel.
+    EXPECT_FALSE(cancel->asyncCancelTimeout());
+
+    // A timeout triggered while no JS is running would terminate the next
+    // script at its first async break check (see TriggerAsyncTimeout above).
+    // Cancelling consumes the pending request, so the script must run to
+    // completion instead.
+    rt->asyncTriggerTimeout();
+    EXPECT_TRUE(cancel->asyncCancelTimeout());
+    // The request was consumed by the first cancel.
+    EXPECT_FALSE(cancel->asyncCancelTimeout());
+
+    // A loop is required: backward branches are where async break checks
+    // are emitted.
+    const char *loop = "var x = 0; for (var i = 0; i < 1000; ++i) x += i; x";
+    EXPECT_EQ(
+        rt->evaluateJavaScript(std::make_unique<StringBuffer>(loop), "")
+            .getNumber(),
+        499500);
+  };
+
+  // Only these runtimes support asyncTriggerTimeout/asyncCancelTimeout.
+  if (auto *hrt = dynamic_cast<HermesRuntime *>(rt.get()))
+    runTest(hrt);
+  else if (auto *hsrt = dynamic_cast<HermesSandboxRuntime *>(rt.get()))
+    runTest(hsrt);
+}
+
 TEST(HermesRuntimeCrashManagerTest, CrashGetStackTrace) {
   class CrashManagerImpl : public hermes::vm::CrashManager {
    public:


### PR DESCRIPTION
The debugger installs breakpoints by overwriting an opcode in the bytecode stream with Debugger, which requires the page to be writable. The patcher uses mprotect to make the page RW; on failure it called hermes_fatal and aborted the process.

If the bytecode lives in a read-only segment (e.g. statically linked into the binary as a const array, ending up in __DATA_CONST / __TEXT_CONST on macOS), mprotect is rejected by the OS (EACCES under hardened runtime) and the abort takes down the whole process. This is reachable in practice because step / restoration / on-load breakpoints install at offset 0 of every CodeBlock about to execute, so stepping into such a CodeBlock from anywhere kills the runtime.

Make the patch best-effort:

- CodeBlock::installBreakpointAtOffset and the static makeWritable helper now return bool. On failure no state is modified.
- Debugger::installBreakpoint returns BreakpointLocation* (nullptr on failure), rolling back the partial breakpointLocations_ entry it just inserted.
- doSetNonUserBreakpoint and setOnLoadBreakpoint silently skip when installBreakpoint fails. Step / restoration / on-load breakpoints are best-effort hints; the only loss is that stepping cannot pause at the entry of a CodeBlock whose page cannot be patched.
- setUserBreakpoint now returns bool so callers can propagate failure to their clients (e.g. CDP could surface a proper error back to DevTools instead of aborting).
- The four call sites that re-install a previously-installed breakpoint (the page is known writable since the original install succeeded) assert the result.