### PR TITLE
Fix: Ensure explicit undefined on optional members

### DIFF
--- a/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/class/members/property/optional/translate-result.shot
+++ b/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/class/members/property/optional/translate-result.shot
@@ -12,7 +12,7 @@ exports[`flowDefToTSDef class/members/property/optional 1`] = `
  */
 
 declare class Foo {
-  prop?: string;
+  prop?: string | undefined;
 }
 "
 `;

--- a/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/component-syntax/component-declaration/translate-result.shot
+++ b/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/component-syntax/component-declaration/translate-result.shot
@@ -14,7 +14,7 @@ import * as React from 'react';
 export declare function Foo(props: {}): React.ReactNode;
 export declare function Foo(props: {
   foo: string;
-  bar?: string;
+  bar?: string | undefined;
 }): React.ReactNode;
 type ExtraPropsFoo = {foo: string};
 export declare function Foo(props: ExtraPropsFoo): React.ReactNode;

--- a/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/component-syntax/component-type-annotation/translate-result.shot
+++ b/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/fixtures/component-syntax/component-type-annotation/translate-result.shot
@@ -12,13 +12,13 @@ exports[`flowDefToTSDef component-syntax/component-type-annotation 1`] = `
 
 import * as React from 'react';
 type T = (props: {}) => React.ReactNode;
-type T = (props: {foo: string; bar?: string}) => React.ReactNode;
+type T = (props: {foo: string; bar?: string | undefined}) => React.ReactNode;
 type ExtraPropsFoo = {foo: string};
 type T = (props: ExtraPropsFoo) => React.ReactNode;
 type ExtraPropsBar = {bar: string};
 type T = (
   props: Omit<ExtraPropsBar, 'ref' | 'foo'> & {
-    ref?: React.Ref<Foo>;
+    ref?: React.Ref<Foo> | undefined;
     foo: string;
   },
 ) => React.ReactNode;

--- a/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/flowDefToTSDef-test.js
+++ b/tools/hermes-parser/js/flow-api-translator/__tests__/flowDefToTSDef/flowDefToTSDef-test.js
@@ -24,3 +24,30 @@ describe('flowDefToTSDef', () => {
     ONLY,
   );
 });
+
+describe('flowDefToTSDef optional members include undefined', () => {
+  // Flow optional members permit `undefined`, so the faithful translation adds
+  // an explicit `| undefined`.
+  test('adds `| undefined` to optional members', async () => {
+    const source = [
+      'export type Foo = {',
+      '  plain?: number,',
+      '  union?: number | string,',
+      '  nullable?: ?number,',
+      '  fn?: () => void,',
+      '  required: number,',
+      '};',
+      '',
+    ].join('\n');
+    const result = await translateFlowDefToTSDef(source, prettierConfig);
+
+    expect(result).toContain('plain?: number | undefined;');
+    expect(result).toContain('union?: number | string | undefined;');
+    expect(result).toContain('fn?: (() => void) | undefined;');
+    // Already-nullable members keep their existing `undefined` (not doubled).
+    expect(result).toContain('nullable?: null | undefined | number;');
+    expect(result).not.toContain('| undefined | undefined');
+    // Required members are untouched.
+    expect(result).toContain('required: number;');
+  });
+});

--- a/tools/hermes-parser/js/flow-api-translator/src/flowDefToTSDef.js
+++ b/tools/hermes-parser/js/flow-api-translator/src/flowDefToTSDef.js
@@ -26,7 +26,10 @@ import {
   unexpectedTranslationError as unexpectedTranslationErrorBase,
 } from './utils/ErrorUtils';
 import {removeAtFlowFromDocblock} from './utils/DocblockUtils';
-import {extractPropertyKeyLiterals} from './utils/TSNodeUtils';
+import {
+  ensureTypeIncludesUndefined,
+  extractPropertyKeyLiterals,
+} from './utils/TSNodeUtils';
 import {EOL} from 'os';
 
 type DeclarationOrUnsupported<T> = T | TSESTree.TSTypeAliasDeclaration;
@@ -3851,7 +3854,12 @@ const getTransforms = (
         typeAnnotation: {
           type: 'TSTypeAnnotation',
           loc: DUMMY_LOC,
-          typeAnnotation: transformTypeAnnotationType(node.value),
+          typeAnnotation:
+            node.optional === true
+              ? ensureTypeIncludesUndefined(
+                  transformTypeAnnotationType(node.value),
+                )
+              : transformTypeAnnotationType(node.value),
         },
       };
     },

--- a/tools/hermes-parser/js/flow-api-translator/src/utils/TSNodeUtils.js
+++ b/tools/hermes-parser/js/flow-api-translator/src/utils/TSNodeUtils.js
@@ -72,3 +72,37 @@ export function extractPropertyKeyLiterals(
   }
   return literals;
 }
+
+/**
+ * Returns a type that is guaranteed to include `undefined`, without duplicating
+ * it when already present.
+ *
+ * Flow's optional members permit `undefined`, so the faithful TypeScript
+ * translation of `foo?: T` is `foo?: T | undefined` (the two are distinct under
+ * `exactOptionalPropertyTypes`).
+ */
+export function ensureTypeIncludesUndefined(
+  typeAnnotation: TSESTree.TypeNode,
+): TSESTree.TypeNode {
+  if (typeAnnotation.type === 'TSUndefinedKeyword') {
+    return typeAnnotation;
+  }
+  if (typeAnnotation.type === 'TSUnionType') {
+    if (typeAnnotation.types.some(type => type.type === 'TSUndefinedKeyword')) {
+      return typeAnnotation;
+    }
+    return {
+      type: 'TSUnionType',
+      loc: DUMMY_LOC,
+      types: [
+        ...typeAnnotation.types,
+        {type: 'TSUndefinedKeyword', loc: DUMMY_LOC},
+      ],
+    };
+  }
+  return {
+    type: 'TSUnionType',
+    loc: DUMMY_LOC,
+    types: [typeAnnotation, {type: 'TSUndefinedKeyword', loc: DUMMY_LOC}],
+  };
+}


### PR DESCRIPTION
Summary:
**Motivation**

See https://github.com/react/react-native/pull/57628.

Flow optional object members permit `undefined` as a value, so the faithful TypeScript translation of `{foo?: T}` is `{foo?: T | undefined}`.

The bare `{foo?: T}` form is stricter under TypeScript compared to Flow:

```js
// Flow's semantics

interface Props {
  onRefresh?: () => void;
}
const a: Props = { onRefresh: undefined }; // ✅ ok
```
```ts
// TypeScript with exactOptionalPropertyTypes: true (i.e. strict mode)

interface Props {
  onRefresh?: () => void;
}
const a: Props = { onRefresh: undefined }; // ❌ error

interface PropsFixed {
  onRefresh?: (() => void) | undefined;
}
const b: PropsFixed = { onRefresh: undefined }; // ✅ ok
```

**This diff**

This makes the translator emit the explicit `| undefined` on optional members by default. Optional members (`?:`) now translate as wider resulting types:

  foo?: number        =>  foo?: number | undefined
  foo?: () => void    =>  foo?: (() => void) | undefined

Members whose type already includes `undefined` (e.g. the maybe type `foo?: ?T` → `null | undefined | T`) are left unchanged (no duplicate `| undefined`). Required members are untouched.

NOTE: **This is a behavior change**: 3 existing fixtures are updated. This is **_borderline_** for counting as semver breaking for this project — emitted types are now wider.

Differential Revision: D113033807


