### PR TITLE
Optimize bigint division for fast path

### DIFF
--- a/lib/Support/BigIntSupport.cpp
+++ b/lib/Support/BigIntSupport.cpp
@@ -1777,6 +1777,23 @@ static OperationStatus compute(
     return OperationStatus::DIVISION_BY_ZERO;
   }
 
+  // Fast path: if lhs < rhs (in absolute value), then quotient is 0 and
+  // remainder is lhs. This avoids expensive division computation.
+  if (lhs.numDigits < rhs.numDigits) {
+    // Quotient is 0
+    if (quoc.digits != nullptr) {
+      quoc.numDigits = 1;
+      quoc.digits[0] = 0;
+    }
+    // Remainder is lhs (with sign preserved)
+    if (rem.digits != nullptr) {
+      auto res = initNonCanonicalWithReadOnlyBigInt(rem, lhs);
+      assert(res == OperationStatus::RETURNED && "rem array is too small");
+      (void)res;
+    }
+    return OperationStatus::RETURNED;
+  }
+
   // tcDivide operates on unsigned number, so just like multiply, the operands
   // must be negated (and the result as well, if appropriate) if they are
   // negative.


### PR DESCRIPTION
## Summary
- Optimized bigint division when lhs.numDigits < rhs.numDigits
- Avoids expensive tcDivide computation for common case
- Performance: O(n) instead of O(n²) for this case

## Changes
- Added fast-path check in div_rem::compute()
- When dividend has fewer digits than divisor, quotient is 0 and remainder is lhs
- Directly sets results without calling expensive tcDivide

## Performance Impact
- Significant speedup for bigint divisions where dividend < divisor
- Eliminates allocation and computation overhead
- Common operation in JavaScript number handling

## Test Plan
- [x] Fast path produces correct quotient (0) and remainder (lhs)
- [x] Works for both positive and negative numbers
- [x] Existing division tests continue to pass