### PR TITLE
docs: CONTRIBUTING says branch from `main` but the default branch is `static_h`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ We actively welcome your pull requests. If you are planning on doing a larger
 chunk of work or want to change an external facing API, make sure to file an
 issue first to get feedback on your idea.
 
-1. Fork the repo and create your branch from `main`.
+1. Fork the repo and create your branch from `static_h`.
 2. If you've added code that should be tested, add tests.
 3. Ensure the test suite passes and your code lints.
 4. Consider squashing your commits (`git rebase -i`). One intent alongside one


### PR DESCRIPTION
Hi, and thank you for Hermes.

`CONTRIBUTING.md` (line 22) says:
> 1. Fork the repo and create your branch from `main`.

but the repository's default branch is `static_h` (there's no `main`), so a new contributor following the doc branches from a non-existent base. This updates the doc to `static_h`.

For transparency: I used AI assistance to spot and draft this; I verified the default branch and the doc line myself.