### PR TITLE
Support urlRegex in Debugger.setBreakpointByUrl

### DIFF
--- a/API/hermes/cdp/DebuggerDomainAgent.cpp
+++ b/API/hermes/cdp/DebuggerDomainAgent.cpp
@@ -21,6 +21,29 @@ using namespace facebook::hermes::debugger;
 static const char *const kBreakpointsKey = "breakpoints";
 static const char *const kBreakpointsActiveKey = "breakpointsActive";
 
+/// Compiles \p pattern (a UTF-8 regex) into Hermes regex bytecode, mirroring
+/// the compilation used for blackbox patterns. Returns std::nullopt if the
+/// pattern is invalid.
+static std::optional<std::vector<uint8_t>> compileUrlRegex(
+    const std::string &pattern) {
+  // We expect pattern to be encoded as UTF-8 in accordance with RFC-8259.
+  // See comment in CDPAgent::handleCommand.
+  std::vector<char16_t> patternUTF16;
+  ::hermes::convertUTF8WithSurrogatesToUTF16(
+      std::back_inserter(patternUTF16),
+      pattern.data(),
+      pattern.data() + pattern.size());
+
+  // Use empty regex flags (not ignore case, not multiline), matching how
+  // blackbox patterns are compiled.
+  ::hermes::regex::Regex<::hermes::regex::UTF16RegexTraits> regex{
+      patternUTF16, {}};
+  if (!regex.valid()) {
+    return std::nullopt;
+  }
+  return regex.compile();
+}
+
 DebuggerDomainAgent::DebuggerDomainAgent(
     int32_t executionContextID,
     HermesRuntime &runtime,
@@ -460,13 +483,26 @@ void DebuggerDomainAgent::setBreakpointByUrl(
 
   // TODO: getLocationByBreakpointRequest(req);
   // TODO: failure to parse
-  if (!req.url.has_value()) {
+  if (!req.url.has_value() && !req.urlRegex.has_value()) {
     sendResponseToClient(
         m::makeErrorResponse(
             req.id,
             m::ErrorCode::InvalidRequest,
-            "URL required; regex unsupported"));
+            "Either url or urlRegex must be specified"));
     return;
+  }
+
+  // Compile and validate the URL regex up front so an invalid pattern is
+  // rejected before any breakpoint is created.
+  std::optional<std::vector<uint8_t>> compiledUrlRegex;
+  if (req.urlRegex.has_value()) {
+    compiledUrlRegex = compileUrlRegex(req.urlRegex.value());
+    if (!compiledUrlRegex.has_value()) {
+      sendResponseToClient(
+          m::makeErrorResponse(
+              req.id, m::ErrorCode::InvalidParams, "Invalid regex pattern"));
+      return;
+    }
   }
 
   // Create the CDP breakpoint
@@ -474,9 +510,10 @@ void DebuggerDomainAgent::setBreakpointByUrl(
   description.line = req.lineNumber;
   description.column = req.columnNumber;
   description.condition = req.condition;
-  const std::string &url = req.url.value();
-  description.url = url;
+  description.url = req.url;
+  description.urlRegex = req.urlRegex;
   auto [breakpointID, breakpoint] = createCDPBreakpoint(std::move(description));
+  breakpoint.compiledUrlRegex = std::move(compiledUrlRegex);
 
   // Create the response
   m::debugger::SetBreakpointByUrlResponse resp;
@@ -484,9 +521,11 @@ void DebuggerDomainAgent::setBreakpointByUrl(
   resp.breakpointId = std::to_string(breakpointID);
 
   // Apply the breakpoint to all matching scripts that are already present,
-  // populating the response with any successful applications.
+  // populating the response with any successful applications. If no scripts
+  // match yet, the breakpoint remains pending and is applied later via
+  // processScript when a matching script loads.
   for (auto &srcLoc : runtime_.getDebugger().getLoadedScripts()) {
-    if (srcLoc.fileName == url) {
+    if (scriptMatchesBreakpoint(breakpoint, srcLoc)) {
       if (std::optional<HermesBreakpointLocation> hermesBreakpoint =
               applyBreakpoint(breakpoint, srcLoc.fileId)) {
         resp.locations.emplace_back(
@@ -776,11 +815,53 @@ void DebuggerDomainAgent::processScript(
     const debugger::SourceLocation &srcLoc) {
   sendScriptParsedNotificationToClient(srcLoc);
   for (auto &[cdpBreakpointID, cdpBreakpoint] : cdpBreakpoints_) {
-    if (srcLoc.fileName == cdpBreakpoint.description.url) {
+    if (scriptMatchesBreakpoint(cdpBreakpoint, srcLoc)) {
       applyBreakpointAndSendNotification(
           cdpBreakpointID, cdpBreakpoint, srcLoc);
     }
   }
+}
+
+bool DebuggerDomainAgent::scriptMatchesBreakpoint(
+    CDPBreakpoint &breakpoint,
+    const debugger::SourceLocation &srcLoc) {
+  const CDPBreakpointDescription &description = breakpoint.description;
+
+  if (description.url.has_value()) {
+    return srcLoc.fileName == description.url.value();
+  }
+
+  if (!description.urlRegex.has_value()) {
+    return false;
+  }
+
+  // Lazily compile and cache the regex bytecode. After a reload the breakpoint
+  // is reconstructed from its description, so the cache may be empty here.
+  if (!breakpoint.compiledUrlRegex.has_value()) {
+    breakpoint.compiledUrlRegex = compileUrlRegex(description.urlRegex.value());
+    if (!breakpoint.compiledUrlRegex.has_value()) {
+      return false;
+    }
+  }
+
+  // We expect fileName to be encoded as UTF-8 in accordance with RFC-8259.
+  // See comment in CDPAgent::handleCommand.
+  std::vector<char16_t> fileNameUTF16;
+  ::hermes::convertUTF8WithSurrogatesToUTF16(
+      std::back_inserter(fileNameUTF16),
+      srcLoc.fileName.data(),
+      srcLoc.fileName.data() + srcLoc.fileName.size());
+
+  uint32_t searchStart = 0;
+  std::vector<::hermes::regex::CapturedRange> captures{};
+  return ::hermes::regex::searchWithBytecode(
+             *breakpoint.compiledUrlRegex,
+             fileNameUTF16.data(),
+             searchStart,
+             fileNameUTF16.size(),
+             &captures,
+             ::hermes::regex::constants::MatchFlagType::matchDefault) ==
+      ::hermes::regex::MatchRuntimeResult::Match;
 }
 
 } // namespace cdp

--- a/API/hermes/cdp/DebuggerDomainAgent.h
+++ b/API/hermes/cdp/DebuggerDomainAgent.h
@@ -41,18 +41,20 @@ struct CDPBreakpointDescription : public StateValue {
     value->column = column;
     value->condition = condition;
     value->url = url;
+    value->urlRegex = urlRegex;
     return value;
   }
 
   /// Determines whether this breakpoint can be persisted across sessions
   bool persistable() const {
     // Only persist breakpoints that can apply to future scripts (i.e.
-    // breakpoints set on a set of files specified by script URL, not
-    // breakpoints set on an exact, session-specific script ID).
-    return url.has_value();
+    // breakpoints set on a set of files specified by script URL or URL regex,
+    // not breakpoints set on an exact, session-specific script ID).
+    return url.has_value() || urlRegex.has_value();
   }
 
   std::optional<std::string> url;
+  std::optional<std::string> urlRegex;
   long long line;
   std::optional<long long> column;
   std::optional<std::string> condition;
@@ -69,6 +71,10 @@ struct CDPBreakpoint {
 
   // Registered breakpoints in Hermes
   std::vector<HermesBreakpoint> hermesBreakpoints;
+
+  // Lazily-compiled bytecode for description.urlRegex. Cached in memory only
+  // (not persisted); recompiled from description.urlRegex after a reload.
+  std::optional<std::vector<uint8_t>> compiledUrlRegex;
 };
 
 struct HermesBreakpointLocation {
@@ -209,6 +215,13 @@ class DebuggerDomainAgent : public DomainAgent {
   std::optional<HermesBreakpointLocation> applyBreakpoint(
       CDPBreakpoint &cdpBreakpoint,
       debugger::ScriptID scriptID);
+
+  /// Determines whether the script at \p srcLoc matches \p breakpoint, either
+  /// by exact URL or by the breakpoint's URL regex. Lazily compiles and caches
+  /// the URL regex bytecode on \p breakpoint.
+  bool scriptMatchesBreakpoint(
+      CDPBreakpoint &breakpoint,
+      const debugger::SourceLocation &srcLoc);
 
   /// Holds a boolean that determines if scripts without a script url
   /// (e.g. anonymous scripts) should be blackboxed.

--- a/unittests/API/CDPAgentTest.cpp
+++ b/unittests/API/CDPAgentTest.cpp
@@ -3283,6 +3283,182 @@ TEST_F(CDPAgentTest, DebuggerBreakpointsPauseVMAfterDomainReload) {
   ensurePaused(waitForMessage(), "other", {{"global", 5, 0}});
 }
 
+TEST_F(CDPAgentTest, DebuggerSetBreakpointByUrlRegexPending) {
+  int msgId = 1;
+  sendAndCheckResponse("Debugger.enable", msgId++);
+
+  // A regex breakpoint is accepted and held as a pending breakpoint, returning
+  // a valid breakpoint id with no resolved locations (no script is loaded that
+  // it could bind to).
+  sendRequest(
+      "Debugger.setBreakpointByUrl", msgId, [](::hermes::JSONEmitter &json) {
+        json.emitKeyValue("urlRegex", ".*");
+        json.emitKeyValue("lineNumber", 1);
+        json.emitKeyValue("columnNumber", 0);
+      });
+  ensureSetBreakpointByUrlResponse(waitForMessage(), msgId++, {});
+}
+
+TEST_F(CDPAgentTest, DebuggerSetBreakpointByUrlRequiresUrlOrRegex) {
+  int msgId = 1;
+  sendAndCheckResponse("Debugger.enable", msgId++);
+
+  // A setBreakpointByUrl request with neither url nor urlRegex is rejected.
+  sendRequest(
+      "Debugger.setBreakpointByUrl", msgId, [](::hermes::JSONEmitter &json) {
+        json.emitKeyValue("lineNumber", 1);
+        json.emitKeyValue("columnNumber", 0);
+      });
+  ensureErrorResponse(waitForMessage(), msgId++);
+}
+
+TEST_F(CDPAgentTest, DebuggerSetBreakpointByUrlRegexResolves) {
+  int msgId = 1;
+  sendAndCheckResponse("Debugger.enable", msgId++);
+
+  scheduleScript(
+      R"(
+    var a = 1 + 2;
+    debugger;      // line 2
+    var b = a / 2; // line 3 - regex breakpoint resolves here
+  )",
+      "http://example.com/foo.js");
+  expectNotification("Debugger.scriptParsed");
+
+  // Hit the debugger statement on line 2.
+  ensurePaused(waitForMessage(), "other", {{"global", 2, 1}});
+
+  // A URL regex with metacharacters (escaped `.`, end anchor) matches the
+  // loaded script's url and binds immediately, resolving to a location on
+  // line 3.
+  sendRequest(
+      "Debugger.setBreakpointByUrl", msgId, [](::hermes::JSONEmitter &json) {
+        json.emitKeyValue("urlRegex", "foo\\.js$");
+        json.emitKeyValue("lineNumber", 3);
+        json.emitKeyValue("columnNumber", 0);
+      });
+  ensureSetBreakpointByUrlResponse(waitForMessage(), msgId++, {{3}});
+
+  // Resume and hit the regex breakpoint on line 3.
+  sendAndCheckResponse("Debugger.resume", msgId++);
+  ensureNotification(waitForMessage(), "Debugger.resumed");
+  ensurePaused(waitForMessage(), "other", {{"global", 3, 1}});
+
+  sendAndCheckResponse("Debugger.resume", msgId++);
+  ensureNotification(waitForMessage(), "Debugger.resumed");
+
+  waitForScheduledScripts();
+}
+
+TEST_F(CDPAgentTest, DebuggerSetBreakpointByUrlRegexResolvesOnMatchingScript) {
+  int msgId = 1;
+  sendAndCheckResponse("Debugger.enable", msgId++);
+
+  // A pending regex breakpoint that only matches script urls containing
+  // "Match".
+  sendRequest(
+      "Debugger.setBreakpointByUrl", msgId, [](::hermes::JSONEmitter &json) {
+        json.emitKeyValue("urlRegex", "Match");
+        json.emitKeyValue("lineNumber", 2);
+        json.emitKeyValue("columnNumber", 0);
+      });
+  ensureSetBreakpointByUrlResponse(waitForMessage(), msgId++, {});
+
+  // A script whose url does not match the regex: no breakpointResolved.
+  scheduleScript(
+      R"(
+        var a = 1;
+        var b = 2;
+        var c = a + b;
+  )",
+      "OtherFile");
+  expectNotification("Debugger.scriptParsed");
+  expectNothing();
+
+  // A script whose url matches the regex: breakpoint resolves to line 2.
+  scheduleScript(
+      R"(
+        var x = 1;
+        var y = 2;
+        var z = x + y;
+  )",
+      "MatchFile");
+  auto parsed = expectNotification("Debugger.scriptParsed");
+  auto scriptId = jsonScope_.getString(parsed, {"params", "scriptId"});
+  auto resolution = expectNotification("Debugger.breakpointResolved");
+  EXPECT_EQ(
+      jsonScope_.getString(resolution, {"params", "location", "scriptId"}),
+      scriptId);
+  EXPECT_EQ(
+      jsonScope_.getNumber(resolution, {"params", "location", "lineNumber"}),
+      2);
+
+  // Line 2 runs at top level, so the VM pauses on the resolved breakpoint.
+  ensurePaused(waitForMessage(), "other", {{"global", 2, 1}});
+  sendAndCheckResponse("Debugger.resume", msgId++);
+  ensureNotification(waitForMessage(), "Debugger.resumed");
+
+  waitForScheduledScripts();
+}
+
+TEST_F(CDPAgentTest, DebuggerSetBreakpointByUrlRegexInvalid) {
+  int msgId = 1;
+  sendAndCheckResponse("Debugger.enable", msgId++);
+
+  // An invalid regex pattern is rejected.
+  sendRequest(
+      "Debugger.setBreakpointByUrl", msgId, [](::hermes::JSONEmitter &json) {
+        json.emitKeyValue("urlRegex", "(");
+        json.emitKeyValue("lineNumber", 1);
+        json.emitKeyValue("columnNumber", 0);
+      });
+  ensureErrorResponse(waitForMessage(), msgId++);
+}
+
+TEST_F(CDPAgentTest, DebuggerRestoreStateRegex) {
+  int msgId = 1;
+
+  // Create a regex breakpoint that will be persisted across reload.
+  sendAndCheckResponse("Debugger.enable", msgId++);
+  sendRequest(
+      "Debugger.setBreakpointByUrl", msgId, [](::hermes::JSONEmitter &json) {
+        json.emitKeyValue("urlRegex", "rl");
+        json.emitKeyValue("lineNumber", 3);
+        json.emitKeyValue("columnNumber", 0);
+      });
+  ensureSetBreakpointByUrlResponse(waitForMessage(), msgId++, {});
+
+  for (int i = 0; i < 2; i++) {
+    if (i == 0) {
+      // Save CDPAgent state on non-runtime thread and shut everything down.
+      preserveStateAndResetTestEnv(false);
+    } else {
+      // Save CDPAgent state on the runtime thread and shut everything down.
+      preserveStateAndResetTestEnv(true);
+    }
+
+    sendAndCheckResponse("Debugger.enable", msgId++);
+    scheduleScript(R"(
+      var a = 1 + 2;
+      var b = a / 2;
+      var c = a + b; // (line 3) hit breakpoint
+      var d = b - c;
+    )");
+    ensureNotification(waitForMessage(), "Debugger.scriptParsed");
+
+    // The persisted regex breakpoint recompiles from its description and binds
+    // to the newly loaded script.
+    auto resolution = expectNotification("Debugger.breakpointResolved");
+    auto resolvedLineNumber =
+        jsonScope_.getNumber(resolution, {"params", "location", "lineNumber"});
+    EXPECT_EQ(resolvedLineNumber, 3);
+    ensurePaused(waitForMessage(), "other", {{"global", 3, 1}});
+
+    sendAndCheckResponse("Debugger.resume", msgId++);
+    ensureNotification(waitForMessage(), "Debugger.resumed");
+  }
+}
+
 TEST_F(CDPAgentTest, DebuggerRestoreState) {
   int msgId = 1;
 


### PR DESCRIPTION
Summary:
**Motivation**: CDP spec / VS Code debugging compatibility.

Hermes' CDP `Debugger.setBreakpointByUrl` rejected any request that used `urlRegex` outright ("URL required; regex unsupported"). This forced clients to work around it: VS Code (via Expo's `VscodeDebuggerSetBreakpointByUrlHandler`) rewrites such requests to a deliberately non-matching `url` so Hermes creates an unbound breakpoint with a valid id, then rebinds it later via `Debugger.setBreakpoint` once the source map loads.

https://github.com/expo/expo/blob/f0387301e9d711bc0f0a4444c6b9c2351b06b855/packages/%40expo/cli/src/start/server/metro/debugging/messageHandlers/VscodeDebuggerSetBreakpointByUrl.ts#L18-L26

This diff makes Hermes accept and resolve `urlRegex` requests natively. Clients no longer need the `Debugger.setBreakpoint` rebind workaround — a regex breakpoint binds against matching scripts on its own and emits `Debugger.breakpointResolved`.

**Changes**
- `setBreakpointByUrl` now requires either `url` or `urlRegex` to be present, and stores whichever locator was provided on the `CDPBreakpointDescription`. A regex breakpoint persists across reload (`persistable()` now covers `urlRegex`).
- Match scripts against a breakpoint by URL regex as well as exact URL. A new `scriptMatchesBreakpoint` helper centralizes the decision used by both `setBreakpointByUrl` (already-loaded scripts) and `processScript` (scripts loaded later).
- Compile the pattern with Hermes' own UTF-16 bytecode regex engine — the same machinery already used for `Debugger.setBlackboxPatterns` — and match with `searchWithBytecode`. The compiled bytecode is cached in memory on the `CDPBreakpoint` and lazily recompiled from `description.urlRegex` after a reload (it is not persisted).
- Reject an invalid regex pattern up front with `InvalidParams` ("Invalid regex pattern") before any breakpoint is created.

Differential Revision: D116627527


