### PR TITLE
fix: IdentifierHashTable growing indefinitely with deleted entries

### DIFF
--- a/lib/VM/detail/IdentifierHashTable.cpp
+++ b/lib/VM/detail/IdentifierHashTable.cpp
@@ -125,7 +125,18 @@ void IdentifierHashTable::insert(uint32_t idx, SymbolID id) {
   ++nonEmptyEntryCount_;
 
   if (shouldGrow()) {
-    growAndRehash(capacity() * 2);
+    if (size_ >= (capacity() >> 2)) {
+      growAndRehash(capacity() * 2);
+    } else {
+      // The load factor is dominated by deleted entries, not live ones.
+      // Rehash at the current capacity to reclaim the deleted entries
+      // instead of growing. This keeps the table capacity proportional to
+      // the peak live identifier count; without it, sustained insert/free
+      // churn of unique identifiers doubles the capacity indefinitely,
+      // because deleted entries count towards shouldGrow() and are only
+      // reclaimed by a rehash.
+      growAndRehash(capacity());
+    }
   }
 }
 
@@ -139,7 +150,9 @@ void IdentifierHashTable::remove(const StringPrimitive *str) {
 
 void IdentifierHashTable::growAndRehash(uint32_t newCapacity) {
   // Guard against potential overflow in the calculation of new capacity.
-  if (LLVM_UNLIKELY(newCapacity <= capacity())) {
+  // newCapacity == capacity() is allowed: it rehashes in place, reclaiming
+  // deleted entries without growing.
+  if (LLVM_UNLIKELY(newCapacity < capacity())) {
     hermes_fatal("too many identifiers created");
   }
   assert(llvh::isPowerOf2_32(newCapacity) && "capacity must be power of 2");

--- a/lib/VM/detail/IdentifierHashTable.cpp
+++ b/lib/VM/detail/IdentifierHashTable.cpp
@@ -129,12 +129,7 @@ void IdentifierHashTable::insert(uint32_t idx, SymbolID id) {
       growAndRehash(capacity() * 2);
     } else {
       // The load factor is dominated by deleted entries, not live ones.
-      // Rehash at the current capacity to reclaim the deleted entries
-      // instead of growing. This keeps the table capacity proportional to
-      // the peak live identifier count; without it, sustained insert/free
-      // churn of unique identifiers doubles the capacity indefinitely,
-      // because deleted entries count towards shouldGrow() and are only
-      // reclaimed by a rehash.
+      // Rehash at the current capacity.
       growAndRehash(capacity());
     }
   }
@@ -150,8 +145,6 @@ void IdentifierHashTable::remove(const StringPrimitive *str) {
 
 void IdentifierHashTable::growAndRehash(uint32_t newCapacity) {
   // Guard against potential overflow in the calculation of new capacity.
-  // newCapacity == capacity() is allowed: it rehashes in place, reclaiming
-  // deleted entries without growing.
   if (LLVM_UNLIKELY(newCapacity < capacity())) {
     hermes_fatal("too many identifiers created");
   }


### PR DESCRIPTION
## Summary

`IdentifierHashTable` capacity grows without bound when its nonEmpty entries count is nearing the capacity. However, this also happens when most of the entries are already invalid.

This PR makes the table rehash in place when the table is dominated by invalid entries (more than 75% entries are invalid).

## Test plan

~30-line standalone script, no dependencies — run with the `hermes` CLI and watch process RSS:

```js
const sink = {};
let interned = 0;
for (let round = 0; round < 240; round++) {
  for (let j = 0; j < 200000; j++) {
    const s = "unique_key_" + interned++ + "_suffix_padding";
    if (s in sink) throw new Error("unreachable");
    const garbage = { a: j, b: [j, j + 1], c: "g" + (j & 1023) }; // drive GC
    if (garbage.a === -1) print(garbage.b, garbage.c);
  }
  const st = HermesInternal.getInstrumentedStats();
  print(round, st.js_heapSize ?? st.heapSize, st.js_numGCs ?? st.numGCs);
}
```

48M unique keys, macOS host CLI built from the same source, RSS sampled at 0.5 s:

| binary | RSS peak | RSS final | JS heap (self-reported) |
|---|---|---|---|
| before | 223 MB | 159 MB | 12.6 MB flat, 3908 GCs |
| after | 68 MB | **36 MB** | 12.6 MB flat, 3916 GCs |

Real-world instance: a React Native app animating interpolated color strings (a library probes a color-keyword dictionary with each animated `hsl(...)` string ≈ 4k unique interned strings/s) grew from 81 MB to 333 MB over 6 hours through seven table doublings (8→16→…→256 MB tables).