### PR TITLE
Fixing small typos in the codebase

### DIFF
--- a/lib/IR/IRVerifier.cpp
+++ b/lib/IR/IRVerifier.cpp
@@ -27,7 +27,7 @@ namespace {
 
 /// IR Verifier - the verifier checks some basic properties of the IR to make
 /// sure that it is not incorrect. For example, it checks that instructions are
-/// dominated by their oparands and that the entry block has no predecessors.
+/// dominated by their operands and that the entry block has no predecessors.
 ///
 /// The verifier also checks if the IR is in optimized form that allows bytecode
 /// generation. For example, it checks that there are no unreachable basic

--- a/lib/IRGen/ESTreeIRGen-expr.cpp
+++ b/lib/IRGen/ESTreeIRGen-expr.cpp
@@ -1420,8 +1420,9 @@ ESTreeIRGen::MemberExpressionResult ESTreeIRGen::emitMemberLoad(
       }
     } else {
       auto *loadProp = Builder.createLoadPropertyInst(baseValue, propValue);
-      loadProp->setType(getTypeContext().unionTy(
-          Type::createString(), Type::createUndefined()));
+      loadProp->setType(
+          getTypeContext().unionTy(
+              Type::createString(), Type::createUndefined()));
       auto *cast =
           Builder.createCheckedTypeCastInst(loadProp, Type::createString());
       return MemberExpressionResult{cast, nullptr, baseValue};

--- a/lib/IRGen/ESTreeIRGen-expr.cpp
+++ b/lib/IRGen/ESTreeIRGen-expr.cpp
@@ -24,7 +24,7 @@ Value *ESTreeIRGen::enforceExprType(hermes::Value *value, ESTree::Node *expr) {
   Type valueType = value->getType();
   TypeContext &tc = getTypeContext();
   // NOTE: equal sets are subsets of each other, but we want to do the fast
-  // check first. In theory, it should catsh 100% of the cases when IRGen is
+  // check first. In theory, it should catch 100% of the cases when IRGen is
   // fully typed.
   if (exprIRType == valueType || tc.isSubsetOf(valueType, exprIRType))
     return value;
@@ -1420,9 +1420,8 @@ ESTreeIRGen::MemberExpressionResult ESTreeIRGen::emitMemberLoad(
       }
     } else {
       auto *loadProp = Builder.createLoadPropertyInst(baseValue, propValue);
-      loadProp->setType(
-          getTypeContext().unionTy(
-              Type::createString(), Type::createUndefined()));
+      loadProp->setType(getTypeContext().unionTy(
+          Type::createString(), Type::createUndefined()));
       auto *cast =
           Builder.createCheckedTypeCastInst(loadProp, Type::createString());
       return MemberExpressionResult{cast, nullptr, baseValue};


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `main`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/HEAD/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.

  Note: We kindly request that pull requests address more than just a single typo.
  While we sincerely appreciate your attention to detail, we would be most grateful
  if typo fixes were batched together to include several corrections. This helps our
  maintainers focus on substantive contributions to the codebase. Thank you for your
  understanding and cooperation!
-->

## Summary

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
-->
Fixes #2051 
This PR fixes 2 small typos in the codebase

`lib/IRGen/ESTreeIRGen-expr.cpp` line 28 — "catsh" should be "catch":
```
// In theory, it should catsh 100% of the cases when IRGen is  
```

`lib/IR/IRVerifier.cpp` line 30 — "oparands" should be "operands":
```
// sure that it is not incorrect. For example, it checks that instructions are  
// dominated by their oparands and that the entry block has no predecessors.  
```

## Test Plan

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes the user interface.
-->
There are none
