### PR TITLE
Accept broader perf annotate file markers

### DIFF
--- a/agent-perf/tests/test_annotate_source.py
+++ b/agent-perf/tests/test_annotate_source.py
@@ -105,6 +105,21 @@ class TestParsePerfAnnotate(unittest.TestCase):
         self.assertEqual(results[0]["file"], "/path/to/file.cpp")
         self.assertEqual(results[1]["file"], "/another/file.cpp")
 
+    def test_file_marker_detection_with_relative_windows_and_spaces(self):
+        """Test file markers that are not absolute Unix paths."""
+        lines = [
+            "myFunc():",
+            "       : relative/path/file.cpp:",
+            "  0.50 :    1: code",
+            "       : C:\\\\src\\\\dir with spaces\\\\file.cpp:",
+            "  1.00 :    2: more code",
+        ]
+        results = parse_perf_annotate(lines)
+
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]["file"], "relative/path/file.cpp")
+        self.assertEqual(results[1]["file"], "C:\\\\src\\\\dir with spaces\\\\file.cpp")
+
     def test_hot_detection(self):
         """Test that hot threshold (>= 1.0%) is correctly applied."""
         lines = [

--- a/agent-perf/tools/annotate_source.py
+++ b/agent-perf/tools/annotate_source.py
@@ -52,8 +52,8 @@ def parse_perf_annotate(
     annotated_line = re.compile(r"^\s*(\d+\.\d+)?\s*:\s*(\d+)?\s*:(.*)$")
     # Alternate simpler format: "  pct : source" without explicit line numbers.
     simple_annotated = re.compile(r"^\s*(\d+\.\d+)?\s*:\s(.*)$")
-    # File path line (appears as comment like "// file.cpp").
-    file_marker = re.compile(r"^\s*:\s*(/\S+\.\w+):$")
+    # File path line emitted before source lines.
+    file_marker = re.compile(r"^\s*:\s*(\S.*\S):$")
 
     line_counter = 0
 


### PR DESCRIPTION
## Summary

`annotate_source.py` only recognized file marker lines that looked like absolute Unix paths without spaces. That leaves relative paths, Windows paths, and paths with spaces as `<unknown>` in JSON and human output.

This change keeps the existing marker structure but accepts any non-empty path text between the marker colon and trailing colon.

## Test Plan

```powershell
python -m unittest agent-perf\tests\test_annotate_source.py
python -m unittest discover -s agent-perf\tests -p "test_*.py"
python -m compileall -q agent-perf
git diff --check static_h..codex/annotate-source-file-markers
```