### PR TITLE
Avoid unnecessary rescans of VariableScopes (#2121)

### DIFF
--- a/include/hermes/IR/IR.h
+++ b/include/hermes/IR/IR.h
@@ -1445,6 +1445,11 @@ class VariableScope
     return children_;
   }
 
+  /// \return whether assignIndexToVariables() has been called already.
+  bool hasAssignedIndices() const {
+    return numVisibleVariables_ != UINT32_MAX;
+  }
+
   /// \return the number of variables that are visible in this scope.
   /// The first numVisibleVariables in this VariableScope are visible to the
   /// debugger.
@@ -2145,7 +2150,25 @@ class Module : public Value {
   FunctionListType compiledFunctions_{};
 
   /// List of all the VariableScopes owned by this module.
+  ///
+  /// Invariant: VariableScopes at the start of the list have Variables with
+  /// assigned indices, while VariableScopes at the end of the list have
+  /// Variables with unassigned indices. New VariableScopes are never added to
+  /// the middle of the list, but they may be deleted from the middle of the
+  /// list without violating the invariant.
   VariableScopeListType variableScopes_{};
+
+  /// List of VariableScopes that may have no users, letting lazy
+  /// compilation reclaim dead scopes without rescanning all of variableScopes_.
+  ///
+  /// Invariant: every user-less scope is a member, so no dead scope is missed.
+  /// Membership does not imply user-less, so entries are re-checked before
+  /// deletion.
+  /// Maintained by addVariableScope() (new scopes) and
+  /// markVariableScopeAsMaybeDead() (last user removed).
+  /// Once it's iterated, this list is cleared but a VariableScope may be
+  /// re-added by one of the above mechanisms.
+  llvh::SmallPtrSet<VariableScope *, 16> maybeDeadVariableScopes_{};
 
   GlobalObject globalObject_{};
   LiteralEmpty literalEmpty{};
@@ -2306,12 +2329,32 @@ class Module : public Value {
     return topLevelFunction_;
   }
 
-  /// Get the list of variable scopes owned by this module.
+  /// \return the list of variable scopes owned by this module.
+  /// NOTE: DO NOT append or remove from the returned list.
+  /// ONLY use addVariableScope and destroyVariableScope for that.
   VariableScopeListType &getVariableScopes() {
     return variableScopes_;
   }
+  /// \return the list of variable scopes owned by this module.
+  /// NOTE: DO NOT append or remove from the returned list.
+  /// ONLY use addVariableScope and destroyVariableScope for that.
   const VariableScopeListType &getVariableScopes() const {
     return variableScopes_;
+  }
+
+  /// Add a VariableScope owned by this Module.
+  void addVariableScope(VariableScope *varScope) {
+    variableScopes_.push_back(varScope);
+    maybeDeadVariableScopes_.insert(varScope);
+  }
+
+  /// Remove and destroy a VariableScope owned by this Module.
+  /// \pre \p variableScope has no users.
+  void destroyVariableScope(VariableScope *varScope);
+
+  /// Remember that a VariableScope lost its last user.
+  void markVariableScopeAsMaybeDead(VariableScope *varScope) {
+    maybeDeadVariableScopes_.insert(varScope);
   }
 
   OptimizationContext &getOptimizationContext() {
@@ -2321,10 +2364,19 @@ class Module : public Value {
     return optContext_;
   }
 
-  /// Assign index to all Variables in all VariableScopes.
+  /// Assign indices to Variables in newly-created VariableScopes.
   void assignIndexToVariables() {
-    for (VariableScope &varScope : variableScopes_)
-      varScope.assignIndexToVariables();
+    // Iterate variableScopes_ backwards, and stop at the first one that has
+    // already been assigned indices. This prevents rescanning VariableScopes
+    // unnecessarily and causing slowdown.
+    // See the invariant on variableScopes_ for why this works.
+    for (auto it = variableScopes_.rbegin(); it != variableScopes_.rend();
+         ++it) {
+      VariableScope *varScope = &*it;
+      if (varScope->hasAssignedIndices())
+        break;
+      varScope->assignIndexToVariables();
+    }
   }
 
   /// Create the specified global property if it doesn't exist. If it does

--- a/lib/IR/IR.cpp
+++ b/lib/IR/IR.cpp
@@ -393,6 +393,10 @@ void Instruction::setOperand(Value *Val, unsigned Index) {
   // Remove the current instruction from the old value that we are removing.
   if (CurrentValue) {
     CurrentValue->removeUse(Operands[Index]);
+    if (auto *variableScope = llvh::dyn_cast<VariableScope>(CurrentValue);
+        variableScope && !variableScope->hasUsers()) {
+      getModule()->markVariableScopeAsMaybeDead(variableScope);
+    }
   }
 
   // Register this instruction as a user of the new value and set the operand.
@@ -777,6 +781,12 @@ void Module::insert(iterator position, Function *F) {
   FunctionList.insert(position, F);
 }
 
+void Module::destroyVariableScope(VariableScope *varScope) {
+  assert(!varScope->hasUsers() && "cannot destroy a varScope with users");
+  maybeDeadVariableScopes_.erase(varScope);
+  variableScopes_.erase(*varScope);
+}
+
 void Module::populateCJSModuleUseGraph() {
   if (!cjsModuleUseGraph_.empty()) {
     return;
@@ -962,15 +972,17 @@ void Module::resetForMoreCompilation() {
   // its variables.
   // Don't delete any unused variables from VariableScopes here, because they
   // may be captured in the future.
-  for (auto it = variableScopes_.begin(); it != variableScopes_.end();) {
-    if (it->hasUsers()) {
-      // Skip VariableScopes with users.
-      ++it;
-    } else {
-      // If no users, delete the VariableScope.
-      it->removeFromScopeChain();
-      variableScopes_.erase(it++);
-    }
+  // We do iterate the SmallPtrSet here but the order doesn't matter.
+  llvh::SmallVector<VariableScope *, 16> deadVariableScopes{};
+  for (VariableScope *varScope : maybeDeadVariableScopes_) {
+    if (!varScope->hasUsers())
+      deadVariableScopes.push_back(varScope);
+  }
+  maybeDeadVariableScopes_.clear();
+  // Delete the VariableScopes with no users.
+  for (VariableScope *varScope : deadVariableScopes) {
+    varScope->removeFromScopeChain();
+    destroyVariableScope(varScope);
   }
 }
 

--- a/lib/IR/IRBuilder.cpp
+++ b/lib/IR/IRBuilder.cpp
@@ -177,7 +177,7 @@ Variable *IRBuilder::createVariable(
 
 VariableScope *IRBuilder::createVariableScope(VariableScope *parentScope) {
   auto *newScope = new VariableScope(parentScope);
-  M->getVariableScopes().push_back(newScope);
+  M->addVariableScope(newScope);
   return newScope;
 }
 

--- a/lib/Optimizer/Scalar/Utils.cpp
+++ b/lib/Optimizer/Scalar/Utils.cpp
@@ -203,7 +203,8 @@ bool deleteUnusedVariables(Module *M) {
       // but may still have users in dead functions, so just move them to the
       // parent and leave it to function DCE to eliminate their usage.
       it->removeFromScopeChain();
-      scopeList.erase(it++);
+      VariableScope *varScope = &*it++;
+      M->destroyVariableScope(varScope);
       continue;
     }
 

--- a/unittests/IR/VariableTest.cpp
+++ b/unittests/IR/VariableTest.cpp
@@ -91,4 +91,36 @@ TEST(VariableTest, ReorderHidden) {
   }
 }
 
+TEST(VariableTest, DeleteScopeAfterLastUserIsRemoved) {
+  auto Ctx = std::make_shared<Context>();
+  Module M{Ctx};
+  IRBuilder Builder{&M};
+
+  auto *topLevel = Builder.createTopLevelFunction("global", true);
+  auto *topLevelBlock = Builder.createBasicBlock(topLevel);
+  Builder.setInsertionBlock(topLevelBlock);
+  Builder.createUnreachableInst();
+
+  auto *varScope = Builder.createVariableScope(nullptr);
+  auto *compiledFunction = Builder.createFunction(
+      "compiled", Function::DefinitionKind::ES5Function, true);
+  auto *compiledBlock = Builder.createBasicBlock(compiledFunction);
+  Builder.setInsertionBlock(compiledBlock);
+  Builder.createCreateScopeInst(varScope, Builder.getEmptySentinel());
+  Builder.createReturnInst(Builder.getLiteralUndefined());
+  compiledFunction->moveToCompiledFunctionList();
+
+  // Clear the initial candidate set while the scope still has a user.
+  M.assignIndexToVariables();
+  M.resetForMoreCompilation();
+  ASSERT_EQ(1u, M.getVariableScopes().size());
+
+  // This is the same removal path used by BytecodeFunction's destructor.
+  compiledFunction->eraseFromCompiledFunctionsNoDestroy();
+  Value::destroy(compiledFunction);
+  M.resetForMoreCompilation();
+
+  EXPECT_TRUE(M.getVariableScopes().empty());
+}
+
 } // end anonymous namespace


### PR DESCRIPTION
Summary:

Lazy compilation was iterating all VariableScopes every time a new
function was called, for two reasons:

1. `assignIndexToVariables`: This is now handled by iterating the list
in reverse, as new VariableScopes are only added to the end of the
list. So if we encounter a VariableScope with the indices already set
we're done.

2. Cleaning up the dead VariableScopes in `resetForMoreCompilation`.
This is now handled by keeping track of a list of
`maybeDeadVariableScopes_` and maintaining that by adding to it when a
new VariableScope is created and when a VariableScope loses all
its users. This means we don't have to check all of them, only the
ones that may potentially be dead.

This speeds up lazy compilation performance on large bundles
significantly.

See https://github.com/facebook/hermes/issues/2048

Reviewed By: micleo2

Differential Revision: D114392997


