### PR TITLE
Make latest-v1 npm tag opt-in for stable releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,11 @@ on:
         required: true
         description: The type of release we are building. It could be release or dry-run
         type: string
+      update-latest-v1:
+        required: false
+        description: Whether to update the latest-v1 npm tag for a release
+        type: boolean
+        default: false
 
 jobs:
   publish:
@@ -98,7 +103,9 @@ jobs:
       - name: Publish to npm
         shell: bash
         run: |
-          node ./utils/scripts/hermes/publish-npm.js -t ${{ inputs.release-type }}
+          node ./utils/scripts/hermes/publish-npm.js \
+            -t ${{ inputs.release-type }} \
+            --update-latest-v1=${{ inputs.update-latest-v1 }}
       - name: Upload npm logs
         uses: actions/upload-artifact@v4.3.4
         with:

--- a/.github/workflows/rn-build-hermes.yml
+++ b/.github/workflows/rn-build-hermes.yml
@@ -11,6 +11,11 @@ on:
           - release
           - dry-run
         default: 'dry-run'
+      update-latest-v1:
+        required: false
+        description: 'Update latest-v1 (unchecked leaves the npm tag unchanged)'
+        type: boolean
+        default: false
   pull_request:
   push:
     branches:
@@ -77,6 +82,7 @@ jobs:
       ]
     with:
       release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
+      update-latest-v1: ${{ github.event_name == 'workflow_dispatch' && inputs.update-latest-v1 }}
   create-tag:
     uses: ./.github/workflows/create-tag.yml
     needs: set_release_type

--- a/utils/scripts/hermes/publish-npm.js
+++ b/utils/scripts/hermes/publish-npm.js
@@ -96,8 +96,6 @@ function getNpmPublishCommand(
   return `npm publish${tagFlag}`;
 }
 
-module.exports = {getNpmPublishCommand};
-
 if (require.main === module) {
   void main();
 }

--- a/utils/scripts/hermes/publish-npm.js
+++ b/utils/scripts/hermes/publish-npm.js
@@ -36,7 +36,7 @@ const yargs = require('yargs');
  * For a release run, this script will:
  *  * Version the release by the version specified in the CMakeLists.txt
  *  * Publish to npm
- *     * without setting a tag
+ *     * optionally updating the `latest-v1` tag
  */
 async function main() {
   const argv = yargs
@@ -46,16 +46,23 @@ async function main() {
       choices: ['dry-run', 'release'],
       default: 'dry-run',
     })
+    .option('update-latest-v1', {
+      describe: 'Publish a release using the latest-v1 npm tag.',
+      type: 'boolean',
+      default: false,
+    })
     .strict().argv;
 
   // $FlowFixMe[prop-missing]
   const buildType = argv.builtType;
+  // $FlowFixMe[prop-missing]
+  const updateLatestV1 = argv.updateLatestV1;
 
   if (!validateBuildType(buildType)) {
     throw new Error(`Unsupported build type: ${buildType}`);
   }
 
-  const result = await publishNpm(buildType);
+  const result = await publishNpm(buildType, updateLatestV1);
 
   if (result && result.code) {
     const version = await getVersion(buildType);
@@ -65,20 +72,31 @@ async function main() {
 
 async function publishNpm(
   buildType /*: BuildType */,
+  updateLatestV1 /*: boolean */,
 ) /*: Promise<ShellString | null> */ {
+  const command = getNpmPublishCommand(buildType, updateLatestV1);
+  const packagePath = path.join(REPO_ROOT, 'npm', 'hermes-compiler');
+  const options /*: ExecOptsSync */ = {cwd: packagePath};
+
+  return exec(command, options);
+}
+
+function getNpmPublishCommand(
+  buildType /*: BuildType */,
+  updateLatestV1 /*: boolean */,
+) /*: string */ {
   let tagFlag = '';
 
   if (buildType === 'dry-run') {
     tagFlag = ` --dry-run`;
-  } else if (buildType === 'release') {
+  } else if (buildType === 'release' && updateLatestV1) {
     tagFlag = ` --tag latest-v1`;
   }
 
-  const packagePath = path.join(REPO_ROOT, 'npm', 'hermes-compiler');
-  const options /*: ExecOptsSync */ = {cwd: packagePath};
-
-  return exec(`npm publish${tagFlag}`, options);
+  return `npm publish${tagFlag}`;
 }
+
+module.exports = {getNpmPublishCommand};
 
 if (require.main === module) {
   void main();


### PR DESCRIPTION
## Summary

Make updating the `latest-v1` npm dist-tag opt-in for releases from `250829098.0.0-stable`.

The manual RN Build Static Hermes workflow now exposes an `Update latest-v1` checkbox, which defaults to unchecked.

- Unchecked: publish the release normally without passing `--tag latest-v1`, leaving the `latest-v1` dist-tag unchanged.
- Checked: publish with `--tag latest-v1`, preserving the existing opt-in behavior.
- Dry runs remain unchanged and use `npm publish --dry-run`.

Push and pull request workflow runs always pass `false`, so they cannot update `latest-v1`.

## Test Plan

- Parsed both modified workflow YAML files successfully.
- Verified the publish script generates:
  - `npm publish --dry-run` for dry runs.
  - `npm publish` for releases when the checkbox is unchecked.
  - `npm publish --tag latest-v1` for releases when the checkbox is checked.
- Verified the new boolean CLI option is accepted and shown in `--help`.
- Ran `git diff --check`.