### PR TITLE
Fix Proxy [[OwnPropertyKeys]] check for integer-index keys (#1609)

### DIFF
--- a/lib/VM/JSProxy.cpp
+++ b/lib/VM/JSProxy.cpp
@@ -12,6 +12,7 @@
 #include "hermes/VM/JSArray.h"
 #include "hermes/VM/JSCallableProxy.h"
 #include "hermes/VM/JSMapImpl.h"
+#include "hermes/VM/Operations.h"
 #include "hermes/VM/PropertyAccessor.h"
 
 #include "llvh/ADT/SetVector.h"
@@ -1495,6 +1496,40 @@ CallResult<PseudoHandle<JSArray>> JSProxy::ownPropertyKeys(
   if (*extensibleRes && nonConfigurable.empty()) {
     //   a. Return trapResult.
     return filterKeys(selfHandle, trapResult, runtime, okFlags);
+  }
+  // Hermes represents integer-index own-property keys internally as numbers,
+  // but [[OwnPropertyKeys]] is specified to return only Strings and Symbols
+  // (see the assert on step 12 above), and the trap result was already
+  // validated to contain only Strings and Symbols. Convert any numeric index
+  // keys in targetKeys to their canonical string form so the SameValue
+  // comparisons below behave correctly; otherwise an integer-index key such as
+  // "12345" on a non-extensible target would never match its string form in
+  // the trap result. See https://github.com/facebook/hermes/issues/1609.
+  {
+    GCScopeMarkerRAII normalizeMarker{runtime};
+    for (uint32_t i = 0, len = JSArray::getLength(*targetKeys, runtime);
+         i < len;
+         ++i) {
+      HermesValue key = targetKeys->at(runtime, i).unboxToHV(runtime);
+      if (!key.isNumber()) {
+        continue;
+      }
+      normalizeMarker.flush();
+      CallResult<PseudoHandle<StringPrimitive>> keyStrRes =
+          numberToStringPrimitive(runtime, key.getNumber());
+      if (LLVM_UNLIKELY(keyStrRes == ExecutionStatus::EXCEPTION)) {
+        return ExecutionStatus::EXCEPTION;
+      }
+      if (LLVM_UNLIKELY(
+              JSArray::setElementAt(
+                  targetKeys,
+                  runtime,
+                  i,
+                  runtime.makeHandle(std::move(*keyStrRes))) ==
+              ExecutionStatus::EXCEPTION)) {
+        return ExecutionStatus::EXCEPTION;
+      }
+    }
   }
   // 18. Let uncheckedResultKeys be a new List which is a copy of trapResult.
   // 19. For each key that is an element of targetNonconfigurableKeys, do

--- a/test/hermes/regress-proxy-ownkeys-numeric-key.js
+++ b/test/hermes/regress-proxy-ownkeys-numeric-key.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -Xes6-proxy -non-strict -O -target=HBC %s | %FileCheck --match-full-lines %s
+
+// Regression test for https://github.com/facebook/hermes/issues/1609
+//
+// A Proxy [[OwnPropertyKeys]] over a non-extensible target used to throw
+// "ownKeys target is non-extensible but key is missing from trap result"
+// whenever the target had an integer-index own key (e.g. "12345"). Hermes
+// represents integer-index keys internally as numbers, but the ownKeys trap
+// result holds them (per spec) as strings, so the SameValue comparison in the
+// non-extensible invariant check never matched.
+
+function ownKeysTrap(t) {
+  return Reflect.ownKeys(t);
+}
+
+// Case 1: preventExtensions with a configurable integer-index key.
+// Exercises the "target configurable keys" invariant loop.
+var t1 = {};
+Object.defineProperty(t1, '12345', {
+  value: 1,
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+Object.preventExtensions(t1);
+var p1 = new Proxy(t1, {ownKeys: ownKeysTrap});
+print('case1:', Object.keys(p1).join(','));
+// CHECK: case1: 12345
+
+// Case 2: frozen (non-configurable) integer-index keys.
+// Exercises the "target non-configurable keys" invariant loop.
+var t2 = Object.freeze({0: 'a', 42: 'b'});
+var p2 = new Proxy(t2, {ownKeys: ownKeysTrap});
+print('case2:', Object.getOwnPropertyNames(p2).join(','));
+// CHECK-NEXT: case2: 0,42
+
+// Case 3: mixed integer-index and string keys, frozen; spec ordering is
+// ascending integer indices first, then string keys in insertion order.
+var t3 = Object.freeze({b: 1, 2: 2, a: 3, 1: 4});
+var p3 = new Proxy(t3, {ownKeys: ownKeysTrap});
+print('case3:', Reflect.ownKeys(p3).join(','));
+// CHECK-NEXT: case3: 1,2,b,a
+
+// Case 4: integer-index keys alongside symbols must still work.
+var s = Symbol('s');
+var t4 = {7: 'x'};
+t4[s] = 'y';
+Object.preventExtensions(t4);
+var p4 = new Proxy(t4, {ownKeys: ownKeysTrap});
+print('case4:', Reflect.ownKeys(p4).map(String).join(','));
+// CHECK-NEXT: case4: 7,Symbol(s)


### PR DESCRIPTION
## Summary

`Reflect.ownKeys` / `Object.keys` / `Object.getOwnPropertyNames` on a `Proxy`
whose target is **non-extensible** and has an **integer-index** own key (e.g.
`"12345"`) throws

```
TypeError: ownKeys target is non-extensible but key is missing from trap result
```

even when the trap faithfully returns the target's own keys. This breaks common
state libraries such as Valtio (see #1609), where a frozen snapshot object with
numeric string keys can no longer be enumerated.

**Root cause.** `JSProxy::ownPropertyKeys` enforces the ES `[[OwnPropertyKeys]]`
invariant (steps 19 and 21) by checking that every own key of the target is
present in the trap result using `SameValue`. Hermes represents integer-index
own-property keys internally as **numbers** (`JSObject::getOwnPropertyKeys`
returns `12345` as a Number), whereas the trap result is validated to contain
only Strings and Symbols and therefore holds the key as the String `"12345"`.
`SameValue(12345, "12345")` is always `false`, so the invariant check fails and
throws. The comparison only runs for non-extensible targets, which is why the
bug only surfaces once the target is frozen / `preventExtensions`'d.

**Fix.** Before the invariant comparisons, normalize any numeric index keys in
`targetKeys` to their canonical string form — the same conversion that for-in
enumeration already performs for numeric array indices
(`Interpreter-slowpaths.cpp`, "We must return the property as a string"). The
returned key list is unchanged (it still comes from the trap result), so this
only removes the spurious invariant failure.

## Test Plan

New regression test `test/hermes/regress-proxy-ownkeys-numeric-key.js` covering:

- an integer-index key on a `preventExtensions` target (configurable-keys loop),
- integer-index keys on a `Object.freeze`d target (non-configurable-keys loop),
- mixed integer/string key ordering, and
- integer-index keys alongside symbols.

```
$ ./build-rel/bin/hermes -Xes6-proxy -non-strict -O -target=HBC \
    test/hermes/regress-proxy-ownkeys-numeric-key.js
case1: 12345
case2: 0,42
case3: 1,2,b,a
case4: 7,Symbol(s)
```

The test passes with this change and fails on the unpatched engine with the
reported `TypeError`. Existing `test/hermes/proxy.js` continues to pass.

Fixes #1609
