### PR TITLE
Force dry-run for staging branches (never release from *-staging)

### DIFF
--- a/.github/workflows/rn-build-hermes.yml
+++ b/.github/workflows/rn-build-hermes.yml
@@ -40,9 +40,10 @@ jobs:
         uses: ./.github/actions/yarn-install
       - id: set_release_type
         run: |
-          # Guard: never allow release mode on non-releasing branches
-          # (static_h and the staging branch), even via workflow_dispatch.
-          if [[ $REF == "refs/heads/static_h" || $REF == "refs/heads/260318099.0.0-staging" ]]; then
+          # Guard: never allow release mode on non-releasing branches:
+          # static_h and any branch whose name ends in `-staging`, even via
+          # workflow_dispatch.
+          if [[ $REF == "refs/heads/static_h" || $REF == refs/heads/*-staging ]]; then
             echo "Branch is a non-releasing branch, forcing dry-run mode"
             echo "RELEASE_TYPE=dry-run" >> $GITHUB_OUTPUT
           elif [[ $EVENT_NAME == "workflow_dispatch" ]]; then

--- a/.github/workflows/rn-build-hermes.yml
+++ b/.github/workflows/rn-build-hermes.yml
@@ -14,10 +14,12 @@ on:
   pull_request:
     branches:
       - static_h
+      - 260318099.0.0-staging
   push:
     branches:
       - 250829098.0.0-stable
       - static_h
+      - 260318099.0.0-staging
 
 jobs:
   set_release_type:
@@ -38,9 +40,10 @@ jobs:
         uses: ./.github/actions/yarn-install
       - id: set_release_type
         run: |
-          # Guard: never allow release mode on static_h branch
-          if [[ $REF == "refs/heads/static_h" ]]; then
-            echo "Branch is static_h, forcing dry-run mode"
+          # Guard: never allow release mode on non-releasing branches
+          # (static_h and the staging branch), even via workflow_dispatch.
+          if [[ $REF == "refs/heads/static_h" || $REF == "refs/heads/260318099.0.0-staging" ]]; then
+            echo "Branch is a non-releasing branch, forcing dry-run mode"
             echo "RELEASE_TYPE=dry-run" >> $GITHUB_OUTPUT
           elif [[ $EVENT_NAME == "workflow_dispatch" ]]; then
             echo "Setting release type to ${{ github.event.inputs.release-type }}"


### PR DESCRIPTION
## Summary

We must **never** release Hermes from a staging branch. This mirrors the `static_h` non-releasing setup in `rn-build-hermes.yml`, and generalizes it to all staging branches.

1. **Force dry-run guard (generalized).** `set_release_type` now forces `RELEASE_TYPE=dry-run` for `static_h` **and any branch whose name ends in `-staging`**, regardless of event type. Previously only `static_h` was guarded, so a manual `workflow_dispatch` with `release-type: release` on a staging branch would have produced a **real release**. The glob (`refs/heads/*-staging`) means future staging branches are covered automatically — important because `workflow_dispatch` has no branch filter and can be run on any branch.

   ```bash
   if [[ $REF == "refs/heads/static_h" || $REF == refs/heads/*-staging ]]; then
     # forced dry-run
   ```

2. **Run CI on the branch.** Added `260318099.0.0-staging` to the `push` and `pull_request` allowlists so the RN build runs on the branch and its PRs (matching how `static_h` runs on itself).

## Behavior after this change

| Ref | Guarded → dry-run? |
|---|---|
| `refs/heads/static_h` | yes |
| `refs/heads/260318099.0.0-staging` | yes |
| `refs/heads/<anything>-staging` | yes |
| `refs/heads/260318099.0.0-stable` | **no** (release branches can still release) |
| `refs/pull/*/merge` (PRs) | dry-run via existing `else` branch |

## Test Plan
- Verified the glob matches `static_h` + `*-staging` and does **not** match `*-stable`.
- CI on this PR triggers "RN Build Static Hermes" with `set_release_type` reporting dry-run.

## Note
The `push`/`pull_request` branch allowlists still list the staging branch explicitly. Converting those to globs (`'*-staging'`) is a possible follow-up; left out here to keep the diff focused on the release-safety guard.