### PR TITLE
Throw TypeError for type and brand errors in TextEncoder/TextDecoder

### DIFF
--- a/API/hermes/extensions/JSIUtils.cpp
+++ b/API/hermes/extensions/JSIUtils.cpp
@@ -18,14 +18,14 @@ TypedArrayBufferInfo getTypedArrayBuffer(
     const char *errorMessage,
     const char *detachedErrorMessage) {
   if (!val.isObject()) {
-    throw jsi::JSError(rt, errorMessage);
+    throwTypeError(rt, errorMessage);
   }
   jsi::Object obj = val.asObject(rt);
 
   // Get the underlying ArrayBuffer via the 'buffer' property
   jsi::Value bufferVal = obj.getProperty(rt, "buffer");
   if (!bufferVal.isObject() || !bufferVal.asObject(rt).isArrayBuffer(rt)) {
-    throw jsi::JSError(rt, errorMessage);
+    throwTypeError(rt, errorMessage);
   }
   jsi::ArrayBuffer arrayBuffer = bufferVal.asObject(rt).getArrayBuffer(rt);
 
@@ -35,7 +35,7 @@ TypedArrayBufferInfo getTypedArrayBuffer(
   llvh::Optional<size_t> byteLength =
       valueToUnsigned<size_t>(obj.getProperty(rt, "byteLength"));
   if (!byteOffset || !byteLength) {
-    throw jsi::JSError(rt, errorMessage);
+    throwTypeError(rt, errorMessage);
   }
 
   // Get raw pointer. data(rt) throws JSINativeException if the buffer is
@@ -51,7 +51,7 @@ TypedArrayBufferInfo getTypedArrayBuffer(
   // be validated.
   size_t bufferSize = arrayBuffer.size(rt);
   if (*byteOffset > bufferSize || *byteLength > bufferSize - *byteOffset) {
-    throw jsi::JSError(rt, errorMessage);
+    throwTypeError(rt, errorMessage);
   }
 
   return TypedArrayBufferInfo(

--- a/API/hermes/extensions/JSIUtils.h
+++ b/API/hermes/extensions/JSIUtils.h
@@ -107,7 +107,7 @@ inline llvh::Optional<T> valueToUnsigned(const jsi::Value &val) {
 /// instanceof Uint8Array. This is more permissive than the spec requires, but
 /// handles cross-realm Uint8Arrays and is consistent with JSI's portable
 /// design. The original VM implementation used internal type checks.
-/// Throws JSError if the object is not a valid TypedArray or is detached.
+/// Throws a TypeError if the object is not a valid TypedArray or is detached.
 /// The returned object keeps the backing ArrayBuffer alive; it must outlive
 /// every use of its data().
 /// \param errorMessage The error message to use if the object is invalid.

--- a/API/hermes/extensions/TextEncoder.cpp
+++ b/API/hermes/extensions/TextEncoder.cpp
@@ -25,15 +25,17 @@ class TextEncoderNativeState : public jsi::NativeState {
 };
 
 /// Validate that 'thisVal' is a TextEncoder instance (has our NativeState).
-/// Throws a JSError if not.
+/// Throws a TypeError if not.
 inline void validateTextEncoder(
     jsi::Runtime &rt,
     const jsi::Value &thisVal,
     const char *methodName) {
   if (!thisVal.isObject() ||
       !thisVal.asObject(rt).hasNativeState<TextEncoderNativeState>(rt)) {
-    throw jsi::JSError(
-        rt, std::string(methodName) + " called on non-TextEncoder object");
+    throwTypeError(
+        rt,
+        (std::string(methodName) + " called on non-TextEncoder object")
+            .c_str());
   }
 }
 
@@ -98,7 +100,7 @@ jsi::Value textEncoderEncodeInto(
   validateTextEncoder(rt, thisVal, "TextEncoder.prototype.encodeInto()");
 
   if (count < 2) {
-    throw jsi::JSError(rt, "TextEncoder.encodeInto requires 2 arguments");
+    throwTypeError(rt, "TextEncoder.encodeInto requires 2 arguments");
   }
 
   jsi::String inputStr = args[0].toString(rt);

--- a/API/hermes/extensions/contrib/TextDecoder.cpp
+++ b/API/hermes/extensions/contrib/TextDecoder.cpp
@@ -48,19 +48,23 @@ class TextDecoderNativeState : public jsi::NativeState {
 };
 
 /// Validate that 'thisVal' is a TextDecoder instance (has our NativeState).
-/// Returns the NativeState pointer, or throws a JSError if invalid.
+/// Returns the NativeState pointer, or throws a TypeError if invalid.
 inline TextDecoderNativeState *getTextDecoderState(
     jsi::Runtime &rt,
     const jsi::Value &thisVal,
     const char *methodName) {
   if (!thisVal.isObject()) {
-    throw jsi::JSError(
-        rt, std::string(methodName) + " called on non-TextDecoder object");
+    throwTypeError(
+        rt,
+        (std::string(methodName) + " called on non-TextDecoder object")
+            .c_str());
   }
   auto obj = thisVal.asObject(rt);
   if (!obj.hasNativeState<TextDecoderNativeState>(rt)) {
-    throw jsi::JSError(
-        rt, std::string(methodName) + " called on non-TextDecoder object");
+    throwTypeError(
+        rt,
+        (std::string(methodName) + " called on non-TextDecoder object")
+            .c_str());
   }
   return obj.getNativeState<TextDecoderNativeState>(rt).get();
 }
@@ -68,7 +72,7 @@ inline TextDecoderNativeState *getTextDecoderState(
 /// Get input bytes from a value that can be ArrayBuffer, TypedArray, or
 /// DataView. Returns an empty view for undefined/null. The result roots the
 /// backing ArrayBuffer, so it must outlive the use of its bytes.
-/// Throws JSError if the value is not a valid buffer type.
+/// Throws a TypeError if the value is not a valid buffer type.
 /// Throws JSINativeException (to be caught by caller) if buffer is detached.
 TypedArrayBufferInfo getInputBytes(jsi::Runtime &rt, const jsi::Value &val) {
   if (val.isUndefined() || val.isNull()) {
@@ -76,7 +80,7 @@ TypedArrayBufferInfo getInputBytes(jsi::Runtime &rt, const jsi::Value &val) {
   }
 
   if (!val.isObject()) {
-    throw jsi::JSError(
+    throwTypeError(
         rt,
         "TextDecoder.prototype.decode() requires an ArrayBuffer or ArrayBufferView");
   }

--- a/test/hermes/contrib/text-decoder.js
+++ b/test/hermes/contrib/text-decoder.js
@@ -552,3 +552,26 @@ print(bomResetDecoder2.decode(Uint8Array.of(0xBF)).length);  // BOM stripped, em
 var utf16OddDecoder = new TextDecoder('utf-16le');
 print(utf16OddDecoder.decode(Uint8Array.of(0x00, 0xD8, 0xD8)).length);
 // CHECK-NEXT: 1
+
+// WebIDL reports a bad receiver and a non-BufferSource input as a TypeError,
+// like the fatal-mode case above. An unknown encoding label stays a RangeError.
+function nameOfThrow(f) {
+  try {
+    f();
+    return 'no throw';
+  } catch (e) {
+    return e.name;
+  }
+}
+print(nameOfThrow(function () {
+  TextDecoder.prototype.decode.call({}, new Uint8Array(1));
+}));
+// CHECK-NEXT: TypeError
+print(nameOfThrow(function () { new TextDecoder().decode({}); }));
+// CHECK-NEXT: TypeError
+print(nameOfThrow(function () { new TextDecoder().decode(123); }));
+// CHECK-NEXT: TypeError
+print(nameOfThrow(function () { new TextDecoder().decode('str'); }));
+// CHECK-NEXT: TypeError
+print(nameOfThrow(function () { new TextDecoder('bogus-enc'); }));
+// CHECK-NEXT: RangeError

--- a/test/hermes/text-encoder.js
+++ b/test/hermes/text-encoder.js
@@ -177,3 +177,26 @@ try {
   print(e.name, e.message);
   // CHECK-NEXT: TypeError TextEncoder.prototype.encodeInto called on a detached ArrayBuffer
 }
+
+// WebIDL reports a bad receiver, a bad destination and a missing argument as a
+// TypeError, like the detached case above.
+function nameOfThrow(f) {
+  try {
+    f();
+    return 'no throw';
+  } catch (e) {
+    return e.name;
+  }
+}
+print(nameOfThrow(function () { TextEncoder.prototype.encode.call({}, 'a'); }));
+// CHECK-NEXT: TypeError
+print(nameOfThrow(function () {
+  TextEncoder.prototype.encodeInto.call({}, 'a', new Uint8Array(4));
+}));
+// CHECK-NEXT: TypeError
+print(nameOfThrow(function () { encoder.encodeInto('a', {}); }));
+// CHECK-NEXT: TypeError
+print(nameOfThrow(function () { encoder.encodeInto('a', 123); }));
+// CHECK-NEXT: TypeError
+print(nameOfThrow(function () { encoder.encodeInto('a'); }));
+// CHECK-NEXT: TypeError


### PR DESCRIPTION
## Summary

Every type and brand check in the `TextEncoder` and `TextDecoder` extensions throws a plain `Error`
where the WHATWG Encoding Standard, via WebIDL, requires a `TypeError`. That breaks the ordinary way
callers handle it:

```js
try {
  decoder.decode(somethingThatIsNotABufferSource);
} catch (e) {
  if (e instanceof TypeError) { /* never taken on Hermes */ }
}
```

The two files already use the `throwTypeError` helper for neighbouring conditions, so this looks like
an oversight rather than a decision. `getTypedArrayBuffer` is the clearest case: the detached-buffer
path calls `throwTypeError` (`JSIUtils.cpp:47`), while the wrong-type and out-of-range paths a few
lines either side use `throw jsi::JSError`, and all of them are WebIDL `TypeError` conditions. The
existing `text-encoder.js` test even asserts `TypeError` for the detached case, right next to the
paths that produce `Error`.

Found by diffing these APIs against Node, which implements the same spec. 11 of the 12 error paths I
exercised disagreed, all in the same direction:

```
                                        before      after     node
decode({})                              Error       TypeError TypeError
decode(123) / decode('str') / [1,2]     Error       TypeError TypeError
decode.call({}, buf)                    Error       TypeError TypeError
encodeInto('a', {}) / ('a', 123)        Error       TypeError TypeError
encodeInto('a')        (missing arg)     Error       TypeError TypeError
encodeInto.call({}, ...)                Error       TypeError TypeError
encode.call({})                         Error       TypeError TypeError
new TextDecoder('bogus-enc')            RangeError  RangeError RangeError
```

The last line is the one that was already right, so it is left alone.

Changed, all reachable from JS:

- `JSIUtils.cpp`, `getTypedArrayBuffer`: non-object argument, a `buffer` that is not an `ArrayBuffer`,
  a `byteOffset`/`byteLength` that is not a valid unsigned integer, and a `byteOffset`/`byteLength`
  pair outside the buffer. Shared by `encodeInto` and `decode`.
- `TextEncoder.cpp`: the `validateTextEncoder` brand check (covers `encode` and `encodeInto`), and
  `encodeInto` called with fewer than two arguments.
- `TextDecoder.cpp`: the `getTextDecoderState` brand check, both branches, which also covers the
  `encoding`, `fatal` and `ignoreBOM` getters, and `decode` given a non-object.

Deliberately not changed: the arity guards in `textEncoderInit` and in the `nativeGetEncoding` /
`nativeGetFatal` / `nativeGetIgnoreBOM` helpers. Those natives are parameters of the extension's own
JS setup function, so they stay in closure scope and are always called with a fixed shape
(`nativeGetEncoding(this)`); the guards are unreachable from user code and are not spec-governed.
Doc comments that said "throws a JSError" are updated to match.

## Test Plan

Added the missing error-type cases to the two existing test files, next to the assertions that
already cover this ground: the detached-buffer `TypeError` check in `test/hermes/text-encoder.js` and
the fatal-mode `TypeError` check in `test/hermes/contrib/text-decoder.js`. The decoder case also
pins `RangeError` for an unknown encoding label so a future sweep does not convert it too.

Confirmed the new expectations fail on the unpatched source, by reverting only
`API/hermes/extensions/` and rebuilding:

```
$ git stash push -- API/hermes/extensions/
$ cmake --build cmake-build-asan --target hermes
$ LIT_OPTS="-j1" LIT_FILTER="text-(encoder|decoder)" cmake --build cmake-build-asan --target check-hermes

test/hermes/contrib/text-decoder.js:569:16: error: CHECK-NEXT: expected string not found in input
test/hermes/text-encoder.js:192:16: error: CHECK-NEXT: expected string not found in input
Failing Tests (2):
  Unexpected Failures: 2
```

With the fix restored, those 4 tests pass.

Whole lit suite, ASan + Debug build with `-O1`, single process (`LIT_OPTS="-j1"`):

```
$ LIT_OPTS="-j1" cmake --build cmake-build-asan --target check-hermes
-- Testing: 4291 tests, single process --
  Expected Passes    : 4098
  Expected Failures  : 6
  Unsupported Tests  : 187
```

No unexpected failures. Also `Total: 64  Pass: 41  Fail: 0  Skip: 23` from the Node-API suite that
runs alongside it.

Also ran the GC probes I had written for the recently landed `getTypedArrayBuffer` rooting fix
(getter-supplied `ArrayBuffer`s, allocation churn inside the `byteOffset`/`byteLength` getters,
reentrant `decode`, lying `byteLength`) under ASan: no new reports, and the lying-getter cases still
get rejected, now as `TypeError`.

`clang-format` run over the four changed C++ files with the repo `.clang-format`; no reformatting
beyond the edited lines.

---

small heads up, i went looking at these extensions after the recent rooting fix in this area and
found the error types by comparing against node rather than reading webidl top to bottom first, so
please tell me if any of the sites i left alone should also change. i talked the classification
through with claude code. freshman in college, still learning where the line is between "spec says
TypeError" and "this is an internal invariant", happy to be corrected.
