### PR TITLE
Promote event loop control JSI interface (#2037)

### DIFF
--- a/API/jsi/jsi/hermes-interfaces.h
+++ b/API/jsi/jsi/hermes-interfaces.h
@@ -26,7 +26,6 @@ namespace debugger {
 class Debugger;
 }
 
-#ifdef JSI_UNSTABLE
 /// IEventLoopControl is defined by the integrator to allow the Runtime to
 /// schedule some task to be run when convenient, and to keep track of "Task
 /// sources". After it is set to a Runtime, the integrator must ensure that the
@@ -79,7 +78,6 @@ struct JSI_EXPORT ISetEventLoopControl : public jsi::ICast {
  protected:
   ~ISetEventLoopControl() = default;
 };
-#endif
 
 /// Interface for Hermes-specific runtime methods.The actual implementations of
 /// the pure virtual methods are provided by Hermes API.


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebook/react-native/pull/57005

Promote `IEventLoopControl` and `ISetEventLoopControl` out of `JSI_UNSTABLE` and make `HermesRuntimeImpl` always implement the setter interface. Keep unrelated unstable APIs such as serialization, tracing helpers, and Worker installation behind `JSI_UNSTABLE`.

Differential Revision: D106744174


