### PR TITLE
Implement Intl.supportedValuesOf

### DIFF
--- a/doc/IntlAPIs.md
+++ b/doc/IntlAPIs.md
@@ -31,6 +31,8 @@ One popular implementation strategy followed by other engines, is to bundle an i
 
 - `Intl.getCanonicalLocales`
 
+- `Intl.supportedValuesOf`
+
 - `String.prototype`
   - `localeCompare`
   - `toLocaleLowerCase`

--- a/include/hermes/Platform/Intl/PlatformIntl.h
+++ b/include/hermes/Platform/Intl/PlatformIntl.h
@@ -84,6 +84,10 @@ using Part = std::unordered_map<std::u16string, std::u16string>;
 vm::CallResult<std::vector<std::u16string>> getCanonicalLocales(
     vm::Runtime &runtime,
     const std::vector<std::u16string> &locales);
+/// https://tc39.es/ecma402/#sec-intl.supportedvaluesof
+vm::CallResult<std::vector<std::u16string>> supportedValuesOf(
+    vm::Runtime &runtime,
+    const std::u16string &key);
 vm::CallResult<std::u16string> toLocaleLowerCase(
     vm::Runtime &runtime,
     const std::vector<std::u16string> &locales,

--- a/include/hermes/VM/PredefinedStrings.def
+++ b/include/hermes/VM/PredefinedStrings.def
@@ -559,6 +559,7 @@ STR(formatToParts, "formatToParts")
 STR(getCanonicalLocales, "getCanonicalLocales")
 STR(resolvedOptions, "resolvedOptions")
 STR(supportedLocalesOf, "supportedLocalesOf")
+STR(supportedValuesOf, "supportedValuesOf")
 #endif
 
 // Define strings like "[object Number]" for all classes.

--- a/lib/Platform/Intl/PlatformIntlAndroid.cpp
+++ b/lib/Platform/Intl/PlatformIntlAndroid.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "hermes/Platform/Intl/PlatformIntl.h"
+#include "SupportedValues.h"
 
 // Android ICU uses different package names than ICU4J, and claims
 // other differences.  So for now, consider this impl specific to
@@ -219,6 +220,22 @@ class JIntl : public jni::JavaClass<JIntl> {
     return method(javaClassStatic(), locales);
   }
 
+  static jni::local_ref<JLocalesList> availableTimeZones() {
+    static const auto method =
+        javaClassStatic()
+            ->getStaticMethod<jni::local_ref<JLocalesList>()>(
+                "availableTimeZones");
+    return method(javaClassStatic());
+  }
+
+  static jni::local_ref<JLocalesList> availableCurrencies() {
+    static const auto method =
+        javaClassStatic()
+            ->getStaticMethod<jni::local_ref<JLocalesList>()>(
+                "availableCurrencies");
+    return method(javaClassStatic());
+  }
+
   static jni::local_ref<jstring> toLocaleLowerCase(
       jni::alias_ref<JLocalesList> locales,
       jni::alias_ref<jstring> str) {
@@ -253,6 +270,26 @@ vm::CallResult<std::vector<std::u16string>> getCanonicalLocales(
   } catch (const std::exception &ex) {
     return runtime.raiseRangeError(ex.what());
   }
+}
+
+// https://tc39.es/ecma402/#sec-intl.supportedvaluesof
+vm::CallResult<std::vector<std::u16string>> supportedValuesOf(
+    vm::Runtime &runtime,
+    const std::u16string &key) {
+  if (auto common = trySupportedValuesOfCommon(key))
+    return std::move(*common);
+  try {
+    if (key == u"timeZone") {
+      return localesFromJava(runtime, JIntl::availableTimeZones());
+    }
+    if (key == u"currency") {
+      return localesFromJava(runtime, JIntl::availableCurrencies());
+    }
+  } catch (const std::exception &ex) {
+    return runtime.raiseRangeError(ex.what());
+  }
+  return runtime.raiseRangeError(
+      vm::TwineChar16("Invalid key: ") + vm::TwineChar16(key.c_str()));
 }
 
 vm::CallResult<std::u16string> toLocaleLowerCase(

--- a/lib/Platform/Intl/PlatformIntlApple.mm
+++ b/lib/Platform/Intl/PlatformIntlApple.mm
@@ -7,8 +7,10 @@
 
 #include "hermes/Platform/Intl/BCP47Parser.h"
 #include "hermes/Platform/Intl/PlatformIntl.h"
+#include "SupportedValues.h"
 
 #import <Foundation/Foundation.h>
+#include <algorithm>
 #include <shared_mutex>
 #include <thread>
 #include <unordered_set>
@@ -908,6 +910,40 @@ vm::CallResult<std::vector<std::u16string>> getCanonicalLocales(
   // 1. Let ll be ? CanonicalizeLocaleList(locales).
   // 2. Return CreateArrayFromList(ll).
   return canonicalizeLocaleList(runtime, locales);
+}
+
+namespace {
+
+std::vector<std::u16string> availableTimeZonesApple() {
+  std::vector<std::u16string> result;
+  for (NSString *name in NSTimeZone.knownTimeZoneNames)
+    result.push_back(nsStringToU16String(name));
+  finalizeSupportedTimeZones(result);
+  return result;
+}
+
+std::vector<std::u16string> availableCurrenciesApple() {
+  std::vector<std::u16string> result;
+  for (NSString *code in [NSLocale ISOCurrencyCodes])
+    result.push_back(nsStringToU16String(code));
+  sortAndUnique(result);
+  return result;
+}
+
+} // namespace
+
+// https://tc39.es/ecma402/#sec-intl.supportedvaluesof
+vm::CallResult<std::vector<std::u16string>> supportedValuesOf(
+    vm::Runtime &runtime,
+    const std::u16string &key) {
+  if (auto common = trySupportedValuesOfCommon(key))
+    return std::move(*common);
+  if (key == u"timeZone")
+    return availableTimeZonesApple();
+  if (key == u"currency")
+    return availableCurrenciesApple();
+  return runtime.raiseRangeError(
+      vm::TwineChar16("Invalid key: ") + vm::TwineChar16(key.c_str()));
 }
 
 /// https://402.ecma-international.org/8.0/#sup-string.prototype.tolocalelowercase

--- a/lib/Platform/Intl/PlatformIntlICU.cpp
+++ b/lib/Platform/Intl/PlatformIntlICU.cpp
@@ -8,6 +8,7 @@
 #include "hermes/Platform/Intl/BCP47Parser.h"
 #include "hermes/Platform/Intl/PlatformIntl.h"
 #include "hermes/Platform/Intl/PlatformIntlShared.h"
+#include "SupportedValues.h"
 #include "impl_icu/Collator.h"
 #include "impl_icu/IntlUtils.h"
 #include "impl_icu/LocaleBCP47Object.h"
@@ -26,7 +27,10 @@
 #include "unicode/dtptngen.h"
 #include "unicode/strenum.h"
 #include "unicode/timezone.h"
+#include "unicode/ucal.h"
+#include "unicode/ucurr.h"
 #include "unicode/udat.h"
+#include "unicode/uenum.h"
 #include "unicode/unistr.h"
 
 using namespace U_ICU_NAMESPACE;
@@ -152,6 +156,63 @@ vm::CallResult<std::unique_ptr<BaseT>> createInstance(
 }
 
 } // namespace
+
+namespace {
+
+std::vector<std::u16string> availableTimeZonesICU() {
+  std::vector<std::u16string> result;
+  UErrorCode status = U_ZERO_ERROR;
+  std::unique_ptr<StringEnumeration> iter(
+      TimeZone::createTimeZoneIDEnumeration(
+          UCAL_ZONE_TYPE_CANONICAL, nullptr, nullptr, status));
+  if (U_FAILURE(status) || !iter) {
+    status = U_ZERO_ERROR;
+    iter.reset(TimeZone::createEnumeration());
+  }
+  if (!iter)
+    return result;
+
+  const UChar *zoneId = iter->unext(nullptr, status);
+  while (zoneId != nullptr && U_SUCCESS(status)) {
+    result.emplace_back(zoneId);
+    zoneId = iter->unext(nullptr, status);
+  }
+  finalizeSupportedTimeZones(result);
+  return result;
+}
+
+std::vector<std::u16string> availableCurrenciesICU() {
+  std::vector<std::u16string> result;
+  UErrorCode status = U_ZERO_ERROR;
+  UEnumeration *en = ucurr_openISOCurrencies(UCURR_ALL, &status);
+  if (U_FAILURE(status) || !en)
+    return result;
+
+  const char *code = uenum_next(en, nullptr, &status);
+  while (code != nullptr && U_SUCCESS(status)) {
+    result.push_back(impl_icu::toUTF16ASCII(code));
+    code = uenum_next(en, nullptr, &status);
+  }
+  uenum_close(en);
+  sortAndUnique(result);
+  return result;
+}
+
+} // namespace
+
+// https://tc39.es/ecma402/#sec-intl.supportedvaluesof
+vm::CallResult<std::vector<std::u16string>> supportedValuesOf(
+    vm::Runtime &runtime,
+    const std::u16string &key) {
+  if (auto common = trySupportedValuesOfCommon(key))
+    return std::move(*common);
+  if (key == u"timeZone")
+    return availableTimeZonesICU();
+  if (key == u"currency")
+    return availableCurrenciesICU();
+  return runtime.raiseRangeError(
+      vm::TwineChar16("Invalid key: ") + vm::TwineChar16(key.c_str()));
+}
 
 // Not yet implemented.
 vm::CallResult<std::u16string> toLocaleLowerCase(

--- a/lib/Platform/Intl/SupportedValues.h
+++ b/lib/Platform/Intl/SupportedValues.h
@@ -1,0 +1,196 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef HERMES_PLATFORMINTL_SUPPORTEDVALUES_H
+#define HERMES_PLATFORMINTL_SUPPORTEDVALUES_H
+
+#ifdef HERMES_ENABLE_INTL
+
+#include <algorithm>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace hermes {
+namespace platform_intl {
+
+inline void sortAndUnique(std::vector<std::u16string> &values) {
+  std::sort(values.begin(), values.end());
+  values.erase(std::unique(values.begin(), values.end()), values.end());
+}
+
+/// Canonicalize Etc/UTC and Etc/GMT to UTC, then sort, unique, and
+/// ensure UTC is present.
+/// https://tc39.es/ecma402/#sec-canonicalizetimezonename
+inline void finalizeSupportedTimeZones(
+    std::vector<std::u16string> &timeZones) {
+  for (auto &tz : timeZones) {
+    if (tz == u"Etc/UTC" || tz == u"Etc/GMT")
+      tz = u"UTC";
+  }
+  sortAndUnique(timeZones);
+  if (std::find(timeZones.begin(), timeZones.end(), u"UTC") ==
+      timeZones.end()) {
+    timeZones.emplace_back(u"UTC");
+    std::sort(timeZones.begin(), timeZones.end());
+  }
+}
+
+template <size_t N>
+inline std::vector<std::u16string> copySorted(
+    const char16_t *const (&values)[N]) {
+  std::vector<std::u16string> result;
+  result.reserve(N);
+  for (const char16_t *v : values)
+    result.emplace_back(v);
+  std::sort(result.begin(), result.end());
+  return result;
+}
+
+/// https://tc39.es/ecma402/#sec-availablecalendars
+inline std::vector<std::u16string> availableCalendars() {
+  // Matches the calendars Hermes already treats as valid.
+  static constexpr const char16_t *kCalendars[] = {
+      u"buddhist",
+      u"chinese",
+      u"coptic",
+      u"dangi",
+      u"ethioaa",
+      u"ethiopic",
+      u"gregory",
+      u"hebrew",
+      u"indian",
+      u"islamic",
+      u"islamic-civil",
+      u"islamic-rgsa",
+      u"islamic-tbla",
+      u"islamic-umalqura",
+      u"iso8601",
+      u"japanese",
+      u"persian",
+      u"roc"};
+  return copySorted(kCalendars);
+}
+
+/// https://tc39.es/ecma402/#sec-availablecanonicalcollations
+inline std::vector<std::u16string> availableCollations() {
+  // "standard" and "search" are excluded by the spec.
+  static constexpr const char16_t *kCollations[] = {
+      u"big5han",
+      u"compat",
+      u"dict",
+      u"direct",
+      u"ducet",
+      u"emoji",
+      u"eor",
+      u"gb2312",
+      u"phonebk",
+      u"phonetic",
+      u"pinyin",
+      u"reformed",
+      u"searchjl",
+      u"stroke",
+      u"trad",
+      u"unihan",
+      u"zhuyin"};
+  return copySorted(kCollations);
+}
+
+/// https://tc39.es/ecma402/#sec-availablecanonicalnumberingsystems
+inline std::vector<std::u16string> availableNumberingSystems() {
+  // Simple numbering systems already treated as valid by Hermes.
+  static constexpr const char16_t *kNumberingSystems[] = {
+      u"adlm",     u"ahom",     u"arab",     u"arabext",  u"bali",
+      u"beng",     u"bhks",     u"brah",     u"cakm",     u"cham",
+      u"deva",     u"diak",     u"fullwide", u"gong",     u"gonm",
+      u"gujr",     u"guru",     u"hanidec",  u"hmng",     u"hmnp",
+      u"java",     u"kali",     u"khmr",     u"knda",     u"lana",
+      u"lanatham", u"laoo",     u"latn",     u"lepc",     u"limb",
+      u"mathbold", u"mathdbl",  u"mathmono", u"mathsanb", u"mathsans",
+      u"mlym",     u"modi",     u"mong",     u"mroo",     u"mtei",
+      u"mymr",     u"mymrshan", u"mymrtlng", u"newa",     u"nkoo",
+      u"olck",     u"orya",     u"osma",     u"rohg",     u"saur",
+      u"segment",  u"shrd",     u"sind",     u"sinh",     u"sora",
+      u"sund",     u"takr",     u"talu",     u"tamldec",  u"telu",
+      u"thai",     u"tibt",     u"tirh",     u"vaii",     u"wara",
+      u"wcho"};
+  return copySorted(kNumberingSystems);
+}
+
+/// https://tc39.es/ecma402/#sec-availablecanonicalunits
+inline std::vector<std::u16string> availableUnits() {
+  static constexpr const char16_t *kUnits[] = {
+      u"acre",
+      u"bit",
+      u"byte",
+      u"celsius",
+      u"centimeter",
+      u"day",
+      u"degree",
+      u"fahrenheit",
+      u"fluid-ounce",
+      u"foot",
+      u"gallon",
+      u"gigabit",
+      u"gigabyte",
+      u"gram",
+      u"hectare",
+      u"hour",
+      u"inch",
+      u"kilobit",
+      u"kilobyte",
+      u"kilogram",
+      u"kilometer",
+      u"liter",
+      u"megabit",
+      u"megabyte",
+      u"meter",
+      u"microsecond",
+      u"mile",
+      u"mile-scandinavian",
+      u"milliliter",
+      u"millimeter",
+      u"millisecond",
+      u"minute",
+      u"month",
+      u"nanosecond",
+      u"ounce",
+      u"percent",
+      u"petabyte",
+      u"pound",
+      u"second",
+      u"stone",
+      u"terabit",
+      u"terabyte",
+      u"week",
+      u"yard",
+      u"year"};
+  return copySorted(kUnits);
+}
+
+/// Handle keys whose values are not platform-specific. Returns
+/// nullopt for timeZone and currency (platform must supply those) and
+/// for invalid keys.
+inline std::optional<std::vector<std::u16string>>
+trySupportedValuesOfCommon(const std::u16string &key) {
+  if (key == u"calendar")
+    return availableCalendars();
+  if (key == u"collation")
+    return availableCollations();
+  if (key == u"numberingSystem")
+    return availableNumberingSystems();
+  if (key == u"unit")
+    return availableUnits();
+  return std::nullopt;
+}
+
+} // namespace platform_intl
+} // namespace hermes
+
+#endif // HERMES_ENABLE_INTL
+
+#endif // HERMES_PLATFORMINTL_SUPPORTEDVALUES_H

--- a/lib/Platform/Intl/java/com/facebook/hermes/intl/Intl.java
+++ b/lib/Platform/Intl/java/com/facebook/hermes/intl/Intl.java
@@ -11,7 +11,11 @@ import android.os.Build;
 import com.facebook.proguard.annotations.DoNotStrip;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Currency;
 import java.util.List;
+import java.util.Locale;
+import java.util.TimeZone;
+import java.util.TreeSet;
 
 @DoNotStrip
 public class Intl {
@@ -76,6 +80,52 @@ public class Intl {
   public static List<String> getCanonicalLocales(List<String> locales)
       throws JSRangeErrorException {
     return canonicalizeLocaleList(locales);
+  }
+
+  // https://tc39.es/ecma402/#sec-availableprimarytimezoneidentifiers
+  @DoNotStrip
+  public static List<String> availableTimeZones() {
+    TreeSet<String> ids = new TreeSet<>();
+    // Use the same ID source as DateTimeFormat.normalizeTimeZone so
+    // every returned value is accepted by Intl.DateTimeFormat.
+    for (String id : TimeZone.getAvailableIDs()) {
+      if ("Etc/UTC".equals(id) || "Etc/GMT".equals(id)) {
+        ids.add("UTC");
+      } else {
+        ids.add(id);
+      }
+    }
+    ids.add("UTC");
+    return new ArrayList<>(ids);
+  }
+
+  // https://tc39.es/ecma402/#sec-availablecanonicalcurrencies
+  @DoNotStrip
+  public static List<String> availableCurrencies() {
+    TreeSet<String> codes = new TreeSet<>();
+    for (Currency currency : Currency.getAvailableCurrencies()) {
+      String code = currency.getCurrencyCode();
+      if (code != null) {
+        code = code.toUpperCase(Locale.US);
+        if (isWellFormedCurrencyCode(code)) {
+          codes.add(code);
+        }
+      }
+    }
+    return new ArrayList<>(codes);
+  }
+
+  private static boolean isWellFormedCurrencyCode(String code) {
+    if (code == null || code.length() != 3) {
+      return false;
+    }
+    for (int i = 0; i < 3; i++) {
+      char c = code.charAt(i);
+      if (c < 'A' || c > 'Z') {
+        return false;
+      }
+    }
+    return true;
   }
 
   // Implementer note: This method corresponds roughly to

--- a/lib/VM/JSLib/Intl.cpp
+++ b/lib/VM/JSLib/Intl.cpp
@@ -1741,6 +1741,26 @@ vm::CallResult<vm::HermesValue> intlGetCanonicalLocales(
   return vm::localesToJS(runtime, std::move(cr.getValue()));
 }
 
+// https://tc39.es/ecma402/#sec-intl.supportedvaluesof
+vm::CallResult<vm::HermesValue> intlSupportedValuesOf(
+    void *,
+    vm::Runtime &runtime) {
+  vm::NativeArgs args = runtime.getCurrentFrame().getNativeArgs();
+  // 1. Set key to ? ToString(key).
+  vm::CallResult<std::u16string> keyRes =
+      vm::stringFromJS(runtime, args.getArgHandle(0));
+  if (LLVM_UNLIKELY(keyRes == vm::ExecutionStatus::EXCEPTION)) {
+    return vm::ExecutionStatus::EXCEPTION;
+  }
+
+  auto cr = platform_intl::supportedValuesOf(runtime, *keyRes);
+  if (cr == vm::ExecutionStatus::EXCEPTION) {
+    return vm::ExecutionStatus::EXCEPTION;
+  }
+  // 16. Return CreateArrayFromList(list).
+  return vm::localesToJS(runtime, std::move(cr.getValue()));
+}
+
 } // namespace
 
 vm::HermesValue createIntlObject(vm::Runtime &runtime) {
@@ -1756,6 +1776,14 @@ vm::HermesValue createIntlObject(vm::Runtime &runtime) {
       vm::Predefined::getSymbolID(vm::Predefined::getCanonicalLocales),
       nullptr,
       intlGetCanonicalLocales,
+      1);
+
+  defineMethod(
+      runtime,
+      lv.intl,
+      vm::Predefined::getSymbolID(vm::Predefined::supportedValuesOf),
+      nullptr,
+      intlSupportedValuesOf,
       1);
 
   {

--- a/test/hermes/intl/intl.js
+++ b/test/hermes/intl/intl.js
@@ -70,6 +70,8 @@ function testParts(parts) {
 assert(Intl !== undefined);
 
 assert(Array.isArray(Intl.getCanonicalLocales('en-US')));
+assert(typeof Intl.supportedValuesOf === 'function');
+assert(Array.isArray(Intl.supportedValuesOf('timeZone')));
 
 testServiceTypes(Intl.Collator);
 testServiceGetterTypes(Intl.Collator, 'compare');

--- a/test/hermes/intl/supported-values-of.js
+++ b/test/hermes/intl/supported-values-of.js
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes %s
+// REQUIRES: intl
+
+function assert(pred, str) {
+  if (!pred) {
+    throw new Error('assertion failed' + (str === undefined ? '' : (': ' + str)));
+  }
+}
+
+function assertThrows(fn, ctor) {
+  try {
+    fn();
+  } catch (e) {
+    assert(e instanceof ctor, 'expected ' + ctor.name + ', got ' + e);
+    return;
+  }
+  throw new Error('expected ' + ctor.name);
+}
+
+function isSortedUnique(arr) {
+  for (var i = 1; i < arr.length; i++) {
+    if (arr[i] <= arr[i - 1])
+      return false;
+  }
+  return true;
+}
+
+function assertStringArray(arr) {
+  assert(Array.isArray(arr));
+  assert(arr.length > 0);
+  for (var i = 0; i < arr.length; i++)
+    assert(typeof arr[i] === 'string');
+  assert(isSortedUnique(arr), 'values must be sorted and unique');
+}
+
+assert(typeof Intl.supportedValuesOf === 'function');
+assert(Intl.supportedValuesOf.length === 1);
+assert(Intl.supportedValuesOf.name === 'supportedValuesOf');
+
+var desc = Object.getOwnPropertyDescriptor(Intl, 'supportedValuesOf');
+assert(desc.writable === true);
+assert(desc.enumerable === false);
+assert(desc.configurable === true);
+
+assertThrows(function() { Intl.supportedValuesOf(); }, RangeError);
+assertThrows(function() { Intl.supportedValuesOf(''); }, RangeError);
+assertThrows(function() { Intl.supportedValuesOf('timezone'); }, RangeError);
+assertThrows(function() { Intl.supportedValuesOf('invalid'); }, RangeError);
+
+var keyObj = {toString: function() { return 'unit'; }};
+assert(Array.isArray(Intl.supportedValuesOf(keyObj)));
+
+var timeZones = Intl.supportedValuesOf('timeZone');
+assertStringArray(timeZones);
+assert(timeZones.indexOf('UTC') !== -1, 'UTC must be supported');
+assert(timeZones.indexOf('Etc/UTC') === -1, 'Etc/UTC is not primary');
+assert(timeZones.indexOf('Etc/GMT') === -1, 'Etc/GMT is not primary');
+assert(
+    new Intl.DateTimeFormat('en', {timeZone: 'UTC'})
+        .resolvedOptions()
+        .timeZone === 'UTC');
+
+var calendars = Intl.supportedValuesOf('calendar');
+assertStringArray(calendars);
+assert(calendars.indexOf('iso8601') !== -1);
+assert(calendars.indexOf('gregory') !== -1);
+
+var collations = Intl.supportedValuesOf('collation');
+assertStringArray(collations);
+assert(collations.indexOf('standard') === -1);
+assert(collations.indexOf('search') === -1);
+
+var currencies = Intl.supportedValuesOf('currency');
+assertStringArray(currencies);
+assert(currencies.indexOf('USD') !== -1);
+for (var i = 0; i < currencies.length; i++) {
+  assert(currencies[i].length === 3);
+  assert(currencies[i] === currencies[i].toUpperCase());
+}
+
+var numberingSystems = Intl.supportedValuesOf('numberingSystem');
+assertStringArray(numberingSystems);
+assert(numberingSystems.indexOf('latn') !== -1);
+
+var units = Intl.supportedValuesOf('unit');
+assertStringArray(units);
+assert(units.indexOf('meter') !== -1);
+assert(units.indexOf('celsius') !== -1);
+assert(units.indexOf('year') !== -1);

--- a/test/shermes/intl/intl.js
+++ b/test/shermes/intl/intl.js
@@ -70,6 +70,8 @@ function testParts(parts) {
 assert(Intl !== undefined);
 
 assert(Array.isArray(Intl.getCanonicalLocales('en-US')));
+assert(typeof Intl.supportedValuesOf === 'function');
+assert(Array.isArray(Intl.supportedValuesOf('timeZone')));
 
 testServiceTypes(Intl.Collator);
 testServiceGetterTypes(Intl.Collator, 'compare');

--- a/test/shermes/intl/supported-values-of.js
+++ b/test/shermes/intl/supported-values-of.js
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %shermes -exec %s
+// REQUIRES: intl
+
+function assert(pred, str) {
+  if (!pred) {
+    throw new Error('assertion failed' + (str === undefined ? '' : (': ' + str)));
+  }
+}
+
+function assertThrows(fn, ctor) {
+  try {
+    fn();
+  } catch (e) {
+    assert(e instanceof ctor, 'expected ' + ctor.name + ', got ' + e);
+    return;
+  }
+  throw new Error('expected ' + ctor.name);
+}
+
+function isSortedUnique(arr) {
+  for (var i = 1; i < arr.length; i++) {
+    if (arr[i] <= arr[i - 1])
+      return false;
+  }
+  return true;
+}
+
+function assertStringArray(arr) {
+  assert(Array.isArray(arr));
+  assert(arr.length > 0);
+  for (var i = 0; i < arr.length; i++)
+    assert(typeof arr[i] === 'string');
+  assert(isSortedUnique(arr), 'values must be sorted and unique');
+}
+
+assert(typeof Intl.supportedValuesOf === 'function');
+assert(Intl.supportedValuesOf.length === 1);
+assert(Intl.supportedValuesOf.name === 'supportedValuesOf');
+
+var desc = Object.getOwnPropertyDescriptor(Intl, 'supportedValuesOf');
+assert(desc.writable === true);
+assert(desc.enumerable === false);
+assert(desc.configurable === true);
+
+assertThrows(function() { Intl.supportedValuesOf(); }, RangeError);
+assertThrows(function() { Intl.supportedValuesOf(''); }, RangeError);
+assertThrows(function() { Intl.supportedValuesOf('timezone'); }, RangeError);
+assertThrows(function() { Intl.supportedValuesOf('invalid'); }, RangeError);
+
+var keyObj = {toString: function() { return 'unit'; }};
+assert(Array.isArray(Intl.supportedValuesOf(keyObj)));
+
+var timeZones = Intl.supportedValuesOf('timeZone');
+assertStringArray(timeZones);
+assert(timeZones.indexOf('UTC') !== -1, 'UTC must be supported');
+assert(timeZones.indexOf('Etc/UTC') === -1, 'Etc/UTC is not primary');
+assert(timeZones.indexOf('Etc/GMT') === -1, 'Etc/GMT is not primary');
+assert(
+    new Intl.DateTimeFormat('en', {timeZone: 'UTC'})
+        .resolvedOptions()
+        .timeZone === 'UTC');
+
+var calendars = Intl.supportedValuesOf('calendar');
+assertStringArray(calendars);
+assert(calendars.indexOf('iso8601') !== -1);
+assert(calendars.indexOf('gregory') !== -1);
+
+var collations = Intl.supportedValuesOf('collation');
+assertStringArray(collations);
+assert(collations.indexOf('standard') === -1);
+assert(collations.indexOf('search') === -1);
+
+var currencies = Intl.supportedValuesOf('currency');
+assertStringArray(currencies);
+assert(currencies.indexOf('USD') !== -1);
+for (var i = 0; i < currencies.length; i++) {
+  assert(currencies[i].length === 3);
+  assert(currencies[i] === currencies[i].toUpperCase());
+}
+
+var numberingSystems = Intl.supportedValuesOf('numberingSystem');
+assertStringArray(numberingSystems);
+assert(numberingSystems.indexOf('latn') !== -1);
+
+var units = Intl.supportedValuesOf('unit');
+assertStringArray(units);
+assert(units.indexOf('meter') !== -1);
+assert(units.indexOf('celsius') !== -1);
+assert(units.indexOf('year') !== -1);


### PR DESCRIPTION
## Summary
- Add `Intl.supportedValuesOf` for `calendar`, `collation`, `currency`, `numberingSystem`, `timeZone`, and `unit`.
- Invalid keys throw `RangeError`. Time zone results are sorted, unique, include `UTC`, and omit `Etc/UTC` / `Etc/GMT`.
- Fixes the TypeError from `Intl.supportedValuesOf('timeZone')` not being a function.

Fixes #910

## Test plan
- [x] `test/hermes/intl/supported-values-of.js`
- [x] `test/hermes/intl/intl.js`
- [x] `test/shermes/intl/supported-values-of.js`
