### PR TITLE
Generalize RN build triggers/guard for future trains + bump version to 260318099.0.0

### DIFF
--- a/.github/workflows/rn-build-hermes.yml
+++ b/.github/workflows/rn-build-hermes.yml
@@ -14,10 +14,13 @@ on:
   pull_request:
     branches:
       - static_h
+      - '*-stable'
+      - '*-staging'
   push:
     branches:
-      - 250829098.0.0-stable
       - static_h
+      - '*-stable'
+      - '*-staging'
 
 permissions:
   contents: read
@@ -56,9 +59,11 @@ jobs:
           GHA_NPM_TOKEN: ${{ secrets.GHA_NPM_TOKEN }}
       - id: set_release_type
         run: |
-          # Guard: never allow release mode on static_h branch
-          if [[ $REF == "refs/heads/static_h" ]]; then
-            echo "Branch is static_h, forcing dry-run mode"
+          # Guard: never allow release mode on non-releasing branches:
+          # static_h and any branch whose name ends in `-staging`, even via
+          # workflow_dispatch.
+          if [[ $REF == "refs/heads/static_h" || $REF == refs/heads/*-staging ]]; then
+            echo "Branch is a non-releasing branch, forcing dry-run mode"
             echo "RELEASE_TYPE=dry-run" >> $GITHUB_OUTPUT
           elif [[ $EVENT_NAME == "workflow_dispatch" ]]; then
             echo "Setting release type to ${{ github.event.inputs.release-type }}"

--- a/npm/hermes-compiler/package.json
+++ b/npm/hermes-compiler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hermes-compiler",
-    "version": "250829098.0.0",
+    "version": "260318099.0.0",
     "private": false,
     "description": "The hermes compiler CLI used during the React Native build process",
     "license": "MIT",


### PR DESCRIPTION
## Summary

Makes `static_h` the source of truth for the RN build's branch handling, so branches cut for **future release trains** (e.g. `26xxxx.*`, `27xxxx.*`) inherit the correct behavior automatically — no per-branch edits to `rn-build-hermes.yml`. Also advances the package version to the next train.

This is the generic form of what #2100 did for `260318099.0.0-staging`.

### 1. Triggers → globs
`push` and `pull_request` now match `static_h`, `'*-stable'`, and `'*-staging'` instead of listing individual branches. Any future stable/staging branch runs the RN build (and is verified on its PRs) out of the box. `250829098.0.0-stable` is now covered by `'*-stable'`.

### 2. Dry-run guard → generalized
`set_release_type` forces `RELEASE_TYPE=dry-run` for `static_h` **and any branch whose name ends in `-staging`**, regardless of event — including `workflow_dispatch`, which has no branch filter and could otherwise be used to cut a real release from a staging branch.

```bash
if [[ $REF == "refs/heads/static_h" || $REF == refs/heads/*-staging ]]; then
  # forced dry-run
```

### 3. Bump version
`npm/hermes-compiler/package.json` bumped from `250829098.0.0` to `260318099.0.0` (the next release train's version).

## Behavior

| Ref | Runs RN build | Release allowed? |
|---|---|---|
| `static_h` | yes | no (forced dry-run) |
| `*-staging` (any) | yes | no (forced dry-run, even via dispatch) |
| `*-stable` (any) | yes | yes, via `workflow_dispatch` with `release` |
| PRs targeting the above | yes | dry-run |

Note: pushing to a `*-stable` branch is dry-run (falls through to the `else`); an actual release still only happens via a manual `workflow_dispatch` selecting `release` on a stable branch — unchanged from today.

## Test Plan
- Verified the guard forces dry-run for `static_h` + `*-staging` and leaves `*-stable` releasable.
- Verified the trigger globs parse to `[static_h, *-stable, *-staging]` for both `push` and `pull_request`.
- Verified `package.json` is valid and version is `260318099.0.0`.
- CI on this PR should trigger "RN Build Static Hermes" in dry-run.