### PR TITLE
Parse quoted RA function names

### DIFF
--- a/agent-perf/tests/test_regalloc_report.py
+++ b/agent-perf/tests/test_regalloc_report.py
@@ -115,6 +115,18 @@ class TestRegAllocReport(unittest.TestCase):
         self.assertEqual(len(functions), 1)
         self.assertEqual(functions[0]["name"], "bar")
 
+    def test_parse_dump_ra_quoted_function_name(self):
+        """Test parsing quoted function names with spaces."""
+        lines = [
+            'function "foo bar"(x) {\n',
+            "  %r0 = LoadParamInst x\n",
+            "  ReturnInst %r0\n",
+            "}\n",
+        ]
+        functions = parse_dump_ra(lines)
+        self.assertEqual(len(functions), 1)
+        self.assertEqual(functions[0]["name"], "foo bar")
+
     def test_parse_dump_ra_multiple_functions(self):
         """Test parsing multiple functions."""
         lines = [

--- a/agent-perf/tools/regalloc_report.py
+++ b/agent-perf/tools/regalloc_report.py
@@ -48,9 +48,11 @@ def parse_dump_ra(lines: List[str]) -> List[Dict[str, Any]]:
     """
     functions: List[Dict[str, Any]] = []
 
-    # Function header pattern: "function <name>(<params>)"
-    # or "function <name>#<id>(<params>)"
-    func_header = re.compile(r"^(?:scope\s+)?function\s+(\S+?)(?:#\d+)?\s*\(")
+    # Function header pattern: "function <name>(<params>)",
+    # "function <name>#<id>(<params>)", or quoted display names.
+    func_header = re.compile(
+        r'^(?:scope\s+)?function\s+(?:"([^"]+)"|(\S+?)(?:#\d+)?)\s*\('
+    )
 
     # Register usage pattern: %rN where N is the register number.
     reg_pattern = re.compile(r"%r(\d+)")
@@ -103,7 +105,7 @@ def parse_dump_ra(lines: List[str]) -> List[Dict[str, Any]]:
         if m_func:
             # Flush previous function.
             flush_function(lineno - 1)
-            current_func = m_func.group(1)
+            current_func = m_func.group(1) or m_func.group(2)
             current_start = lineno
             continue
 


### PR DESCRIPTION
Summary:
- Parse quoted shermes -dump-ra function display names that contain spaces.
- Preserve existing parsing for unquoted function names and #id suffixes.

Test Plan:
- python -m unittest agent-perf\tests\test_regalloc_report.py
- python -m unittest discover -s agent-perf\tests -p "test_*.py"
- python -m compileall -q agent-perf
- git diff --check