### PR TITLE
Filter single-file JS scan inputs

### DIFF
--- a/agent-perf/tests/test_js_antipattern_scan.py
+++ b/agent-perf/tests/test_js_antipattern_scan.py
@@ -331,6 +331,17 @@ class TestJsAntipatternScan(unittest.TestCase):
         finally:
             os.unlink(filepath)
 
+    def test_collect_js_files_rejects_non_js_file(self):
+        """Test collect_js_files rejects a single non-JavaScript file."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            filepath = f.name
+
+        try:
+            files = collect_js_files(filepath)
+            self.assertEqual(files, [])
+        finally:
+            os.unlink(filepath)
+
     def test_collect_js_files_directory(self):
         """Test collect_js_files with a directory."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/agent-perf/tools/js_antipattern_scan.py
+++ b/agent-perf/tools/js_antipattern_scan.py
@@ -280,7 +280,8 @@ def collect_js_files(path: str) -> List[str]:
     """Collect JavaScript files from a path (file or directory)."""
     js_extensions = {".js", ".mjs", ".cjs", ".jsx"}
     if os.path.isfile(path):
-        return [path]
+        _, ext = os.path.splitext(path)
+        return [path] if ext in js_extensions else []
     files = []
     try:
         for entry in os.listdir(path):


### PR DESCRIPTION
Summary:
- Apply the JavaScript extension allowlist to single-file inputs as well as directory inputs.
- Return no files for non-JS single-file paths.

Test Plan:
- python -m unittest agent-perf\tests\test_js_antipattern_scan.py
- python -m unittest discover -s agent-perf\tests -p "test_*.py"
- python -m compileall -q agent-perf
- git diff --check