### PR TITLE
Rebalance external memory accounting in OrderedHashMapBase::clear()

### DIFF
--- a/lib/VM/OrderedHashMap.cpp
+++ b/lib/VM/OrderedHashMap.cpp
@@ -215,8 +215,6 @@ ExecutionStatus OrderedHashMapBase<BucketType, Derived>::rehash(
   // Create a new hash table.
   std::vector<uint32_t> newHashTable;
   newHashTable.resize(*newCapacity, kHashTableElementUnused);
-  runtime.getHeap().creditExternalMemory(
-      *self, *newCapacity * sizeof(uint32_t));
 
   // Create a new data table.
   auto dataTableRes = StorageType::create(
@@ -275,9 +273,19 @@ ExecutionStatus OrderedHashMapBase<BucketType, Derived>::rehash(
   rawSelf->updateIteratorIndicesForRehash(runtime);
 
   rawSelf->deletedCount_ = 0;
-  uint32_t oldSizeInBytes = rawSelf->hashTable_.size() * sizeof(uint32_t);
+  // The external memory credit tracks hashTable_.size() * sizeof(uint32_t).
+  // The new table may be larger or smaller than the old one, so settle the
+  // difference in whichever direction it went.
+  const uint32_t oldSizeInBytes = rawSelf->hashTable_.size() * sizeof(uint32_t);
+  const uint32_t newSizeInBytes = newHashTable.size() * sizeof(uint32_t);
   rawSelf->hashTable_ = std::move(newHashTable);
-  runtime.getHeap().debitExternalMemory(*self, oldSizeInBytes);
+  if (newSizeInBytes >= oldSizeInBytes) {
+    runtime.getHeap().creditExternalMemory(
+        *self, newSizeInBytes - oldSizeInBytes);
+  } else {
+    runtime.getHeap().debitExternalMemory(
+        *self, oldSizeInBytes - newSizeInBytes);
+  }
   rawSelf->dataTable_.setNonNull(runtime, *lv.newDataTable, runtime.getHeap());
   return ExecutionStatus::RETURNED;
 }
@@ -671,11 +679,19 @@ ExecutionStatus OrderedHashMapBase<BucketType, Derived>::clear(
     return ExecutionStatus::RETURNED;
   }
 
-  // Clear the hash table.
+  // Clear the hash table. The external memory credit tracks
+  // hashTable_.size() * sizeof(uint32_t), so debit the difference between the
+  // discarded table and the reinitialized one.
+  const uint32_t oldSizeInBytes = self->hashTable_.size() * sizeof(uint32_t);
   self->hashTable_ = std::vector<uint32_t>();
   // Resize the hash table to the initial size.
   self->hashTable_.resize(kInitialCapacity, kHashTableElementUnused);
   self->capacity_ = kInitialCapacity;
+  constexpr uint32_t newSizeInBytes = kInitialCapacity * sizeof(uint32_t);
+  assert(
+      oldSizeInBytes >= newSizeInBytes &&
+      "Capacity never shrinks below kInitialCapacity");
+  runtime.getHeap().debitExternalMemory(*self, oldSizeInBytes - newSizeInBytes);
 
   // Resize the data table back to 0.
   self->dataTable_.getNonNull(runtime)->clear(runtime);


### PR DESCRIPTION
## Summary
`OrderedHashMapBase::clear()` discards the grown hash table without debiting its external-memory credit and reinitializes to `kInitialCapacity` without crediting it. `initializeStorage()` and `rehash()` maintain the invariant that the cell's external credit equals `hashTable_.size() * sizeof(uint32_t)`, and `cleanUp()` debits exactly the current size — so the credit stranded by `clear()` is never returned, not even when the cell dies.

Every `Set`/`Map` `clear()` + refill cycle therefore strands `(capacity - kInitialCapacity) * sizeof(uint32_t)` bytes of phantom credit. Long-running embedders with per-frame clear/refill patterns (e.g. three.js render loops, which clear a per-object `Set` in every uniform upload cycle) watch `js_externalBytes` climb to the configured heap limit and abort with a spurious OOM. We measured ~360KB/s of phantom growth (~14KB per render call, always exact 64-byte multiples) in a WebGPU game loop on Hermes, with an abort at a 1GB heap cap after ~35 minutes, while the live set stayed constant.

Details and repro: #2111

## Fix
Mirror the `initializeStorage()`/`rehash()` bookkeeping in `clear()`: debit the discarded table's bytes, credit the reinitialized table's bytes.

## Validation
In our embedder (JSI, Hades GC), 20,000 cycles of `set.clear()` + refilling 48 entries grew `js_externalBytes` by ~3.8MB before this change and by ~0 after it; a previously-OOMing 60+ minute game session now holds external memory flat. Happy to add a VMRuntime unit test if you'd like one — pointer to the preferred test file welcome.

Fixes #2111