### PR TITLE
Fix -commonjs compilation crash and empty output (#1990)

### DIFF
--- a/lib/IRGen/ESTreeIRGen.cpp
+++ b/lib/IRGen/ESTreeIRGen.cpp
@@ -303,6 +303,13 @@ void ESTreeIRGen::doCJSModule(
   assert(Root && "no root in ESTreeIRGen");
   auto *func = cast<ESTree::FunctionExpressionNode>(Root);
 
+  // Create a top level FunctionContext that will never be executed, because
+  // genBasicFunction reads state from the current function context (e.g. the
+  // class contexts captured when enqueueing the compilation of the module
+  // function).
+  FunctionContext topLevelFunctionContext{
+      this, Mod->getTopLevelFunction(), nullptr};
+
   // Take care of the additions to the global scope that this module could
   // have done. A module can only add ambient global properties. Look for new
   // ones (customData == nullptr) and declare them.

--- a/lib/Optimizer/Scalar/FunctionAnalysis.cpp
+++ b/lib/Optimizer/Scalar/FunctionAnalysis.cpp
@@ -406,8 +406,9 @@ void analyzeFunctionCallsites(Function *F) {
   // Attempt to start from a position of knowing all callsites.
   F->getAttributesRef(M)._allCallsitesKnownInStrictMode = true;
 
-  if (F->isGlobalScope()) {
-    // global function is called by the runtime, so its callsites aren't known.
+  if (F->isGlobalScope() || M->findCJSModule(F)) {
+    // The global function and CommonJS module functions are called by the
+    // runtime, so their callsites aren't known.
     F->getAttributesRef(M)._allCallsitesKnownInStrictMode = false;
   }
 

--- a/lib/Optimizer/Scalar/Utils.cpp
+++ b/lib/Optimizer/Scalar/Utils.cpp
@@ -243,8 +243,9 @@ bool deleteUnusedFunctionsAndVariables(Module *M) {
     for (auto &F : *M) {
       // Delete any functions that do not have any uses other than in their own
       // bodies. The top level function does not have an explicit user, so check
-      // for it directly.
-      if (&F != M->getTopLevelFunction() &&
+      // for it directly. CommonJS module functions are only referenced by the
+      // module's CJS module table, so they must also be kept.
+      if (&F != M->getTopLevelFunction() && !M->findCJSModule(&F) &&
           llvh::all_of(F.getUsers(), [&F](Instruction *user) {
             // Use must be from another function to be meaningful.
             return user->getFunction() == &F;

--- a/test/hermes/cjs-module.js
+++ b/test/hermes/cjs-module.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -commonjs %s | %FileCheck --match-full-lines %s
+// RUN: %hermes -O0 -commonjs %s | %FileCheck --match-full-lines %s
+// RUN: %hermes -O -commonjs %s | %FileCheck --match-full-lines %s
+
+// Regression test for #1990: compiling with -commonjs used to crash IRGen
+// because doCJSModule ran without an active FunctionContext, and the
+// optimizer used to delete CJS module functions as unused.
+
+print('cjs module start');
+// CHECK: cjs module start
+
+print(typeof exports, typeof require, typeof module);
+// CHECK-NEXT: object function object
+
+exports.foo = 42;
+print(module.exports.foo);
+// CHECK-NEXT: 42


### PR DESCRIPTION
## Summary

Fixes #1990.

`hermes -commonjs` segfaulted on any input. The crash is a null dereference in `genBasicFunction`: its enqueued compilation lambda captures `curFunction()->typedClassContext` / `legacyClassContext` at enqueue time, and `doCJSModule` was the only `genBasicFunction` entry point that did not establish an active `FunctionContext` first (`doIt`, `doItInScope` and `doLazyFunction` all do). In a release build `curFunction()` returns the null `functionContext_`, which matches the ASan trace in the issue (`ESTreeIRGen-func.cpp:390:43`, READ at offset 0x148). The fix creates a top-level `FunctionContext`, mirroring `doLazyFunction`.

With the crash fixed, `-commonjs` still silently produced empty bytecode (`CommonJS module count: 0`, nothing executed) at the default optimization level, because two optimizer passes do not treat CJS module functions as roots — they have no IR users, they are only referenced from the module's CJS module table and called by the runtime's `require` machinery:

- `deleteUnusedFunctionsAndVariables` deleted them as unused (on `main`, DCE explicitly skips `M->findCJSModule(&F)`; that check was lost in this helper on `static_h`).
- `analyzeFunctionCallsites` marked them `allCallsitesKnownInStrictMode`/`unreachable` and their bodies were gutted, producing a segfault at `-O`; only the global function was exempted as "called by the runtime".

`FuncSigOpts` already special-cases CJS module functions (`F.isGlobalScope() || M->findCJSModule(&F)`), so this brings the other two passes in line with it. These are the only two `isGlobalScope()` special cases in `lib/Optimizer` without the CJS check.

## Test Plan

New regression test `test/hermes/cjs-module.js` compiles and runs a CommonJS module at the default optimization level, `-O0` and `-O`. TDD verified against each fix:

- Unpatched: `hermes -commonjs test.js` → `Segmentation fault` (exit 139) at any opt level.
- With only the IRGen fix: `-O0` runs correctly, but default/`-O` produce no output (module deleted as unused), and after also fixing `deleteUnusedFunctionsAndVariables`, `-O` segfaults on the gutted `unreachable` body — each optimizer fix addresses an observed failure mode.
- With all three fixes:

```
$ hermes -commonjs test/hermes/cjs-module.js     # same with -O0 / -O
cjs module start
object function object
42
```

Multi-module `require()` round trip (also with `-O` and `-O -fstatic-require`):

```
$ hermes -commonjs main.js dep.js
hello world
$ hermes -commonjs -dump-bytecode main.js dep.js | grep 'CommonJS module count'
  CommonJS module count: 2
```

lit suites for the affected components (`test/hermes`, `test/IRGen`, `test/Optimizer`, `test/BCGen`, `test/Sema`, `test/AST`, `test/Parser`, release Linux build): 1046 passes, 0 failures caused by this change (the 640 pre-existing failures in my environment are all missing `shermes`/`hbcdump` binaries, verified by grepping every failure log).

Code formatted with clang-format (no diff).