### PR TITLE
[AI] fix(vm): correct typo in RegExp[Symbol.split] TypeError message

### DIFF
--- a/lib/VM/JSLib/RegExp.cpp
+++ b/lib/VM/JSLib/RegExp.cpp
@@ -1961,7 +1961,7 @@ regExpPrototypeSymbolSplit(void *, Runtime &runtime, NativeArgs args) {
   // 2. If Type(rx) is not Object, throw a TypeError exception.
   if (LLVM_UNLIKELY(!vmisa<JSObject>(args.getThisArg()))) {
     return runtime.raiseTypeError(
-        "Cannot call RegExp.protoype[Symbol.split] on a non-object.");
+        "Cannot call RegExp.prototype[Symbol.split] on a non-object.");
   }
   // 3. Let S be ToString(string).
   auto strRes = toString_RJS(runtime, args.getArgHandle(0));


### PR DESCRIPTION
## Summary

Fixes a typo in the user-facing TypeError message thrown when RegExp.prototype[Symbol.split] is called on a non-object: protoype -> prototype.

Before:
> Cannot call RegExp.protoype[Symbol.split] on a non-object.

After:
> Cannot call RegExp.prototype[Symbol.split] on a non-object.

This is a single-line string-literal change in lib/VM/JSLib/RegExp.cpp. No code paths, tests, or snapshots reference the old message (verified by repo-wide search).

## Test Plan

- Repo-wide grep confirms no test asserts on the old string.
- Change is limited to a string literal; covered by existing CI build.