### PR TITLE
JIT: Fix stale comments in the emitter (#2137)

### DIFF
--- a/include/hermes/ConsoleHost/ConsoleHost.h
+++ b/include/hermes/ConsoleHost/ConsoleHost.h
@@ -173,6 +173,11 @@ struct ExecuteOptions {
   /// Emit counters in JIT'ed code.
   bool jitEmitCounters{false};
 
+  /// Largest lazy JIT id assignable to a HiddenClass. Lowered only by tests,
+  /// so that the exhaustion path can be reached without interning 65535
+  /// hidden classes.
+  uint32_t jitHCIdLimit{0xFFFF};
+
   /// If non-null, holds statistics for every garbage collection that occurs.
   const std::vector<::hermes::vm::GCAnalyticsEvent> *gcAnalyticsEvents{nullptr};
 

--- a/include/hermes/VM/JIT/JIT.h
+++ b/include/hermes/VM/JIT/JIT.h
@@ -114,6 +114,9 @@ class JITContext {
   /// Set the memory limit for JIT'ed code in bytes.
   void setMemoryLimit(uint32_t memoryLimit) {}
 
+  /// Set the largest lazy JIT id assignable to a HiddenClass (testing only).
+  void setHCIdLimit(uint32_t hcIdLimit) {}
+
   /// Set the default threshold for function execution count before a function
   /// is compiled. On a per-function basis, the count may be altered based on
   /// internal heuristics.

--- a/include/hermes/VM/JIT/PerfJitDump.h
+++ b/include/hermes/VM/JIT/PerfJitDump.h
@@ -52,6 +52,12 @@ class PerfJitDump {
   /// \param offset Current offset of the jitted code.
   void addCodeComment(llvh::StringRef comment, uint32_t offset);
 
+  /// Drop the debug entries accumulated for a function that will not be
+  /// installed. Entries are normally consumed by writeCodeLoadRecord(), which
+  /// a failed compilation never reaches, so without this they would be
+  /// attributed to whichever function is compiled next.
+  void discardPendingCodeComments();
+
  private:
   struct DebugEntry;
 
@@ -91,6 +97,8 @@ class PerfJitDump {
   void writeCodeLoadRecord(const char *, uint32_t, llvh::StringRef) {}
 
   void addCodeComment(llvh::StringRef, uint32_t offset) {}
+
+  void discardPendingCodeComments() {}
 };
 } // namespace hermes::vm
 

--- a/include/hermes/VM/JIT/arm64/JIT.h
+++ b/include/hermes/VM/JIT/arm64/JIT.h
@@ -134,6 +134,11 @@ class JITContext {
     memoryLimit_ = memoryLimit;
   }
 
+  /// Set the largest lazy JIT id assignable to a HiddenClass. Exposed only so
+  /// that tests can reach the exhaustion path without interning 65535 hidden
+  /// classes; production code should leave this at the default.
+  void setHCIdLimit(uint32_t hcIdLimit);
+
   /// Set the flag to emit asserts in the JIT'ed code.
   void setEmitAsserts(bool emitAsserts) {
     emitAsserts_ = emitAsserts;

--- a/include/hermes/VM/RuntimeFlags.h
+++ b/include/hermes/VM/RuntimeFlags.h
@@ -241,6 +241,14 @@ struct VMOnlyRuntimeFlags {
       llvh::cl::desc("maximum size for JIT code (in bytes)"),
       llvh::cl::init(32u << 20)};
 
+  llvh::cl::opt<uint32_t> JITHCIdLimit{
+      "Xjit-hc-id-limit",
+      llvh::cl::Hidden,
+      llvh::cl::cat(RuntimeCategory),
+      llvh::cl::desc(
+          "largest lazy JIT id assignable to a HiddenClass (testing only)"),
+      llvh::cl::init(0xFFFF)};
+
   /// To get the value of this CLI option, use the method below.
   llvh::cl::opt<unsigned> DumpJITCode{
       "Xdump-jitcode",

--- a/lib/ConsoleHost/ConsoleHost.cpp
+++ b/lib/ConsoleHost/ConsoleHost.cpp
@@ -968,6 +968,7 @@ bool executeHBCBytecodeImpl(
   runtime->getJITContext().setCrashOnError(options.jitCrashOnError);
   runtime->getJITContext().setEmitAsserts(options.jitEmitAsserts);
   runtime->getJITContext().setEmitCounters(options.jitEmitCounters);
+  runtime->getJITContext().setHCIdLimit(options.jitHCIdLimit);
 
   if (options.perfProfJitDumpFd != -1) {
     runtime->getJITContext().initPerfProfData(

--- a/lib/VM/JIT/PerfJitDump.cpp
+++ b/lib/VM/JIT/PerfJitDump.cpp
@@ -239,6 +239,14 @@ void PerfJitDump::writeCommentLine(llvh::StringRef comment) {
   commentFileOS_ << comment;
 }
 
+void PerfJitDump::discardPendingCodeComments() {
+  // The comment lines themselves have already been written to commentFile_
+  // and cannot be taken back, but they are only ever referenced by debug
+  // entries, so dropping the entries is enough to keep the next function's
+  // line attribution correct.
+  debugEntries_.clear();
+}
+
 void PerfJitDump::addCodeComment(llvh::StringRef comment, uint32_t offset) {
   // Note: currently there is an issue that if this is the first comment to
   // current jitted function, but not the first line in the comment file, when

--- a/lib/VM/JIT/arm64/JIT.cpp
+++ b/lib/VM/JIT/arm64/JIT.cpp
@@ -31,6 +31,11 @@ JITContext::JITContext(bool enable) : enabled_(enable) {
 
 JITContext::~JITContext() = default;
 
+void JITContext::setHCIdLimit(uint32_t hcIdLimit) {
+  if (impl_)
+    impl_->hcIdLimit = std::min<uint32_t>(hcIdLimit, Impl::kHCIdOverflow);
+}
+
 void JITContext::dumpCounters(llvh::raw_ostream &os) {
   static constexpr const char *kCounterNames[] = {
 #define COUNTER_NAME(name) #name,

--- a/lib/VM/JIT/arm64/JIT.cpp
+++ b/lib/VM/JIT/arm64/JIT.cpp
@@ -220,8 +220,14 @@ JITCompiledFunctionPtr JITContext::Compiler::compileCodeBlock() {
     // case the code was never installed and there is nothing for these targets
     // to point at; computing them from a null base would store bogus pointers
     // into the module's tables.
-    if (!res)
+    if (!res) {
+      // Nothing was installed, so the comments collected for this function
+      // have no code to attach to. Drop them, or they would be attributed to
+      // whichever function is compiled next.
+      if (jc_.perfJitDump_)
+        jc_.perfJitDump_->discardPendingCodeComments();
       return res;
+    }
 
     // Translate now-bound labels to targets.
     uint64_t funcStart = reinterpret_cast<uint64_t>(res);
@@ -271,6 +277,9 @@ JITCompiledFunctionPtr JITContext::Compiler::compileCodeBlock() {
         LLVM_DEBUG(printError(llvh::outs()));
       }
     }
+
+    if (jc_.perfJitDump_)
+      jc_.perfJitDump_->discardPendingCodeComments();
 
     codeBlock_->setDontJIT(true);
     return nullptr;

--- a/lib/VM/JIT/arm64/JIT.cpp
+++ b/lib/VM/JIT/arm64/JIT.cpp
@@ -216,6 +216,12 @@ JITCompiledFunctionPtr JITContext::compileImpl(
 JITCompiledFunctionPtr JITContext::Compiler::compileCodeBlock() {
   if (_sh_setjmp(errorJmpBuf_) == 0) {
     auto res = compileCodeBlockImpl();
+    // compileCodeBlockImpl returns null when it hits the memory limit, in which
+    // case the code was never installed and there is nothing for these targets
+    // to point at; computing them from a null base would store bogus pointers
+    // into the module's tables.
+    if (!res)
+      return res;
 
     // Translate now-bound labels to targets.
     uint64_t funcStart = reinterpret_cast<uint64_t>(res);

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -1751,7 +1751,7 @@ uint16_t Emitter::initHCLazyIDMayAlloc(HiddenClass *hc) {
     return id;
 
   // Too many IDs. Fail.
-  if (jitImpl_.prevHCId == JITContext::Impl::kHCIdOverflow)
+  if (jitImpl_.prevHCId >= jitImpl_.hcIdLimit)
     return 0;
 
   struct : Locals {
@@ -5120,9 +5120,12 @@ class HERMES_ATTRIBUTE_INTERNAL_LINKAGE Emitter::GetByIdImpl {
           cacheEntry->clazz.getNoBarrierUnsafe() &&
           cacheEntry->negMatchClazz.getNoBarrierUnsafe()) {
         ++JITNumGetByIdSpec;
-        emitParentSpecialization(shvDecode, cacheEntry);
-        // We don't try other things after parent specialization.
-        return;
+        if (emitParentSpecialization(shvDecode, cacheEntry)) {
+          // We don't try other things after parent specialization.
+          return;
+        }
+        // If it emitted nothing, fall through to the generic tier below
+        // rather than leaving the site with no inline cache at all.
       }
     }
 
@@ -5218,14 +5221,18 @@ class HERMES_ATTRIBUTE_INTERNAL_LINKAGE Emitter::GetByIdImpl {
 
   /// Emit a specialization for accessing a property on the parent.
   /// Does not preserve temps. Assumes no fast path runs after it.
-  void emitParentSpecialization(
+  /// \return true if code was emitted. When it returns false nothing has been
+  ///   emitted, so the caller is free to emit another tier instead.
+  bool emitParentSpecialization(
       Emit_sh_shv_decode &shvDecode,
       ReadPropertyCacheEntry *cacheEntry) {
     // Obtain the HC IDs for the object's class and the parent class.
+    // NOTE: every bail-out below must happen before the first instruction is
+    // emitted, so that returning false leaves the caller a clean slate.
     auto clazzID = _.initHCLazyIDMayAlloc(
         cacheEntry->negMatchClazz.get(_.runtime_, _.runtime_.getHeap()));
     if (!clazzID)
-      return;
+      return false;
 
     // NOTE: the call above is a GC safepoint (it may create or grow the
     // usedHCs ArrayStorage), so cacheEntry->clazz, a WeakRoot, may have been
@@ -5237,7 +5244,7 @@ class HERMES_ATTRIBUTE_INTERNAL_LINKAGE Emitter::GetByIdImpl {
         cacheEntry->clazz.get(_.runtime_, _.runtime_.getHeap());
     auto parentClsID = _.initHCLazyIDMayAlloc(parentCls);
     if (!parentClsID)
-      return;
+      return false;
 
     _.comment("// Get from parent specialization");
 
@@ -5268,6 +5275,7 @@ class HERMES_ATTRIBUTE_INTERNAL_LINKAGE Emitter::GetByIdImpl {
     shvDecode.emitAll(a);
     a.b(contLab);
     a.bind(failSpecLab);
+    return true;
   }
 };
 

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -25,6 +25,8 @@
 #include "hermes/VMLayouts/StackFrameLayout.h"
 #include "llvh/ADT/Statistic.h"
 
+#include <limits>
+
 #define DEBUG_TYPE "jit"
 
 STATISTIC(
@@ -2446,25 +2448,37 @@ void Emitter::loadParam(FR frRes, uint32_t paramIndex) {
 
   HWReg hwRes = getOrAllocFRInGpX(frRes, false);
 
-  // FIXME: handle integer overflow better?
-  int32_t ofs = ((int)StackFrameLayout::ThisArg - (int32_t)paramIndex) *
-      (int)sizeof(SHLegacyValue);
-  if (ofs >= 0)
-    hermes_fatal("JIT integer overflow");
-  EXPECT_ERROR(
-      asmjit::kErrorInvalidDisplacement,
-      err = a.ldur(hwRes.a64GpX(), a64::Mem(xFrame, ofs)));
-  // Does the offset fit in the 9-bit signed offset?
-  if (err) {
-    ofs = -ofs;
-    a64::GpX xRes = hwRes.a64GpX();
-    if (ofs <= 4095) {
-      a.sub(xRes, xFrame, ofs);
-    } else {
-      loadBits64InGp(xRes, ofs, nullptr);
-      a.sub(xRes, xFrame, xRes);
+  // Compute the frame offset in 64 bits. paramIndex is a UInt32 operand of
+  // LoadParamLong, and (ThisArg - paramIndex) * sizeof(SHLegacyValue)
+  // overflows int32 from paramIndex 2^28 upwards, long before that range is
+  // exhausted.
+  int64_t ofs64 = ((int64_t)StackFrameLayout::ThisArg - (int64_t)paramIndex) *
+      (int64_t)sizeof(SHLegacyValue);
+  assert(ofs64 < 0 && "frame offset of a parameter must be negative");
+
+  if (LLVM_UNLIKELY(ofs64 <= std::numeric_limits<int32_t>::min())) {
+    // The parameter is so far away that no argument count can reach it, so
+    // the comparison above always branches. Emit the branch unconditionally
+    // rather than a fast path that cannot be reached and whose offset would
+    // not encode; the slow path yields undefined, which is the right answer.
+    a.b(slowPathLab);
+  } else {
+    int32_t ofs = (int32_t)ofs64;
+    EXPECT_ERROR(
+        asmjit::kErrorInvalidDisplacement,
+        err = a.ldur(hwRes.a64GpX(), a64::Mem(xFrame, ofs)));
+    // Does the offset fit in the 9-bit signed offset?
+    if (err) {
+      ofs = -ofs;
+      a64::GpX xRes = hwRes.a64GpX();
+      if (ofs <= 4095) {
+        a.sub(xRes, xFrame, ofs);
+      } else {
+        loadBits64InGp(xRes, ofs, nullptr);
+        a.sub(xRes, xFrame, xRes);
+      }
+      a.ldr(xRes, a64::Mem(xRes));
     }
-    a.ldr(xRes, a64::Mem(xRes));
   }
 
   a.bind(contLab);

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -1726,23 +1726,23 @@ void Emitter::callThunk(void *fn, const char *name) {
 
 void Emitter::callThunkWithSavedIP(void *fn, const char *name) {
   // Save the current IP in the runtime.
-  getBytecodeIP(a64::x16);
-  a.str(a64::x16, a64::Mem(xRuntime, RuntimeOffsets::currentIP));
+  getBytecodeIP(xScratch);
+  a.str(xScratch, a64::Mem(xRuntime, RuntimeOffsets::currentIP));
 
   // Call the passed function.
   callThunk(fn, name);
 
   if (emitAsserts_) {
     // Invalidate the current IP to make sure it is set before the next call.
-    a.mov(a64::x16, Runtime::kInvalidCurrentIP);
-    a.str(a64::x16, a64::Mem(xRuntime, RuntimeOffsets::currentIP));
+    a.mov(xScratch, Runtime::kInvalidCurrentIP);
+    a.str(xScratch, a64::Mem(xRuntime, RuntimeOffsets::currentIP));
   }
 }
 
 void Emitter::callWithoutThunk(void *fn, const char *name) {
   comment("// call %s", name);
-  loadBits64InGp(a64::x16, (uint64_t)fn, name);
-  a.blr(a64::x16);
+  loadBits64InGp(xScratch, (uint64_t)fn, name);
+  a.blr(xScratch);
 }
 
 void Emitter::emitIncrementCounter(JitCounter counter) {
@@ -6409,8 +6409,8 @@ void Emitter::emitThunks() {
   comment("// Thunks");
   for (const auto &th : thunks_) {
     a.bind(th.first);
-    a.ldr(a64::x16, a64::Mem(roDataLabel_, th.second));
-    a.br(a64::x16);
+    a.ldr(xScratch, a64::Mem(roDataLabel_, th.second));
+    a.br(xScratch);
   }
 }
 

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -1737,9 +1737,6 @@ uint16_t Emitter::initHCLazyIDMayAlloc(HiddenClass *hc) {
   if (jitImpl_.prevHCId == JITContext::Impl::kHCIdOverflow)
     return 0;
 
-  id = ++jitImpl_.prevHCId;
-  hc->setLazyJITId(id);
-
   struct : Locals {
     PinnedValue<HiddenClass> hc;
   } lv;
@@ -1747,15 +1744,40 @@ uint16_t Emitter::initHCLazyIDMayAlloc(HiddenClass *hc) {
   lv.hc = hc;
 
   if (jitImpl_.usedHCs.isUndefined()) {
+    CallResult<HermesValue> cr = ArrayStorageSmall::create(runtime_, 8);
+    if (LLVM_UNLIKELY(cr == ExecutionStatus::EXCEPTION)) {
+      // Failing to pin is not fatal: report "no id" and let the caller fall
+      // back to a non-specialized path. Swallow the pending OOM, since we are
+      // in the compiler and there is nobody to propagate it to.
+      runtime_.clearThrownValue();
+      return 0;
+    }
     // We would like to use a long-lived object, but we can't, because
     // ArrayStorage cannot be long-lived: it can be allocated that way
     // initially, but when it grows, it is allocated "normally".
-    jitImpl_.usedHCs = runtime_.ignoreAllocationFailure(
-        ArrayStorageSmall::create(runtime_, 8));
+    jitImpl_.usedHCs = *cr;
   }
 
+  // Pin the class before assigning the id, so that the invariant
+  // "id != 0 implies the class is in usedHCs" cannot be broken by a failed
+  // allocation. usedHCs is the only strong root for these classes, and the id
+  // is baked into immutable machine code, so an id on an unpinned class would
+  // be a dangling reference.
   auto mh = MutableHandle<ArrayStorageSmall>::vmcast(&jitImpl_.usedHCs);
-  ArrayStorageSmall::push_back(mh, runtime_, lv.hc);
+  if (LLVM_UNLIKELY(
+          ArrayStorageSmall::push_back(mh, runtime_, lv.hc) ==
+          ExecutionStatus::EXCEPTION)) {
+    // Failing to pin is not fatal: report "no id" and let the caller fall
+    // back to a non-specialized path. Swallow the pending OOM, since we are
+    // in the compiler and there is nobody to propagate it to.
+    runtime_.clearThrownValue();
+    return 0;
+  }
+
+  id = ++jitImpl_.prevHCId;
+  // Note: use the pinned handle rather than the raw argument, which the
+  // allocation above may have invalidated by moving the object.
+  lv.hc->setLazyJITId(id);
 
   return id;
 }

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -3295,7 +3295,7 @@ void Emitter::newObjectWithBuffer(
     // Populate the size.
     a.mov(xTmp, numIndirectSlots);
     a.str(
-        xTmp,
+        xTmp.w(),
         a64::Mem(
             xObj,
             heapAlignSize(cellSize<JSObject>()) +

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -4603,8 +4603,24 @@ void Emitter::throwIfThisInitialized(FR frInput) {
 
   asmjit::Label slowPathLab = newSlowPathLabel();
 
-  // TODO: Add back the sync/free calls inside try.
+  // We have to sync registers when the throw is inside a try region
+  // because we could read from the FRs again in this function.
   // Outside a try it's not observable behavior.
+  // Note that only the sync is needed, not a free. A free is required when a
+  // call is emitted on a path that continues in this basic block, since temps
+  // are caller-saved. Here the only call is the non-returning throw in the
+  // out-of-line slow path; the fall-through path calls nothing, and the catch
+  // handler begins a new basic block, which re-normalizes temp state anyway.
+  // Freeing would only force needless reloads for the rest of the block.
+  //
+  // Cf. fastArrayLoad's #else (non-compressed-pointer) path, which syncs
+  // without freeing for the same reason. Its
+  // HERMESVM_COMPRESSED_POINTERS/HERMESVM_BOXED_DOUBLES path is not
+  // comparable: it emits an unconditional runtime call, so it must sync and
+  // free regardless of isInTry(). Cf. also throwInst, which syncs only under
+  // isInTry() but frees unconditionally, because it emits its call inline.
+  if (isInTry())
+    syncAllFRTempExcept({});
   HWReg hwInput = getOrAllocFRInGpX(frInput, true);
   HWReg hwTemp = allocTempGpX();
   freeReg(hwTemp);

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -6532,7 +6532,10 @@ void Emitter::callBuiltin(FR frRes, uint32_t builtinIndex, uint32_t argc) {
       frRes.index(),
       getBuiltinMethodName(builtinIndex),
       argc);
-  // CallBuiltin internally sets "this", so we don't sync it to memory.
+  // The ThisArg slot is not populated by bytecode; _jit_call_builtin
+  // initializes it. Note that the syncAllFRTempExcept({}) below does write
+  // the ThisArg FR to memory along with everything else — it is simply that
+  // whatever it writes there is dead, since the handler overwrites it.
 #ifndef NDEBUG
   uint32_t nRegs = frameRegs_.size();
 

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -88,9 +88,9 @@ void emit_sh_ljs_tag_is_pointer(a64::Assembler &a, const a64::GpX &xTagReg) {
   static_assert(
       HERMESVALUE_VERSION == 2,
       "All tags above HVTag_FirstPointer are pointers");
-  // The valid pointer tags are: 0xfc (FirstPointer) to 0xff (LastTag), but
-  // all sign extended to 64 bits.
-  // We need an unsigned comparison (tag >= 0xfc) to catch all pointers.
+  // The valid pointer tags are: 0xfd (HVTag_FirstPointer) to 0xff
+  // (HVTag_Last), but all sign extended to 64 bits.
+  // We need an unsigned comparison (tag >= 0xfd) to catch all pointers.
   // Doubles may have 0 in the tag bits, e.g. so we have to use
   // unsigned condition codes to make sure they don't get detected as pointers.
   a.cmn(xTagReg, -HVTag_FirstPointer);
@@ -4109,7 +4109,8 @@ void Emitter::loadFromEnvironment(FR frRes, FR frEnv, uint32_t slot) {
 void Emitter::storeToEnvironment(bool np, FR frEnv, uint32_t slot, FR frValue) {
   // TODO: this should really be inlined!
   comment(
-      "// StoreNPToEnvironment r%u, %u, r%u",
+      np ? "// StoreNPToEnvironment r%u, %u, r%u"
+         : "// StoreToEnvironment r%u, %u, r%u",
       frEnv.index(),
       slot,
       frValue.index());
@@ -4430,10 +4431,7 @@ void Emitter::loadThisNS(FR frRes) {
        .hwRes = hwRes,
        .emittingIP = emittingIP,
        .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: LoadThisNS r%u, r%u",
-             sl.frRes.index(),
-             sl.frInput1.index());
+         em.comment("// Slow path: LoadThisNS r%u", sl.frRes.index());
          em.a.bind(sl.slowPathLab);
          em.a.mov(a64::x0, xRuntime);
          em.a.ldur(
@@ -6986,10 +6984,9 @@ void Emitter::bitNot(FR frRes, FR frInput) {
        .emittingIP = emittingIP,
        .emit = [](Emitter &em, SlowPath &sl) {
          em.comment(
-             "// bitNot r%u, r%u, r%u",
+             "// Slow path: bitNot r%u, r%u",
              sl.frRes.index(),
-             sl.frInput1.index(),
-             sl.frInput2.index());
+             sl.frInput1.index());
          em.a.bind(sl.slowPathLab);
          em.a.mov(a64::x0, xRuntime);
          em.loadFrameAddr(a64::x1, sl.frInput1);

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -612,6 +612,30 @@ void emit_cmp_imm32(
   }
 }
 
+/// Add an unsigned 24-bit immediate to a register, in place.
+/// ADD's immediate is 12 bits, optionally shifted left by 12, so a value that
+/// is neither small enough nor a clean multiple of 4096 needs two
+/// instructions. Splitting it that way avoids needing a scratch register,
+/// which matters at the call-setup sites where every argument register is
+/// already spoken for.
+void emit_add_imm_u24(a64::Assembler &a, const a64::GpX &xReg, uint32_t imm32) {
+  assert(
+      imm32 <= 0xFFFFFF &&
+      "immediate must fit in 24 bits; ADD has no shift-24 form");
+  if (a64::Utils::isAddSubImm(imm32)) {
+    a.add(xReg, xReg, imm32);
+    return;
+  }
+  uint32_t hi = imm32 & ~UINT32_C(0xFFF);
+  uint32_t lo = imm32 & UINT32_C(0xFFF);
+  assert(
+      a64::Utils::isAddSubImm(hi) &&
+      "high part should encode as a shifted immediate");
+  a.add(xReg, xReg, hi);
+  if (lo)
+    a.add(xReg, xReg, lo);
+}
+
 /// Load the slot16 from a cache entry.
 /// \param xResReg The register to load the slot16 into.
 /// \param xPropCacheReg The register containing the pointer to the start of
@@ -4313,7 +4337,7 @@ void Emitter::createThis(
   } else {
     a.ldr(a64::x3, a64::Mem(roDataLabel_, roOfsReadPropertyCachePtr_));
     if (cacheIdx != 0)
-      a.add(a64::x3, a64::x3, sizeof(SHReadPropertyCacheEntry) * cacheIdx);
+      emit_add_imm_u24(a, a64::x3, sizeof(SHReadPropertyCacheEntry) * cacheIdx);
   }
   EMIT_RUNTIME_CALL(
       *this,
@@ -5010,7 +5034,8 @@ class HERMES_ATTRIBUTE_INTERNAL_LINKAGE Emitter::GetByIdImpl {
     } else {
       a.ldr(a64::x3, a64::Mem(_.roDataLabel_, _.roOfsReadPropertyCachePtr_));
       if (cacheIdx != 0)
-        a.add(a64::x3, a64::x3, sizeof(SHReadPropertyCacheEntry) * cacheIdx);
+        emit_add_imm_u24(
+            a, a64::x3, sizeof(SHReadPropertyCacheEntry) * cacheIdx);
     }
     _.callThunkWithSavedIP((void *)shImpl, shImplName);
 
@@ -5335,7 +5360,7 @@ void Emitter::getByIdWithReceiver(
   } else {
     a.ldr(a64::x4, a64::Mem(roDataLabel_, roOfsReadPropertyCachePtr_));
     if (cacheIdx != 0)
-      a.add(a64::x4, a64::x4, sizeof(SHReadPropertyCacheEntry) * cacheIdx);
+      emit_add_imm_u24(a, a64::x4, sizeof(SHReadPropertyCacheEntry) * cacheIdx);
   }
   EMIT_RUNTIME_CALL(
       *this,

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -5114,13 +5114,12 @@ class HERMES_ATTRIBUTE_INTERNAL_LINKAGE Emitter::GetByIdImpl {
         cacheEntry->numGoodChanges == 1) {
       if (cacheEntry->clazz.getNoBarrierUnsafe() &&
           !cacheEntry->negMatchClazz.getNoBarrierUnsafe()) {
-        ++JITNumGetByIdSpec;
-        emitObjectSpecialization(shvDecode, cacheEntry);
+        JITNumGetByIdSpec += emitObjectSpecialization(shvDecode, cacheEntry);
       } else if (
           cacheEntry->clazz.getNoBarrierUnsafe() &&
           cacheEntry->negMatchClazz.getNoBarrierUnsafe()) {
-        ++JITNumGetByIdSpec;
         if (emitParentSpecialization(shvDecode, cacheEntry)) {
+          ++JITNumGetByIdSpec;
           // We don't try other things after parent specialization.
           return;
         }
@@ -5191,14 +5190,16 @@ class HERMES_ATTRIBUTE_INTERNAL_LINKAGE Emitter::GetByIdImpl {
   }
 
   /// Emit a specialization for accessing a property on the object.
-  void emitObjectSpecialization(
+  /// \return true if code was emitted. When it returns false nothing has
+  ///   been emitted.
+  bool emitObjectSpecialization(
       Emit_sh_shv_decode &shvDecode,
       ReadPropertyCacheEntry *cacheEntry) {
     // Obtain the HC ID.
     auto clazzID = _.initHCLazyIDMayAlloc(
         cacheEntry->clazz.get(_.runtime_, _.runtime_.getHeap()));
     if (!clazzID)
-      return;
+      return false;
 
     _.comment("// Get from object specialization");
 
@@ -5217,6 +5218,7 @@ class HERMES_ATTRIBUTE_INTERNAL_LINKAGE Emitter::GetByIdImpl {
     shvDecode.emitFirstCase(a);
     a.b(contLab);
     a.bind(failSpecLab);
+    return true;
   }
 
   /// Emit a specialization for accessing a property on the parent.

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -362,9 +362,7 @@ constexpr uint32_t kMaxInlineBaseOffset = maxNaturalBaseOffset(8);
 /// Load a value with the specified width from the base register with an
 /// unsigned immediate offset. The wrapper is necessary since the immediate
 /// offset for loads is limited to 12-bits and may not always be sufficient, in
-/// which case we need to use alternate techniques. The base and destination
-/// registers must not be the same, since in rare cases we need to use the
-/// destination register as scratch.
+/// which case we need to use alternate techniques.
 ///
 /// \param WIDTH The width of the load, in bytes. Must be one of 1, 2, 4, or 8.
 /// \param INLINE_LOAD If true, the offset must be less than or equal to
@@ -4075,11 +4073,15 @@ void Emitter::loadFromEnvironment(FR frRes, FR frEnv, uint32_t slot) {
   // get pointer.
   emit_sh_ljs_get_pointer(a, xTmp1, xTmp1);
 
-  a.ldr(
+  // xScratch is touched only if the offset is too large for the scaled
+  // immediate: LoadFromEnvironmentL carries a UInt16 slot, and past slot
+  // ~4092 the displacement no longer encodes.
+  emit_load_from_base_offset<sizeof(SHLegacyValue)>(
+      a,
       xTmp1,
-      a64::Mem(
-          xTmp1,
-          offsetof(SHEnvironment, slots) + sizeof(SHLegacyValue) * slot));
+      xTmp1,
+      xScratch,
+      offsetof(SHEnvironment, slots) + sizeof(SHLegacyValue) * slot);
 
   freeReg(hwTmp1);
   HWReg hwRes = getOrAllocFRInAnyReg(frRes, false, hwTmp1);

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -5467,6 +5467,13 @@ void Emitter::jmpTypeOfIs(
     typesToCheck = invertedTypes;
   }
 
+  // Nothing left to check means the answer does not depend on the input: an
+  // empty origTypes matches nothing, so falling through is already right,
+  // while an all-bits origTypes inverts to empty and matches everything, so
+  // the branch is unconditional. None of the checks below are emitted.
+  if (typesToCheck.count() == 0 && invert)
+    a.b(target);
+
   // doneLab goes at the end of the instruction if there's multiple bits to
   // check, allowing short-circuiting the remaining checks if one of the
   // TypeOfIsTypes bits matches the kind of the input.
@@ -5639,6 +5646,14 @@ void Emitter::typeOfIs(FR frRes, FR frInput, TypeOfIsTypes origTypes) {
     invert = true;
     typesToCheck = invertedTypes;
   }
+
+  // Nothing left to check means the answer does not depend on the input: an
+  // empty origTypes matches nothing, and an all-bits origTypes inverts to
+  // empty and matches everything. Either way the result is the same constant
+  // the individual cases produce when no tag can match, and none of the checks
+  // below are emitted.
+  if (typesToCheck.count() == 0)
+    a.mov(xRes, invert ? 1 : 0);
 
   // matchLab goes directly to the end of the instruction if there are multiple
   // bits to check, allowing short-circuiting the remaining checks if one of the

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -1240,10 +1240,27 @@ void Emitter::enter(uint32_t numCount, uint32_t npCount) {
     frameRegs_[frIndex].globalType = FRType::UnknownNonPtr;
   }
 
-  if (!codeBlock_->getRuntimeModule()
-           ->getBytecode()
-           ->getExceptionTable(codeBlock_->getFunctionID())
-           .empty())
+  bool hasExceptionTable = !codeBlock_->getRuntimeModule()
+                                ->getBytecode()
+                                ->getExceptionTable(codeBlock_->getFunctionID())
+                                .empty();
+
+  // A function with exception handlers must end up with no global registers.
+  // longjmp restores callee-saved registers to their values at the setjmp,
+  // so a global register would present a stale value to a catch handler;
+  // correctness depends on every FR's canonical location being the memory
+  // frame, which is also what makes the isInTry() sync in the throwing
+  // emitters sufficient.
+  //
+  // Nothing here enforces that: it holds because
+  // RegisterAllocator::getRegClass (lib/BCGen/RegAlloc.cpp) forces
+  // RegClass::Other for any function containing a try, which leaves both
+  // counts at zero. That is a contract with another module, so check it.
+  assert(
+      (!hasExceptionTable || (numCount == 0 && npCount == 0)) &&
+      "function with exception handlers must have no global registers");
+
+  if (hasExceptionTable)
     catchTableLabel_ = a.newNamedLabel("CATCH_TABLE");
 
   frameSetup(

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -4165,6 +4165,7 @@ void Emitter::createClosure(
       functionID);
   syncAllFRTempExcept(frRes != frEnv ? frRes : FR());
   syncToFrame(frEnv);
+  freeAllFRTempExcept({});
 
   a.mov(a64::x0, xRuntime);
   loadFrameAddr(a64::x1, frEnv);
@@ -4176,7 +4177,6 @@ void Emitter::createClosure(
           SHRuntime *, const SHLegacyValue *, SHRuntimeModule *, uint32_t),
       _sh_ljs_create_bytecode_closure);
 
-  freeAllFRTempExcept({});
   HWReg hwRes = getOrAllocFRInAnyReg(frRes, false, HWReg::gpX(0));
   movHWFromHW<false>(hwRes, HWReg::gpX(0));
   frUpdatedWithHW(frRes, hwRes);
@@ -4249,6 +4249,7 @@ void Emitter::createGenerator(
       functionID);
   syncAllFRTempExcept(frRes != frEnv ? frRes : FR());
   syncToFrame(frEnv);
+  freeAllFRTempExcept({});
 
   a.mov(a64::x0, xRuntime);
   a.mov(a64::x1, xFrame);
@@ -4265,7 +4266,6 @@ void Emitter::createGenerator(
           uint32_t),
       _interpreter_create_generator);
 
-  freeAllFRTempExcept({});
   HWReg hwRes = getOrAllocFRInAnyReg(frRes, false, HWReg::gpX(0));
   movHWFromHW<false>(hwRes, HWReg::gpX(0));
   frUpdatedWithHW(frRes, hwRes);

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -3307,9 +3307,10 @@ void Emitter::newObjectWithBuffer(
       }
     }
 
-    /// Store a simple SmallHermesValue into the current offset in the object.
-    void storeVal(SmallHermesValue val) {
-      em.loadSmallHermesValueInGpX(xTmp, val, "object literal buffer val");
+    /// Store whatever is already in xTmp into the current offset in the
+    /// object, falling back to a register offset when the displacement is too
+    /// large to encode.
+    void storeTmpAtCurrentOffset() {
       asmjit::Error err;
       EXPECT_ERROR(
           asmjit::kErrorInvalidDisplacement,
@@ -3318,6 +3319,12 @@ void Emitter::newObjectWithBuffer(
         em.a.mov(xTmp2, currentOffset());
         emit_store_shv(em.a, xTmp, a64::Mem(xObj, xTmp2));
       }
+    }
+
+    /// Store a simple SmallHermesValue into the current offset in the object.
+    void storeVal(SmallHermesValue val) {
+      em.loadSmallHermesValueInGpX(xTmp, val, "object literal buffer val");
+      storeTmpAtCurrentOffset();
     }
 
     /// Advance internal state to the next slot, updating the counter and any
@@ -3360,8 +3367,9 @@ void Emitter::newObjectWithBuffer(
       // We know it's not null because we allocated it at JIT compile time.
       emit_sh_cp_encode_non_null(em.a, xTmp);
       emit_shv_string(em.a, xTmp);
-      // Store to storage.
-      emit_store_shv(em.a, xTmp, a64::Mem(xObj, currentOffset()));
+      // Store to storage, falling back to a register offset when the
+      // displacement does not encode, as storeVal does.
+      storeTmpAtCurrentOffset();
 
       advance();
     }

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -3545,7 +3545,10 @@ void Emitter::newTypedObjectWithBuffer(
       valBufferOffset,
       nonEnumerable);
 
-  syncAllFRTempExcept(frRes != frParent ? frRes : FR{});
+  // We unconditionally skip frRes here because we handle frParent with the
+  // syncToFrame below.
+  syncAllFRTempExcept(frRes);
+  syncToFrame(frParent);
   freeAllFRTempExcept({});
   a.mov(a64::x0, xRuntime);
   loadBits64InGp(a64::x1, (uint64_t)codeBlock_, "CodeBlock");
@@ -5878,6 +5881,9 @@ void Emitter::stringSwitchImm(
 
   // End of the basic block.
   syncAllFRTempExcept({});
+  // The handler reads the value through the frame address passed below, so
+  // the slot has to hold the current value.
+  syncToFrame(frInput);
 
   a.mov(a64::x0, (uint64_t)runtimeModule);
   a.mov(a64::w1, tableIndex);

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -1721,6 +1721,13 @@ void Emitter::emitIncrementCounter(JitCounter counter) {
 }
 
 uint16_t Emitter::initHCLazyIDMayAlloc(HiddenClass *hc) {
+  // Callers pass the result of WeakRoot::get(), which is null if the GC has
+  // cleared the root. Since 0 already means "no id" and every caller checks
+  // for it, tolerating null here keeps all present and future call sites safe
+  // without each of them having to re-validate across safepoints.
+  if (!hc)
+    return 0;
+
   uint16_t id = hc->getLazyJITId();
   // Assign a new ID to the HC if we have to.
   if (id != 0)
@@ -5164,8 +5171,16 @@ class HERMES_ATTRIBUTE_INTERNAL_LINKAGE Emitter::GetByIdImpl {
         cacheEntry->negMatchClazz.get(_.runtime_, _.runtime_.getHeap()));
     if (!clazzID)
       return;
-    auto parentClsID = _.initHCLazyIDMayAlloc(
-        cacheEntry->clazz.get(_.runtime_, _.runtime_.getHeap()));
+
+    // NOTE: the call above is a GC safepoint (it may create or grow the
+    // usedHCs ArrayStorage), so cacheEntry->clazz, a WeakRoot, may have been
+    // cleared in the meantime. initHCLazyIDMayAlloc tolerates a null class,
+    // so this re-read is not load-bearing on its own; it is here to keep the
+    // safepoint visible at the point where it matters, since nothing else in
+    // this function suggests the previous line can collect.
+    HiddenClass *parentCls =
+        cacheEntry->clazz.get(_.runtime_, _.runtime_.getHeap());
+    auto parentClsID = _.initHCLazyIDMayAlloc(parentCls);
     if (!parentClsID)
       return;
 

--- a/lib/VM/JIT/arm64/JitEmitter.h
+++ b/lib/VM/JIT/arm64/JitEmitter.h
@@ -195,6 +195,11 @@ static constexpr auto xRuntime = a64::x19;
 // x20 is frame
 static constexpr auto xFrame = a64::x20;
 
+/// Scratch register. x16/x17 sit outside the register allocator and are used
+/// as scratch (thunk targets, IP materialization); nothing holds a value in
+/// them across an emitter call.
+static constexpr auto xScratch = a64::x16;
+
 /// GP arg registers (inclusive).
 // static constexpr std::pair<uint8_t, uint8_t> kGPArgs(0, 7);
 /// Temporary GP registers (inclusive).
@@ -915,12 +920,22 @@ class Emitter {
   void typedLoadParent(FR frRes, FR frObj);
 
  private:
+  /// \return the byte offset of \p fr's slot from xFrame.
+  static constexpr inline uint32_t frByteOffset(FR fr) {
+    return (fr.index() + hbc::StackFrameLayout::FirstLocal) *
+        sizeof(SHLegacyValue);
+  }
+
+  /// \return true if \p ofs encodes as the scaled immediate of an LDR/STR
+  /// of a 64-bit register. The immediate is 12 bits scaled by 8, and frame
+  /// offsets are always multiples of 8, so only the upper bound can fail.
+  static constexpr inline bool isFrameImmOffset(uint32_t ofs) {
+    return ofs <= 4095 * 8;
+  }
+
   /// Create an a64::Mem to a specifc frame register.
   static constexpr inline a64::Mem frA64Mem(FR fr) {
-    // FIXME: check if the offset fits
-    auto ofs = (fr.index() + hbc::StackFrameLayout::FirstLocal) *
-        sizeof(SHLegacyValue);
-    return a64::Mem(xFrame, ofs);
+    return a64::Mem(xFrame, frByteOffset(fr));
   }
 
   /// Return true if we are logging, false otherwise.
@@ -953,18 +968,34 @@ class Emitter {
       const a64::GpX &xTemp);
 
   void _loadFrame(HWReg dest, FR rFrom) {
-    // FIXME: check if the offset fits
+    uint32_t ofs = frByteOffset(rFrom);
+    if (LLVM_LIKELY(isFrameImmOffset(ofs))) {
+      if (dest.isGpX())
+        a.ldr(dest.a64GpX(), a64::Mem(xFrame, ofs));
+      else
+        a.ldr(dest.a64VecD(), a64::Mem(xFrame, ofs));
+      return;
+    }
+    a.mov(xScratch, ofs);
     if (dest.isGpX())
-      a.ldr(dest.a64GpX(), frA64Mem(rFrom));
+      a.ldr(dest.a64GpX(), a64::Mem(xFrame, xScratch));
     else
-      a.ldr(dest.a64VecD(), frA64Mem(rFrom));
+      a.ldr(dest.a64VecD(), a64::Mem(xFrame, xScratch));
   }
   void _storeFrame(HWReg src, FR rFrom) {
-    // FIXME: check if the offset fits
+    uint32_t ofs = frByteOffset(rFrom);
+    if (LLVM_LIKELY(isFrameImmOffset(ofs))) {
+      if (src.isGpX())
+        a.str(src.a64GpX(), a64::Mem(xFrame, ofs));
+      else
+        a.str(src.a64VecD(), a64::Mem(xFrame, ofs));
+      return;
+    }
+    a.mov(xScratch, ofs);
     if (src.isGpX())
-      a.str(src.a64GpX(), frA64Mem(rFrom));
+      a.str(src.a64GpX(), a64::Mem(xFrame, xScratch));
     else
-      a.str(src.a64VecD(), frA64Mem(rFrom));
+      a.str(src.a64VecD(), a64::Mem(xFrame, xScratch));
   }
 
   bool isTempGpX(HWReg hwReg) const {

--- a/lib/VM/JIT/arm64/JitHandlers.cpp
+++ b/lib/VM/JIT/arm64/JitHandlers.cpp
@@ -491,6 +491,11 @@ SHLegacyValue _jit_call_builtin(
     newFrame.getSHLocalsRef() = HermesValue::encodeNativePointer(nullptr);
     newFrame.getArgCountRef() = HermesValue::encodeNativeUInt32(argCount);
     newFrame.getNewTargetRef() = HermesValue::encodeUndefinedValue();
+    // "thisArg" is implicitly assumed to be "undefined": the bytecode never
+    // populates the slot (HBCISel::verifyCall asserts CallBuiltin's `this` is
+    // a non-register-allocated LiteralUndefined), so it must be set here, the
+    // same way the interpreter's implCallBuiltin does.
+    newFrame.getThisArgRef() = HermesValue::encodeUndefinedValue();
 
     auto callee =
         vmcast<NativeFunction>(runtime.getBuiltinCallable(builtinMethodID));

--- a/lib/VM/JIT/arm64/JitHandlers.cpp
+++ b/lib/VM/JIT/arm64/JitHandlers.cpp
@@ -483,23 +483,25 @@ SHLegacyValue _jit_call_builtin(
     uint32_t builtinMethodID) {
   auto res = [&]() {
     Runtime &runtime = getRuntime(shr);
-    StackFramePtr newFrame(runtime.getStackPointer());
-    newFrame.getPreviousFrameRef() = HermesValue::encodeNativePointer(frame);
-    newFrame.getSavedIPRef() =
-        HermesValue::encodeNativePointer(runtime.getCurrentIP());
-    newFrame.getSavedCodeBlockRef() = HermesValue::encodeNativePointer(nullptr);
-    newFrame.getSHLocalsRef() = HermesValue::encodeNativePointer(nullptr);
-    newFrame.getArgCountRef() = HermesValue::encodeNativeUInt32(argCount);
-    newFrame.getNewTargetRef() = HermesValue::encodeUndefinedValue();
-    // "thisArg" is implicitly assumed to be "undefined": the bytecode never
-    // populates the slot (HBCISel::verifyCall asserts CallBuiltin's `this` is
-    // a non-register-allocated LiteralUndefined), so it must be set here, the
-    // same way the interpreter's implCallBuiltin does.
-    newFrame.getThisArgRef() = HermesValue::encodeUndefinedValue();
-
+    // Non-allocating, so it is safe to resolve the callee before the frame
+    // exists.
     auto callee =
         vmcast<NativeFunction>(runtime.getBuiltinCallable(builtinMethodID));
-    newFrame.getCalleeClosureOrCBRef() = HermesValue::encodeObjectValue(callee);
+    auto newFrame = StackFramePtr::initFrame(
+        runtime.getStackPointer(),
+        StackFramePtr(toPHV(frame)),
+        runtime.getCurrentIP(),
+        /* savedCodeBlock */ nullptr,
+        /* locals */ nullptr,
+        argCount,
+        HermesValue::encodeObjectValue(callee),
+        HermesValue::encodeUndefinedValue());
+    // "thisArg" is implicitly assumed to be "undefined": the bytecode never
+    // populates the slot (HBCISel::verifyCall asserts CallBuiltin's `this` is
+    // a non-register-allocated LiteralUndefined), and initFrame writes only
+    // the seven metadata slots, so it must be set here, the same way the
+    // interpreter's implCallBuiltin does.
+    newFrame.getThisArgRef() = HermesValue::encodeUndefinedValue();
 
     GCScopeMarkerRAII marker{runtime};
     return NativeFunction::_nativeCall(callee, runtime);

--- a/lib/VM/JIT/arm64/JitImpl.h
+++ b/lib/VM/JIT/arm64/JitImpl.h
@@ -21,6 +21,11 @@ class JITContext::Impl {
 
   static constexpr uint16_t kHCIdOverflow = 0xFFFF;
 
+  /// The largest id assignable to a hidden class. Lowered only by tests, so
+  /// that the exhaustion path can be reached without interning 65535 hidden
+  /// classes; the true ceiling is the width of HiddenClass::lazyJITId_.
+  uint16_t hcIdLimit{kHCIdOverflow};
+
   /// Hidden classes that we used by the emitted JIT code. Since we never
   /// throw away code, they can never be freed.
   /// This value is either Undefined or  a pointer to ArrayStorageSmall. It is

--- a/lib/VM/StaticH.cpp
+++ b/lib/VM/StaticH.cpp
@@ -529,22 +529,25 @@ extern "C" SHLegacyValue _sh_ljs_call_builtin(
     uint32_t builtinMethodID) {
   auto res = [&]() {
     Runtime &runtime = getRuntime(shr);
-    StackFramePtr newFrame(runtime.getStackPointer());
-    newFrame.getPreviousFrameRef() = HermesValue::encodeNativePointer(frame);
-    newFrame.getSavedIPRef() = HermesValue::encodeNativePointer(nullptr);
-    newFrame.getSavedCodeBlockRef() = HermesValue::encodeNativePointer(nullptr);
-    newFrame.getSHLocalsRef() = HermesValue::encodeNativePointer(nullptr);
-    newFrame.getArgCountRef() = HermesValue::encodeNativeUInt32(argCount);
-    newFrame.getNewTargetRef() = HermesValue::encodeUndefinedValue();
-    // "thisArg" is implicitly assumed to be "undefined": the compiler never
-    // populates the slot (CallBuiltin's `this` is lowered to an
-    // ImplicitMovInst, which emits no code), so it must be set here, the same
-    // way the interpreter's implCallBuiltin does.
-    newFrame.getThisArgRef() = HermesValue::encodeUndefinedValue();
-
+    // Non-allocating, so it is safe to resolve the callee before the frame
+    // exists.
     auto callee =
         vmcast<NativeFunction>(runtime.getBuiltinCallable(builtinMethodID));
-    newFrame.getCalleeClosureOrCBRef() = HermesValue::encodeObjectValue(callee);
+    auto newFrame = StackFramePtr::initFrame(
+        runtime.getStackPointer(),
+        StackFramePtr(toPHV(frame)),
+        /* savedIP */ nullptr,
+        /* savedCodeBlock */ nullptr,
+        /* locals */ nullptr,
+        argCount,
+        HermesValue::encodeObjectValue(callee),
+        HermesValue::encodeUndefinedValue());
+    // "thisArg" is implicitly assumed to be "undefined": the compiler never
+    // populates the slot (CallBuiltin's `this` is lowered to an
+    // ImplicitMovInst, which emits no code), and initFrame writes only the
+    // seven metadata slots, so it must be set here, the same way the
+    // interpreter's implCallBuiltin does.
+    newFrame.getThisArgRef() = HermesValue::encodeUndefinedValue();
 
     GCScopeMarkerRAII marker{runtime};
     return NativeFunction::_nativeCall(callee, runtime);

--- a/lib/VM/StaticH.cpp
+++ b/lib/VM/StaticH.cpp
@@ -536,6 +536,11 @@ extern "C" SHLegacyValue _sh_ljs_call_builtin(
     newFrame.getSHLocalsRef() = HermesValue::encodeNativePointer(nullptr);
     newFrame.getArgCountRef() = HermesValue::encodeNativeUInt32(argCount);
     newFrame.getNewTargetRef() = HermesValue::encodeUndefinedValue();
+    // "thisArg" is implicitly assumed to be "undefined": the compiler never
+    // populates the slot (CallBuiltin's `this` is lowered to an
+    // ImplicitMovInst, which emits no code), so it must be set here, the same
+    // way the interpreter's implCallBuiltin does.
+    newFrame.getThisArgRef() = HermesValue::encodeUndefinedValue();
 
     auto callee =
         vmcast<NativeFunction>(runtime.getBuiltinCallable(builtinMethodID));

--- a/test/jit/call-builtin-this.js
+++ b/test/jit/call-builtin-this.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -fno-inline -fstatic-builtins -Xjit=force -Xjit-crash-on-error %s | %FileCheck --match-full-lines %s
+// REQUIRES: jit
+
+// CallBuiltin's "this" is never populated by bytecode, so the runtime helper
+// must initialize it to undefined. Every call in a function shares the same
+// outgoing ThisArg slot, so a preceding ordinary call leaves its receiver
+// there; if the builtin call does not overwrite it, Array.from() sees that
+// stale receiver as its "this" and uses it as the constructor C.
+
+function Poison(n) {
+  this.iAmPoison = true;
+  this.length = n;
+}
+Poison.probe = function () {
+  return 1;
+};
+
+function test(arr) {
+  // Ordinary call whose "this" is Poison, poisoning the shared slot.
+  Poison.probe();
+  // CallBuiltin: must not observe Poison as its "this".
+  return Array.from(arr);
+}
+
+var r = test([10, 20, 30]);
+
+print(Array.isArray(r));
+// CHECK: true
+print(r.constructor === Array);
+// CHECK-NEXT: true
+print(r.iAmPoison);
+// CHECK-NEXT: undefined
+print(r[0], r[1], r[2]);
+// CHECK-NEXT: 10 20 30

--- a/test/jit/deep-environment.js
+++ b/test/jit/deep-environment.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: echo "function outer(x){ var a0=x++;" "var a"{1..4200}"=x++;" "function cap(){return a0" "+a"{1..4200} "; } function inner(){return a4200;} if(x<0) return cap(); return inner(); } print(outer(7));" | %hermes - -O -fno-inline -Xjit=force -Xjit-crash-on-error | %FileCheck --match-full-lines %s
+// REQUIRES: jit
+
+// The above echo generates an environment with 4201 slots:
+//   function outer(x){
+//     var a0=x++; ... var a4200=x++;
+//     function cap(){ return a0 + ... + a4200; }   // captures everything
+//     function inner(){ return a4200; }            // reads the highest slot
+//     if (x<0) return cap();
+//     return inner();
+//   }
+//
+// An environment slot sits at offsetof(SHEnvironment, slots) + 8 * slot, so
+// past slot ~4092 the LDR displacement no longer encodes.
+//
+// Three details are load-bearing. cap is never called, so it is never JIT'ed
+// and its own huge frame does not come into it; it exists only to force every
+// variable into the environment. inner stays tiny, so the function under test
+// does not also need thousands of frame registers, which is a separate limit
+// (see large-frame.js). And -fno-inline is required: otherwise inner is
+// inlined into outer and the environment load disappears entirely.
+
+// CHECK: 4207

--- a/test/jit/getbyid-spec-exhausted.js
+++ b/test/jit/getbyid-spec-exhausted.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -fno-inline -Xjit -Xjit-threshold=1 -Xjit-crash-on-error -Xjit-hc-id-limit=0 %s | %FileCheck --match-full-lines %s
+// RUN: %hermes -fno-inline -Xjit -Xjit-threshold=1 -Xjit-crash-on-error -Xjit-hc-id-limit=0 -Xdump-jitcode=3 %s 2>&1 | %FileCheck --match-full-lines --check-prefix=JITCODE %s
+// REQUIRES: jit
+
+// When the lazy JIT id space is exhausted, initHCLazyIDMayAlloc returns 0 and
+// the GetById specializations cannot be emitted. The site must then fall back
+// to the generic inline cache, rather than compiling with no cache at all.
+//
+// -Xjit-hc-id-limit makes this reachable without interning 65535 hidden
+// classes. A limit of 0 exhausts the space before the first assignment, so
+// every specialization bails deterministically.
+
+// Each of these reads a property off the prototype, which is the shape that
+// selects parent specialization -- the tier that returns early and, before
+// the fall-back, left the site with no inline cache at all.
+function getA(o) {
+  return o.pa;
+}
+function getB(o) {
+  return o.pb;
+}
+function getC(o) {
+  return o.pc;
+}
+function getD(o) {
+  return o.pd;
+}
+
+function make(name, val) {
+  var proto = {};
+  proto[name] = val;
+  var o = {};
+  o["own_" + name] = 1;
+  Object.setPrototypeOf(o, proto);
+  return o;
+}
+
+var oa = make("pa", 10);
+var ob = make("pb", 20);
+var oc = make("pc", 30);
+var od = make("pd", 40);
+
+// Warm each site so its cache entry is a monomorphic negMatch, then keep
+// calling so every function crosses the JIT threshold.
+var sum = 0;
+for (var i = 0; i < 20; ++i) {
+  sum += getA(oa);
+  sum += getB(ob);
+  sum += getC(oc);
+  sum += getD(od);
+}
+
+print(sum);
+// CHECK: 2000
+
+// Values must still be correct for classes that never received an id.
+print(getA(oa), getB(ob), getC(oc), getD(od));
+// CHECK-NEXT: 10 20 30 40
+
+// Reading through a different shape must still work, exercising the generic
+// cache's miss path at a site whose specialization could not be emitted.
+print(getA(make("pa", 11)), getD(make("pd", 44)));
+// CHECK-NEXT: 11 44
+
+// The generic tier must be present in each compiled function. Without the
+// fall-back these functions emit neither a specialization nor a property
+// cache: the fast path just runs off into the slow-path call, and the
+// "Read property cache" marker is absent between the function label and its
+// completion message.
+// JITCODE: getA:
+// JITCODE: // Read property cache
+// JITCODE: JIT successfully compiled FunctionID 1, 'getA'
+// JITCODE: getB:
+// JITCODE: // Read property cache
+// JITCODE: JIT successfully compiled FunctionID 2, 'getB'
+// JITCODE: getC:
+// JITCODE: // Read property cache
+// JITCODE: JIT successfully compiled FunctionID 3, 'getC'
+// JITCODE: getD:
+// JITCODE: // Read property cache
+// JITCODE: JIT successfully compiled FunctionID 4, 'getD'

--- a/test/jit/large-frame.js
+++ b/test/jit/large-frame.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: echo "function f(x){ var a0=x++;" "var a"{1..4200}"=x++;" "return a0" "+a"{1..4200} ";} print(f(7));" | %hermes - -O -Xjit=force -Xjit-crash-on-error | %FileCheck --match-full-lines %s
+// REQUIRES: jit
+
+// The above echo generates a function with 4201 simultaneously live locals:
+//   function f(x){ var a0=x++; ... var a4200=x++; return a0 + ... + a4200; }
+//
+// A frame slot sits at (index + FirstLocal) * 8 from xFrame, so past about
+// 4090 registers the offset no longer fits the scaled immediate of LDR/STR.
+// _loadFrame and _storeFrame used to emit it unconditionally, so a function
+// this size failed to JIT. x++ keeps each initializer distinct; using the
+// same value lets the optimizer collapse them and the frame never grows.
+
+// CHECK: 8851507

--- a/test/jit/large_literal_obj_strings.js
+++ b/test/jit/large_literal_obj_strings.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: echo "var obj ={p0" ":\"s\",p"{1..4200} ":\"s\"}; print(obj.p4200);" | %hermes - -target=HBC -O -gc-sanitize-handles=0 -Xjit=force -Xjit-crash-on-error | %FileCheck --match-full-lines %s
+// REQUIRES: jit
+
+// The above echo generates an object literal with string values:
+//   var obj = {p0:"s", p1:"s", ... p4200:"s"}; print(obj.p4200);
+//
+// Past indirect slot ~4090 the store offset no longer encodes as a scaled
+// immediate. storeVal, used for number/bool/null/undefined literals, has
+// always fallen back to a register offset; the string path did not, so a
+// literal this size failed to JIT with InvalidDisplacement. The number
+// equivalent is covered by large_literal_obj.js, which is why this only
+// exercises string values.
+
+// CHECK: s

--- a/test/jit/many-property-caches.js
+++ b/test/jit/many-property-caches.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: echo "function f(o){return o.p0" "+o.p"{1..200} ';} var o={}; for(var i=0;i<=200;++i) o["p"+i]=i; print(f(o));' | %hermes - -O -Xjit=force -Xjit-crash-on-error | %FileCheck --match-full-lines %s
+// REQUIRES: jit
+
+// The above echo generates:
+//   function f(o){ return o.p0 + o.p1 + ... + o.p200; }
+//   var o={}; for (var i=0;i<=200;++i) o["p"+i]=i; print(f(o));
+//
+// Property cache indices are allocated per property name, so 201 distinct
+// names give indices up to 200. Cache entries are 24 bytes, and the byte
+// offset of entry 171 is 4104, one step past the 4095 ceiling of an ADD
+// immediate. Every site that indexes the cache array has to cope with that.
+//
+// Note that repeating a single site 200 times proves nothing here: those all
+// share one index. The names have to differ.
+
+// CHECK: 20100

--- a/test/jit/throw-this-initialized-in-try.js
+++ b/test/jit/throw-this-initialized-in-try.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -fno-inline -Xjit=force -Xjit-crash-on-error %s | %FileCheck --match-full-lines %s
+// REQUIRES: jit
+
+// ThrowIfThisInitialized longjmps to a catch handler in the same function,
+// which reads its frame registers from memory. Check that values assigned
+// before the throw survive, in the shapes where a live value could plausibly
+// still be sitting in a temp register.
+//
+// NOTE: this is a smoke test, not a regression test for the in-try sync in
+// Emitter::throwIfThisInitialized. It passes with or without that sync, and
+// cannot be made to fail: ThrowIfThisInitialized is always emitted
+// immediately after the super call, and callImpl already flushes every live
+// FR before any call, so no JS-producible shape leaves a dirty FR between the
+// call and the check. Its value is locking the behavior in for the x86-64
+// port.
+
+class Base {
+  constructor() {
+    this.b = 1;
+  }
+}
+
+// Straight-line double super().
+class Straight extends Base {
+  constructor(y) {
+    var x = -1;
+    try {
+      super();
+      x = y + 1;
+      super();
+    } catch (e) {
+      print("Straight", x);
+    }
+  }
+}
+new Straight(41);
+// CHECK: Straight 42
+
+// A single super() site executed twice by a loop.
+class LoopSuper extends Base {
+  constructor(y) {
+    var x = -1;
+    try {
+      for (var i = 0; i < 2; ++i) {
+        x = y + i;
+        super();
+      }
+    } catch (e) {
+      print("LoopSuper", x);
+    }
+  }
+}
+new LoopSuper(41);
+// CHECK-NEXT: LoopSuper 42
+
+// Several independent live values across the throw.
+class ManyLive extends Base {
+  constructor(y) {
+    var a = -1,
+      b = -2,
+      c = -3;
+    try {
+      super();
+      a = y + 1;
+      b = y * 2;
+      c = y - 1;
+      super();
+    } catch (e) {
+      print("ManyLive", a, b, c);
+    }
+  }
+}
+new ManyLive(41);
+// CHECK-NEXT: ManyLive 42 82 40
+
+// A value derived from the object the first super() produced.
+class FromThis extends Base {
+  constructor(y) {
+    var x = -1;
+    try {
+      super();
+      x = this.b + y;
+      super();
+    } catch (e) {
+      print("FromThis", x);
+    }
+  }
+}
+new FromThis(41);
+// CHECK-NEXT: FromThis 42

--- a/test/shermes/call-builtin-this.js
+++ b/test/shermes/call-builtin-this.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %shermes -fno-inline -fstatic-builtins -exec %s | %FileCheck --match-full-lines %s
+
+// CallBuiltin's "this" is never populated by the compiler: the SH backend
+// lowers it to an ImplicitMovInst which emits no code, so _sh_ljs_call_builtin
+// must initialize the slot itself. Every call in a function shares the same
+// outgoing ThisArg slot, so a preceding ordinary call leaves its receiver
+// there; if the builtin call does not overwrite it, Array.from() sees that
+// stale receiver as its "this" and uses it as the constructor C.
+
+function Poison(n) {
+  this.iAmPoison = true;
+  this.length = n;
+}
+Poison.probe = function () {
+  return 1;
+};
+
+function test(arr) {
+  // Ordinary call whose "this" is Poison, poisoning the shared slot.
+  Poison.probe();
+  // CallBuiltin: must not observe Poison as its "this".
+  return Array.from(arr);
+}
+
+var r = test([10, 20, 30]);
+
+print(Array.isArray(r));
+// CHECK: true
+print(r.constructor === Array);
+// CHECK-NEXT: true
+print(r.iAmPoison);
+// CHECK-NEXT: undefined
+print(r[0], r[1], r[2]);
+// CHECK-NEXT: 10 20 30

--- a/tools/hermes/hermes.cpp
+++ b/tools/hermes/hermes.cpp
@@ -149,6 +149,7 @@ static int executeHBCBytecodeFromCL(
   options.jitCrashOnError = flags.JITCrashOnError;
   options.jitEmitAsserts = flags.JITEmitAsserts;
   options.jitEmitCounters = flags.JITEmitCounters;
+  options.jitHCIdLimit = flags.JITHCIdLimit;
   options.stopAfterInit = flags.StopAfterInit;
   options.forceGCBeforeStats = flags.GCBeforeStats;
   options.sampleProfiling = flags.SampleProfiling;


### PR DESCRIPTION
Summary:

A group of cosmetic items in the emitter. None of them change emitted
code.

- The `bitNot` and `loadThisNS` slow paths printed sl.frInput2 and
  sl.frInput1 in their debug comments, neither of which the
  corresponding `SlowPath` is ever given, so both rendered whatever the
  designated initializer left behind. Print only the operands that are
  set, and label `bitNot`'s as a slow path like its neighbours.
- `storeToEnvironment` logged "`StoreNPToEnvironment`" regardless of its
  np argument, so half the listings named the wrong instruction.
- `emit_sh_ljs_tag_is_pointer`'s comment said pointer tags start at
  0xfc. `HVTag_First` is 0xf9 and `HVTag_FirstPointer` is the fifth
  entry, 0xfd; 0xfc is `HVTag_Unused`, or `HVTag_RawHV32` under boxed
  doubles. The code itself uses the enum and was always right.

Reviewed By: avp

Differential Revision: D116223323
