### PR TITLE
Enable CI on 260318099.0.0-stable and bump version to 260318099.0.0

### DIFF
--- a/.github/workflows/rn-build-hermes.yml
+++ b/.github/workflows/rn-build-hermes.yml
@@ -14,6 +14,7 @@ on:
   pull_request:
     branches:
       - static_h
+      - 260318099.0.0-stable
   push:
     branches:
       - 250829098.0.0-stable

--- a/.github/workflows/rn-build-hermes.yml
+++ b/.github/workflows/rn-build-hermes.yml
@@ -17,6 +17,7 @@ on:
   push:
     branches:
       - 250829098.0.0-stable
+      - 260318099.0.0-stable
       - static_h
 
 jobs:

--- a/npm/hermes-compiler/package.json
+++ b/npm/hermes-compiler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hermes-compiler",
-    "version": "250829098.0.0",
+    "version": "260318099.0.0",
     "private": false,
     "description": "The hermes compiler CLI used during the React Native build process",
     "license": "MIT",


### PR DESCRIPTION
## Summary

Prepares the `260318099.0.0-stable` release branch for releasing:

### 1. Run CI on the branch (push + PRs)
The build jobs (`build_hermesc_windows`, `build_hermesc_apple`, `build_hermesc_linux`, `build_android`, etc.) are reusable `on: workflow_call` workflows — they only run when the orchestrator `rn-build-hermes.yml` ("RN Build Static Hermes") invokes them, and its `push`/`pull_request` triggers use branch allowlists that were missing this release branch. Added `260318099.0.0-stable` to **both**:
- **push** — builds run automatically once a change lands on the release branch.
- **pull_request** — builds run on PRs targeting the release branch, so changes are verified *before* merge.

### 2. Bump package version
`npm/hermes-compiler/package.json` was still `250829098.0.0` (the previous train). Bumped it to `260318099.0.0` to match this branch's release train.

## Verification
Confirmed on this PR: the `RN Build Static Hermes` workflow is triggered by the `pull_request` event, and `set_release_type` + the `build_hermesc_*` / `build_android` jobs run.

## Note
The allowlists must be updated by hand for every new stable branch. A follow-up could switch them to a glob (e.g. `- '*-stable'`) so future release branches are covered automatically — intentionally left out here to keep the release-branch change minimal.