### PR TITLE
Prepare fixes for Hermes 250829098.0.17

### DIFF
--- a/API/jsi/jsi/test/testlib.cpp
+++ b/API/jsi/jsi/test/testlib.cpp
@@ -1095,7 +1095,8 @@ namespace {
 
 unsigned countOccurences(const std::string& of, const std::string& in) {
   unsigned occurences = 0;
-  std::string::size_type lastOccurence = -1;
+  std::string::size_type lastOccurence =
+      static_cast<std::string::size_type>(-1);
   while ((lastOccurence = in.find(of, lastOccurence + 1)) !=
          std::string::npos) {
     occurences++;

--- a/include/hermes/IR/IR.h
+++ b/include/hermes/IR/IR.h
@@ -1836,6 +1836,11 @@ class VariableScope
     return children_;
   }
 
+  /// \return whether assignIndexToVariables() has been called already.
+  bool hasAssignedIndices() const {
+    return numVisibleVariables_ != UINT32_MAX;
+  }
+
   /// \return the number of variables that are visible in this scope.
   /// The first numVisibleVariables in this VariableScope are visible to the
   /// debugger.
@@ -2516,7 +2521,25 @@ class Module : public Value {
   FunctionListType compiledFunctions_{};
 
   /// List of all the VariableScopes owned by this module.
+  ///
+  /// Invariant: VariableScopes at the start of the list have Variables with
+  /// assigned indices, while VariableScopes at the end of the list have
+  /// Variables with unassigned indices. New VariableScopes are never added to
+  /// the middle of the list, but they may be deleted from the middle of the
+  /// list without violating the invariant.
   VariableScopeListType variableScopes_{};
+
+  /// List of VariableScopes that may have no users, letting lazy
+  /// compilation reclaim dead scopes without rescanning all of variableScopes_.
+  ///
+  /// Invariant: every user-less scope is a member, so no dead scope is missed.
+  /// Membership does not imply user-less, so entries are re-checked before
+  /// deletion.
+  /// Maintained by addVariableScope() (new scopes) and
+  /// markVariableScopeAsMaybeDead() (last user removed).
+  /// Once it's iterated, this list is cleared but a VariableScope may be
+  /// re-added by one of the above mechanisms.
+  llvh::SmallPtrSet<VariableScope *, 16> maybeDeadVariableScopes_{};
 
   GlobalObject globalObject_{};
   LiteralEmpty literalEmpty{};
@@ -2669,12 +2692,32 @@ class Module : public Value {
     return topLevelFunction_;
   }
 
-  /// Get the list of variable scopes owned by this module.
+  /// \return the list of variable scopes owned by this module.
+  /// NOTE: DO NOT append or remove from the returned list.
+  /// ONLY use addVariableScope and destroyVariableScope for that.
   VariableScopeListType &getVariableScopes() {
     return variableScopes_;
   }
+  /// \return the list of variable scopes owned by this module.
+  /// NOTE: DO NOT append or remove from the returned list.
+  /// ONLY use addVariableScope and destroyVariableScope for that.
   const VariableScopeListType &getVariableScopes() const {
     return variableScopes_;
+  }
+
+  /// Add a VariableScope owned by this Module.
+  void addVariableScope(VariableScope *varScope) {
+    variableScopes_.push_back(varScope);
+    maybeDeadVariableScopes_.insert(varScope);
+  }
+
+  /// Remove and destroy a VariableScope owned by this Module.
+  /// \pre \p variableScope has no users.
+  void destroyVariableScope(VariableScope *varScope);
+
+  /// Remember that a VariableScope lost its last user.
+  void markVariableScopeAsMaybeDead(VariableScope *varScope) {
+    maybeDeadVariableScopes_.insert(varScope);
   }
 
   OptimizationContext &getOptimizationContext() {
@@ -2684,10 +2727,19 @@ class Module : public Value {
     return optContext_;
   }
 
-  /// Assign index to all Variables in all VariableScopes.
+  /// Assign indices to Variables in newly-created VariableScopes.
   void assignIndexToVariables() {
-    for (VariableScope &varScope : variableScopes_)
-      varScope.assignIndexToVariables();
+    // Iterate variableScopes_ backwards, and stop at the first one that has
+    // already been assigned indices. This prevents rescanning VariableScopes
+    // unnecessarily and causing slowdown.
+    // See the invariant on variableScopes_ for why this works.
+    for (auto it = variableScopes_.rbegin(); it != variableScopes_.rend();
+         ++it) {
+      VariableScope *varScope = &*it;
+      if (varScope->hasAssignedIndices())
+        break;
+      varScope->assignIndexToVariables();
+    }
   }
 
   /// Create the specified global property if it doesn't exist. If it does

--- a/include/hermes/VM/Debugger/Debugger.h
+++ b/include/hermes/VM/Debugger/Debugger.h
@@ -618,6 +618,10 @@ class Debugger {
     auto aLoc = getLocationForState(a);
     auto bLoc = getLocationForState(b);
 
+    // Locations may be missing (null codeBlock or no debug info).
+    if (!aLoc.hasValue() || !bLoc.hasValue())
+      return false;
+
     // Same statement in the same codeBlock, but different offsets.
     return a.codeBlock == b.codeBlock && aLoc->statement == bLoc->statement &&
         a.offset != b.offset;
@@ -625,6 +629,8 @@ class Debugger {
 
   OptValue<hbc::DebugSourceLocation> getLocationForState(
       const InterpreterState &state) const {
+    if (state.codeBlock == nullptr)
+      return llvh::None;
     return state.codeBlock->getSourceLocation(state.offset);
   }
 

--- a/include/hermes/VM/Debugger/Debugger.h
+++ b/include/hermes/VM/Debugger/Debugger.h
@@ -165,8 +165,10 @@ class Debugger {
   OptValue<StepMode> curStepMode_{llvh::None};
 
   /// If not None, the debugger is attempting to find a place to break after an
-  /// AsyncTrigger, and the PauseReason should be set to this value instead of
-  /// StepFinish.
+  /// AsyncTrigger, and the pause it eventually reaches is reported with this
+  /// reason rather than StepFinish. Finishing a step takes priority: this is
+  /// cleared only where it is consumed, so a pause that abandons the trigger
+  /// leaves it set and it may be stale.
   OptValue<PauseReason> asyncTriggerPauseReason_{llvh::None};
 
   /// If true, all code blocks are breakpointed,
@@ -627,6 +629,9 @@ class Debugger {
         a.offset != b.offset;
   }
 
+  /// \return the source location of \p state, or None if \p state has no
+  /// CodeBlock (as in a default-constructed InterpreterState) or its CodeBlock
+  /// has no debug info at that offset.
   OptValue<hbc::DebugSourceLocation> getLocationForState(
       const InterpreterState &state) const {
     if (state.codeBlock == nullptr)

--- a/include/hermes/VM/Runtime.h
+++ b/include/hermes/VM/Runtime.h
@@ -107,6 +107,18 @@ class SamplingProfiler;
 class JSArray;
 #endif
 
+/// Wrap \p code in a source Buffer suitable for compiling with \p compileFlags.
+/// When the resulting module will retain its source buffer -- i.e. lazy or
+/// full-debug-info compilation, matching keepCompilationData in
+/// createBCProviderFromSrc -- the bytes are copied so the buffer owns them.
+/// Otherwise they are borrowed from \p code, which is safe because the buffer
+/// is dropped once compilation finishes. Copying in the retained case avoids a
+/// use-after-free when \p code does not outlive the module (e.g. a transient
+/// eval or debugger command string).
+std::unique_ptr<Buffer> makeCompilationSourceBuffer(
+    llvh::StringRef code,
+    const hbc::CompileFlags &compileFlags);
+
 /// Number of stack words after the top of frame that we always ensure are
 /// available. This is necessary so we can perform native calls with small
 /// number of arguments without checking.

--- a/include/hermes/VM/detail/IdentifierHashTable.h
+++ b/include/hermes/VM/detail/IdentifierHashTable.h
@@ -56,8 +56,18 @@ class IdentifierHashTable {
     return cap - (cap >> 2) < nonEmptyEntryCount_;
   }
 
-  /// Grow the hash table and rehash with \p newCapacity.
+  /// Grow the hash table to \p newCapacity and rehash into it. Aborts unless
+  /// \p newCapacity is strictly greater than the current capacity; this also
+  /// guards against a wrapped-around computation in the caller (e.g. an
+  /// overflowing capacity() * 2 or NextPowerOf2()).
   void growAndRehash(uint32_t newCapacity);
+
+  /// Rehash all valid entries into a freshly allocated table of \p newCapacity,
+  /// dropping deleted entries. \p newCapacity must be a power of two that is
+  /// greater than or equal to the current capacity. Unlike growAndRehash() an
+  /// equal capacity is allowed (in-place compaction), so this must not be used
+  /// where an overflow check is required.
+  void rehash(uint32_t newCapacity);
 
   /// HashIteratorWrapper is a thin wrapper around char* and char16_t*
   /// to make sure that when iterating on it, *itr always return a

--- a/lib/IR/IR.cpp
+++ b/lib/IR/IR.cpp
@@ -388,6 +388,10 @@ void Instruction::setOperand(Value *Val, unsigned Index) {
   // Remove the current instruction from the old value that we are removing.
   if (CurrentValue) {
     CurrentValue->removeUse(Operands[Index]);
+    if (auto *variableScope = llvh::dyn_cast<VariableScope>(CurrentValue);
+        variableScope && !variableScope->hasUsers()) {
+      getModule()->markVariableScopeAsMaybeDead(variableScope);
+    }
   }
 
   // Register this instruction as a user of the new value and set the operand.
@@ -772,6 +776,12 @@ void Module::insert(iterator position, Function *F) {
   FunctionList.insert(position, F);
 }
 
+void Module::destroyVariableScope(VariableScope *varScope) {
+  assert(!varScope->hasUsers() && "cannot destroy a varScope with users");
+  maybeDeadVariableScopes_.erase(varScope);
+  variableScopes_.erase(*varScope);
+}
+
 void Module::populateCJSModuleUseGraph() {
   if (!cjsModuleUseGraph_.empty()) {
     return;
@@ -957,15 +967,17 @@ void Module::resetForMoreCompilation() {
   // its variables.
   // Don't delete any unused variables from VariableScopes here, because they
   // may be captured in the future.
-  for (auto it = variableScopes_.begin(); it != variableScopes_.end();) {
-    if (it->hasUsers()) {
-      // Skip VariableScopes with users.
-      ++it;
-    } else {
-      // If no users, delete the VariableScope.
-      it->removeFromScopeChain();
-      variableScopes_.erase(it++);
-    }
+  // We do iterate the SmallPtrSet here but the order doesn't matter.
+  llvh::SmallVector<VariableScope *, 16> deadVariableScopes{};
+  for (VariableScope *varScope : maybeDeadVariableScopes_) {
+    if (!varScope->hasUsers())
+      deadVariableScopes.push_back(varScope);
+  }
+  maybeDeadVariableScopes_.clear();
+  // Delete the VariableScopes with no users.
+  for (VariableScope *varScope : deadVariableScopes) {
+    varScope->removeFromScopeChain();
+    destroyVariableScope(varScope);
   }
 }
 

--- a/lib/IR/IRBuilder.cpp
+++ b/lib/IR/IRBuilder.cpp
@@ -177,7 +177,7 @@ Variable *IRBuilder::createVariable(
 
 VariableScope *IRBuilder::createVariableScope(VariableScope *parentScope) {
   auto *newScope = new VariableScope(parentScope);
-  M->getVariableScopes().push_back(newScope);
+  M->addVariableScope(newScope);
   return newScope;
 }
 

--- a/lib/Optimizer/Scalar/LowerGeneratorFunction.cpp
+++ b/lib/Optimizer/Scalar/LowerGeneratorFunction.cpp
@@ -200,6 +200,14 @@ void LowerToStateMachine::convert() {
   auto *valueParam =
       builder_.createJSDynamicParam(inner_, builder_.createIdentifier("value"));
   movePastFirstInBlock(builder_, &*inner_->begin());
+  // Reset the leaked user source location so the synthetic resume prologue is
+  // not mistaken for real user code (e.g. a breakpoint on that line resolving
+  // here). Use the inner function's own declaration location rather than "no
+  // location": it matches a normal function's prologue and the sibling
+  // scaffolding (getParentOuterScope_), and gives the executing-generator
+  // TypeError thrown from this entry dispatch a real line in stack traces
+  // rather than a raw-address fallback.
+  builder_.setLocation(inner_->getSourceRange().Start);
   auto *loadActionParam = builder_.createLoadParamInst(actionParam);
   auto *loadValueParam = builder_.createLoadParamInst(valueParam);
 
@@ -614,6 +622,9 @@ void LowerToStateMachine::lowerToSwitch(
   auto *throwBecauseExecutingBB = builder_.createBasicBlock(inner_);
   auto *checkIfCompletedBB = builder_.createBasicBlock(inner_);
   builder_.setInsertionBlock(newBeginBB);
+  // Don't leak a user source line onto the synthetic entry dispatch; this
+  // location persists through the scaffolding created below.
+  builder_.setLocation(inner_->getSourceRange().Start);
 
   auto *loadState =
       builder_.createLoadFrameInst(getParentOuterScope_, genState);
@@ -851,6 +862,9 @@ void LowerToStateMachine::lowerToSwitch(
   }
 
   builder_.setInsertionBlock(userCodeSwitchBB);
+  // The user-block loop above left a user source line on the builder; reset it
+  // so the synthetic dispatch/catch scaffolding isn't taken for user code.
+  builder_.setLocation(inner_->getSourceRange().Start);
   builder_.createStoreFrameInst(
       getParentOuterScope_,
       builder_.getLiteralNumber((uint8_t)State::Executing),

--- a/lib/Optimizer/Scalar/Utils.cpp
+++ b/lib/Optimizer/Scalar/Utils.cpp
@@ -203,7 +203,8 @@ bool deleteUnusedVariables(Module *M) {
       // but may still have users in dead functions, so just move them to the
       // parent and leave it to function DCE to eliminate their usage.
       it->removeFromScopeChain();
-      scopeList.erase(it++);
+      VariableScope *varScope = &*it++;
+      M->destroyVariableScope(varScope);
       continue;
     }
 

--- a/lib/VM/Debugger/Debugger.cpp
+++ b/lib/VM/Debugger/Debugger.cpp
@@ -464,7 +464,11 @@ CallResult<bool> Debugger::runUntilValidPauseLocation(InterpreterState &state) {
       // We're stepping out now.
       breakpointCaller(/*forRestorationBreakpoint*/ false);
       pauseOnAllCodeBlocks_ = true;
-      curStepMode_ = StepMode::Out;
+      // Only convert an in-progress step to a step out. This is also reached
+      // while looking for a pause location for an AsyncTrigger, where there is
+      // no step to convert and preStepState_ holds no meaningful value.
+      if (curStepMode_)
+        curStepMode_ = StepMode::Out;
       isDebugging_ = false;
       return false;
     }

--- a/lib/VM/JSLib/eval.cpp
+++ b/lib/VM/JSLib/eval.cpp
@@ -58,14 +58,8 @@ CallResult<HermesValue> evalInEnvironment(
 
   std::unique_ptr<hbc::BCProvider> bytecode;
   {
-    std::unique_ptr<hermes::Buffer> buffer;
-    if (compileFlags.lazy) {
-      buffer.reset(new hermes::OwnedMemoryBuffer(
-          llvh::MemoryBuffer::getMemBufferCopy(utf8code)));
-    } else {
-      buffer.reset(new hermes::OwnedMemoryBuffer(
-          llvh::MemoryBuffer::getMemBuffer(utf8code)));
-    }
+    std::unique_ptr<hermes::Buffer> buffer =
+        makeCompilationSourceBuffer(utf8code, compileFlags);
 
     if (codeBlock) {
       assert(

--- a/lib/VM/Runtime.cpp
+++ b/lib/VM/Runtime.cpp
@@ -1020,18 +1020,28 @@ static CallResult<HermesValue> interpretFunctionWithRandomStack(
   return runtime.interpretFunction(globalCode);
 }
 
+std::unique_ptr<Buffer> makeCompilationSourceBuffer(
+    llvh::StringRef code,
+    const hbc::CompileFlags &compileFlags) {
+  // The compiled module retains its source buffer when compiling lazily or with
+  // full debug info (see keepCompilationData in BCProviderFromSrc), so in those
+  // cases the buffer must own its bytes: `code` may not outlive the module (for
+  // example a transient eval or debugger command string). Otherwise the buffer
+  // is dropped after compilation, so borrowing `code` is safe.
+  if (compileFlags.lazy || compileFlags.debug) {
+    return std::make_unique<OwnedMemoryBuffer>(
+        llvh::MemoryBuffer::getMemBufferCopy(code));
+  }
+  return std::make_unique<OwnedMemoryBuffer>(
+      llvh::MemoryBuffer::getMemBuffer(code));
+}
+
 CallResult<HermesValue> Runtime::run(
     llvh::StringRef code,
     llvh::StringRef sourceURL,
     const hbc::CompileFlags &compileFlags) {
-  std::unique_ptr<hermes::Buffer> buffer;
-  if (compileFlags.lazy) {
-    buffer.reset(new hermes::OwnedMemoryBuffer(
-        llvh::MemoryBuffer::getMemBufferCopy(code)));
-  } else {
-    buffer.reset(
-        new hermes::OwnedMemoryBuffer(llvh::MemoryBuffer::getMemBuffer(code)));
-  }
+  std::unique_ptr<hermes::Buffer> buffer =
+      makeCompilationSourceBuffer(code, compileFlags);
   return run(std::move(buffer), sourceURL, compileFlags);
 }
 

--- a/lib/VM/detail/IdentifierHashTable.cpp
+++ b/lib/VM/detail/IdentifierHashTable.cpp
@@ -125,7 +125,13 @@ void IdentifierHashTable::insert(uint32_t idx, SymbolID id) {
   ++nonEmptyEntryCount_;
 
   if (shouldGrow()) {
-    growAndRehash(capacity() * 2);
+    if (size_ >= (capacity() >> 2)) {
+      growAndRehash(capacity() * 2);
+    } else {
+      // The load factor is dominated by deleted entries, not live ones.
+      // Compact in place at the current capacity instead of growing.
+      rehash(capacity());
+    }
   }
 }
 
@@ -138,10 +144,17 @@ void IdentifierHashTable::remove(const StringPrimitive *str) {
 }
 
 void IdentifierHashTable::growAndRehash(uint32_t newCapacity) {
-  // Guard against potential overflow in the calculation of new capacity.
+  // A new capacity that is not strictly greater than the current one means the
+  // caller's computation overflowed (e.g. capacity() * 2 or NextPowerOf2()
+  // wrapped around), so there is no room to actually grow.
   if (LLVM_UNLIKELY(newCapacity <= capacity())) {
     hermes_fatal("too many identifiers created");
   }
+  rehash(newCapacity);
+}
+
+void IdentifierHashTable::rehash(uint32_t newCapacity) {
+  assert(newCapacity >= capacity() && "rehash must not shrink the table");
   assert(llvh::isPowerOf2_32(newCapacity) && "capacity must be power of 2");
   CompactTable tmpTable(newCapacity, table_.getCurrentScale());
   tmpTable.swap(table_);

--- a/test/BCGen/HBC/async-function.js
+++ b/test/BCGen/HBC/async-function.js
@@ -267,7 +267,7 @@ var simpleAsyncFE = async function () {
 // CHECK-NEXT:2: start = L3, end = L5, target = L5
 
 // CHECK:Function<?anon_0_simpleAwait>(1 params, 21 registers, 0 numbers, 0 non-pointers):
-// CHECK-NEXT:Offset in debug table: source 0x003d
+// CHECK-NEXT:Offset in debug table: source 0x0045
 // CHECK-NEXT:    LoadParam         r3, 2
 // CHECK-NEXT:    LoadParam         r4, 1
 // CHECK-NEXT:    GetParentEnvironment r2, 0
@@ -397,7 +397,7 @@ var simpleAsyncFE = async function () {
 // CHECK-NEXT:4: start = L6, end = L8, target = L8
 
 // CHECK:Function<?anon_0_simpleAsyncFE>(1 params, 21 registers, 0 numbers, 0 non-pointers):
-// CHECK-NEXT:Offset in debug table: source 0x005c
+// CHECK-NEXT:Offset in debug table: source 0x0064
 // CHECK-NEXT:    LoadParam         r3, 2
 // CHECK-NEXT:    LoadParam         r4, 1
 // CHECK-NEXT:    GetParentEnvironment r2, 0
@@ -547,23 +547,27 @@ var simpleAsyncFE = async function () {
 // CHECK-NEXT:  0x0028  function idx 3, starts at line 19 col 21
 // CHECK-NEXT:    bc 33: line 19 col 21
 // CHECK-NEXT:  0x0030  function idx 7, starts at line 10 col 1
+// CHECK-NEXT:    bc 43: line 10 col 1
 // CHECK-NEXT:    bc 121: line 11 col 3
-// CHECK-NEXT:  0x003d  function idx 8, starts at line 14 col 1
-// CHECK-NEXT:    bc 43: line 15 col 11
+// CHECK-NEXT:    bc 157: line 10 col 1
+// CHECK-NEXT:    bc 178: line 10 col 1
+// CHECK-NEXT:    bc 220: line 10 col 1
+// CHECK-NEXT:  0x0045  function idx 8, starts at line 14 col 1
+// CHECK-NEXT:    bc 43: line 14 col 1
 // CHECK-NEXT:    bc 131: line 16 col 3
 // CHECK-NEXT:    bc 150: line 15 col 11
 // CHECK-NEXT:    bc 169: line 15 col 11
 // CHECK-NEXT:    bc 255: line 15 col 11
-// CHECK-NEXT:    bc 291: line 15 col 11
-// CHECK-NEXT:    bc 312: line 15 col 11
-// CHECK-NEXT:    bc 354: line 15 col 11
-// CHECK-NEXT:  0x005c  function idx 9, starts at line 19 col 21
-// CHECK-NEXT:    bc 43: line 20 col 11
+// CHECK-NEXT:    bc 291: line 14 col 1
+// CHECK-NEXT:    bc 312: line 14 col 1
+// CHECK-NEXT:    bc 354: line 14 col 1
+// CHECK-NEXT:  0x0064  function idx 9, starts at line 19 col 21
+// CHECK-NEXT:    bc 43: line 19 col 21
 // CHECK-NEXT:    bc 131: line 21 col 3
 // CHECK-NEXT:    bc 150: line 20 col 11
 // CHECK-NEXT:    bc 169: line 20 col 11
 // CHECK-NEXT:    bc 255: line 20 col 11
-// CHECK-NEXT:    bc 291: line 20 col 11
-// CHECK-NEXT:    bc 312: line 20 col 11
-// CHECK-NEXT:    bc 354: line 20 col 11
-// CHECK-NEXT:  0x007b  end of debug source table
+// CHECK-NEXT:    bc 291: line 19 col 21
+// CHECK-NEXT:    bc 312: line 19 col 21
+// CHECK-NEXT:    bc 354: line 19 col 21
+// CHECK-NEXT:  0x0083  end of debug source table

--- a/test/BCGen/HBC/es6/generator.js
+++ b/test/BCGen/HBC/es6/generator.js
@@ -404,7 +404,7 @@ function *args() {
 // CHECK-NEXT:    bc 23: line 10 col 1
 // CHECK-NEXT:    bc 36: line 10 col 1
 // CHECK-NEXT:  0x0011  function idx 3, starts at line 10 col 1
-// CHECK-NEXT:    bc 43: line 13 col 5
+// CHECK-NEXT:    bc 43: line 10 col 1
 // CHECK-NEXT:    bc 114: line 12 col 10
 // CHECK-NEXT:    bc 138: line 13 col 5
 // CHECK-NEXT:    bc 157: line 13 col 5
@@ -413,17 +413,17 @@ function *args() {
 // CHECK-NEXT:    bc 284: line 13 col 14
 // CHECK-NEXT:    bc 294: line 13 col 12
 // CHECK-NEXT:    bc 312: line 13 col 5
-// CHECK-NEXT:    bc 352: line 13 col 5
-// CHECK-NEXT:    bc 373: line 13 col 5
-// CHECK-NEXT:    bc 415: line 13 col 5
+// CHECK-NEXT:    bc 352: line 10 col 1
+// CHECK-NEXT:    bc 373: line 10 col 1
+// CHECK-NEXT:    bc 415: line 10 col 1
 // CHECK-NEXT:  0x003c  function idx 4, starts at line 18 col 1
-// CHECK-NEXT:    bc 43: line 19 col 3
+// CHECK-NEXT:    bc 43: line 18 col 1
 // CHECK-NEXT:    bc 119: line 20 col 1
 // CHECK-NEXT:    bc 134: line 19 col 3
 // CHECK-NEXT:    bc 153: line 19 col 3
 // CHECK-NEXT:    bc 219: line 19 col 18
 // CHECK-NEXT:    bc 237: line 19 col 3
-// CHECK-NEXT:    bc 277: line 19 col 3
-// CHECK-NEXT:    bc 298: line 19 col 3
-// CHECK-NEXT:    bc 340: line 19 col 3
+// CHECK-NEXT:    bc 277: line 18 col 1
+// CHECK-NEXT:    bc 298: line 18 col 1
+// CHECK-NEXT:    bc 340: line 18 col 1
 // CHECK-NEXT:  0x005e  end of debug source table

--- a/test/debugger/breakpoint-after-eval.js
+++ b/test/debugger/breakpoint-after-eval.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hdb %s < %s.debug | %FileCheck --match-full-lines %s
+// REQUIRES: debugger
+
+// Regression test: evaluating an expression in a frame (`exec`) must not leave
+// a runtime module whose source buffer aliases the debugger's transient command
+// text. The eval used to borrow (not copy) the command string, so after that
+// debugger session resumed, a breakpoint resolved at a *later* pause -- which
+// walks the source of every runtime module, including the stale eval module --
+// read freed memory (ASan: stack-use-after-return in
+// SourceErrorManager::findForCoordsImpl). This test evals at one pause, resumes,
+// then sets a by-line breakpoint at a later pause; it crashes under ASan without
+// the fix.
+function foo() {
+  var x = 1;
+  debugger;
+  var y = 2;
+  debugger;
+  return x + y;
+}
+print(foo());
+print('DONE');
+// CHECK: Break on 'debugger' statement in foo: {{.*}}:22:3
+// CHECK-NEXT: 1
+// CHECK-NEXT: Continuing execution
+// CHECK-NEXT: Break on 'debugger' statement in foo: {{.*}}:24:3
+// CHECK-NEXT: Set breakpoint 1 at {{.*}}:25:{{[0-9]+}}
+// CHECK-NEXT: Continuing execution
+// CHECK-NEXT: Break on breakpoint 1 in foo: {{.*}}:25:{{[0-9]+}}
+// CHECK-NEXT: Continuing execution
+// CHECK-NEXT: 3
+// CHECK-NEXT: DONE

--- a/test/debugger/breakpoint-after-eval.js.debug
+++ b/test/debugger/breakpoint-after-eval.js.debug
@@ -1,0 +1,5 @@
+exec x
+continue
+break 25
+continue
+continue

--- a/test/debugger/generator-scope-at-breakpoint.js
+++ b/test/debugger/generator-scope-at-breakpoint.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hdb --Xes6-block-scoping %s < %s.debug | %FileCheck --match-full-lines %s
+// REQUIRES: debugger
+
+// Regression test: a breakpoint on a yield line must resolve to real user
+// code, not the generator's synthetic resume prologue. The lowering pass used
+// to stamp the prologue (which runs at the lowest offsets on every resume) with
+// the source line of the last yield, so a breakpoint on that line paused at the
+// scope-less function entry and no variables were visible.
+//
+// Uses `info variables` (not `exec`) and sets no breakpoint after any eval, to
+// avoid an unrelated stale-eval-module issue in breakpoint resolution.
+(function () {
+  function* gen() {
+    let outer = 20;
+    for (let i = 0; i < 2; i++) {
+      let v3 = 30;
+      yield i;
+      yield v3 + outer; // Breakpoint set on this line (the last yield).
+    }
+  }
+  let g = gen();
+  debugger;
+  g.next();
+  g.next();
+  g.next();
+})();
+// CHECK: Break on 'debugger' statement in {{.*}}
+// CHECK-NEXT: Set breakpoint {{[0-9]+}} at {{.*}}:25:7
+// CHECK-NEXT: Continuing execution
+// CHECK-NEXT: Break on breakpoint {{[0-9]+}} in gen: {{.*}}:25:7
+// The scope must be populated with the in-scope variables at the yield.
+// CHECK-DAG: {{.*}}v3 = 30
+// CHECK-DAG: {{.*}}outer = 20
+// CHECK-DAG: {{.*}}i = 0
+// CHECK: Continuing execution

--- a/test/debugger/generator-scope-at-breakpoint.js.debug
+++ b/test/debugger/generator-scope-at-breakpoint.js.debug
@@ -1,0 +1,4 @@
+break 25
+continue
+info variables
+continue

--- a/test/hermes/intl/date-time-format-apple.js
+++ b/test/hermes/intl/date-time-format-apple.js
@@ -61,7 +61,7 @@ print(new Intl.DateTimeFormat('en-US', { dateStyle: 'short', timeStyle: 'medium'
 // CHECK-NEXT: 1/9/52, 8:04:03{{.+}}AM
 
 print(new Intl.DateTimeFormat('de-DE', { dateStyle: 'full', timeStyle: 'long' }).format(oldDate));
-// CHECK-NEXT: Mittwoch, 9. Januar 1952 um 08:04:03 GMT
+// CHECK-NEXT: Mittwoch, 9. Januar 1952 um 08:04:03 GMT{{([+]0)?}}
 
 print(new Intl.DateTimeFormat('it-IT', { dateStyle: 'long', timeStyle: 'short' }).format(oldDate))
 // CHECK-NEXT: 9 gennaio 1952{{.+}}08:04

--- a/unittests/API/DebuggerTest.cpp
+++ b/unittests/API/DebuggerTest.cpp
@@ -548,6 +548,43 @@ static std::unique_ptr<hermes::Buffer> makeAsyncBreakCode() {
   return builder.generateBytecodeBuffer();
 };
 
+/// \return the bytecode buffer for a module in which no instruction has a
+/// source location, so that servicing an async break has to walk all the way
+/// to the Ret to look for a valid pause location.
+static std::unique_ptr<hermes::Buffer> makeAsyncBreakAtRetCode() {
+  using Loc = hermes::hbc::DebugSourceLocation;
+  hermes::hbc::SimpleBytecodeBuilder builder;
+  hermes::hbc::BytecodeInstructionGenerator instGen;
+
+  hermes::hbc::DebugInfo debugInfo{};
+  hermes::hbc::DebugInfoGenerator debugGen{debugInfo};
+  debugGen.addFilename("ret.js");
+
+  instGen.emitAsyncBreakCheck();
+  uint32_t addOffset = instGen.getCurrentLocation();
+  instGen.emitAddEmptyString(0, 0);
+  uint32_t retOffset = instGen.getCurrentLocation();
+  instGen.emitRet(0);
+
+  debugGen.appendSourceLocations(
+      Loc{0, 1, 0, 0, 0}, // Use filename 1 to generate a region.
+      0,
+      {
+          // AsyncBreakCheck, offset 0 has no source location.
+          Loc{0, 0, 0, 0, 0},
+      });
+  std::move(debugGen).generate();
+  builder.setDebugInfo(&debugInfo);
+
+  EXPECT_FALSE(debugInfo.getLocationForAddress(0, 0).hasValue());
+  EXPECT_FALSE(debugInfo.getLocationForAddress(0, addOffset).hasValue());
+  EXPECT_FALSE(debugInfo.getLocationForAddress(0, retOffset).hasValue());
+
+  builder.addFunction(1, 1, instGen.acquireBytecode());
+
+  return builder.generateBytecodeBuffer();
+};
+
 } // namespace
 
 TEST_F(DebuggerAPITest, ExplicitAsyncBreakLocationTest) {
@@ -574,6 +611,25 @@ TEST_F(DebuggerAPITest, ImplicitAsyncBreakLocationTest) {
       observer.pauseReasons);
   ASSERT_EQ(observer.stackTraces.size(), 1);
   EXPECT_EQ(observer.stackTraces.front().callFrameForIndex(0).location.line, 1);
+}
+
+TEST_F(DebuggerAPITest, ImplicitAsyncBreakAtRetTest) {
+  // Looking for a valid pause location walks to a Ret, which must not
+  // synthesize a step out: there is no step in progress, so preStepState_
+  // holds no meaningful value and the pending implicit trigger, not
+  // StepFinish, is the reason for the pause that eventually happens.
+  auto buffer = makeAsyncBreakAtRetCode();
+  rt->getDebugger().triggerAsyncPause(AsyncPauseKind::Implicit);
+  rt->evaluateJavaScript(
+      std::make_shared<BufferAdapter>(std::move(buffer)), "ret.js");
+
+  // Walking to the Ret leaves every code block breakpointed, so the next
+  // script pauses on entry. That is where the trigger gets delivered.
+  eval("var x = 5;");
+
+  EXPECT_EQ(
+      std::vector<PauseReason>({PauseReason::AsyncTriggerImplicit}),
+      observer.pauseReasons);
 }
 
 #endif

--- a/unittests/API/DebuggerTest.cpp
+++ b/unittests/API/DebuggerTest.cpp
@@ -440,6 +440,47 @@ TEST_F(DebuggerAPITest, GetLoadedScriptsTest) {
   EXPECT_TRUE(foundAfterGC);
 }
 
+// Regression test: the source passed to Runtime::run must not be borrowed when
+// the compiled module retains its source buffer, which it does under the
+// debugger (full debug info). Here the source string is destroyed right after
+// debugJavaScript returns. A later by-line breakpoint resolution walks every
+// runtime module's source; with eager compilation this used to borrow the
+// source string, so the read hit freed memory (ASan: heap-use-after-free in
+// SourceErrorManager::findForCoordsImpl). The buffer must own its bytes.
+TEST_F(DebuggerAPITest, RunDoesNotBorrowTransientSourceTest) {
+  // Force eager compilation so Runtime::run takes the (previously) borrowing
+  // path; lazy compilation already copied the source.
+  std::unique_ptr<HermesRuntime> runtime = makeHermesRuntime(
+      hermes::vm::RuntimeConfig::Builder()
+          .withCompilationMode(
+              hermes::vm::CompilationMode::ForceEagerCompilation)
+          .build());
+
+  {
+    // Heap-allocated (non-SSO) source that is freed at the end of this scope,
+    // immediately after compilation completes.
+    std::string transientSource =
+        "function foo() {\n  var x = 1;\n  return x;\n}\nfoo();\n";
+    runtime->debugJavaScript(transientSource, "transient.js", {});
+  }
+
+  // Resolving a by-line breakpoint (no column) walks each module's source via
+  // findSMRangeForLine; if the module borrowed the now-freed source, this reads
+  // freed memory. With the fix the buffer is owned, so this is safe.
+  SourceLocation loc;
+  loc.line = 3; // 'return x;'
+  runtime->getDebugger().setBreakpoint(loc);
+
+  // Reaching here without an ASan failure is the assertion; also confirm the
+  // runtime is still usable.
+  EXPECT_EQ(
+      7,
+      runtime->global()
+          .getPropertyAsFunction(*runtime, "eval")
+          .call(*runtime, "3 + 4")
+          .asNumber());
+}
+
 TEST_F(DebuggerAPITest, ImplicitAsyncPauseTest) {
   rt->getDebugger().triggerAsyncPause(AsyncPauseKind::Implicit);
   eval("var x = 5;");

--- a/unittests/IR/VariableTest.cpp
+++ b/unittests/IR/VariableTest.cpp
@@ -91,4 +91,36 @@ TEST(VariableTest, ReorderHidden) {
   }
 }
 
+TEST(VariableTest, DeleteScopeAfterLastUserIsRemoved) {
+  auto Ctx = std::make_shared<Context>();
+  Module M{Ctx};
+  IRBuilder Builder{&M};
+
+  auto *topLevel = Builder.createTopLevelFunction("global", true);
+  auto *topLevelBlock = Builder.createBasicBlock(topLevel);
+  Builder.setInsertionBlock(topLevelBlock);
+  Builder.createUnreachableInst();
+
+  auto *varScope = Builder.createVariableScope(nullptr);
+  auto *compiledFunction = Builder.createFunction(
+      "compiled", Function::DefinitionKind::ES5Function, true);
+  auto *compiledBlock = Builder.createBasicBlock(compiledFunction);
+  Builder.setInsertionBlock(compiledBlock);
+  Builder.createCreateScopeInst(varScope, Builder.getEmptySentinel());
+  Builder.createReturnInst(Builder.getLiteralUndefined());
+  compiledFunction->moveToCompiledFunctionList();
+
+  // Clear the initial candidate set while the scope still has a user.
+  M.assignIndexToVariables();
+  M.resetForMoreCompilation();
+  ASSERT_EQ(1u, M.getVariableScopes().size());
+
+  // This is the same removal path used by BytecodeFunction's destructor.
+  compiledFunction->eraseFromCompiledFunctionsNoDestroy();
+  Value::destroy(compiledFunction);
+  M.resetForMoreCompilation();
+
+  EXPECT_TRUE(M.getVariableScopes().empty());
+}
+
 } // end anonymous namespace

--- a/unittests/VMRuntime/IdentifierTableTest.cpp
+++ b/unittests/VMRuntime/IdentifierTableTest.cpp
@@ -92,6 +92,54 @@ TEST_F(IdentifierTableLargeHeapTest, LookupTest) {
 }
 #endif
 
+// The identifier hash table must keep its memory bounded when a bounded set
+// of live entries is churned repeatedly. Freed entries leave "deleted"
+// tombstones that count towards the load factor which triggers a rehash, so
+// the table must reclaim them in place rather than growing capacity forever.
+//
+// This interns ~500K unique symbols, so it is gated off under handle
+// sanitization, where it would be prohibitively slow.
+#if HERMESVM_SANITIZE_HANDLES == 0
+TEST_F(IdentifierTableLargeHeapTest, HashTableBoundedWithDeletedEntries) {
+  IdentifierTable &table = runtime.getIdentifierTable();
+
+  constexpr size_t kBatch = 1000;
+  constexpr size_t kRounds = 500;
+
+  size_t counter = 0;
+  auto internAndDropBatch = [&]() {
+    for (size_t i = 0; i < kBatch; ++i) {
+      // Flush handles each iteration so the interned symbols are not kept
+      // alive by the handle scope and can be freed by the collection below.
+      GCScopeMarkerRAII marker{runtime};
+      std::string s = "unique_ident_" + std::to_string(counter++);
+      auto symRes =
+          table.getSymbolHandle(runtime, ASCIIRef{s.data(), s.size()});
+      ASSERT_FALSE(isException(symRes));
+    }
+    // With no remaining references, the just-interned symbols are freed,
+    // turning their hash table slots into tombstones.
+    runtime.collect("test");
+  };
+
+  // Warm up so the table reaches its steady-state capacity for kBatch entries.
+  internAndDropBatch();
+  const size_t baseline = table.additionalMemorySize();
+
+  for (size_t r = 0; r < kRounds; ++r) {
+    internAndDropBatch();
+  }
+
+  // The live entry count per round is constant, so the footprint must stay
+  // bounded. Without in-place rehashing it grows with the total number of
+  // interned strings (tens of x over this loop).
+  const size_t finalSize = table.additionalMemorySize();
+  EXPECT_LE(finalSize, baseline * 2)
+      << "IdentifierHashTable grew unboundedly with deleted entries: baseline="
+      << baseline << " final=" << finalSize;
+}
+#endif
+
 using IdentifierTableTest = RuntimeTestFixture;
 
 TEST_F(IdentifierTableTest, NotUniquedSymbol) {


### PR DESCRIPTION
## Summary

Cherry-pick the fixes intended for the Hermes V1 250829098.0.17 release onto `250829098.0.0-stable`.

This includes:
- Fix unbounded IdentifierHashTable growth from deleted entries.
- Accept GMT+0 in the Apple Intl test.
- Fix debugger handling around async interrupts and breaks.
- Fix generator prologue debug source locations.
- Fix a use-after-free involving borrowed compilation source buffers.
- Fix the JSI test CQS implicit-cast signal.
- Avoid unnecessary VariableScope rescans during lazy compilation.

The formatting-only ktfmt update was intentionally excluded because it is unrelated to these fixes.

## Test Plan

- All cherry-picks applied cleanly.
- Verified each cherry-picked commit has the same stable patch ID as its source commit.
- Ran `git diff --check 250829098.0.0-stable..HEAD`.
- Confirmed the working tree is clean.
- Full build and test suite not run.