### PR TITLE
Limit JS single-line loop scope

### DIFF
--- a/agent-perf/tests/test_js_antipattern_scan.py
+++ b/agent-perf/tests/test_js_antipattern_scan.py
@@ -132,6 +132,24 @@ class TestJsAntipatternScan(unittest.TestCase):
         finally:
             os.unlink(filepath)
 
+    def test_single_line_loop_does_not_leak_scope(self):
+        """Test that single-line loops do not mark following lines as loop body."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".js", delete=False) as f:
+            f.write("for (let i = 0; i < 10; i++) console.log(obj[key]);\n")
+            f.write("console.log(obj[key]);\n")
+            f.flush()
+            filepath = f.name
+
+        try:
+            findings = scan_js_file(filepath)
+            mega_findings = [
+                f for f in findings if f["pattern"] == "megamorphic_access"
+            ]
+            self.assertEqual(len(mega_findings), 1)
+            self.assertEqual(mega_findings[0]["line"], 1)
+        finally:
+            os.unlink(filepath)
+
     def test_dynamic_property_name_detected(self):
         """Test detection of computed property names."""
         with tempfile.NamedTemporaryFile(mode="w", suffix=".js", delete=False) as f:

--- a/agent-perf/tools/js_antipattern_scan.py
+++ b/agent-perf/tools/js_antipattern_scan.py
@@ -61,6 +61,7 @@ def scan_js_file(filepath: str) -> List[Dict]:
     for i, line in enumerate(lines):
         stripped = line.strip()
         lineno = i + 1
+        single_line_loop = False
 
         # Skip block comments.
         if "/*" in stripped and "*/" not in stripped:
@@ -78,6 +79,7 @@ def scan_js_file(filepath: str) -> List[Dict]:
         if re.search(r"\b(for|while|do)\s*[\(\{]", stripped):
             in_loop = True
             loop_brace_depth = 0
+            single_line_loop = "{" not in stripped and ";" in stripped
         if in_loop:
             loop_brace_depth += line.count("{") - line.count("}")
             if loop_brace_depth < 0:
@@ -272,6 +274,10 @@ def scan_js_file(filepath: str) -> List[Dict]:
                             ),
                         }
                     )
+
+        if single_line_loop:
+            in_loop = False
+            loop_brace_depth = 0
 
     return findings
 


### PR DESCRIPTION
Summary:
- Reset JS loop tracking after scanning a single-line loop statement.
- Prevent following dynamic property accesses from being classified as loop-local megamorphic accesses.

Test Plan:
- python -m unittest agent-perf\tests\test_js_antipattern_scan.py
- python -m unittest discover -s agent-perf\tests -p "test_*.py"
- python -m compileall -q agent-perf
- git diff --check