### PR TITLE
Filter single-file C++ scan inputs

### DIFF
--- a/agent-perf/tests/test_antipattern_scan.py
+++ b/agent-perf/tests/test_antipattern_scan.py
@@ -185,6 +185,17 @@ class TestAntipatternScan(unittest.TestCase):
         finally:
             os.unlink(filepath)
 
+    def test_collect_files_rejects_non_cpp_file(self):
+        """Test collect_files rejects a single non-C++ file."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            filepath = f.name
+
+        try:
+            files = collect_files(filepath)
+            self.assertEqual(files, [])
+        finally:
+            os.unlink(filepath)
+
     def test_collect_files_directory(self):
         """Test collect_files with a directory."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/agent-perf/tools/antipattern_scan.py
+++ b/agent-perf/tools/antipattern_scan.py
@@ -217,7 +217,8 @@ def collect_files(path: str) -> List[str]:
     """Collect C++ source files from a path (file or directory)."""
     cpp_extensions = {".cpp", ".cc", ".cxx", ".h", ".hpp", ".hxx"}
     if os.path.isfile(path):
-        return [path]
+        _, ext = os.path.splitext(path)
+        return [path] if ext in cpp_extensions else []
     files = []
     # Non-recursive: only scan the immediate directory.
     # For recursive scanning, the user should specify individual files or use


### PR DESCRIPTION
Summary:
- Apply the C++ extension allowlist to single-file inputs as well as directory inputs.
- Return no files for non-C++ single-file paths.

Test Plan:
- python -m unittest agent-perf\tests\test_antipattern_scan.py
- python -m unittest discover -s agent-perf\tests -p "test_*.py"
- python -m compileall -q agent-perf
- git diff --check