### PR TITLE
Preserve nm symbol names with spaces

### DIFF
--- a/agent-perf/tests/test_binary_size_analyzer.py
+++ b/agent-perf/tests/test_binary_size_analyzer.py
@@ -68,6 +68,11 @@ class TestParseNmOutput(unittest.TestCase):
         syms = parse_nm_output(nm_output)
         self.assertEqual(syms, {})
 
+    def test_symbol_names_with_spaces_are_preserved(self):
+        nm_output = "0000000000401000 00000100 T _foo symbol clone\n"
+        syms = parse_nm_output(nm_output)
+        self.assertEqual(syms["_foo symbol clone"], 100)
+
 
 class TestCompareSymbols(unittest.TestCase):
     def test_size_increase(self):

--- a/agent-perf/tools/binary_size_analyzer.py
+++ b/agent-perf/tools/binary_size_analyzer.py
@@ -36,7 +36,7 @@ def parse_nm_output(text):
     """
     symbols = {}
     for line in text.strip().splitlines():
-        parts = line.split()
+        parts = line.split(maxsplit=3)
         if len(parts) < 4:
             continue
         size_str, sym_type, name = parts[1], parts[2], parts[3]


### PR DESCRIPTION
## Summary

`binary_size_analyzer.py` parsed `nm --print-size --radix=d` rows with an unrestricted `split()` and then kept only `parts[3]` as the symbol name. If `nm` output contains a symbol display name with spaces or suffix text, the analyzer truncates it before comparison and classification.

This change limits splitting to the first three fields and keeps the remainder of the row as the symbol name.

## Test Plan

```powershell
python -m unittest agent-perf\tests\test_binary_size_analyzer.py
python -m unittest discover -s agent-perf\tests -p "test_*.py"
python -m compileall -q agent-perf
git diff --check static_h..codex/binary-size-symbol-names-with-spaces
```