### PR TITLE
Add npm metadata for babel-plugin-syntax-hermes-parser

### DIFF
--- a/tools/hermes-parser/js/babel-plugin-syntax-hermes-parser/package.json
+++ b/tools/hermes-parser/js/babel-plugin-syntax-hermes-parser/package.json
@@ -6,7 +6,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git@github.com:facebook/hermes.git"
+    "url": "git+https://github.com/facebook/hermes.git",
+    "directory": "tools/hermes-parser/js/babel-plugin-syntax-hermes-parser"
+  },
+  "homepage": "https://github.com/facebook/hermes/tree/main/tools/hermes-parser/js/babel-plugin-syntax-hermes-parser#readme",
+  "bugs": {
+    "url": "https://github.com/facebook/hermes/issues"
   },
   "dependencies": {
     "hermes-parser": "0.26.0"


### PR DESCRIPTION
Summary:
- Add homepage metadata for the babel-plugin-syntax-hermes-parser npm package.
- Add bugs.url metadata pointing to the Hermes issue tracker.

Validation:
- node -e "const p=require('./tools/hermes-parser/js/babel-plugin-syntax-hermes-parser/package.json'); if(!p.homepage || !p.bugs?.url) process.exit(1)"
- git diff --check

Bounty: https://github.com/charles-openclaw/charles-microbounties/issues/1171