### PR TITLE
Run GitHub actions through latest Node.js LTS by default (currently v24)

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -4,7 +4,7 @@ inputs:
   node-version:
     description: 'The node.js version to use'
     required: false
-    default: '22.14.0'
+    default: 'lts/*'
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
Summary:
As part of migrating npm publishing to [Trusted Publish (OIDC)](https://docs.npmjs.com/trusted-publishers/), we'll need to use `npm` CLI at minimum 11.5.1, which is bundled with Node v24.

This bumps the `setup-node` action for both publishing branches to the alias `lts/*` from the fixed `22.14.0`. Version ranges should be preferred over fixed versions to allow security fixes to be picked up in any case - this goes further than strictly necessary by moving to the dynamic `lts/*` alias (latest LTS). IMO that feels like a sensible, low-maintenance default.

Differential Revision: D109435888


