### PR TITLE
Skip C++ comments in antipattern scan

### DIFF
--- a/agent-perf/tests/test_antipattern_scan.py
+++ b/agent-perf/tests/test_antipattern_scan.py
@@ -122,6 +122,22 @@ class TestAntipatternScan(unittest.TestCase):
         finally:
             os.unlink(filepath)
 
+    def test_block_comment_content_not_detected(self):
+        """Test that anti-patterns inside block comments are skipped."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".cpp", delete=False) as f:
+            f.write("/* virtual void foo();\n")
+            f.write("   int x = map[key] + map[key];\n")
+            f.write('   for (;;) { str += "x"; }\n')
+            f.write("*/\n")
+            f.flush()
+            filepath = f.name
+
+        try:
+            findings = scan_file(filepath)
+            self.assertEqual(findings, [])
+        finally:
+            os.unlink(filepath)
+
     def test_unnecessary_copy_detected(self):
         """Test that unnecessary auto copies are detected."""
         with tempfile.NamedTemporaryFile(mode="w", suffix=".cpp", delete=False) as f:

--- a/agent-perf/tools/antipattern_scan.py
+++ b/agent-perf/tools/antipattern_scan.py
@@ -78,10 +78,23 @@ def scan_file(filepath: str) -> List[Dict]:
     in_loop = False
     loop_depth = 0
     brace_depth_at_loop = 0  # noqa: F841
+    in_comment_block = False
 
     for i, line in enumerate(lines):
         stripped = line.strip()
         lineno = i + 1
+
+        # Skip whole-line comments before running pattern heuristics.
+        if in_comment_block:
+            if "*/" in stripped:
+                in_comment_block = False
+            continue
+        if stripped.startswith("/*"):
+            if "*/" not in stripped:
+                in_comment_block = True
+            continue
+        if stripped.startswith("//"):
+            continue
 
         # Track loop context.
         if re.match(r"\b(for|while|do)\b", stripped):
@@ -157,7 +170,7 @@ def scan_file(filepath: str) -> List[Dict]:
                 )
 
         # 4. Virtual dispatch detection (calls through virtual methods).
-        if re.search(r"\bvirtual\b", stripped) and not stripped.startswith("//"):
+        if re.search(r"\bvirtual\b", stripped):
             findings.append(
                 {
                     "file": filepath,


### PR DESCRIPTION
Summary:
- Skip whole-line // comments and block comments before applying C++ anti-pattern heuristics.
- Avoid false positives for patterns that appear only inside comments.

Test Plan:
- python -m unittest agent-perf\tests\test_antipattern_scan.py
- python -m unittest discover -s agent-perf\tests -p "test_*.py"
- python -m compileall -q agent-perf
- git diff --check