### PR TITLE
Update Github CI to use VS2026 on Windows (#2061)

### DIFF
--- a/.github/workflows/build-hermesc-windows.yml
+++ b/.github/workflows/build-hermesc-windows.yml
@@ -4,7 +4,7 @@ on: workflow_call
 
 jobs:
   build-hermesc-windows:
-    runs-on: windows-2025
+    runs-on: windows-2022
     env:
       HERMES_WS_DIR: 'C:\tmp\hermes'
       HERMES_TARBALL_ARTIFACTS_DIR: 'C:\tmp\hermes\hermes-runtime-darwin'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,7 +158,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2025, windows-11-arm]
+        os: [windows-2022, windows-11-arm]
         build_type: [Debug, Release]
         target_cpu: [x86_64, arm64]
         cmake_flags: ["", "-DBOOST_CONTEXT_IMPLEMENTATION=winfib"]
@@ -167,9 +167,9 @@ jobs:
             target_cpu: x86_64
           - os: windows-11-arm
             cmake_flags: ""
-          - os: windows-2025
+          - os: windows-2022
             target_cpu: arm64
-          - os: windows-2025
+          - os: windows-2022
             cmake_flags: "-DBOOST_CONTEXT_IMPLEMENTATION=winfib"
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Summary:

The default VS version on windows-2025 is now VS2026:
https://github.blog/changelog/2026-02-05-github-actions-early-february-2026-updates/#windows-server-2025-with-visual-studio-2026-image-now-available-for-github-hosted-runners

Differential Revision: D108902142


