### PR TITLE
fix: Promise.prototype.finally() must passthrough when onFinally is not callable

### DIFF
--- a/lib/InternalBytecode/01-Promise.js
+++ b/lib/InternalBytecode/01-Promise.js
@@ -397,6 +397,15 @@
   };
 
   core.prototype.finally = function (f) {
+    // Per ECMA-262 §27.2.5.3 (Promise.prototype.finally), when onFinally
+    // is not callable it must be passed straight through to then(), so
+    // the resulting Promise simply mirrors the receiver. Without this
+    // guard, calling f() below throws "undefined is not a function" for
+    // the no-arg / undefined / null cases that V8, JavaScriptCore and
+    // SpiderMonkey all accept as passthrough.
+    if (typeof f !== 'function') {
+      return this.then(f, f);
+    }
     return this.then(function (value) {
       return core.resolve(f()).then(function () {
         return value;

--- a/test/hermes/promise-finally.js
+++ b/test/hermes/promise-finally.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -Xes6-promise %s | %FileCheck --match-full-lines %s
+// RUN: %hermes -Xmicrotask-queue %s | %FileCheck --match-full-lines %s
+// RUN: %hermesc -O -emit-binary -out %t.hbc %s && %hermes -Xes6-promise %t.hbc | %FileCheck --match-full-lines %s
+
+// Regression test for Promise.prototype.finally with a non-callable
+// onFinally. Per ECMA-262 §27.2.5.3, when IsCallable(onFinally) is false
+// the value/rejection of the receiver must pass straight through.
+
+print('promise-finally');
+// CHECK-LABEL: promise-finally
+
+// 1) No-arg call: value passes through.
+Promise.resolve('ok').finally().then(function (v) {
+  print('no-arg:', v);
+});
+// CHECK-NEXT: no-arg: ok
+
+// 2) Explicit undefined: value passes through.
+Promise.resolve('ok').finally(undefined).then(function (v) {
+  print('undefined:', v);
+});
+// CHECK-NEXT: undefined: ok
+
+// 3) null: value passes through.
+Promise.resolve('ok').finally(null).then(function (v) {
+  print('null:', v);
+});
+// CHECK-NEXT: null: ok
+
+// 4) Rejection passes through unchanged when onFinally is not callable.
+Promise.reject(new Error('x')).finally().then(function () {
+  print('rejection: unexpected resolve');
+}, function (e) {
+  print('rejection:', e.message);
+});
+// CHECK-NEXT: rejection: x
+
+// 5) Sanity: callable onFinally still works (no regression).
+Promise.resolve('ok').finally(function () {}).then(function (v) {
+  print('callable:', v);
+});
+// CHECK-NEXT: callable: ok


### PR DESCRIPTION
## Summary

`Promise.prototype.finally()` in Hermes rejects with `TypeError: undefined is not a function` when `onFinally` is not callable. Per ECMA-262 [§27.2.5.3](https://tc39.es/ecma262/#sec-promise.prototype.finally), a non-callable `onFinally` must be treated as a passthrough — `thenFinally` and `catchFinally` are set to `onFinally` itself (steps 6.a and 7.a), so `then(onFinally, onFinally)` mirrors the receiver's value/rejection.

This was discovered in a React Native 0.85.3 app where calling `.finally()` on a fetch promise crashed on cold start. The same call works in every other engine.

## Minimal repro

```js
// hermes -Xes6-promise
Promise.resolve('ok').finally().then(print, e => print('REJECTED', e.message));
// before: REJECTED undefined is not a function
// after:  ok
```

For comparison, V8 / JSC / SpiderMonkey:

```
$ node -e "Promise.resolve('ok').finally().then(console.log)"
ok
```

## Cause

`lib/InternalBytecode/01-Promise.js` is generated from the `promise@8.3.0` npm polyfill, which calls `f()` unconditionally:

```js
core.prototype.finally = function (f) {
  return this.then(function (value) {
    return core.resolve(f()).then(function () { return value; });
  }, function (err) {
    return core.resolve(f()).then(function () { throw err; });
  });
};
```

`f()` throws when `f` is `undefined` / `null` / any non-callable.

## Fix

If `onFinally` is not a function, forward it straight to `this.then(f, f)`. This is exactly what the spec describes when `IsCallable(onFinally)` is false, and it matches what Hermes already does on the `static_h` branch (`lib/InternalJavaScript/01-Promise.js`):

```js
if (typeof onFinally !== 'function') {
  thenFinally = onFinally;
  catchFinally = onFinally;
}
// ...
return this.then(thenFinally, catchFinally);
```

The diff to the generated polyfill is a 9-line guard:

```js
if (typeof f !== 'function') {
  return this.then(f, f);
}
```

## Before / after

| Call | Engine spec | Hermes (before) | Hermes (after) |
|---|---|---|---|
| `Promise.resolve('ok').finally()` | resolves `'ok'` | rejects `TypeError` | resolves `'ok'` |
| `Promise.resolve('ok').finally(undefined)` | resolves `'ok'` | rejects `TypeError` | resolves `'ok'` |
| `Promise.resolve('ok').finally(null)` | resolves `'ok'` | rejects `TypeError` | resolves `'ok'` |
| `Promise.reject(new Error('x')).finally()` | rejects `Error('x')` | rejects `TypeError` | rejects `Error('x')` |
| `Promise.resolve('ok').finally(() => {})` | resolves `'ok'` | resolves `'ok'` | resolves `'ok'` |

## Tests

Added `test/hermes/promise-finally.js` covering all five rows above. It follows the same `lit` + `FileCheck` convention as the existing `test/hermes/promise.js` and runs under the same three configurations (`-Xes6-promise`, `-Xmicrotask-queue`, and via `hermesc -emit-binary`).

I was unable to run `check-hermes` locally in this environment (system `libicu-dev` isn't installed, so CMake configuration fails before building). I verified the patched logic in isolation against V8 (Node) and the outputs match in all five cases. CI here will confirm against the real engine.

## Scope

- `lib/InternalBytecode/01-Promise.js` — 9-line guard added to the `finally` polyfill.
- `test/hermes/promise-finally.js` — new file, covers the spec passthrough cases plus a no-regression sanity check.

No other files touched. No formatting / lint / copyright changes elsewhere. The fix on the `static_h` branch is already correct, so no change needed there.

## Notes

I see the project requires a CLA — I'll sign it when CLA-bot prompts.
