### PR TITLE
Handle try-catch-finally in CheckImplicitReturn

### DIFF
--- a/lib/Sema/CheckImplicitReturn.cpp
+++ b/lib/Sema/CheckImplicitReturn.cpp
@@ -247,44 +247,55 @@ class CheckImplicitReturn {
   }
 
   // \return the termination result of a try statement.
+  // A try statement may have a handler, a finalizer, or both. In compile mode
+  // SemanticResolver rewrites the both-present form into nested try statements
+  // before this runs, but in parser mode (resolveASTForParser) it does not, so
+  // the node reaching here can still carry both children. The rewrite is only
+  // a restatement of the language semantics -- "try B catch H finally F" is
+  // "try { try B catch H } finally F" -- so the two cases are composed here in
+  // that same order rather than handled by a third rule.
   TerminationResult checkTerminationTryStatement(
       ESTree::TryStatementNode *node) {
-    auto tryRes = checkTermination(node->_block);
-
     assert(
-        !(node->_handler && node->_finalizer) &&
-        "try-catch-finally should have been transformed by SemanticResolver");
+        (node->_handler || node->_finalizer) &&
+        "try statement must have a handler or a finalizer");
+
+    TerminationResult tryRes = checkTermination(node->_block);
     if (node->_handler) {
-      // Both the try and catch must be terminating if there's no finalizer.
+      // Both the try and catch must be terminating for the pair to terminate.
       auto catchRes = checkTermination(
           llvh::cast<ESTree::CatchClauseNode>(node->_handler)->_body);
       tryRes.targetLabels.insert(
           catchRes.targetLabels.begin(), catchRes.targetLabels.end());
+    }
+
+    if (!node->_finalizer)
       return tryRes;
-    } else {
-      auto finallyRes = checkTermination(node->_finalizer);
-      if (finallyRes.mustTerminate()) {
-        // If the finally block terminates, the try-finally will terminate after
-        // executing the finally.
-        return finallyRes;
-      }
-      if (tryRes.mustTerminate() && finallyRes.mustExecuteNextStatement()) {
-        // If the try definitely terminates and the finally can't break
-        // to another handler in this function, the try-finally will definitely
-        // terminate.
-        // However, we also check that the finally has no control flow
-        // that would prevent the try from being able to terminate, e.g.
-        //     label:
-        //       try { return 1; }
-        //       finally { break label; }
-        // needs to avoid this branch, which mustExecuteNextStatement checks.
-        return tryRes;
-      }
-      // Otherwise, we just combine the possible next points of the try-finally.
-      tryRes.targetLabels.insert(
-          finallyRes.targetLabels.begin(), finallyRes.targetLabels.end());
+
+    // tryRes now describes the whole "try B" or "try B catch H" that the
+    // finally protects, since the finalizer runs however that part completes.
+    auto finallyRes = checkTermination(node->_finalizer);
+    if (finallyRes.mustTerminate()) {
+      // If the finally block terminates, the try-finally will terminate after
+      // executing the finally.
+      return finallyRes;
+    }
+    if (tryRes.mustTerminate() && finallyRes.mustExecuteNextStatement()) {
+      // If the try definitely terminates and the finally can't break
+      // to another handler in this function, the try-finally will definitely
+      // terminate.
+      // However, we also check that the finally has no control flow
+      // that would prevent the try from being able to terminate, e.g.
+      //     label:
+      //       try { return 1; }
+      //       finally { break label; }
+      // needs to avoid this branch, which mustExecuteNextStatement checks.
       return tryRes;
     }
+    // Otherwise, we just combine the possible next points of the try-finally.
+    tryRes.targetLabels.insert(
+        finallyRes.targetLabels.begin(), finallyRes.targetLabels.end());
+    return tryRes;
   }
 
   // \return the termination result of a switch statement, accounting for breaks

--- a/test/Sema/implicit-return-try-catch-finally.js
+++ b/test/Sema/implicit-return-try-catch-finally.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermesc -dump-sema %s | %FileCheck %s
+// RUN: %hermesc -Xcompile=false -dump-sema %s | %FileCheck %s
+
+// The answers CheckImplicitReturn gives for a try statement carrying both a
+// handler and a finalizer. Both RUN lines deliberately share one set of
+// expectations: the compiler splits "try B catch H finally F" into nested try
+// statements before the check runs and the parser entry point does not, so the
+// two paths have to agree, and this fails if they ever stop agreeing.
+//
+// A Func line does not name its function, so each one below is followed by a
+// check for a uniquely named parameter, which ties it to the function it came
+// from. The first Func line is the global function holding the declarations.
+
+// CHECK:Func loose mayReachImplicitReturn
+
+// Nothing terminates.
+function fallsThrough(pFallsThrough) {
+  try { g(); } catch (e) { g(); } finally { g(); }
+}
+// CHECK:Func loose mayReachImplicitReturn
+// CHECK:Decl %d.{{[0-9]+}} 'pFallsThrough' Parameter
+
+// The try returns but the handler completes normally.
+function catchFallsThrough(pCatchFallsThrough) {
+  try { return 1; } catch (e) { g(); } finally { g(); }
+}
+// CHECK:Func loose mayReachImplicitReturn
+// CHECK:Decl %d.{{[0-9]+}} 'pCatchFallsThrough' Parameter
+
+// Try and catch both return and the finalizer completes normally, so the
+// finalizer cannot redirect control anywhere.
+function bothReturn(pBothReturn) {
+  try { return 1; } catch (e) { return 2; } finally { g(); }
+}
+// CHECK:Func loose noImplicitReturn
+// CHECK:Decl %d.{{[0-9]+}} 'pBothReturn' Parameter
+
+// A return in the finalizer overrides however the protected part completed,
+// including the handler falling through.
+function finallyReturns(pFinallyReturns) {
+  try { g(); } catch (e) { g(); } finally { return 1; }
+}
+// CHECK:Func loose noImplicitReturn
+// CHECK:Decl %d.{{[0-9]+}} 'pFinallyReturns' Parameter
+
+// 'break lbl' in the finalizer continues after the labeled block, so the end
+// of the function is reachable even though try and catch both return.
+function finallyBreaks(pFinallyBreaks) {
+  lbl: {
+    try { return 1; } catch (e) { return 2; } finally { break lbl; }
+  }
+}
+// CHECK:Func loose mayReachImplicitReturn
+// CHECK:Decl %d.{{[0-9]+}} 'pFinallyBreaks' Parameter
+
+// A finalizer that only sometimes breaks reaches both the label and its own
+// next statement, so it neither terminates nor unconditionally continues.
+function finallyBreaksSometimes(pFinallyBreaksSometimes) {
+  lbl: {
+    try { return 1; } catch (e) { return 2; } finally { if (g()) break lbl; }
+  }
+}
+// CHECK:Func loose mayReachImplicitReturn
+// CHECK:Decl %d.{{[0-9]+}} 'pFinallyBreaksSometimes' Parameter


### PR DESCRIPTION
Summary:
CheckImplicitReturn handled a try statement with a handler or with a
finalizer, but not one with both. SemanticResolver rewrites
"try B catch H finally F" into that nested pair, but only when compile_
is set, so resolveASTForParser passes the combined form straight
through: it tripped the assert, and under NDEBUG the handler branch ran
and the finalizer was ignored.

Handle the combined form the same way the nested pair is handled: the
handler rule over the block, then the finalizer rule over that result.
The finalizer half is unchanged apart from losing a level of
indentation.

The test runs both -Xcompile settings against one set of expectations,
so the two paths disagreeing is itself a failure.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Reviewed By: avp

Differential Revision: D115669841


