### PR TITLE
Match indented perf annotate source functions

### DIFF
--- a/agent-perf/tests/test_annotate_source.py
+++ b/agent-perf/tests/test_annotate_source.py
@@ -90,6 +90,19 @@ class TestParsePerfAnnotate(unittest.TestCase):
         results = parse_perf_annotate(lines, function_filter="Function")
         self.assertEqual(len(results), 2)
 
+    def test_function_filter_matches_indented_headers(self):
+        """Test function filters against indented perf annotate headers."""
+        lines = [
+            "  someFunction():",
+            "  0.50 :    1: code1",
+            "  anotherFunction():",
+            "  1.00 :    1: code2",
+        ]
+
+        results = parse_perf_annotate(lines, function_filter="another")
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["source"], " code2")
+
     def test_file_marker_detection(self):
         """Test that file markers are detected and set."""
         lines = [

--- a/agent-perf/tools/annotate_source.py
+++ b/agent-perf/tools/annotate_source.py
@@ -46,7 +46,7 @@ def parse_perf_annotate(
     in_target = function_filter is None  # If no filter, include everything.
 
     # Matches the function header produced by perf annotate.
-    func_header = re.compile(r"^(\S.*):$")
+    func_header = re.compile(r"^\s*(\S.*):\s*$")
     # Matches annotated source lines.  The percentage may be absent (cold line).
     # Format: "  percentage : source" or "         : source"
     annotated_line = re.compile(r"^\s*(\d+\.\d+)?\s*:\s*(\d+)?\s*:(.*)$")
@@ -62,7 +62,7 @@ def parse_perf_annotate(
 
         # Detect function headers.
         m_func = func_header.match(raw)
-        if m_func and not raw.startswith(" "):
+        if m_func and not m_func.group(1).startswith(":"):
             current_function = m_func.group(1).strip()
             if function_filter:
                 in_target = function_filter.lower() in current_function.lower()


### PR DESCRIPTION
Summary:
- Recognize indented function headers in perf annotate source output.
- Keep file marker lines from being treated as function headers.

Test Plan:
- python -m unittest agent-perf\tests\test_annotate_source.py
- python -m unittest discover -s agent-perf\tests -p "test_*.py"
- python -m compileall -q agent-perf
- git diff --check