### PR TITLE
Avoid storing Module/SemContext in non-debug global eval

### DIFF
--- a/include/hermes/BCGen/HBC/BCProviderFromSrc.h
+++ b/include/hermes/BCGen/HBC/BCProviderFromSrc.h
@@ -36,11 +36,13 @@ class BCProviderFromSrc final : public BCProviderBase {
     /// IR Module used for compiling more code into this BytecodeModule.
     /// May be shared with other BCProviders during local eval,
     /// which reuses SemContext and the IR but makes a new BCProvider.
+    /// May be nullptr if no further compilation is possible.
     std::shared_ptr<Module> M;
 
     /// SemContext used for compiling more code into this BytecodeModule.
     /// May be shared with other BCProviders during local eval,
     /// which reuses SemContext and the IR but makes a new BCProvider.
+    /// May be nullptr if no further compilation is possible.
     std::shared_ptr<sema::SemContext> semCtx;
 
     /// The file and source map ID cache used for compiling more code into this

--- a/lib/BCGen/HBC/BCProviderFromSrc.cpp
+++ b/lib/BCGen/HBC/BCProviderFromSrc.cpp
@@ -247,8 +247,15 @@ BCProviderFromSrc::create(
   if (context->getSourceErrorManager().getErrorCount() > 0) {
     return {nullptr, getErrorString()};
   }
-  auto result =
-      createFromBytecodeModule(std::move(BM), CompilationData{opts, M, semCtx});
+  bool keepCompilationData =
+      context->getDebugInfoSetting() == DebugInfoSetting::ALL ||
+      context->isLazyCompilation();
+  auto result = createFromBytecodeModule(
+      std::move(BM),
+      CompilationData{
+          opts,
+          keepCompilationData ? M : nullptr,
+          keepCompilationData ? semCtx : nullptr});
   if (compileFlags.requireSingleFunction &&
       !isSingleFunctionExpression(parsed.getValue())) {
     return {nullptr, "Invalid function expression"};

--- a/lib/BCGen/HBC/Bytecode.cpp
+++ b/lib/BCGen/HBC/Bytecode.cpp
@@ -25,7 +25,7 @@ BytecodeModule::~BytecodeModule() {
   functions_.clear();
 
   // Clean up any other parts of the IR that are no longer used.
-  if (bcProviderFromSrc_) {
+  if (bcProviderFromSrc_ && bcProviderFromSrc_->getModule()) {
     bcProviderFromSrc_->getModule()->resetForMoreCompilation();
   }
 }


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebook/hermes/pull/2053

`BCProviderFromSrc` is typically used in debug and dev scenarios, but some users also invoke it via production global `eval`.

We don't want to keep the `M` and `semCtx` alive for these cases, because the debugger doesn't exist and there's no lazy compilation to require this data. It just bloats memory usage and is never accessed.

Note that this won't reduce memory usage for large `eval` strings when smart compilation is enabled, because that still uses lazy compilation. To fix it in those scenarios, the user must also pass `CompilationMode::ForceEagerCompilation` to `RuntimeConfig`.

Ran a simple `eval` benchmark:
```
(function() {
  globalThis.arr = [];
  var N = 10_000;
  for (var i = 0; i < N; ++i) {
    var f = (1,eval)(`
    function foo_${i}() {}
    `);
    globalThis.arr.push(f);
  }

  // loop while we check the memory
  gc();
  for (;;) {}
})();
```

This diff takes the total memory usage from 950 MB to 140 MB (measured with Activity Monitor on M4 Max MacBook).

Reviewed By: lavenzg

Differential Revision: D108782017

fbshipit-source-id: 526f1ab1e3c4347d312270f11c6ba3ca5813fb4a