### PR TITLE
Guard debugger null deref and spurious StepFinish on async interrupt

### DIFF
--- a/include/hermes/VM/Debugger/Debugger.h
+++ b/include/hermes/VM/Debugger/Debugger.h
@@ -620,6 +620,10 @@ class Debugger {
     auto aLoc = getLocationForState(a);
     auto bLoc = getLocationForState(b);
 
+    // Locations may be missing (null codeBlock or no debug info).
+    if (!aLoc.hasValue() || !bLoc.hasValue())
+      return false;
+
     // Same statement in the same codeBlock, but different offsets.
     return a.codeBlock == b.codeBlock && aLoc->statement == bLoc->statement &&
         a.offset != b.offset;
@@ -627,6 +631,8 @@ class Debugger {
 
   OptValue<hbc::DebugSourceLocation> getLocationForState(
       const InterpreterState &state) const {
+    if (state.codeBlock == nullptr)
+      return llvh::None;
     return state.codeBlock->getSourceLocation(state.offset);
   }
 

--- a/lib/VM/Debugger/Debugger.cpp
+++ b/lib/VM/Debugger/Debugger.cpp
@@ -244,8 +244,12 @@ ExecutionStatus Debugger::runDebugger(
         // Continue to run the debugger loop.
 
         // Done stepping.
-        pauseReason =
-            curStepMode_ ? PauseReason::StepFinish : *asyncTriggerPauseReason_;
+        // Prefer a pending async-trigger reason: runUntilValidPauseLocation's
+        // Ret branch can synthesize curStepMode_ while servicing an async
+        // interrupt, which would surface implicit CDP interrupts as
+        // user-visible StepFinish pauses.
+        pauseReason = asyncTriggerPauseReason_ ? *asyncTriggerPauseReason_
+                                               : PauseReason::StepFinish;
         curStepMode_ = llvh::None;
         asyncTriggerPauseReason_ = llvh::None;
       } else {


### PR DESCRIPTION
## Summary

Fixes a null-pointer `SIGSEGV` in the Hermes debugger that fires when React Native DevTools (CDP) attaches to a New-Architecture app, plus a second bug that surfaces every attach as a spurious "paused in debugger".

Both stem from the `Ret` branch of `Debugger::runUntilValidPauseLocation` switching to `StepMode::Out` without initializing `preStepState_`. On the next pause, `getLocationForState(preStepState_)` dereferences `preStepState_.codeBlock == nullptr`, and `sameStatementDifferentInstruction` dereferences both `OptValue` locations without `hasValue()` checks. Separately, the branch synthesizes `curStepMode_` while only servicing an implicit interrupt, so `runDebugger` reports `PauseReason::StepFinish` instead of the pending async-trigger reason.

Closes #2118.

## Changes

- `include/hermes/VM/Debugger/Debugger.h`
  - `getLocationForState`: return `llvh::None` when `state.codeBlock == nullptr`.
  - `sameStatementDifferentInstruction`: `return false` when either location has no value.
- `lib/VM/Debugger/Debugger.cpp` (`runDebugger`)
  - Prefer a pending `asyncTriggerPauseReason_` over synthesizing `PauseReason::StepFinish`.

## Credit

Root-cause analysis and the original fix are **@Elehiggle's**, from facebook/react-native#55571 (credited via `Co-authored-by:` on the commit). This PR carries that fix upstream to Hermes, where the code lives; the RN issue is closed/stale with the fix sitting in a comment.

## Testing

Verified manually on a from-source Android build (RN 0.85.3 / Hermes v0.16.0, New Architecture + Bridgeless, physical arm64 device): attached React Native DevTools, set a breakpoint in app JS — it pauses and steps correctly, with no `SIGSEGV` and no spurious "paused in debugger". Without the patch the same sequence crashes reliably.

**No automated test included.** This is a defensive null/`hasValue` guard on a debugger/CDP-attach code path that is awkward to exercise in the existing unit tests. Happy to add a regression test if maintainers can point me at the right harness (e.g. under `unittests/API` or the debugger lit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
