### PR TITLE
Graft "[SH] Fix: JSI_UNSTABLE CMake flag should be OFF by default" to shermes/stable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,7 +313,7 @@ set(LLVM_FORCE_ENABLE_STATS OFF CACHE BOOL
 set(QEMU_RUN_PREFIX "" CACHE STRING
   "Command prefix for invoking cross-compiled binaries with QEMU.")
 
-set(JSI_UNSTABLE ON CACHE BOOL "Enable the JSI unstable APIs.")
+set(JSI_UNSTABLE OFF CACHE BOOL "Enable the JSI unstable APIs.")
 
 if (NOT QEMU_RUN_PREFIX STREQUAL "")
   add_definitions(-DQEMU_MODE)


### PR DESCRIPTION
Summary:
This should be OFF by default. We are already explicitly passing
`-DJSI_UNSTABLE=ON` in places we want to use unstable features (e.g.,
in unit tests or internal test jobs).

This was not an issue before because previous OSS hermes stable does not have
this flag. But the new stable does now. And RN's own JSI copy is not built with
this flag ON so it causes ABI mismatch.

Reviewed By: avp

Differential Revision: D112848886


