### PR TITLE
Skip single-line JS block comments

### DIFF
--- a/agent-perf/tests/test_js_antipattern_scan.py
+++ b/agent-perf/tests/test_js_antipattern_scan.py
@@ -288,6 +288,20 @@ class TestJsAntipatternScan(unittest.TestCase):
         finally:
             os.unlink(filepath)
 
+    def test_single_line_block_comment_not_scanned(self):
+        """Test that single-line block comments are skipped."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".js", delete=False) as f:
+            f.write("/* eval('test') */\n")
+            f.flush()
+            filepath = f.name
+
+        try:
+            findings = scan_js_file(filepath)
+            eval_findings = [f for f in findings if f["pattern"] == "eval_usage"]
+            self.assertEqual(len(eval_findings), 0)
+        finally:
+            os.unlink(filepath)
+
     def test_format_human_empty(self):
         """Test format_human with no findings."""
         result = format_human([])

--- a/agent-perf/tools/js_antipattern_scan.py
+++ b/agent-perf/tools/js_antipattern_scan.py
@@ -63,6 +63,8 @@ def scan_js_file(filepath: str) -> List[Dict]:
         lineno = i + 1
 
         # Skip block comments.
+        if "/*" in stripped and "*/" in stripped:
+            continue
         if "/*" in stripped and "*/" not in stripped:
             in_comment_block = True
             continue


### PR DESCRIPTION
Summary:
- Skip single-line /* ... */ block comments before running JS anti-pattern checks.
- Prevent comment-only eval/slow-path examples from being reported as real findings.

Test Plan:
- python -m unittest agent-perf\tests\test_js_antipattern_scan.py
- python -m unittest discover -s agent-perf\tests -p "test_*.py"
- python -m compileall -q agent-perf
- git diff --check