### PR TITLE
Bump hermes-compiler version to 260318099.0.2

### DIFF
--- a/npm/hermes-compiler/package.json
+++ b/npm/hermes-compiler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hermes-compiler",
-    "version": "260318099.0.1",
+    "version": "260318099.0.2",
     "private": false,
     "description": "The hermes compiler CLI used during the React Native build process",
     "license": "MIT",


### PR DESCRIPTION
## Summary
I'm releasing a new version (260318099.0.1) of the Hermes engine to have React Native on main run with this version.
The source code for Hermes should always track the next version, hence the version bump.

## Test Plan
N/A