### PR TITLE
Classify more binary-size arithmetic symbols

### DIFF
--- a/agent-perf/tests/test_binary_size_analyzer.py
+++ b/agent-perf/tests/test_binary_size_analyzer.py
@@ -141,6 +141,11 @@ class TestClassifySymbol(unittest.TestCase):
         self.assertEqual(classify_symbol("_sh_ljs_add_rjs"), "arithmetic")
         self.assertEqual(classify_symbol("_sh_ljs_sub_rjs"), "arithmetic")
         self.assertEqual(classify_symbol("_sh_ljs_mul_rjs"), "arithmetic")
+        self.assertEqual(classify_symbol("_sh_ljs_div_rjs"), "arithmetic")
+        self.assertEqual(classify_symbol("_sh_ljs_mod_rjs"), "arithmetic")
+        self.assertEqual(classify_symbol("_sh_ljs_inc_rjs"), "arithmetic")
+        self.assertEqual(classify_symbol("_sh_ljs_dec_rjs"), "arithmetic")
+        self.assertEqual(classify_symbol("_sh_ljs_negate_rjs"), "arithmetic")
 
     def test_generated_js(self):
         self.assertEqual(classify_symbol("_0_global"), "generated_js")

--- a/agent-perf/tools/binary_size_analyzer.py
+++ b/agent-perf/tools/binary_size_analyzer.py
@@ -121,7 +121,7 @@ def classify_symbol(name):
         return "property_put"
     if "_sh_ljs_call" in name or "_sh_ljs_construct" in name:
         return "calls"
-    if "_sh_ljs_add" in name or "_sh_ljs_sub" in name or "_sh_ljs_mul" in name:
+    if re.search(r"_sh_ljs_(add|sub|mul|div|mod|inc|dec|negate)", name):
         return "arithmetic"
     if "_0_global" in name or re.match(r"_\d+_", name):
         return "generated_js"


### PR DESCRIPTION
Summary:
- Classify additional _sh_ljs arithmetic runtime symbols in binary size reports.
- Cover div, mod, inc, dec, and negate alongside add, sub, and mul.

Test Plan:
- python -m unittest agent-perf\tests\test_binary_size_analyzer.py
- python -m unittest discover -s agent-perf\tests -p "test_*.py"
- python -m compileall -q agent-perf
- git diff --check