### PR TITLE
Fix Windows CI and revert unreleased .0.16 version bump

### DIFF
--- a/.github/workflows/build-hermesc-windows.yml
+++ b/.github/workflows/build-hermesc-windows.yml
@@ -4,7 +4,7 @@ on: workflow_call
 
 jobs:
   build-hermesc-windows:
-    runs-on: windows-2025
+    runs-on: windows-2022
     env:
       HERMES_WS_DIR: 'C:\tmp\hermes'
       HERMES_TARBALL_ARTIFACTS_DIR: 'C:\tmp\hermes\hermes-runtime-darwin'

--- a/npm/hermes-compiler/package.json
+++ b/npm/hermes-compiler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hermes-compiler",
-    "version": "250829098.0.16",
+    "version": "250829098.0.15",
     "private": false,
     "description": "The hermes compiler CLI used during the React Native build process",
     "license": "MIT",


### PR DESCRIPTION
## Summary

Unblocks releasing from the `250829098.0.0-stable` branch. Two independent fixes:

### 1. Revert "Bump version to 250829098.0.16"
`hermes-compiler` was bumped to `250829098.0.16`, but `250829098.0.15` was never actually released. This reverts the bump so `.0.15` can be released.

### 2. Pin Windows CI to `windows-2022`
The `windows-2025` runner image was upgraded by GitHub to ship **Visual Studio 18 (2026)** (`C:\Program Files\Microsoft Visual Studio\18\Enterprise`). The workflow hardcodes the `Visual Studio 17 2022` CMake generator, so configuration fails with:

```
CMake Error at CMakeLists.txt:65 (project):
  Generator
    Visual Studio 17 2022
  could not find any instance of Visual Studio.
```

Pinning back to `windows-2022` restores a runner that ships VS 17 2022, matching both the hardcoded generator and the deliberately-pinned CMake 3.31.6. This is the same fix applied on `260318099.0.0-stable` (#2061), where the Windows build job passed.

> Note: `windows-2022` is older but still fully GitHub-supported. The forward-looking fix (windows-2025 + `Visual Studio 18 2026` generator + a CMake bump past 3.31.6, validated against the MSVC 2026 toolchain) is better landed on `static_h`/main with its own CI cycle.

## Test Plan
CI signals — in particular `build_hermesc_windows`.