### PR TITLE
Fix: move task when adding it to SerialExecutor and reset it to nullptr when using libc++ (#2133)

### DIFF
--- a/lib/Support/SerialExecutor.cpp
+++ b/lib/Support/SerialExecutor.cpp
@@ -73,7 +73,13 @@ void SerialExecutor::add(std::function<void()> task) {
     threadState_ = ThreadState::Initialized;
   }
 
-  tasks_.push_back(task);
+  tasks_.push_back(std::move(task));
+  // Some C++ std implementations of move for std::function does not empty the
+  // source task if it's a small lambda (inlined storage). So we explicitly
+  // reset it to nullptr. This is an edge case for finalizer executor: the
+  // source task may hold a shared_ptr alive and hence not destructed in the
+  // background thread.
+  task = nullptr;
   wakeUpSig_.notify_one();
 }
 


### PR DESCRIPTION
Summary:

This fixes a race condition for finalizer executor: the task is supposed to destroy HostObjects
if the refCount of shared_ptr to it is 1. But since here the source task still holds a copy
of the shared_ptr, it will not be destroyed on the finalizer thread. So we need to reset
it before notifying the executor event loop.

Differential Revision: D115945725


