### PR TITLE
Port: Use clock_gettime_nsec_np(CLOCK_UPTIME_RAW) for CPU samples timestamps on Apple platforms

### DIFF
--- a/include/hermes/Support/OSCompat.h
+++ b/include/hermes/Support/OSCompat.h
@@ -237,6 +237,16 @@ std::vector<bool> sched_getaffinity();
 /// or -1 on error.
 int sched_getcpu();
 
+/// \return a high-resolution monotonic timestamp suitable for use by the
+/// sampling profiler. On Apple platforms this is sourced from
+/// mach_absolute_time() rather than std::chrono::steady_clock, because
+/// steady_clock on Apple is backed by mach_continuous_time() which advances
+/// during device sleep — using it would shift CPU profile samples out of the
+/// host trace's time window when comparing against other Apple subsystems.
+/// On all other platforms this returns std::chrono::steady_clock::now().
+/// Async-signal-safe.
+std::chrono::steady_clock::time_point sampling_clock_now() noexcept;
+
 #ifdef _WINDOWS
 
 #define STDIN_FILENO 0

--- a/lib/Support/OSCompatPosix.cpp
+++ b/lib/Support/OSCompatPosix.cpp
@@ -65,6 +65,7 @@
 
 #ifdef __APPLE__
 #include <TargetConditionals.h>
+#include <time.h>
 #endif
 
 #include "llvh/Config/config.h"
@@ -812,6 +813,17 @@ std::vector<bool> sched_getaffinity() {
 int sched_getcpu() {
   // Not yet supported.
   return -1;
+}
+#endif
+
+#ifdef __APPLE__
+std::chrono::steady_clock::time_point sampling_clock_now() noexcept {
+  auto ns = static_cast<int64_t>(clock_gettime_nsec_np(CLOCK_UPTIME_RAW));
+  return std::chrono::steady_clock::time_point(std::chrono::nanoseconds(ns));
+}
+#else
+std::chrono::steady_clock::time_point sampling_clock_now() noexcept {
+  return std::chrono::steady_clock::now();
 }
 #endif
 

--- a/lib/Support/OSCompatWindows.cpp
+++ b/lib/Support/OSCompatWindows.cpp
@@ -554,6 +554,10 @@ int sched_getcpu() {
   return -1;
 }
 
+std::chrono::steady_clock::time_point sampling_clock_now() noexcept {
+  return std::chrono::steady_clock::now();
+}
+
 bool set_env(const char *name, const char *value) {
   // Setting an env var to empty requires a lot of hacks on Windows
   assert(*value != '\0' && "value cannot be empty string");

--- a/lib/VM/Profiler/SamplingProfiler.cpp
+++ b/lib/VM/Profiler/SamplingProfiler.cpp
@@ -9,6 +9,7 @@
 
 #if HERMESVM_SAMPLING_PROFILER_AVAILABLE
 
+#include "hermes/Support/OSCompat.h"
 #include "hermes/VM/Callable.h"
 #include "hermes/VM/HostModel.h"
 #include "hermes/VM/Runtime.h"
@@ -129,7 +130,7 @@ uint32_t SamplingProfiler::walkRuntimeStack(
     }
   }
   sampleStorage.tid = threadID_;
-  sampleStorage.timeStamp = std::chrono::steady_clock::now();
+  sampleStorage.timeStamp = oscompat::sampling_clock_now();
   return numSkipped;
 }
 


### PR DESCRIPTION
## Summary
- Cherry-pick of 792883973339a930de4b59754e8cbb14d76ef813 (D106844928) onto `250829098.0.0-stable`
- On Apple platforms, `std::chrono::steady_clock` uses `mach_continuous_time()` which includes device sleep time, skewing CPU profile samples
- Replaces it with `clock_gettime_nsec_np(CLOCK_UPTIME_RAW)` (backed by `mach_absolute_time`) for the sampling profiler, aligning with Apple's recommended approach and other iOS subsystems like `UITouch`

## Changes
- **`OSCompat.h`**: Declare `sampling_clock_now()` returning `steady_clock::time_point`
- **`OSCompatPosix.cpp`**: Apple implementation using `clock_gettime_nsec_np(CLOCK_UPTIME_RAW)`, fallback to `steady_clock::now()` on other POSIX
- **`OSCompatWindows.cpp`**: Windows implementation using `steady_clock::now()`
- **`SamplingProfiler.cpp`**: Use `oscompat::sampling_clock_now()` instead of `std::chrono::steady_clock::now()`

## Test plan
- Clean cherry-pick with no conflicts — diff is identical to the original commit on `static_h`