### PR TITLE
Parse generated function ids in antipattern scan

### DIFF
--- a/agent-perf/tests/test_generated_code_antipatterns.py
+++ b/agent-perf/tests/test_generated_code_antipatterns.py
@@ -187,6 +187,26 @@ class TestGeneratedCodeAntipatterns(unittest.TestCase):
         finally:
             os.unlink(filepath)
 
+    def test_function_with_id_reports_function_name(self):
+        """Test that function#id definitions are attributed to the base name."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".c", delete=False) as f:
+            f.write("static SHLegacyValue _2_bar#123(SHRuntime* shr) {\n")
+            f.write("  _sh_throw();\n")
+            f.write("  int x = 5;\n")
+            f.write("}\n")
+            f.flush()
+            filepath = f.name
+
+        try:
+            findings = scan_generated_c(filepath)
+            unreachable = [
+                f for f in findings if f["pattern"] == "unreachable_after_throw"
+            ]
+            self.assertEqual(len(unreachable), 1)
+            self.assertEqual(unreachable[0]["function"], "_2_bar")
+        finally:
+            os.unlink(filepath)
+
     def test_format_human_empty(self):
         """Test format_human with no findings."""
         result = format_human([])

--- a/agent-perf/tools/generated_code_antipatterns.py
+++ b/agent-perf/tools/generated_code_antipatterns.py
@@ -42,7 +42,7 @@ from typing import Dict, List, Optional
 
 
 # Pattern to match function definitions in generated C.
-FUNC_DEF_RE = re.compile(r"^(?:static\s+)?\w[\w\s*]*\s+(_\d+_\w+)\s*\(")
+FUNC_DEF_RE = re.compile(r"^(?:static\s+)?\w[\w\s*]*\s+(_\d+_\w+)(?:#\d+)?\s*\(")
 FUNC_END_RE = re.compile(r"^}")
 
 


### PR DESCRIPTION
## Summary

`generated_code_antipatterns.py` already had a test comment for generated functions with `#id` suffixes, but its function-definition regex did not actually accept that suffix. Findings inside declarations such as `_2_bar#123(...)` could therefore lose the generated function attribution.

This change accepts an optional numeric `#id` suffix while preserving the base function name in reports.

## Test Plan

```powershell
python -m unittest agent-perf\tests\test_generated_code_antipatterns.py
python -m unittest discover -s agent-perf\tests -p "test_*.py"
python -m compileall -q agent-perf
git diff --check static_h..codex/generated-antipattern-function-ids
```