### PR TITLE
Limit C++ single-line loop scope

### DIFF
--- a/agent-perf/tests/test_antipattern_scan.py
+++ b/agent-perf/tests/test_antipattern_scan.py
@@ -94,6 +94,22 @@ class TestAntipatternScan(unittest.TestCase):
         finally:
             os.unlink(filepath)
 
+    def test_single_line_loop_does_not_leak_scope(self):
+        """Test that single-line loops do not mark following lines as loop body."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".cpp", delete=False) as f:
+            f.write('for (int i = 0; i < 10; i++) str += "x";\n')
+            f.write('str += "outside";\n')
+            f.flush()
+            filepath = f.name
+
+        try:
+            findings = scan_file(filepath)
+            concat = [f for f in findings if f["pattern"] == "string_concat_loop"]
+            self.assertEqual(len(concat), 1)
+            self.assertEqual(concat[0]["line"], 1)
+        finally:
+            os.unlink(filepath)
+
     def test_virtual_dispatch_detected(self):
         """Test that virtual function declarations are detected."""
         with tempfile.NamedTemporaryFile(mode="w", suffix=".cpp", delete=False) as f:

--- a/agent-perf/tools/antipattern_scan.py
+++ b/agent-perf/tools/antipattern_scan.py
@@ -82,6 +82,7 @@ def scan_file(filepath: str) -> List[Dict]:
     for i, line in enumerate(lines):
         stripped = line.strip()
         lineno = i + 1
+        single_line_loop = False
 
         # Track loop context.
         if re.match(r"\b(for|while|do)\b", stripped):
@@ -89,6 +90,7 @@ def scan_file(filepath: str) -> List[Dict]:
                 in_loop = True
                 loop_depth = 0
                 _ = 0  # brace_depth_at_loop placeholder
+                single_line_loop = "{" not in stripped and ";" in stripped
         if in_loop:
             loop_depth += line.count("{") - line.count("}")
             if loop_depth < 0:
@@ -209,6 +211,10 @@ def scan_file(filepath: str) -> List[Dict]:
                         "estimated_impact": "medium",
                     }
                 )
+
+        if single_line_loop:
+            in_loop = False
+            loop_depth = 0
 
     return findings
 


### PR DESCRIPTION
Summary:
- Reset C++ loop tracking after scanning a single-line loop statement.
- Prevent string concatenation after such a loop from being reported as loop-local work.

Test Plan:
- python -m unittest agent-perf\tests\test_antipattern_scan.py
- python -m unittest discover -s agent-perf\tests -p "test_*.py"
- python -m compileall -q agent-perf
- git diff --check