### PR TITLE
Extend CallRequire to importDefault

### DIFF
--- a/include/hermes/BCGen/HBC/BytecodeList.def
+++ b/include/hermes/BCGen/HBC/BytecodeList.def
@@ -608,6 +608,15 @@ DEFINE_RET_TARGET(CallWithNewTargetLong)
 DEFINE_OPCODE_3(CallRequire, Reg8, Reg8, UInt32)
 DEFINE_RET_TARGET(CallRequire)
 
+/// Metro importDefault of a module by (literal) index: returns the ESM/CJS
+/// default-interop value, served from a per-RuntimeModule native cache. Like
+/// CallRequire but for the importDefault helper.
+/// Arg1 is the destination of the return value.
+/// Arg2 is the importDefault closure to invoke on a cache miss.
+/// Arg3 is the module index argument, as an immediate.
+DEFINE_OPCODE_3(CallRequireImportDefault, Reg8, Reg8, UInt32)
+DEFINE_RET_TARGET(CallRequireImportDefault)
+
 // Enforce the order.
 ASSERT_MONOTONE_INCREASING(
     Call,

--- a/include/hermes/IR/Attributes.def
+++ b/include/hermes/IR/Attributes.def
@@ -50,4 +50,9 @@ ATTRIBUTE(CallInst, isNativeJSFunction, "njsf")
 /// function, which has known semantics we can assume in optimization.
 ATTRIBUTE(CallInst, isMetroRequire, "metro-require")
 
+/// Indicates that the call is known to be a call to the Metro importDefault
+/// helper (ESM/CJS default-import interop over a module id), which has known
+/// semantics we can assume in optimization / lower to a native cached read.
+ATTRIBUTE(CallInst, isMetroImportDefault, "metro-import-default")
+
 #undef ATTRIBUTE

--- a/include/hermes/VM/RuntimeModule-inline.h
+++ b/include/hermes/VM/RuntimeModule-inline.h
@@ -48,6 +48,17 @@ HermesValue RuntimeModule::getModuleExport(uint32_t modIndex) const {
   }
 }
 
+HermesValue RuntimeModule::getModuleImportedDefault(uint32_t modIndex) const {
+  // Mirrors getModuleExport, over the importDefault memoization cache.
+  if (LLVM_LIKELY(
+          moduleImportedDefaults_ &&
+          modIndex < moduleImportedDefaults_->size())) {
+    return moduleImportedDefaults_->at(modIndex);
+  } else {
+    return HermesValue::encodeEmptyValue();
+  }
+}
+
 } // namespace vm
 } // namespace hermes
 

