### PR TITLE
Support default perf report rows in agent perf tools

### DIFF
--- a/agent-perf/tests/test_profile_to_json.py
+++ b/agent-perf/tests/test_profile_to_json.py
@@ -58,6 +58,48 @@ class TestParsePerfReport(unittest.TestCase):
         self.assertEqual(results[1]["samples"], 0)
         self.assertEqual(results[1]["percentage"], 5.67)
 
+    def test_parse_default_children_self_format(self):
+        """Test parsing perf's default Children/Self percentage columns."""
+        lines = [
+            "# Children      Self  Command  Shared Object       Symbol",
+            "    25.00%    12.50%  hermes   libhermes.so        [.] hotFunction",
+            "     8.00%     1.25%  hermes   [kernel.kallsyms]   [k] page_fault",
+        ]
+        results = parse_perf_report(lines)
+
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]["function"], "hotFunction")
+        self.assertEqual(results[0]["module"], "libhermes.so")
+        self.assertEqual(results[0]["samples"], 0)
+        self.assertEqual(results[0]["percentage"], 12.50)
+
+        self.assertEqual(results[1]["function"], "page_fault")
+        self.assertEqual(results[1]["module"], "[kernel.kallsyms]")
+        self.assertEqual(results[1]["percentage"], 1.25)
+
+    def test_parse_module_names_with_spaces(self):
+        """Test parsing module names that contain spaces."""
+        lines = [
+            "     4.00%     2.00%  hermes   JIT code            [.] jittedFunction",
+        ]
+        results = parse_perf_report(lines)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["module"], "JIT code")
+        self.assertEqual(results[0]["function"], "jittedFunction")
+        self.assertEqual(results[0]["percentage"], 2.00)
+
+    def test_parse_function_names_with_bracket_suffixes(self):
+        """Test parsing function names that contain bracketed suffixes."""
+        lines = [
+            "     4.00%     2.00%  hermes   libhermes.so        [.] foo[abi:cxx11]",
+        ]
+        results = parse_perf_report(lines)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["module"], "libhermes.so")
+        self.assertEqual(results[0]["function"], "foo[abi:cxx11]")
+
     def test_skip_comment_and_empty_lines(self):
         """Test that comment and empty lines are skipped."""
         lines = [

--- a/agent-perf/tests/test_runtime_call_profiler.py
+++ b/agent-perf/tests/test_runtime_call_profiler.py
@@ -235,6 +235,37 @@ class TestParsePerfReportSh(unittest.TestCase):
         self.assertEqual(result[0]["samples"], 0)  # Default when not present
         self.assertEqual(result[0]["module"], "libhermes.so")
 
+    def test_handles_default_children_self_format(self):
+        """Test parsing perf's default Children/Self percentage columns."""
+        lines = [
+            "# Children      Self  Command  Shared Object       Symbol",
+            "    20.00%    10.50%  app      libhermes.so        [.] _sh_ljs_add_rjs",
+            "     7.00%     3.25%  app      libhermes.so        [.] _sh_push_locals",
+            "     2.00%     0.50%  app      libhermes.so        [.] helper_func",
+        ]
+
+        result = parse_perf_report_sh(lines)
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["function"], "_sh_ljs_add_rjs")
+        self.assertEqual(result[0]["percentage"], 10.50)
+        self.assertEqual(result[0]["samples"], 0)
+        self.assertEqual(result[1]["function"], "_sh_push_locals")
+        self.assertEqual(result[1]["percentage"], 3.25)
+
+    def test_handles_modules_with_spaces(self):
+        """Test parsing _sh_* entries from modules whose names contain spaces."""
+        lines = [
+            "     4.00%     2.00%  app      JIT code            [.] _sh_ljs_call_rjs",
+        ]
+
+        result = parse_perf_report_sh(lines)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["module"], "JIT code")
+        self.assertEqual(result[0]["function"], "_sh_ljs_call_rjs")
+        self.assertEqual(result[0]["percentage"], 2.00)
+
     def test_skips_comments_and_empty_lines(self):
         """Test that comments and empty lines are skipped."""
         lines = [

--- a/agent-perf/tools/perf_report_parser.py
+++ b/agent-perf/tools/perf_report_parser.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Helpers for parsing perf report --stdio symbol rows."""
+
+import re
+from typing import Dict, Optional
+
+
+_PERCENT_RE = re.compile(r"^\d+(?:\.\d+)?%$")
+_SYMBOL_TYPE_RE = re.compile(r"\[[^\]]\]\s+")
+
+
+def parse_perf_report_line(line: str) -> Optional[Dict]:
+    """Parse one perf report --stdio symbol row.
+
+    Supports the compact formats used by agent-perf tools:
+        12.34%  1234  hermes  libhermes.so  [.] someFunction
+        12.34%        hermes  libhermes.so  [.] someFunction
+
+    It also supports perf's default Children/Self layout:
+        12.34%  5.67%  hermes  libhermes.so  [.] someFunction
+
+    Returns None for comments, empty lines, headers, and unrecognized rows.
+    """
+    line = line.rstrip("\n")
+    if not line.strip() or line.lstrip().startswith("#"):
+        return None
+
+    symbol_match = _SYMBOL_TYPE_RE.search(line)
+    if not symbol_match:
+        return None
+
+    function = line[symbol_match.end() :].strip()
+    if not function:
+        return None
+
+    prefix = line[: symbol_match.start()].strip()
+    tokens = prefix.split()
+    if not tokens:
+        return None
+
+    idx = 0
+    percentages = []
+    while idx < len(tokens) and _PERCENT_RE.match(tokens[idx]):
+        percentages.append(float(tokens[idx][:-1]))
+        idx += 1
+
+    if not percentages:
+        return None
+
+    samples = 0
+    if idx < len(tokens) and tokens[idx].isdigit():
+        samples = int(tokens[idx])
+        idx += 1
+
+    if idx >= len(tokens):
+        return None
+
+    idx += 1  # command
+    if idx >= len(tokens):
+        return None
+
+    return {
+        "function": function,
+        "module": " ".join(tokens[idx:]),
+        "samples": samples,
+        "percentage": percentages[-1],
+    }

--- a/agent-perf/tools/profile_to_json.py
+++ b/agent-perf/tools/profile_to_json.py
@@ -21,9 +21,10 @@ Examples:
 
 import argparse
 import json
-import re
 import sys
 from typing import Dict, List, Optional
+
+from perf_report_parser import parse_perf_report_line
 
 
 def parse_perf_report(lines: List[str]) -> List[Dict]:
@@ -37,54 +38,10 @@ def parse_perf_report(lines: List[str]) -> List[Dict]:
     Returns a list of dicts with keys: function, module, samples, percentage.
     """
     results = []
-    # Pattern matches lines like:
-    #   12.34%  1234  command  module  [.] function
-    # The percentage may or may not have leading spaces.
-    # Some versions omit sample counts; we handle both.
-    pattern_with_samples = re.compile(
-        r"^\s*(\d+\.\d+)%\s+"  # percentage
-        r"(\d+)\s+"  # sample count
-        r"(\S+)\s+"  # command
-        r"(\S+)\s+"  # shared object / module
-        r"\[.\]\s+"  # symbol type indicator [.] or [k] etc.
-        r"(.+?)\s*$"  # function name
-    )
-    pattern_no_samples = re.compile(
-        r"^\s*(\d+\.\d+)%\s+"  # percentage
-        r"(\S+)\s+"  # command
-        r"(\S+)\s+"  # shared object / module
-        r"\[.\]\s+"  # symbol type indicator
-        r"(.+?)\s*$"  # function name
-    )
-
     for line in lines:
-        line = line.rstrip("\n")
-        # Skip comment and empty lines.
-        if not line or line.startswith("#"):
-            continue
-
-        m = pattern_with_samples.match(line)
-        if m:
-            results.append(
-                {
-                    "function": m.group(5),
-                    "module": m.group(4),
-                    "samples": int(m.group(2)),
-                    "percentage": float(m.group(1)),
-                }
-            )
-            continue
-
-        m = pattern_no_samples.match(line)
-        if m:
-            results.append(
-                {
-                    "function": m.group(4),
-                    "module": m.group(3),
-                    "samples": 0,
-                    "percentage": float(m.group(1)),
-                }
-            )
+        entry = parse_perf_report_line(line)
+        if entry:
+            results.append(entry)
 
     return results
 

--- a/agent-perf/tools/runtime_call_profiler.py
+++ b/agent-perf/tools/runtime_call_profiler.py
@@ -37,6 +37,8 @@ import sys
 from collections import Counter, defaultdict
 from typing import Dict, List, Optional
 
+from perf_report_parser import parse_perf_report_line
+
 
 # Category classification for _sh_* functions (same categories as
 # generated_code_analyzer.py for consistency).
@@ -121,55 +123,16 @@ def parse_perf_report_sh(lines: List[str]) -> List[Dict]:
     """
     results = []
 
-    # Matches perf report lines with sample counts.
-    pattern_with_samples = re.compile(
-        r"^\s*(\d+\.\d+)%\s+"
-        r"(\d+)\s+"
-        r"(\S+)\s+"
-        r"(\S+)\s+"
-        r"\[.\]\s+"
-        r"(.+?)\s*$"
-    )
-    # Matches perf report lines without sample counts.
-    pattern_no_samples = re.compile(
-        r"^\s*(\d+\.\d+)%\s+"
-        r"(\S+)\s+"
-        r"(\S+)\s+"
-        r"\[.\]\s+"
-        r"(.+?)\s*$"
-    )
-
     for line in lines:
-        line = line.rstrip("\n")
-        if not line or line.startswith("#"):
-            continue
-
-        func_name = None
-        module = None
-        samples = 0
-        pct = 0.0
-
-        m = pattern_with_samples.match(line)
-        if m:
-            pct = float(m.group(1))
-            samples = int(m.group(2))
-            module = m.group(4)
-            func_name = m.group(5)
-        else:
-            m = pattern_no_samples.match(line)
-            if m:
-                pct = float(m.group(1))
-                module = m.group(3)
-                func_name = m.group(4)
-
-        if func_name and func_name.startswith("_sh_"):
+        entry = parse_perf_report_line(line)
+        if entry and entry["function"].startswith("_sh_"):
             results.append(
                 {
-                    "function": func_name,
-                    "module": module or "<unknown>",
-                    "samples": samples,
-                    "percentage": pct,
-                    "category": categorize(func_name),
+                    "function": entry["function"],
+                    "module": entry["module"],
+                    "samples": entry["samples"],
+                    "percentage": entry["percentage"],
+                    "category": categorize(entry["function"]),
                 }
             )
 


### PR DESCRIPTION
## Summary

`profile_to_json.py` and `runtime_call_profiler.py` only parsed perf rows with one percentage column, with or without a sample count. Default `perf report --stdio` output commonly uses `Children` and `Self` percentage columns before `Command`, `Shared Object`, and `Symbol`, so those rows were ignored.

This change adds a shared perf report row parser and reuses it from both tools. The parser now handles:

- existing single-percentage rows with samples
- existing single-percentage rows without samples
- default `Children` / `Self` rows, using `Self` as the per-symbol percentage
- bracketed modules such as `[kernel.kallsyms]`
- module names with spaces
- function names with bracketed suffixes such as `[abi:cxx11]`

## Test Plan

```powershell
python -m unittest agent-perf\tests\test_profile_to_json.py agent-perf\tests\test_runtime_call_profiler.py
python -m unittest discover -s agent-perf\tests -p "test_*.py"
python -m compileall -q agent-perf
git diff --check
```

All commands passed locally.

## Branch

`codex/agent-perf-default-perf-report`

## Commit

`0a00509e0a8546f7cb148dda0fab3f9efbb332bb`