### PR TITLE
Fix constant folding of null + -0 (folds to -0 instead of +0)

### DIFF
--- a/lib/IR/IREval.cpp
+++ b/lib/IR/IREval.cpp
@@ -482,7 +482,10 @@ Literal *hermes::evalBinaryOperator(
 
       if (leftNull) {
         if (rightLiteralNum) {
-          return rhs;
+          // `null` coerces to +0, and +0 + -0 is +0, not -0, so the operand
+          // cannot be returned unchanged. Adding +0 is correct for every
+          // other value too. (NaN operands are already handled above.)
+          return builder.getLiteralNumber(0 + rightLiteralNum->getValue());
         } else if (rightStr) {
           SmallString<256> result =
               buildString("null", ctx.toString(rightStr->getValue()));
@@ -492,7 +495,8 @@ Literal *hermes::evalBinaryOperator(
 
       if (rightNull) {
         if (leftLiteralNum) {
-          return lhs;
+          // Same signed-zero reason as the `leftNull` case above.
+          return builder.getLiteralNumber(leftLiteralNum->getValue() + 0);
         } else if (leftStr) {
           SmallString<256> result =
               buildString(ctx.toString(leftStr->getValue()), "null");

--- a/test/Optimizer/simplify.js
+++ b/test/Optimizer/simplify.js
@@ -111,6 +111,10 @@ function add_null(x, y) {
   sink("hello" + null)
 
   sink(null + null)
+
+  // null coerces to +0, and +0 + -0 is +0, not -0.
+  sink(null + -0)
+  sink(-0 + null)
 }
 
 function mul_null(x, y) {
@@ -657,6 +661,8 @@ function objectCond() {
 // CHECK-NEXT:  %3 = CallInst (:any) %0: any, empty: any, false: boolean, empty: any, undefined: undefined, undefined: undefined, "nullhello": string
 // CHECK-NEXT:  %4 = CallInst (:any) %0: any, empty: any, false: boolean, empty: any, undefined: undefined, undefined: undefined, "hellonull": string
 // CHECK-NEXT:  %5 = CallInst (:any) %0: any, empty: any, false: boolean, empty: any, undefined: undefined, undefined: undefined, 0: number
+// CHECK-NEXT:  %6 = CallInst (:any) %0: any, empty: any, false: boolean, empty: any, undefined: undefined, undefined: undefined, 0: number
+// CHECK-NEXT:  %7 = CallInst (:any) %0: any, empty: any, false: boolean, empty: any, undefined: undefined, undefined: undefined, 0: number
 // CHECK-NEXT:       ReturnInst undefined: undefined
 // CHECK-NEXT:function_end
 


### PR DESCRIPTION
## Summary

`evalBinaryOperator()` in `lib/IR/IREval.cpp` folds `null + <number literal>` by returning the
number operand unchanged:

```cpp
if (leftNull) {
  if (rightLiteralNum) {
    return rhs;
```

That leans on `null` coercing to `+0` and on `0 + x == x`. The second half is not true for a
negative zero: `+0 + -0` is `+0`, not `-0` (IEEE 754, and ES2025 `Number::add`). The `rightNull`
branch a few lines below has the same problem with the operands swapped.

The result is an optimizer-only miscompile. Under `-O` the folded constant keeps the sign of the
literal, while the interpreter and `-O0` correctly produce `+0`:

```js
print(1 / (null + -0));           // -O0: Infinity   -O (before): -Infinity
print(1 / (-0 + null));           // -O0: Infinity   -O (before): -Infinity
print(Object.is(null + -0, -0));  // -O0: false      -O (before): true
```

V8 agrees with `-O0` on all three. `null * -0` is not affected, since the `*` folder got explicit
signed-zero handling in #2132, and that fix is what made me look at `+`.

The change computes the sum instead of returning the operand. `0 + x` is `x` for every value
except `-0`, where it gives `+0`, so no other folding result moves. NaN operands never reach this
code, they are handled earlier in the same function.

One thing worth stating since the fix looks like a no-op: the host compiler will not undo it.
`0.0 + x -> x` is not a valid transform under IEEE 754 semantics, precisely because of `-0`.
Hermes does not build with `-ffast-math` or `-fno-signed-zeros`, and I checked that clang at `-O3`
still emits the `fadd` rather than dropping it.

## Test Plan

Added the two operand orders to the existing `add_null` case in `test/Optimizer/simplify.js`,
matching what #2132 did for `mul_null`. The regenerated IR folds both to `0: number`.

The IR printer does distinguish the two zeros (`mul_null` already expects `-0: number` for
`null * -3`), so this expectation is a real check rather than a decorative one. Confirmed by
reverting only the source fix and rerunning:

```
$ git stash push -- lib/IR/IREval.cpp
$ cmake --build cmake-build-asan --target hermes
$ LIT_OPTS="-j1" LIT_FILTER="Optimizer/simplify.js" cmake --build cmake-build-asan --target check-hermes

test/Optimizer/simplify.js:664:16: error: CHECK-NEXT: is not on the line after the previous match
// CHECK-NEXT:  %6 = CallInst (:any) ... 0: number
note: non-matching line after previous match is here
 %6 = CallInst (:any) ... -0: number

Failing Tests (1):
    Hermes :: Optimizer/simplify.js
```

It passes again with the fix restored, and `-O` then matches `-O0` and V8 on all three lines of
the repro above.

Lit suite, ASan + Debug build with `-O1`, single process (`LIT_OPTS="-j1"`):

- `check-hermes`, whole suite: 4290 tests, 4097 expected passes, 6 expected failures,
  187 unsupported, 0 unexpected failures.
- `test/Optimizer`, `test/IRGen`, `test/hermes` on their own: 1045 tests, 978 expected passes,
  6 expected failures, 61 unsupported, 0 unexpected failures.

Ran `clang-format` with the repo `.clang-format` over the changed file; no reformatting needed.

---

apologies if anything here is off, i found this by following the `*` folding fix in #2132 into the
neighbouring `+` case and then checking it against `-O0` and v8 rather than reading the spec first,
and i talked through the reasoning with claude code. freshman in college, doing my best to
contribute something useful. happy to be told i got it wrong.
