### PR TITLE
Recognize alternate RA spill slot forms

### DIFF
--- a/agent-perf/tests/test_regalloc_report.py
+++ b/agent-perf/tests/test_regalloc_report.py
@@ -103,6 +103,18 @@ class TestRegAllocReport(unittest.TestCase):
         self.assertIn(5, functions[0]["spill_slots"])
         self.assertIn(10, functions[0]["spill_slots"])
 
+    def test_parse_dump_ra_extract_alternate_spill_slot_forms(self):
+        """Test extraction of dotted and bracketed spill slot forms."""
+        lines = [
+            "function foo(a) {\n",
+            "  StoreStackInst %r0, %stack.5\n",
+            "  LoadStackInst %stack[6]\n",
+            "}\n",
+        ]
+        functions = parse_dump_ra(lines)
+        self.assertIn(5, functions[0]["spill_slots"])
+        self.assertIn(6, functions[0]["spill_slots"])
+
     def test_parse_dump_ra_function_with_id(self):
         """Test parsing function#id format."""
         lines = [

--- a/agent-perf/tools/regalloc_report.py
+++ b/agent-perf/tools/regalloc_report.py
@@ -62,6 +62,7 @@ def parse_dump_ra(lines: List[str]) -> List[Dict[str, Any]]:
     spill_marker = re.compile(r"\b(Spill|Reload|SpillInst|ReloadInst)\b", re.IGNORECASE)
     # Mov to stack for spill.
     mov_spill = re.compile(r"\bMov(?:Inst)?\b.*%stack")
+    spill_slot_pattern = re.compile(r"%stack(?:\.|\[)?(\d+)\]?")
 
     current_func: Optional[str] = None
     current_start: int = 0
@@ -94,6 +95,10 @@ def parse_dump_ra(lines: List[str]) -> List[Dict[str, Any]]:
         instr_count = 0
         spill_slots = set()
 
+    def collect_spill_slots(line: str) -> None:
+        for slot_match in spill_slot_pattern.finditer(line):
+            spill_slots.add(int(slot_match.group(1)))
+
     for i, raw_line in enumerate(lines):
         line = raw_line.rstrip("\n")
         lineno = i + 1
@@ -121,19 +126,14 @@ def parse_dump_ra(lines: List[str]) -> List[Dict[str, Any]]:
         # Detect spills.
         if spill_store.search(line) or spill_load.search(line):
             spills += 1
-            # Try to extract spill slot identifier.
-            slot_match = re.search(r"%stack(\d+)", line)
-            if slot_match:
-                spill_slots.add(int(slot_match.group(1)))
+            collect_spill_slots(line)
 
         if spill_marker.search(line):
             spills += 1
 
         if mov_spill.search(line):
             spills += 1
-            slot_match = re.search(r"%stack(\d+)", line)
-            if slot_match:
-                spill_slots.add(int(slot_match.group(1)))
+            collect_spill_slots(line)
 
     # Flush last function.
     flush_function(len(lines))


### PR DESCRIPTION
## Summary

`regalloc_report.py` counted spill instructions but only extracted spill slot IDs written as `%stack5`. Other common textual forms such as `%stack.5` or `%stack[5]` were counted as spills but omitted from `spill_slots`.

This change centralizes spill-slot extraction and recognizes all three forms while keeping the existing `%stack5` behavior.

## Test Plan

```powershell
python -m unittest agent-perf\tests\test_regalloc_report.py
python -m unittest discover -s agent-perf\tests -p "test_*.py"
python -m compileall -q agent-perf
git diff --check static_h..codex/regalloc-spill-slot-forms
```