--- a/include/hermes/VM/RuntimeModule.h
+++ b/include/hermes/VM/RuntimeModule.h
@@ -176,6 +176,10 @@ class RuntimeModule final : public llvh::ilist_node<RuntimeModule> {
   /// the module has not yet been initialized.
   ArrayStorageBase<HermesValue> *moduleExports_{nullptr};
 
+  /// Indexed by module id: the memoized importDefault (ESM/CJS default-interop)
+  /// value of each module.  isEmpty means not yet computed.
+  ArrayStorageBase<HermesValue> *moduleImportedDefaults_{nullptr};
+
   /// Registers the created RuntimeModule with \p domain, resulting in
   /// \p domain owning it. The RuntimeModule will be freed when the
   /// domain is collected..
@@ -462,6 +466,15 @@ class RuntimeModule final : public llvh::ilist_node<RuntimeModule> {
   /// of the cache, and attempts to reallocate it fail.  If that occurs,
   /// the array size will remain unchanged.
   void setModuleExport(Runtime &runtime, uint32_t modIndex, Handle<> modExport);
+
+  /// Returns the memoized importDefault value for module \p modIndex, or empty
+  /// if not yet computed.
+  inline HermesValue getModuleImportedDefault(uint32_t modIndex) const;
+
+  /// Attempts to memoize the importDefault value for module \p modIndex. Same
+  /// failure semantics as setModuleExport.
+  void
+  setModuleImportedDefault(Runtime &runtime, uint32_t modIndex, Handle<> value);
 
   /// The \p cases pointer points the the start of the string switch
   /// table for a StringSwitchImm instruction; \p size is the size of that

--- a/lib/BCGen/HBC/ISel.cpp
+++ b/lib/BCGen/HBC/ISel.cpp
@@ -1815,6 +1815,17 @@ void HBCISel::generateCallInst(CallInst *Inst, BasicBlock *next) {
     return;
   }
 
+  // Handle Metro importDefault calls specially (native cached default read).
+  if (Inst->getAttributes(Inst->getModule()).isMetroImportDefault) {
+    auto *litNum = llvh::cast<LiteralNumber>(Inst->getArgument(1));
+    assert(
+        litNum->isUInt32Representible() &&
+        "Or should not have been optimized.");
+    BCFGen_->emitCallRequireImportDefault(
+        encodeValue(Inst), encodeValue(Inst->getCallee()), litNum->asUInt32());
+    return;
+  }
+
   auto output = encodeValue(Inst);
   auto function = encodeValue(Inst->getCallee());
   bool newTargetIsUndefined = llvh::isa<LiteralUndefined>(Inst->getNewTarget());

--- a/lib/Optimizer/Scalar/MetroRequireOpt.cpp
+++ b/lib/Optimizer/Scalar/MetroRequireOpt.cpp
@@ -86,8 +86,14 @@ class MetroRequireImpl {
   bool run();
 
  private:
-  void resolveMetroModule(Function *moduleFunction);
-  void resolveRequireCall(Function *moduleFunction, CallInst *call);
+  void resolveMetroModule(
+      Function *moduleFunction,
+      unsigned paramIndex,
+      bool isImportDefault);
+  void resolveRequireCall(
+      Function *moduleFunction,
+      CallInst *call,
+      bool isImportDefault);
 
   /// Attempt to resolve the specified require() target. On failure report a
   /// warning at the specified location and return nullptr.
@@ -112,13 +118,32 @@ bool MetroRequireImpl::run() {
 }
 
 static constexpr unsigned kRequireIndex = 2;
+static constexpr unsigned kImportDefaultIndex = 3;
 
-void MetroRequireImpl::resolveMetroModule(Function *moduleFactoryFunction) {
+bool MetroRequireImpl::run() {
+  for (const auto &jsModuleFactoryFunc : M_->jsModuleFactoryFunctions()) {
+    // The `require` param (index 2) and the `importDefault` param (index 3) are
+    // both tracked; calls to them with a literal module id are marked so
+    // codegen can lower them to the native cached read (CallRequire /
+    // CallRequireImportDefault).
+    resolveMetroModule(
+        jsModuleFactoryFunc, kRequireIndex, /*isImportDefault*/ false);
+    resolveMetroModule(
+        jsModuleFactoryFunc, kImportDefaultIndex, /*isImportDefault*/ true);
+  }
+
+  return resolvedRequireCalls_;
+}
+
+void MetroRequireImpl::resolveMetroModule(
+    Function *moduleFactoryFunction,
+    unsigned paramIndex,
+    bool isImportDefault) {
   // Module factory functions must have enough arguments (including 'this')
-  // to make kRequireIndex a valid argument index.
-  assert(
-      moduleFactoryFunction->getJSDynamicParams().size() > kRequireIndex &&
-      "Metro module functions missing parameters");
+  // to make paramIndex a valid argument index.
+  if (moduleFactoryFunction->getJSDynamicParams().size() <= paramIndex) {
+    return;
+  }
 
   // A phi is the 'require' function iff all it's input values are.
   // But we will discover this only over time, as the different arguments
@@ -180,10 +205,10 @@ void MetroRequireImpl::resolveMetroModule(Function *moduleFactoryFunction) {
     }
   };
 
-  // Add all usages of the "require" parameter to the worklist, which then may
+  // Add all usages of the tracked parameter to the worklist, which then may
   // add more usages and so on.
   for (auto *I :
-       moduleFactoryFunction->getJSDynamicParam(kRequireIndex)->getUsers()) {
+       moduleFactoryFunction->getJSDynamicParam(paramIndex)->getUsers()) {
     assert(
         llvh::isa<LoadParamInst>(I) &&
         "Use of JSDynamicParam must be LoadParamInst");
@@ -211,7 +236,8 @@ void MetroRequireImpl::resolveMetroModule(Function *moduleFactoryFunction) {
       }
 
       if (call->getCallee() == U.V) {
-        resolveRequireCall(moduleFactoryFunction, llvh::cast<CallInst>(call));
+        resolveRequireCall(
+            moduleFactoryFunction, llvh::cast<CallInst>(call), isImportDefault);
       }
     } else if (auto *SS = llvh::dyn_cast<StoreStackInst>(U.I)) {
       // Storing "require" into a stack location.  Record that this location
@@ -299,7 +325,8 @@ void MetroRequireImpl::resolveMetroModule(Function *moduleFactoryFunction) {
 
 void MetroRequireImpl::resolveRequireCall(
     Function *moduleFactoryFunction,
-    CallInst *call) {
+    CallInst *call,
+    bool isImportDefault) {
   ++NumRequireCalls;
   constexpr unsigned kRequireArgs = 2;
   if (call->getNumArguments() < kRequireArgs) {
@@ -357,7 +384,12 @@ void MetroRequireImpl::resolveRequireCall(
     return;
   }
 
-  call->getAttributesRef(moduleFactoryFunction->getParent()).isMetroRequire = 1;
+  auto &attrs = call->getAttributesRef(moduleFactoryFunction->getParent());
+  if (isImportDefault) {
+    attrs.isMetroImportDefault = 1;
+  } else {
+    attrs.isMetroRequire = 1;
+  }
   resolvedRequireCalls_ = true;
 
   ++NumRequireCallsResolved;

--- a/lib/VM/Interpreter-internal.h
+++ b/lib/VM/Interpreter-internal.h
@@ -164,6 +164,12 @@ ExecutionStatus doCallRequireSlowPath_RJS(
     const Inst *ip,
     RuntimeModule *runtimeModule);
 
+ExecutionStatus doCallRequireImportDefaultSlowPath_RJS(
+    Runtime &runtime,
+    PinnedHermesValue *frameRegs,
+    const Inst *ip,
+    RuntimeModule *runtimeModule);
+
 ExecutionStatus doGetByIdSlowPath_RJS(
     Runtime &runtime,
     PinnedHermesValue *frameRegs,

--- a/lib/VM/Interpreter-slowpaths.cpp
+++ b/lib/VM/Interpreter-slowpaths.cpp
@@ -1415,6 +1415,35 @@ ExecutionStatus doCallRequireSlowPath_RJS(
   return ExecutionStatus::RETURNED;
 }
 
+ExecutionStatus doCallRequireImportDefaultSlowPath_RJS(
+    Runtime &runtime,
+    PinnedHermesValue *frameRegs,
+    const Inst *ip,
+    RuntimeModule *runtimeModule) {
+  uint32_t modIndex = ip->iCallRequireImportDefault.op3;
+
+  // The value should be a Callable (the importDefault helper), or else we
+  // raise.
+  const auto importDefaultFunc = Handle<>(&O2REG(CallRequireImportDefault));
+  auto importDefaultCallable = Handle<Callable>::dyn_vmcast(importDefaultFunc);
+  if (LLVM_UNLIKELY(!importDefaultCallable)) {
+    return runtime.raiseTypeErrorForValue(
+        importDefaultFunc, " is not a function");
+  }
+
+  CallResult<PseudoHandle<>> value = Callable::executeCall1(
+      importDefaultCallable,
+      runtime,
+      HandleRootOwner::getUndefinedValue(),
+      HermesValue::encodeTrustedNumberValue(modIndex));
+  if (LLVM_UNLIKELY(value == ExecutionStatus::EXCEPTION))
+    return ExecutionStatus::EXCEPTION;
+  O1REG(CallRequireImportDefault) = value->get();
+  runtimeModule->setModuleImportedDefault(
+      runtime, modIndex, Handle<>(&O1REG(CallRequireImportDefault)));
+  return ExecutionStatus::RETURNED;
+}
+
 ExecutionStatus doGetByIdSlowPath_RJS(
     Runtime &runtime,
     PinnedHermesValue *frameRegs,

--- a/lib/VM/Interpreter.cpp
+++ b/lib/VM/Interpreter.cpp
@@ -1362,6 +1362,26 @@ tailCall:
         DISPATCH;
       }
 
+      CASE(CallRequireImportDefault) {
+        uint32_t modIndex = ip->iCallRequireImportDefault.op3;
+        RuntimeModule *runtimeModule = curCodeBlock->getRuntimeModule();
+        HermesValue cached = runtimeModule->getModuleImportedDefault(modIndex);
+        if (LLVM_LIKELY(!cached.isEmpty())) {
+          // Cache hit: return the memoized importDefault value.
+          O1REG(CallRequireImportDefault) = cached;
+        } else {
+          CAPTURE_IP_ASSIGN(
+              ExecutionStatus res,
+              doCallRequireImportDefaultSlowPath_RJS(
+                  runtime, frameRegs, ip, runtimeModule));
+          if (LLVM_UNLIKELY(res == ExecutionStatus::EXCEPTION))
+            goto exception;
+          gcScope.flushToSmallCount(KEEP_HANDLES);
+        }
+        ip = NEXTINST(CallRequireImportDefault);
+        DISPATCH;
+      }
+
       CASE(GetBuiltinClosure) {
         uint8_t methodIndex = ip->iCallBuiltin.op2;
         Callable *closure = runtime.getBuiltinCallable(methodIndex);

--- a/lib/VM/RuntimeModule.cpp
+++ b/lib/VM/RuntimeModule.cpp
@@ -350,6 +350,7 @@ void RuntimeModule::markRoots(RootAcceptor &acceptor, bool markLongLived) {
   }
 
   acceptor.acceptPtr(moduleExports_);
+  acceptor.acceptPtr(moduleImportedDefaults_);
 }
 
 void RuntimeModule::markWeakRoots(
@@ -414,6 +415,13 @@ void RuntimeModule::setModuleExport(
     uint32_t modIndex,
     Handle<> modExport) {
   module_export_cache::set(runtime, moduleExports_, modIndex, modExport);
+}
+
+void RuntimeModule::setModuleImportedDefault(
+    Runtime &runtime,
+    uint32_t modIndex,
+    Handle<> value) {
+  module_export_cache::set(runtime, moduleImportedDefaults_, modIndex, value);
 }
 
 void RuntimeModule::initializeStringSwitchImmTable(


### PR DESCRIPTION
Summary:
Prototype: give Metro importDefault calls the same native cached-read treatment
as require() (CallRequire), so ESM/CJS default imports skip the JS
metroImportDefault helper (Map.get + interop) on the hot path.

- Attributes.def: new isMetroImportDefault CallInst attribute.
- MetroRequireOpt: generalized to also track the importDefault param (JSDynamic
  index 3) and mark calls with a literal module id as isMetroImportDefault.
- BytecodeList.def: new CallRequireImportDefault opcode (mirrors CallRequire).
- ISel: lower isMetroImportDefault calls to CallRequireImportDefault.
- RuntimeModule: new per-module moduleImportedDefaults_ cache (mirrors
  moduleExports_), with getter/setter and GC marking.
- Interpreter + slowpath: CallRequireImportDefault reads the memoized default
  from the native cache, falling back to calling the importDefault helper once
  and caching the result.

Semantics match today's memoized importDefault (snapshot); this is the native
equivalent, for the ~40% of WildeBundle import sites that are default imports.

NOT YET DONE (prototype): Static-Hermes native backend (StaticH.cpp /
SH.cpp / LowerCalls / LoadConstants), JIT RuntimeOffsets, and CSE handling for
the new attribute; unbuilt/untested.

Differential Revision: D111629267


