### PR TITLE
Fix constant folding of null * Infinity (folds to 0 instead of NaN)

### DIFF
--- a/lib/IR/IREval.cpp
+++ b/lib/IR/IREval.cpp
@@ -540,6 +540,15 @@ Literal *hermes::evalBinaryOperator(
 
       if ((leftNull && rightLiteralNum) || (rightNull && leftLiteralNum) ||
           (leftNull && rightNull)) {
+        // `null` coerces to +0. Multiplying 0 by a non-finite value is NaN,
+        // not 0: 0 * (+-Infinity) == NaN. (NaN operands are already handled
+        // above.) Only fold to a signed zero when the numeric operand is
+        // finite.
+        LiteralNumber *numOperand =
+            leftLiteralNum ? leftLiteralNum : rightLiteralNum;
+        if (numOperand && std::isinf(numOperand->getValue())) {
+          return builder.getLiteralNaN();
+        }
         if ((leftLiteralNum && std::signbit(leftLiteralNum->getValue())) ||
             (rightLiteralNum && std::signbit(rightLiteralNum->getValue()))) {
           return builder.getLiteralNegativeZero();

--- a/test/Optimizer/simplify.js
+++ b/test/Optimizer/simplify.js
@@ -122,6 +122,11 @@ function mul_null(x, y) {
   sink(-3 * null)
 
   sink(null * null)
+
+  // null coerces to +0, and 0 * (+/-Infinity) is NaN, not 0.
+  sink(null * (1 / 0))
+  sink(null * (-1 / 0))
+  sink((1 / 0) * null)
 }
 
 function left_shift_num(x, y) {
@@ -663,6 +668,9 @@ function objectCond() {
 // CHECK-NEXT:  %3 = CallInst (:any) %0: any, empty: any, false: boolean, empty: any, undefined: undefined, undefined: undefined, -0: number
 // CHECK-NEXT:  %4 = CallInst (:any) %0: any, empty: any, false: boolean, empty: any, undefined: undefined, undefined: undefined, -0: number
 // CHECK-NEXT:  %5 = CallInst (:any) %0: any, empty: any, false: boolean, empty: any, undefined: undefined, undefined: undefined, 0: number
+// CHECK-NEXT:  %6 = CallInst (:any) %0: any, empty: any, false: boolean, empty: any, undefined: undefined, undefined: undefined, NaN: number
+// CHECK-NEXT:  %7 = CallInst (:any) %0: any, empty: any, false: boolean, empty: any, undefined: undefined, undefined: undefined, NaN: number
+// CHECK-NEXT:  %8 = CallInst (:any) %0: any, empty: any, false: boolean, empty: any, undefined: undefined, undefined: undefined, NaN: number
 // CHECK-NEXT:       ReturnInst undefined: undefined
 // CHECK-NEXT:function_end
 


### PR DESCRIPTION
## Summary

The `*` constant folder in `evalBinaryOperator()` (`lib/IR/IREval.cpp`)
special-cases `null * <number literal>` and folds it to a signed zero, on the
assumption that `null` coerces to `+0` and `0 * x == 0`. That assumption is
wrong for a non-finite operand: `0 * (+/-Infinity)` is `NaN`, not `0`. NaN
operands are already handled earlier in the function, so only `+/-Infinity`
reached this path and was folded incorrectly.

The effect is an optimizer-only miscompile. Under `-O`, `null * Infinity` (and
`null * -Infinity`, `null * (1 / 0)`, `Infinity * null`, ...) evaluated to `0`,
while the interpreter and `-O0` correctly produce `NaN`:

```js
print(null * Infinity);   // -O0: NaN   -O (before this fix): 0
```

The fix folds to a signed zero only when the numeric operand is finite;
otherwise it returns `NaN`. Signed-zero behavior for finite operands is
unchanged (`null * -5` still folds to `-0`).

## Test Plan

Extended the `mul_null` case in `test/Optimizer/simplify.js` with the Infinity
cases; the regenerated IR folds them to `NaN: number`. This expectation fails on
the unpatched compiler (which folds to `0: number`) and passes with the fix.

Verified `null * Infinity` now prints `NaN` under both `-O` and `-O0`, matching
the spec and other engines, and that finite folding is preserved
(`1 / (null * -5)` is `-Infinity`).

Ran the affected lit suites locally (Debug build):

- `test/Optimizer` — 113 passed, 1 expected failure, 19 unsupported (shermes)
- `test/IRGen` — 121 passed
- `test/hermes` — 567 passed
