### PR TITLE
Treat missing PMU counters as unavailable

### DIFF
--- a/agent-perf/tests/test_pmu_anomalies.py
+++ b/agent-perf/tests/test_pmu_anomalies.py
@@ -86,6 +86,25 @@ class TestComputeMetrics(unittest.TestCase):
         self.assertIsNone(metrics["l1_dcache_miss_rate"])
         self.assertIsNone(metrics["dtlb_miss_rate"])
 
+    def test_missing_numerator_does_not_imply_zero_rate(self):
+        """Test missing numerator counters return None instead of 0.0."""
+        data = {
+            "instructions": 1000000,
+            "cycles": 500000,
+            "branch_instructions": 200000,
+            "L1_icache_loads": 500000,
+            "L1_dcache_loads": 800000,
+            "dTLB_loads": 800000,
+        }
+
+        metrics = compute_metrics(data)
+
+        self.assertAlmostEqual(metrics["ipc"], 2.0, places=4)
+        self.assertIsNone(metrics["branch_miss_rate"])
+        self.assertIsNone(metrics["l1_icache_miss_rate"])
+        self.assertIsNone(metrics["l1_dcache_miss_rate"])
+        self.assertIsNone(metrics["dtlb_miss_rate"])
+
     def test_zero_denominators(self):
         """Test metrics computation with zero denominators returns None."""
         data = {

--- a/agent-perf/tools/pmu_anomalies.py
+++ b/agent-perf/tools/pmu_anomalies.py
@@ -112,25 +112,41 @@ def safe_div(a: float, b: float) -> Optional[float]:
     return a / b
 
 
+def get_float(data: Dict[str, Any], key: str) -> Optional[float]:
+    """Return a counter as float, or None if the counter is absent."""
+    if key not in data:
+        return None
+    return float(data[key])
+
+
+def safe_rate(
+    data: Dict[str, Any],
+    numerator_key: str,
+    denominator_key: str,
+    scale: float = 1.0,
+) -> Optional[float]:
+    """Return a scaled rate, or None if either counter is absent."""
+    numerator = get_float(data, numerator_key)
+    denominator = get_float(data, denominator_key)
+    if numerator is None or denominator is None:
+        return None
+    return safe_div(numerator * scale, denominator)
+
+
 def compute_metrics(data: Dict[str, Any]) -> Dict[str, Optional[float]]:
     """Derive rate metrics from raw PMU counters."""
-    instructions = float(data.get("instructions", 0))
-    cycles = float(data.get("cycles", 0))
-    branch_instr = float(data.get("branch_instructions", 0))
-    branch_misses = float(data.get("branch_misses", 0))
-    l1i_loads = float(data.get("L1_icache_loads", 0))
-    l1i_misses = float(data.get("L1_icache_misses", 0))
-    l1d_loads = float(data.get("L1_dcache_loads", 0))
-    l1d_misses = float(data.get("L1_dcache_misses", 0))
-    dtlb_loads = float(data.get("dTLB_loads", 0))
-    dtlb_misses = float(data.get("dTLB_misses", 0))
-
     return {
-        "ipc": safe_div(instructions, cycles),
-        "branch_miss_rate": safe_div(branch_misses * 100, branch_instr),
-        "l1_icache_miss_rate": safe_div(l1i_misses * 100, l1i_loads),
-        "l1_dcache_miss_rate": safe_div(l1d_misses * 100, l1d_loads),
-        "dtlb_miss_rate": safe_div(dtlb_misses * 100, dtlb_loads),
+        "ipc": safe_rate(data, "instructions", "cycles"),
+        "branch_miss_rate": safe_rate(
+            data, "branch_misses", "branch_instructions", scale=100
+        ),
+        "l1_icache_miss_rate": safe_rate(
+            data, "L1_icache_misses", "L1_icache_loads", scale=100
+        ),
+        "l1_dcache_miss_rate": safe_rate(
+            data, "L1_dcache_misses", "L1_dcache_loads", scale=100
+        ),
+        "dtlb_miss_rate": safe_rate(data, "dTLB_misses", "dTLB_loads", scale=100),
     }
 
 


### PR DESCRIPTION
## Summary

`pmu_anomalies.py` used `data.get(..., 0)` for every raw counter. That makes a missing numerator indistinguishable from a real zero counter, so partially collected PMU JSON can produce misleading `0.0` rates instead of `N/A`.

This change returns `None` when either side of a metric is absent, preserving the existing divide-by-zero handling for present zero denominators.

## Test Plan

```powershell
python -m unittest agent-perf\tests\test_pmu_anomalies.py
python -m unittest discover -s agent-perf\tests -p "test_*.py"
python -m compileall -q agent-perf
git diff --check static_h..codex/pmu-missing-counters
```