### PR TITLE
Flush trailing generated-code call blocks

### DIFF
--- a/agent-perf/tests/test_generated_code_antipatterns.py
+++ b/agent-perf/tests/test_generated_code_antipatterns.py
@@ -78,6 +78,26 @@ class TestGeneratedCodeAntipatterns(unittest.TestCase):
         finally:
             os.unlink(filepath)
 
+    def test_excessive_function_calls_detected_at_function_end(self):
+        """Test detection when a consecutive call block reaches function end."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".c", delete=False) as f:
+            f.write("static SHLegacyValue _1_foo(SHRuntime* shr) {\n")
+            for i in range(10):
+                f.write(f"  _sh_ljs_call_{i}();\n")
+            f.write("}\n")
+            f.flush()
+            filepath = f.name
+
+        try:
+            findings = scan_generated_c(filepath)
+            excessive = [
+                f for f in findings if f["pattern"] == "excessive_function_calls"
+            ]
+            self.assertEqual(len(excessive), 1)
+            self.assertIn("consecutive", excessive[0]["detail"])
+        finally:
+            os.unlink(filepath)
+
     def test_unnecessary_gc_root_detected(self):
         """Test detection of unnecessary GC root push/pop."""
         with tempfile.NamedTemporaryFile(mode="w", suffix=".c", delete=False) as f:

--- a/agent-perf/tools/generated_code_antipatterns.py
+++ b/agent-perf/tools/generated_code_antipatterns.py
@@ -82,6 +82,25 @@ def scan_generated_c(filepath: str) -> List[Dict]:
     consecutive_calls = 0
     call_block_start = 0
 
+    def flush_call_block(last_call_line: int) -> None:
+        nonlocal consecutive_calls
+        if consecutive_calls > 8:
+            findings.append(
+                {
+                    "file": filepath,
+                    "line": call_block_start,
+                    "pattern": "excessive_function_calls",
+                    "detail": (
+                        f"{consecutive_calls} consecutive runtime calls "
+                        f"(lines {call_block_start}-{last_call_line}) "
+                        f"may prevent register allocation optimization"
+                    ),
+                    "severity": "high",
+                    "function": current_func or "<global>",
+                }
+            )
+        consecutive_calls = 0
+
     for i, raw_line in enumerate(lines):
         line = raw_line.rstrip("\n")
         stripped = line.strip()
@@ -98,6 +117,7 @@ def scan_generated_c(filepath: str) -> List[Dict]:
                 func_local_count += 1
 
             if brace_depth <= 0:
+                flush_call_block(lineno - 1)
                 # End of function: check for large stack frame.
                 if func_local_count > 50:
                     findings.append(
@@ -189,22 +209,7 @@ def scan_generated_c(filepath: str) -> List[Dict]:
                 call_block_start = lineno
             consecutive_calls += 1
         else:
-            if consecutive_calls > 8:
-                findings.append(
-                    {
-                        "file": filepath,
-                        "line": call_block_start,
-                        "pattern": "excessive_function_calls",
-                        "detail": (
-                            f"{consecutive_calls} consecutive runtime calls "
-                            f"(lines {call_block_start}-{lineno - 1}) "
-                            f"may prevent register allocation optimization"
-                        ),
-                        "severity": "high",
-                        "function": func_name,
-                    }
-                )
-            consecutive_calls = 0
+            flush_call_block(lineno - 1)
 
         # --- 4. Unnecessary GC root management ---
         if "_sh_push_locals" in stripped or "_sh_new_gcscope" in stripped:


### PR DESCRIPTION
## Summary

`generated_code_antipatterns.py` reports excessive consecutive `_sh_*` runtime calls only when a non-call line terminates the block. If a long runtime-call block reaches the end of a generated function, function-boundary handling runs first and resets state, so the high-density call block is missed.

This change extracts call-block flushing into a helper and uses it both for ordinary non-call terminators and function-end boundaries. A regression test covers a function ending immediately after ten consecutive `_sh_*` calls.

## Test Plan

```powershell
python -m unittest agent-perf\tests\test_generated_code_antipatterns.py
python -m unittest discover -s agent-perf\tests -p "test_*.py"
python -m compileall -q agent-perf
git diff --check
```

All commands passed locally.

## Branch

`codex/generated-code-tail-call-blocks`

## Commit

`0b7f73e971327862e6e56a8d1648a369127e4d25`