### PR TITLE
chore: Add missing npm data

### DIFF
--- a/tools/hermes-parser/js/babel-plugin-syntax-hermes-parser/package.json
+++ b/tools/hermes-parser/js/babel-plugin-syntax-hermes-parser/package.json
@@ -4,6 +4,8 @@
   "description": "Babel plugin which switches Babel to use the Hermes parser.",
   "main": "dist/index.js",
   "license": "MIT",
+  "homepage": "https://github.com/facebook/hermes#readme",
+  "bugs": "https://github.com/facebook/hermes/issues",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/facebook/hermes.git",

--- a/tools/hermes-parser/js/flow-api-translator/package.json
+++ b/tools/hermes-parser/js/flow-api-translator/package.json
@@ -4,6 +4,8 @@
   "description": "Toolkit for creating Flow and TypeScript compatible libraries from Flow source code.",
   "main": "dist/index.js",
   "license": "MIT",
+  "homepage": "https://github.com/facebook/hermes#readme",
+  "bugs": "https://github.com/facebook/hermes/issues",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/facebook/hermes.git",

--- a/tools/hermes-parser/js/hermes-eslint/package.json
+++ b/tools/hermes-parser/js/hermes-eslint/package.json
@@ -4,6 +4,8 @@
   "description": "A custom parser for ESLint using the Hermes parser",
   "main": "dist/index.js",
   "license": "MIT",
+  "homepage": "https://github.com/facebook/hermes#readme",
+  "bugs": "https://github.com/facebook/hermes/issues",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/facebook/hermes.git",

--- a/tools/hermes-parser/js/hermes-estree/package.json
+++ b/tools/hermes-parser/js/hermes-estree/package.json
@@ -4,6 +4,8 @@
   "description": "Flow types for the Flow-ESTree spec produced by the hermes parser",
   "main": "dist/index.js",
   "license": "MIT",
+  "homepage": "https://github.com/facebook/hermes#readme",
+  "bugs": "https://github.com/facebook/hermes/issues",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/facebook/hermes.git",

--- a/tools/hermes-parser/js/hermes-parser/package.json
+++ b/tools/hermes-parser/js/hermes-parser/package.json
@@ -4,6 +4,8 @@
   "description": "A JavaScript parser built from the Hermes engine",
   "main": "dist/index.js",
   "license": "MIT",
+  "homepage": "https://github.com/facebook/hermes#readme",
+  "bugs": "https://github.com/facebook/hermes/issues",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/facebook/hermes.git",

--- a/tools/hermes-parser/js/hermes-transform/package.json
+++ b/tools/hermes-parser/js/hermes-transform/package.json
@@ -4,6 +4,8 @@
   "description": "Tools built on top of Hermes-ESTree to enable codebase transformation",
   "main": "dist/index.js",
   "license": "MIT",
+  "homepage": "https://github.com/facebook/hermes#readme",
+  "bugs": "https://github.com/facebook/hermes/issues",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/facebook/hermes.git",

--- a/tools/hermes-parser/js/prettier-plugin-hermes-parser/package.json
+++ b/tools/hermes-parser/js/prettier-plugin-hermes-parser/package.json
@@ -3,6 +3,8 @@
   "version": "0.36.1",
   "description": "Hermes parser plugin for Prettier.",
   "license": "MIT",
+  "homepage": "https://github.com/facebook/hermes#readme",
+  "bugs": "https://github.com/facebook/hermes/issues",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/facebook/hermes.git",

--- a/tools/hermes-parser/js/prettier-plugin-hermes-parser/package.json
+++ b/tools/hermes-parser/js/prettier-plugin-hermes-parser/package.json
@@ -3,6 +3,8 @@
   "version": "0.37.0",
   "description": "Hermes parser plugin for Prettier.",
   "license": "MIT",
+  "homepage": "https://github.com/facebook/hermes#readme",
+  "bugs": "https://github.com/facebook/hermes/issues",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/facebook/hermes.git",


### PR DESCRIPTION

## Summary

All packages in npm from [hermes-team](https://www.npmjs.com/~hermes-team) has no links to github repo or homepage 

See:

<img width="1300" height="701" alt="Screenshot 2026-06-17 at 11 45 08" src="https://github.com/user-attachments/assets/b18c8128-6ed0-4905-8d70-bbf98a260cba" />



React as comparison: 

<img width="1327" height="693" alt="Screenshot 2026-06-17 at 11 43 22" src="https://github.com/user-attachments/assets/39b65ed6-eb3a-48a4-b612-9b042aa6afed" />




## Test Plan

...