### PR TITLE
Cherry-pick: Set home object correctly in object literal accessors

### DIFF
--- a/lib/IRGen/ESTreeIRGen-expr.cpp
+++ b/lib/IRGen/ESTreeIRGen-expr.cpp
@@ -1634,7 +1634,7 @@ Value *ESTreeIRGen::genObjectExpr(ESTree::ObjectExpressionNode *Expr) {
             Builder.createIdentifier("get " + keyStr.str()),
             /* superClassNode */ nullptr,
             Function::DefinitionKind::ES5Function,
-            /* homeObject */ nullptr,
+            /* homeObject */ capturedObj,
             /* parentNode */ propValue->getterProp);
       }
 
@@ -1645,7 +1645,7 @@ Value *ESTreeIRGen::genObjectExpr(ESTree::ObjectExpressionNode *Expr) {
             Builder.createIdentifier("set " + keyStr.str()),
             /* superClassNode */ nullptr,
             Function::DefinitionKind::ES5Function,
-            /* homeObject */ nullptr,
+            /* homeObject */ capturedObj,
             /* parentNode */ propValue->setterProp);
       }
 

--- a/test/hermes/object-literal-getter-super.js
+++ b/test/hermes/object-literal-getter-super.js
@@ -20,3 +20,19 @@ var object = {
 Object.setPrototypeOf(object, proto);
 print(object.a);
 // CHECK: a proto m
+
+// Test that accessors without computed names can also refer to super.
+(function () {
+  let v1 = {
+    get a() {
+      let x = super.m;
+      print(x);
+    }
+  }
+  let parent = { m: 12 };
+  v1.a;
+// CHECK-NEXT: undefined
+  Object.setPrototypeOf(v1, parent);
+  v1.a;
+// CHECK-NEXT: 12
+})();


### PR DESCRIPTION
## Summary

Cherry-pick of `18a9634659443c92d481efe71b0c2aea9e6c464b` from `static_h` to the `250829098.0.0-stable` branch.

`genObjectExpr` passes `nullptr` as the home object when generating an object-literal getter or setter function, instead of `capturedObj`. Any `super.<x>` inside such an accessor then compiles against a null home object and SIGSEGVs `hermesc` at compile time. The regular-method path on this branch already passes `capturedObj`, so this makes accessors consistent with methods.

This landed on `static_h` after the branch was cut (2025-08-29), so it is missing from the V1 line React Native ships (needed by facebook/react-native#56816). Authored by @fbmal7, reviewed internally by avp.

## Test plan

- Clean cherry-pick, no conflicts. Carries the upstream test `test/hermes/object-literal-getter-super.js`.
- Built `hermesc` from `250829098.0.0-stable` (`517edaff8`): the baseline compiler SIGSEGVs compiling an object literal with `get x() { return super.y }`. With this cherry-pick it compiles clean.
- `LIT_FILTER="object-literal-getter-super" cmake --build build --target check-hermes` passes.
