### PR TITLE
Add missing `Promise.prototype[Symbol.toStringTag]` prop

### DIFF
--- a/lib/InternalJavaScript/01-Promise.js
+++ b/lib/InternalJavaScript/01-Promise.js
@@ -853,6 +853,12 @@
   // See InternalBytecode/README.md for more details.
 
 
+  Object.defineProperty(Promise.prototype, Symbol.toStringTag, {
+    value: 'Promise',
+    configurable: true,
+    enumerable: false,
+    writable: false
+  });
 
 
   // Expose Promise to global, with the spec attributes for

--- a/test/hermes/promise-to-string-tag.js
+++ b/test/hermes/promise-to-string-tag.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes %s | %FileCheck --match-full-lines %s
+// RUN: %hermes -Xmicrotask-queue %s | %FileCheck --match-full-lines %s
+
+print('promise-toStringTag');
+// CHECK-LABEL: promise-toStringTag
+
+// 1. check toStringTag value
+print(Promise.prototype[Symbol.toStringTag]);
+// CHECK-NEXT: Promise
+
+// 2. not writable
+Promise.prototype[Symbol.toStringTag] = '1'
+print(Promise.prototype[Symbol.toStringTag]);
+// CHECK-NEXT: Promise
+
+// 3. Should be inherited by subclass
+class MyPromise extends Promise {}
+
+print(MyPromise.prototype[Symbol.toStringTag]);
+// CHECK-NEXT: Promise


### PR DESCRIPTION


## Summary

issue: https://github.com/facebook/hermes/issues/1009

## Test Plan

```bash
LIT_OPTS="-j1" LIT_FILTER="promise-to-string-tag.js" cmake --build build --target check-hermes
```