### PR TITLE
Fix OSS stable tagging on 260318099.0.0-stable (#2096)

### DIFF
--- a/.github/workflows/rn-build-hermes.yml
+++ b/.github/workflows/rn-build-hermes.yml
@@ -16,7 +16,7 @@ on:
       - static_h
   push:
     branches:
-      - 250829098.0.0-stable
+      - 260318099.0.0-stable
       - static_h
 
 jobs:

--- a/npm/hermes-compiler/package.json
+++ b/npm/hermes-compiler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hermes-compiler",
-    "version": "250829098.0.0",
+    "version": "260318099.0.1",
     "private": false,
     "description": "The hermes compiler CLI used during the React Native build process",
     "license": "MIT",


### PR DESCRIPTION
Summary:

We should create tag off 260318099.0.0-stable branch when changes made to it now. 
This should not affect existing tagging to the old stable branch.

Differential Revision: D110783760


