### PR TITLE
Fix async arrow non simple params bug

### DIFF
--- a/test/hermes/regress-async-arrow.js
+++ b/test/hermes/regress-async-arrow.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -O %s | %FileCheck --match-full-lines %s
+// RUN: %hermes -O -emit-binary -out %t.hbc %s && %hermes %t.hbc | %FileCheck --match-full-lines %s
+// RUN: %shermes -exec %s | %FileCheck --match-full-lines %s
+
+print("async arrow");
+// CHECK: async arrow
+
+function foo() {
+  return 10;
+}
+
+(async (x = foo()) => {
+  print (await Promise.resolve("hello"));
+})()
+// CHECK-NEXT: hello


### PR DESCRIPTION
Summary:
Add missing logic in async arrow functions for non simple parameters. This logic is copied over from the existing codepath in `genBasicFunction`.

Reviewed By: avp

Differential Revision: D81596715

fbshipit-source-id: ac3accf710f3d32db24743674e590700beb18bb0
