### PR TITLE
Keep skipped source lines in SH source maps

### DIFF
--- a/agent-perf/tests/test_sh_source_mapper.py
+++ b/agent-perf/tests/test_sh_source_mapper.py
@@ -77,6 +77,8 @@ var y = 43;
         self.assertEqual(len(mappings), 2)
         self.assertEqual(mappings[0]["c_line"], 3)
         self.assertEqual(mappings[1]["c_line"], 5)
+        self.assertEqual(mappings[0]["js_line"], 10)
+        self.assertEqual(mappings[1]["js_line"], 12)
 
     def test_skips_bare_braces(self):
         source = """
@@ -89,6 +91,23 @@ var x = 42;
         # Bare { and } should not create mappings
         self.assertEqual(len(mappings), 1)
         self.assertEqual(mappings[0]["c_source"], "var x = 42;")
+        self.assertEqual(mappings[0]["js_line"], 11)
+
+    def test_skipped_braces_advance_subsequent_js_lines(self):
+        source = """
+#line 10 "input.js"
+{
+var x = 42;
+}
+var y = 43;
+"""
+        mappings = parse_line_directives(source)
+
+        self.assertEqual(len(mappings), 2)
+        self.assertEqual(mappings[0]["c_source"], "var x = 42;")
+        self.assertEqual(mappings[0]["js_line"], 11)
+        self.assertEqual(mappings[1]["c_source"], "var y = 43;")
+        self.assertEqual(mappings[1]["js_line"], 13)
 
     def test_multiple_files_in_same_c_output(self):
         source = """

--- a/agent-perf/tools/sh_source_mapper.py
+++ b/agent-perf/tools/sh_source_mapper.py
@@ -82,7 +82,7 @@ def parse_line_directives(source: str) -> List[Dict]:
                         "c_source": stripped,
                     }
                 )
-                current_js_line += 1
+            current_js_line += 1
 
     return mappings
 


### PR DESCRIPTION
## Summary

`sh_source_mapper.py` intentionally skips empty source lines and bare braces when building mappings, but it also skipped advancing the current JS line number for those lines. That made every later mapping in the same `#line` region drift upward when the source contained blank lines or standalone braces.

This change keeps the existing behavior of not emitting mapping entries for empty lines and bare braces, while still accounting for those source lines before mapping subsequent code.

## Test Plan

```powershell
python -m unittest agent-perf\tests\test_sh_source_mapper.py
python -m unittest discover -s agent-perf\tests -p "test_*.py"
python -m compileall -q agent-perf
git diff --check
```

All commands passed locally.

## Branch

`codex/sh-source-mapper-line-accounting`

## Commit

`75f7d4b6d2a899cc6a81368fa35e31868284a5f9`