### PR TITLE
napi: give hermes_napi.h public API C linkage

### DIFF
--- a/API/napi/hermes_napi.h
+++ b/API/napi/hermes_napi.h
@@ -10,6 +10,8 @@
 
 #include "hermes/napi/node_api.h"
 
+EXTERN_C_START
+
 //===========================================================================
 // Host integration interface
 //===========================================================================
@@ -265,5 +267,7 @@ NAPI_EXTERN napi_status NAPI_CDECL hermes_run_bytecode(
     const char *source_url,
     const hermes_bytecode_flags *flags,
     napi_value *result);
+
+EXTERN_C_END
 
 #endif // HERMES_NAPI_HERMES_NAPI_H


### PR DESCRIPTION
## Summary

The public `hermes_napi_*` / `hermes_run_*` entry points in `API/napi/hermes_napi.h` are decorated with `NAPI_EXTERN NAPI_CDECL` (added in #2044), where `NAPI_EXTERN` expands to `__attribute__((visibility("default")))` on non-Windows. However, unlike the sibling headers `js_native_api.h` and `node_api.h`, `hermes_napi.h` does not wrap its declarations in `extern "C"`, so these functions get C++ linkage.

With C++ linkage the symbols are name-mangled and are not exported from a library built with `-fvisibility=hidden` (the root `CMakeLists.txt` appends this globally). Consumers linking the resulting shared library therefore hit undefined symbols such as `hermes_napi_create_env`, while the `extern "C"` symbols from `js_native_api.h` / `node_api.h` export as expected.

This wraps the declarations in `EXTERN_C_START` / `EXTERN_C_END` — the same macros used by the sibling headers, already in scope via the `node_api.h` include — so `NAPI_EXTERN`'s `visibility("default")` takes effect and the entry points are exported.

These are a C API (a Hermes extension of the C Node-API), so `extern "C"` is the correct linkage on its own merits. This is the natural follow-up to #2044, which intended to export these symbols.

Note: this changes the exported symbols from mangled C++ names to their C names (e.g. `hermes_napi_create_env`). The `= nullptr` default argument on `hermes_napi_create_env` is a call-site feature and is compatible with `extern "C"` linkage.

## Test plan

- [ ] Build with default flags and confirm `hermes_napi_create_env` and the other entry points appear in the exported symbol table of the built shared library.