### PR TITLE
Fix crash due to concurrent access to `napi_env__::pendingFinalizers_`

### DIFF
--- a/API/napi/hermes_napi.cpp
+++ b/API/napi/hermes_napi.cpp
@@ -100,30 +100,39 @@ void napi_env__::queuePendingFinalizer(
     napi_finalize cb,
     void *data,
     void *hint) {
+  std::lock_guard<std::mutex> lock(pendingFinalizersMutex_);
   pendingFinalizers_.push_back({cb, data, hint});
 }
 
 void napi_env__::drainPendingFinalizers() {
-  if (drainingFinalizers_ || pendingFinalizers_.empty())
-    return;
-  drainingFinalizers_ = true;
+  std::vector<PendingFinalizer> batch;
+  {
+    std::lock_guard<std::mutex> lock(pendingFinalizersMutex_);
+    if (drainingFinalizers_ || pendingFinalizers_.empty())
+      return;
+    drainingFinalizers_ = true;
+    batch.swap(pendingFinalizers_);
+  }
 
   // Process in batches: swap out the current queue so callbacks that
   // trigger further GC (adding new entries) don't invalidate our
   // iteration. Loop until the queue is fully drained.
-  while (!pendingFinalizers_.empty()) {
-    std::vector<PendingFinalizer> batch;
-    batch.swap(pendingFinalizers_);
-
+  while (true) {
     napi_handle_scope scope = nullptr;
     napi_open_handle_scope(this, &scope);
     for (auto &pf : batch) {
       pf.cb(this, pf.data, pf.hint);
     }
     napi_close_handle_scope(this, scope);
-  }
 
-  drainingFinalizers_ = false;
+    std::lock_guard<std::mutex> lock(pendingFinalizersMutex_);
+    if (pendingFinalizers_.empty()) {
+      drainingFinalizers_ = false;
+      break;
+    }
+    batch.clear();
+    batch.swap(pendingFinalizers_);
+  }
 }
 
 napi_env__::~napi_env__() {

--- a/API/napi/hermes_napi_impl.h
+++ b/API/napi/hermes_napi_impl.h
@@ -17,6 +17,7 @@
 #include <cassert>
 #include <deque>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -460,6 +461,10 @@ struct napi_env__ {
   /// callbacks here. The queue is drained at safe points via
   /// drainPendingFinalizers().
   std::vector<PendingFinalizer> pendingFinalizers_;
+
+  /// Guards pendingFinalizers_ and drainingFinalizers_. Hades GC can queue
+  /// finalizers from a background thread while the JS thread drains them.
+  std::mutex pendingFinalizersMutex_;
 
   /// True while drainPendingFinalizers() is executing, to prevent
   /// re-entrant draining (a callback may trigger GC which queues more).


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `main`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/HEAD/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.

  Note: We kindly request that pull requests address more than just a single typo.
  While we sincerely appreciate your attention to detail, we would be most grateful
  if typo fixes were batched together to include several corrections. This helps our
  maintainers focus on substantive contributions to the codebase. Thank you for your
  understanding and cooperation!
-->

## Summary

The `napi_env__::pendingFinalizers_` member variable is concurrently accessed by two threads (GC & JS), causing memory corruption and a crash.

Below, you can find slimmed-down stack traces from two threads when the crash happens. They don't happen exactly at the same time, but help to see where the problem is:

```
AsanDie() 0x00007680b05e19a0
**sanitizer::Die() 0x00007680b0561fec
~ScopedInErrorReport() 0x00007680b05dc7af
ReportFreeNotMalloced() 0x00007680b05dcd7b
operator delete() 0x00007680b05e6c18
[Inlined] std::**ndk1::**libcpp_operator_delete[abi:nn180000]<…>(void \*) new:280
[Inlined] std::**ndk1::**do_deallocate_handle_size[abi:nn180000]<…>(void \*, unsigned long) new:302
[Inlined] std::**ndk1::**libcpp_deallocate[abi:nn180000](void \*, unsigned long, unsigned long) new:317
[Inlined] std::**ndk1::allocator::deallocate[abi:nn180000](napi*env**::PendingFinalizer \*, unsigned long) allocator.h:131
[Inlined] std::**ndk1::allocator_traits::deallocate[abi:nn180000](std::**ndk1::allocator<…> &, napi_env**::PendingFinalizer *, unsigned long) allocator*traits.h:289
[Inlined] std::**ndk1::**split_buffer::~**split_buffer() **split_buffer:355
[Inlined] std::**ndk1::vector::**push_back_slow_path<…>(napi_env**::PendingFinalizer &&) vector:1457
[Inlined] std::**ndk1::vector::push_back[abi:nn180000](napi_env**::PendingFinalizer &&) vector:1479
napi_env**::queuePendingFinalizer(void (*)(napi_env** *, void *, void *), void *, void *) hermes_napi.cpp:103
finalizeNapiObjectData(hermes::vm::HadesGC &, hermes::vm::NativeState *) hermes_napi_wrap.cpp:41
[Inlined] hermes::vm::VTable::finalizeIfExists(hermes::vm::GCCell \*, hermes::vm::HadesGC &) const VTable.h:191
hermes::vm::HadesGC::OldGen::sweepNext(bool) HadesGC.cpp:1168
hermes::vm::HadesGC::incrementalCollect(bool) HadesGC.cpp:1698
...
```

```
art*sigsegv_fault 0x0000799fc8cff670
art::art_sigsegv_handler(int, siginfo*, void*) (.**uniq.101192393727222708201094543451577629235) 0x0000799fc8d00189
art::SignalChain::Handler(int, siginfo *, void *) 0x000079a27c9ccdaf
**restore_rt 0x000079a27116b2b0
napi_env**::drainPendingFinalizers() hermes_napi.cpp:121
napi_new_instance(napi_env, napi_value, size_t, const napi_value *, napi_value *) hermes_napi_function.cpp:338
...
```

## Test Plan

I'm not sure how you test concurrency bugs, but I'm open to adding new tests if you suggest your recommended approach.