### PR TITLE
Accept 0x-prefixed annotate addresses

### DIFF
--- a/agent-perf/tests/test_annotate_disasm.py
+++ b/agent-perf/tests/test_annotate_disasm.py
@@ -229,6 +229,18 @@ class TestParseDisasmAnnotations(unittest.TestCase):
         self.assertEqual(results[0]["address"], "0x4005a3")
         self.assertEqual(results[1]["address"], "0xabc123")
 
+    def test_parse_address_with_existing_0x_prefix(self):
+        """Test parsing assembly lines whose address already has 0x."""
+        lines = [
+            "  func():",
+            "  1.00  :  0x4005a3: nop",
+        ]
+        results = parse_disasm_annotations(lines)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["address"], "0x4005a3")
+        self.assertEqual(results[0]["instruction"], "nop")
+
     def test_unknown_function_when_no_header(self):
         """Test that function is <unknown> when no header seen."""
         lines = [

--- a/agent-perf/tools/annotate_disasm.py
+++ b/agent-perf/tools/annotate_disasm.py
@@ -56,7 +56,7 @@ def parse_disasm_annotations(
     # Format: "  pct  :  addr: instruction" or "       :  addr: instruction"
     asm_line = re.compile(
         r"^\s*(\d+\.\d+)?\s*:\s*"  # optional percentage
-        r"([0-9a-fA-F]+):\s+"  # hex address
+        r"(?:0x)?([0-9a-fA-F]+):\s+"  # hex address
         r"(.+?)\s*$"  # instruction text
     )
 


### PR DESCRIPTION
Summary:
- Accept perf annotate disassembly addresses that already include a 0x prefix.
- Keep normalized output in the existing 0x-prefixed address format.

Test Plan:
- python -m unittest agent-perf\tests\test_annotate_disasm.py
- python -m unittest discover -s agent-perf\tests -p "test_*.py"
- python -m compileall -q agent-perf
- git diff --check