### PR TITLE
Handle single-line functions in type coverage

### DIFF
--- a/agent-perf/tests/test_type_coverage_analyzer.py
+++ b/agent-perf/tests/test_type_coverage_analyzer.py
@@ -88,6 +88,19 @@ static SHLegacyValue _0_func(SHRuntime *shr, SHLegacyValue *frame) {
         # Should count all three calls
         self.assertEqual(sum(result["global_calls"].values()), 3)
 
+    def test_single_line_functions_are_counted_separately(self):
+        source = """
+static SHLegacyValue _0_func1(SHRuntime *shr, SHLegacyValue *frame) { return _sh_ljs_add(shr, 1, 2); }
+static SHLegacyValue _1_func2(SHRuntime *shr, SHLegacyValue *frame) { return _sh_ljs_mul(shr, 3, 4); }
+"""
+        result = extract_runtime_calls(source)
+
+        self.assertEqual(len(result["functions"]), 2)
+        self.assertEqual(result["functions"]["_0_func1"]["_sh_ljs_add"], 1)
+        self.assertEqual(result["functions"]["_1_func2"]["_sh_ljs_mul"], 1)
+        self.assertEqual(result["function_lines"]["_0_func1"], 1)
+        self.assertEqual(result["function_lines"]["_1_func2"], 1)
+
 
 class TestCompare(unittest.TestCase):
     """Test comparison of typed vs untyped generated code."""

--- a/agent-perf/tools/type_coverage_analyzer.py
+++ b/agent-perf/tools/type_coverage_analyzer.py
@@ -58,6 +58,16 @@ def extract_runtime_calls(source: str) -> Dict[str, Any]:
     brace_depth = 0
     func_line_count = 0
 
+    def flush_current_function() -> None:
+        nonlocal current_func, current_calls, func_line_count
+        if current_func is None:
+            return
+        functions[current_func] = current_calls
+        function_lines[current_func] = func_line_count
+        current_func = None
+        current_calls = Counter()
+        func_line_count = 0
+
     for line in lines:
         if current_func is not None:
             brace_depth += line.count("{") - line.count("}")
@@ -69,11 +79,7 @@ def extract_runtime_calls(source: str) -> Dict[str, Any]:
                 global_calls[call] += 1
 
             if brace_depth <= 0:
-                functions[current_func] = current_calls
-                function_lines[current_func] = func_line_count
-                current_func = None
-                current_calls = Counter()
-                func_line_count = 0
+                flush_current_function()
                 continue
         else:
             m_func = FUNC_DEF_RE.match(line)
@@ -87,6 +93,9 @@ def extract_runtime_calls(source: str) -> Dict[str, Any]:
                     call = m.group(1)
                     current_calls[call] += 1
                     global_calls[call] += 1
+
+                if brace_depth <= 0:
+                    flush_current_function()
 
     return {
         "global_calls": global_calls,


### PR DESCRIPTION
## Summary

`type_coverage_analyzer.py` had the same one-line generated C function boundary issue in its per-function runtime-call extractor. A function that starts and ends on the same line was not finalized immediately, which could incorrectly attribute later calls to the wrong function.

This change adds a small finalization helper and flushes balanced one-line functions as soon as they are seen.

## Test Plan

```powershell
python -m unittest agent-perf\tests\test_type_coverage_analyzer.py
python -m unittest discover -s agent-perf\tests -p "test_*.py"
python -m compileall -q agent-perf
git diff --check static_h..codex/type-coverage-single-line-functions
```