### PR TITLE
Cherry-pick: Fix class variable caching bugs when class is in finally block

### DIFF
--- a/lib/IRGen/ESTreeIRGen.h
+++ b/lib/IRGen/ESTreeIRGen.h
@@ -612,6 +612,33 @@ class ESTreeIRGen {
   /// guaranteed to be, if any.
   llvh::DenseMap<const flow::ClassType::Field *, Function *> finalMethods_{};
 
+  /// Internal variables created during legacy class compilation.
+  /// These need to be cached so they can be reused when the same class
+  /// is compiled multiple times (e.g., in a finally block).
+  struct LegacyClassVars {
+    /// Variable holding the class constructor object.
+    Variable *classVar{nullptr};
+    /// Variable holding the class prototype object.
+    Variable *prototypeVar{nullptr};
+    /// Variable holding the instance elements initializer closure.
+    /// May be nullptr if there are no instance elements.
+    Variable *instElemInitFuncVar{nullptr};
+    /// Variable holding the static private brand (for static private methods).
+    Variable *staticBrand{nullptr};
+    /// Variable holding the instance private brand (for instance private
+    /// methods).
+    Variable *instanceBrand{nullptr};
+    /// Map from computed property nodes to their key variables.
+    llvh::DenseMap<ESTree::ClassPropertyNode *, Variable *> computedFieldKeys{};
+
+    LegacyClassVars() = default;
+    LegacyClassVars(Variable *cls, Variable *proto)
+        : classVar(cls), prototypeVar(proto) {}
+  };
+
+  /// Map from a class AST node to its internal variables.
+  llvh::DenseMap<ESTree::ClassLikeNode *, LegacyClassVars> legacyClassVars_{};
+
   /// A queue of "entities" that have been forward declared and mapped in
   /// \c compiledEntities_, but need to be actually compiled. This makes the
   /// compiler non-recursive.
@@ -1327,8 +1354,10 @@ class ESTreeIRGen {
   /// Declare all private names in the class' scope. This will setup the
   /// customData for all private name decls to point to the required state
   /// needed for IRGen to handle usages involving that private name.
+  /// \param classNode The class AST node, used for caching internal variables.
   /// \param scope The lexical scope, can't be null.
   void emitPrivateNameDeclarations(
+      ESTree::ClassLikeNode *classNode,
       sema::LexicalScope *scope,
       Identifier className);
 

--- a/test/IRGen/class-static-in-finally.js
+++ b/test/IRGen/class-static-in-finally.js
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -O0 %s -dump-ir | %FileCheckOrRegen --match-full-lines %s
+
+// Regression test: class with static property in finally block.
+// The finally block causes code to be emitted twice. Previously,
+// internal class variables were created fresh on each compilation,
+// but initializer functions were cached. This caused the static
+// initializer to load from an uninitialized variable, crashing at
+// runtime with "PutOwn requires object operand".
+
+function main() {
+    try {
+        throw 1;
+    } finally {
+        class C5 {
+            static g = "-10238";
+        }
+    }
+}
+main();
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:scope %VS0 []
+
+// CHECK:function global(): any
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = CreateScopeInst (:environment) %VS0: any, empty: any
+// CHECK-NEXT:       DeclareGlobalVarInst "main": string
+// CHECK-NEXT:  %2 = CreateFunctionInst (:object) %0: environment, %VS0: any, %main(): functionCode
+// CHECK-NEXT:       StorePropertyLooseInst %2: object, globalObject: object, "main": string
+// CHECK-NEXT:  %4 = AllocStackInst (:any) $?anon_0_ret: any
+// CHECK-NEXT:       StoreStackInst undefined: undefined, %4: any
+// CHECK-NEXT:  %6 = LoadPropertyInst (:any) globalObject: object, "main": string
+// CHECK-NEXT:  %7 = CallInst (:any) %6: any, empty: any, false: boolean, empty: any, undefined: undefined, undefined: undefined
+// CHECK-NEXT:       StoreStackInst %7: any, %4: any
+// CHECK-NEXT:  %9 = LoadStackInst (:any) %4: any
+// CHECK-NEXT:        ReturnInst %9: any
+// CHECK-NEXT:function_end
+
+// CHECK:scope %VS1 [C5: any, C5#1: any, ?C5.prototype: object, ?C5: object]
+
+// CHECK:function main(): any
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = GetParentScopeInst (:environment) %VS0: any, %parentScope: environment
+// CHECK-NEXT:  %1 = CreateScopeInst (:environment) %VS1: any, %0: environment
+// CHECK-NEXT:       TryStartInst %BB1, %BB2
+// CHECK-NEXT:%BB1:
+// CHECK-NEXT:  %3 = CatchInst (:any)
+// CHECK-NEXT:       StoreFrameInst %1: environment, undefined: undefined, [%VS1.C5]: any
+// CHECK-NEXT:       StoreFrameInst %1: environment, undefined: undefined, [%VS1.C5#1]: any
+// CHECK-NEXT:  %6 = AllocStackInst (:object) $?anon_1_clsPrototype: any
+// CHECK-NEXT:  %7 = CreateClassInst (:object) %1: environment, %VS1: any, %C5(): functionCode, empty: any, %6: object
+// CHECK-NEXT:  %8 = LoadStackInst (:object) %6: object
+// CHECK-NEXT:       StoreFrameInst %1: environment, %7: object, [%VS1.C5#1]: any
+// CHECK-NEXT:        StoreFrameInst %1: environment, %7: object, [%VS1.?C5]: object
+// CHECK-NEXT:        StoreFrameInst %1: environment, %8: object, [%VS1.?C5.prototype]: object
+// CHECK-NEXT:  %12 = CreateFunctionInst (:object) %1: environment, %VS1: any, %<static_elements_initializer:C5>(): functionCode
+// CHECK-NEXT:  %13 = CallInst (:any) %12: object, %<static_elements_initializer:C5>(): functionCode, true: boolean, %1: environment, undefined: undefined, %7: object
+// CHECK-NEXT:        StoreFrameInst %1: environment, %7: object, [%VS1.C5]: any
+// CHECK-NEXT:        ThrowInst %3: any
+// CHECK-NEXT:%BB2:
+// CHECK-NEXT:        ThrowInst 1: number, %BB1
+// CHECK-NEXT:function_end
+
+// CHECK:scope %VS2 [this: object]
+
+// CHECK:base constructor C5(): object
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = GetParentScopeInst (:environment) %VS1: any, %parentScope: environment
+// CHECK-NEXT:  %1 = CreateScopeInst (:environment) %VS2: any, %0: environment
+// CHECK-NEXT:  %2 = GetNewTargetInst (:object) %new.target: object
+// CHECK-NEXT:  %3 = LoadPropertyInst (:any) %2: object, "prototype": string
+// CHECK-NEXT:  %4 = AllocObjectLiteralInst (:object) %3: any
+// CHECK-NEXT:       StoreFrameInst %1: environment, %4: object, [%VS2.this]: object
+// CHECK-NEXT:  %6 = LoadFrameInst (:object) %1: environment, [%VS2.this]: object
+// CHECK-NEXT:       ReturnInst %6: object
+// CHECK-NEXT:function_end
+
+// CHECK:scope %VS3 []
+
+// CHECK:function <static_elements_initializer:C5>(): undefined
+// CHECK-NEXT:%BB0:
+// CHECK-NEXT:  %0 = GetParentScopeInst (:environment) %VS1: any, %parentScope: environment
+// CHECK-NEXT:  %1 = CreateScopeInst (:environment) %VS3: any, %0: environment
+// CHECK-NEXT:  %2 = LoadFrameInst (:object) %0: environment, [%VS1.?C5]: object
+// CHECK-NEXT:       DefineOwnPropertyInst "-10238": string, %2: object, "g": string, true: boolean
+// CHECK-NEXT:       ReturnInst undefined: undefined
+// CHECK-NEXT:function_end

--- a/test/IRGen/private-properties.js
+++ b/test/IRGen/private-properties.js
@@ -91,9 +91,9 @@ function simpleMethods() {
 // CHECK-NEXT:       StoreFrameInst %1: environment, undefined: undefined, [%VS2.B]: any
 // CHECK-NEXT:       StoreFrameInst %1: environment, undefined: undefined, [%VS2.B#1]: any
 // CHECK-NEXT:  %4 = CreatePrivateNameInst (:privateName) "B": string
-// CHECK-NEXT:       StoreFrameInst %1: environment, %4: privateName, [%VS2.?instance_brand_B]: privateName
+// CHECK-NEXT:       StoreFrameInst %1: environment, %4: privateName, [%VS2.?static_brand_B]: privateName
 // CHECK-NEXT:  %6 = CreatePrivateNameInst (:privateName) "B": string
-// CHECK-NEXT:       StoreFrameInst %1: environment, %6: privateName, [%VS2.?static_brand_B]: privateName
+// CHECK-NEXT:       StoreFrameInst %1: environment, %6: privateName, [%VS2.?instance_brand_B]: privateName
 // CHECK-NEXT:  %8 = CreateFunctionInst (:object) %1: environment, %VS2: any, %<instance_members_initializer:B>(): functionCode
 // CHECK-NEXT:       StoreFrameInst %1: environment, %8: object, [%VS2.<instElemInitFunc:B>]: object
 // CHECK-NEXT:  %10 = AllocStackInst (:object) $?anon_0_clsPrototype: any

--- a/test/IRGen/regress-class-recompiled.js
+++ b/test/IRGen/regress-class-recompiled.js
@@ -34,7 +34,7 @@
 // CHECK-NEXT:       ReturnInst %6: any
 // CHECK-NEXT:function_end
 
-// CHECK:scope %VS1 [e: any, C1: any, C1#1: any, ?C1.prototype: object, ?C1: object, <instElemInitFunc:C1>: object, ?C1.prototype#1: object, ?C1#1: object, <instElemInitFunc:C1>#1: object]
+// CHECK:scope %VS1 [e: any, C1: any, C1#1: any, ?C1.prototype: object, ?C1: object, <instElemInitFunc:C1>: object]
 
 // CHECK:function ""(): any
 // CHECK-NEXT:%BB0:
@@ -46,13 +46,13 @@
 // CHECK-NEXT:       StoreFrameInst %1: environment, undefined: undefined, [%VS1.C1]: any
 // CHECK-NEXT:       StoreFrameInst %1: environment, undefined: undefined, [%VS1.C1#1]: any
 // CHECK-NEXT:  %6 = CreateFunctionInst (:object) %1: environment, %VS1: any, %<instance_members_initializer:C1>(): functionCode
-// CHECK-NEXT:       StoreFrameInst %1: environment, %6: object, [%VS1.<instElemInitFunc:C1>#1]: object
+// CHECK-NEXT:       StoreFrameInst %1: environment, %6: object, [%VS1.<instElemInitFunc:C1>]: object
 // CHECK-NEXT:  %8 = AllocStackInst (:object) $?anon_1_clsPrototype: any
 // CHECK-NEXT:  %9 = CreateClassInst (:object) %1: environment, %VS1: any, %C1(): functionCode, empty: any, %8: object
 // CHECK-NEXT:  %10 = LoadStackInst (:object) %8: object
 // CHECK-NEXT:        StoreFrameInst %1: environment, %9: object, [%VS1.C1#1]: any
-// CHECK-NEXT:        StoreFrameInst %1: environment, %9: object, [%VS1.?C1#1]: object
-// CHECK-NEXT:        StoreFrameInst %1: environment, %10: object, [%VS1.?C1.prototype#1]: object
+// CHECK-NEXT:        StoreFrameInst %1: environment, %9: object, [%VS1.?C1]: object
+// CHECK-NEXT:        StoreFrameInst %1: environment, %10: object, [%VS1.?C1.prototype]: object
 // CHECK-NEXT:  %14 = CreateFunctionInst (:object) %1: environment, %VS1: any, %<static_elements_initializer:C1>(): functionCode
 // CHECK-NEXT:  %15 = CallInst (:any) %14: object, %<static_elements_initializer:C1>(): functionCode, true: boolean, %1: environment, undefined: undefined, %9: object
 // CHECK-NEXT:        StoreFrameInst %1: environment, %9: object, [%VS1.C1]: any

--- a/test/hermes/class-in-finally.js
+++ b/test/hermes/class-in-finally.js
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -O0 %s | %FileCheck --match-full-lines %s
+// RUN: %hermes -O %s | %FileCheck --match-full-lines %s
+
+// Test that classes work correctly when defined inside finally blocks.
+// Finally blocks emit code twice (normal flow + exception handler),
+// which requires proper caching of internal variables.
+
+function testStaticProperty() {
+    try {
+        throw 1;
+    } finally {
+        class C {
+            static g = 42;
+        }
+        print(C.g);
+// CHECK: 42
+    }
+}
+try { testStaticProperty(); } catch (e) {}
+print("testStaticProperty passed");
+// CHECK-NEXT: testStaticProperty passed
+
+function testInstanceProperty() {
+    try {
+        throw 1;
+    } finally {
+        class C {
+            f = 52;
+        }
+        print(new C().f);
+// CHECK-NEXT: 52
+    }
+}
+try { testInstanceProperty(); } catch (e) {}
+print("testInstanceProperty passed");
+// CHECK-NEXT: testInstanceProperty passed
+
+function testComputedProperty() {
+    var key = "x";
+    try {
+        throw 1;
+    } finally {
+        class C {
+            static [key] = 42;
+            [key] = 52;
+        }
+        print(C[key]);
+// CHECK-NEXT: 42
+        print(new C()[key]);
+// CHECK-NEXT: 52
+    }
+}
+try { testComputedProperty(); } catch (e) {}
+print("testComputedProperty passed");
+// CHECK-NEXT: testComputedProperty passed
+
+function testPrivateMethod() {
+    try {
+        throw 1;
+    } finally {
+        class C {
+            #m() { return 62; }
+            call() { return this.#m(); }
+        }
+        print(new C().call());
+// CHECK-NEXT: 62
+    }
+}
+try { testPrivateMethod(); } catch (e) {}
+print("testPrivateMethod passed");
+// CHECK-NEXT: testPrivateMethod passed
+
+function testStaticPrivateMethod() {
+    try {
+        throw 1;
+    } finally {
+        class C {
+            static #m() { return 72; }
+            static call() { return C.#m(); }
+        }
+        print(C.call());
+// CHECK-NEXT: 72
+    }
+}
+try { testStaticPrivateMethod(); } catch (e) {}
+print("testStaticPrivateMethod passed");
+// CHECK-NEXT: testStaticPrivateMethod passed
+
+function testPrivateAccessor() {
+    try {
+        throw 1;
+    } finally {
+        class C {
+            #val = 82;
+            get #x() { return this.#val; }
+            set #x(v) { this.#val = v; }
+            call() { this.#x = this.#x + 10; return this.#x; }
+        }
+        print(new C().call());
+// CHECK-NEXT: 92
+    }
+}
+try { testPrivateAccessor(); } catch (e) {}
+print("testPrivateAccessor passed");
+// CHECK-NEXT: testPrivateAccessor passed


### PR DESCRIPTION
## Summary

Cherry-pick of `1e94fbe0ebb46d676ff656287e17c58839765e73` from `static_h` to the `250829098.0.0-stable` branch.

A `finally` block emits its body twice, once for normal flow and once for the exception path. On the second emission, legacy class compilation created fresh internal Variables (class and prototype vars, the instance-element init function, computed field keys, private brands) while cached functions reached via `findCompiledEntity` still referenced the originals, miscompiling classes declared in `finally` blocks. The fix caches these in a `LegacyClassVars` struct keyed by the class AST node (`legacyClassVars_`) and emits private-brand stores unconditionally.

This landed on `static_h` after the branch was cut (2025-08-29), so it is missing from the V1 line React Native ships (needed by facebook/react-native#56816). The stacked typed-class sibling `639e5d6af` is intentionally not included: it fixes the Static Hermes typed class path, which standard React Native JS does not exercise. Authored by @tmikov, reviewed internally by @fbmal7.

## Test plan

- Clean cherry-pick, no conflicts. Carries the upstream tests: new `test/IRGen/class-static-in-finally.js` and `test/hermes/class-in-finally.js`, a CHECK update to `test/IRGen/regress-class-recompiled.js` that drops the duplicate `?C1#1`, `?C1.prototype#1`, `<instElemInitFunc:C1>#1` Variables the bug produced, and a brand-store ordering update to `test/IRGen/private-properties.js`.
- Built `hermes` and `hermesc` from `250829098.0.0-stable` (`517edaff8`): the baseline fails `regress-class-recompiled.js` and the runtime `class-in-finally.js`. With this cherry-pick all four bundled tests pass.
- `LIT_FILTER="class-in-finally|regress-class-recompiled|class-static-in-finally" cmake --build build --target check-hermes` passes.
