### PR TITLE
Handle single-line generated C functions

### DIFF
--- a/agent-perf/tests/test_generated_code_analyzer.py
+++ b/agent-perf/tests/test_generated_code_analyzer.py
@@ -250,6 +250,21 @@ static SHLegacyValue _1_func2(SHRuntime *shr, SHLegacyValue *frame) {
         self.assertEqual(result["functions"][1]["name"], "_1_func2")
         self.assertEqual(result["summary"]["total_runtime_calls"], 2)
 
+    def test_single_line_functions_are_closed_immediately(self):
+        source = """
+static SHLegacyValue _0_func1(SHRuntime *shr, SHLegacyValue *frame) { return _sh_ljs_add(shr, 1, 2); }
+static SHLegacyValue _1_func2(SHRuntime *shr, SHLegacyValue *frame) { return _sh_ljs_mul(shr, 3, 4); }
+"""
+        result = parse_generated_c(source)
+
+        self.assertEqual(len(result["functions"]), 2)
+        self.assertEqual(result["functions"][0]["name"], "_0_func1")
+        self.assertEqual(result["functions"][0]["line_count"], 1)
+        self.assertEqual(result["functions"][0]["total_runtime_calls"], 1)
+        self.assertEqual(result["functions"][1]["name"], "_1_func2")
+        self.assertEqual(result["functions"][1]["line_count"], 1)
+        self.assertEqual(result["functions"][1]["total_runtime_calls"], 1)
+
 
 class TestDetectPatterns(unittest.TestCase):
     """Test anti-pattern detection."""

--- a/agent-perf/tools/generated_code_analyzer.py
+++ b/agent-perf/tools/generated_code_analyzer.py
@@ -149,6 +149,39 @@ def parse_generated_c(source: str) -> Dict[str, Any]:
     current_func_lines: int = 0
     brace_depth: int = 0
 
+    def flush_current_function(end_line: int) -> None:
+        nonlocal current_func, current_func_calls, current_func_gc_scopes
+        nonlocal current_func_lines
+        if current_func is None:
+            return
+
+        total_calls = sum(current_func_calls.values())
+        func_categories: Counter = Counter()
+        for name, count in current_func_calls.items():
+            func_categories[categorize_call(name)] += count
+
+        functions.append(
+            {
+                "name": current_func,
+                "start_line": current_func_start + 1,
+                "end_line": end_line,
+                "line_count": current_func_lines,
+                "total_runtime_calls": total_calls,
+                "gc_scopes": current_func_gc_scopes,
+                "calls_per_line": (
+                    round(total_calls / current_func_lines, 3)
+                    if current_func_lines > 0
+                    else 0
+                ),
+                "call_breakdown": dict(func_categories),
+                "top_calls": current_func_calls.most_common(10),
+            }
+        )
+        current_func = None
+        current_func_calls = Counter()
+        current_func_gc_scopes = 0
+        current_func_lines = 0
+
     for i, line in enumerate(lines):
         # Track brace depth for function boundary detection.
         if current_func is not None:
@@ -168,32 +201,7 @@ def parse_generated_c(source: str) -> Dict[str, Any]:
 
             # End of function.
             if brace_depth <= 0:
-                total_calls = sum(current_func_calls.values())
-                func_categories: Counter = Counter()
-                for name, count in current_func_calls.items():
-                    func_categories[categorize_call(name)] += count
-
-                functions.append(
-                    {
-                        "name": current_func,
-                        "start_line": current_func_start + 1,
-                        "end_line": i + 1,
-                        "line_count": current_func_lines,
-                        "total_runtime_calls": total_calls,
-                        "gc_scopes": current_func_gc_scopes,
-                        "calls_per_line": (
-                            round(total_calls / current_func_lines, 3)
-                            if current_func_lines > 0
-                            else 0
-                        ),
-                        "call_breakdown": dict(func_categories),
-                        "top_calls": current_func_calls.most_common(10),
-                    }
-                )
-                current_func = None
-                current_func_calls = Counter()
-                current_func_gc_scopes = 0
-                current_func_lines = 0
+                flush_current_function(i + 1)
                 continue
 
         # Look for function start.
@@ -213,6 +221,9 @@ def parse_generated_c(source: str) -> Dict[str, Any]:
 
             if "_sh_push_locals" in line or "_sh_new_gcscope" in line:
                 current_func_gc_scopes += 1
+
+            if brace_depth <= 0:
+                flush_current_function(i + 1)
 
     # --- Detect patterns / anti-patterns ---
     patterns = _detect_patterns(source, lines, functions)


### PR DESCRIPTION
## Summary

`generated_code_analyzer.py` did not close functions whose opening and closing braces are on the same line. A generated C function such as `static ... { return _sh_ljs_add(...); }` left parser state open, so the next generated function could be folded into the previous one.

This change factors function finalization into a helper and flushes immediately when a function header line has balanced braces. The existing multi-line function behavior is unchanged.

## Test Plan

```powershell
python -m unittest agent-perf\tests\test_generated_code_analyzer.py
python -m unittest discover -s agent-perf\tests -p "test_*.py"
python -m compileall -q agent-perf
git diff --check static_h..codex/generated-analyzer-single-line-functions
```