### PR TITLE
Add utils/jit dump comparison tools (#2153)

### DIFF
--- a/lib/VM/JIT/arm64/JitEmitter-alloc.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-alloc.cpp
@@ -44,7 +44,7 @@ void Emitter::bumpAllocAndUnpoison(
   a.mov(a64::x0, xOut);
   a.mov(a64::x1, sz);
   // Unpoison the newly allocated memory.
-  EMIT_RUNTIME_CALL_WITHOUT_THUNK_AND_SAVED_IP(
+  EMIT_RUNTIME_CALL_WITHOUT_SAVED_IP(
       *this,
       void (*)(void const volatile *, size_t),
       __asan_unpoison_memory_region);

--- a/lib/VM/JIT/arm64/JitEmitter-arith.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-arith.cpp
@@ -44,28 +44,23 @@ void Emitter::toNumber(FR frRes, FR frInput) {
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .frInput1 = frInput,
-       .hwRes = hwRes,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: toNumber r%u, r%u",
-             sl.frRes.index(),
-             sl.frInput1.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.loadFrameAddr(a64::x1, sl.frInput1);
-         EMIT_RUNTIME_CALL(
-             em,
-             double (*)(SHRuntime *, const SHLegacyValue *),
-             _sh_ljs_to_double_rjs);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::vecD(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [frRes, frInput, hwRes](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: toNumber r%u, r%u", frRes.index(), frInput.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.loadFrameAddr(a64::x1, frInput);
+        EMIT_RUNTIME_CALL(
+            em,
+            double (*)(SHRuntime *, const SHLegacyValue *),
+            _sh_ljs_to_double_rjs);
+        em.movHWFromHW<false>(hwRes, HWReg::vecD(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::toNumeric(FR frRes, FR frInput) {
@@ -97,28 +92,23 @@ void Emitter::toNumeric(FR frRes, FR frInput) {
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .frInput1 = frInput,
-       .hwRes = hwRes,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: toNumeric r%u, r%u",
-             sl.frRes.index(),
-             sl.frInput1.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.loadFrameAddr(a64::x1, sl.frInput1);
-         EMIT_RUNTIME_CALL(
-             em,
-             SHLegacyValue (*)(SHRuntime *, const SHLegacyValue *),
-             _sh_ljs_to_numeric_rjs);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [frRes, frInput, hwRes](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: toNumeric r%u, r%u", frRes.index(), frInput.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.loadFrameAddr(a64::x1, frInput);
+        EMIT_RUNTIME_CALL(
+            em,
+            SHLegacyValue (*)(SHRuntime *, const SHLegacyValue *),
+            _sh_ljs_to_numeric_rjs);
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::toInt32(FR frRes, FR frInput, bool isSigned) {
@@ -161,32 +151,26 @@ void Emitter::toInt32(FR frRes, FR frInput, bool isSigned) {
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .name = isSigned ? "ToInt32" : "ToUint32",
-       .frRes = frRes,
-       .frInput1 = frInput,
-       .hwRes = hwRes,
-       .slowCall = isSigned ? (void *)_sh_ljs_to_int32_rjs
-                            : (void *)_sh_ljs_to_uint32_rjs,
-       .slowCallName =
-           isSigned ? "_sh_ljs_to_int32_rjs" : "_sh_ljs_to_uint32_rjs",
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: %s, r%u, r%u, r%u",
-             sl.name,
-             sl.frRes.index(),
-             sl.frInput1.index(),
-             sl.frInput2.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.loadFrameAddr(a64::x1, sl.frInput1);
-         em.callThunkWithSavedIP((void *)sl.slowCall, sl.slowCallName);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::vecD(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [isSigned, frRes, frInput, hwRes](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: %s, r%u, r%u",
+            isSigned ? "ToInt32" : "ToUint32",
+            frRes.index(),
+            frInput.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.loadFrameAddr(a64::x1, frInput);
+        em.callThunkWithSavedIP(
+            isSigned ? (void *)_sh_ljs_to_int32_rjs
+                     : (void *)_sh_ljs_to_uint32_rjs,
+            isSigned ? "_sh_ljs_to_int32_rjs" : "_sh_ljs_to_uint32_rjs");
+        em.movHWFromHW<false>(hwRes, HWReg::vecD(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::addEmptyString(FR frRes, FR frInput) {
@@ -217,28 +201,25 @@ void Emitter::addEmptyString(FR frRes, FR frInput) {
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .frInput1 = frInput,
-       .hwRes = hwRes,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: AddEmptyString r%u, r%u",
-             sl.frRes.index(),
-             sl.frInput1.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.loadFrameAddr(a64::x1, sl.frInput1);
-         EMIT_RUNTIME_CALL(
-             em,
-             SHLegacyValue (*)(SHRuntime *, const SHLegacyValue *),
-             _sh_ljs_add_empty_string_rjs);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [frRes, frInput, hwRes](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: AddEmptyString r%u, r%u",
+            frRes.index(),
+            frInput.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.loadFrameAddr(a64::x1, frInput);
+        EMIT_RUNTIME_CALL(
+            em,
+            SHLegacyValue (*)(SHRuntime *, const SHLegacyValue *),
+            _sh_ljs_add_empty_string_rjs);
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::arithUnop(
@@ -297,29 +278,21 @@ void Emitter::arithUnop(
   freeAllFRTempExcept(frRes);
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .name = name,
-       .frRes = frRes,
-       .frInput1 = frInput,
-       .hwRes = hwRes,
-       .slowCall = slowCall,
-       .slowCallName = slowCallName,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: %s r%u, r%u",
-             sl.name,
-             sl.frRes.index(),
-             sl.frInput1.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.loadFrameAddr(a64::x1, sl.frInput1);
-         em.callThunkWithSavedIP(sl.slowCall, sl.slowCallName);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [name, frRes, frInput, hwRes, slowCall, slowCallName](
+          Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: %s r%u, r%u", name, frRes.index(), frInput.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.loadFrameAddr(a64::x1, frInput);
+        em.callThunkWithSavedIP(slowCall, slowCallName);
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::booleanNot(FR frRes, FR frInput) {
@@ -378,28 +351,23 @@ void Emitter::bitNot(FR frRes, FR frInput) {
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .frInput1 = frInput,
-       .hwRes = hwRes,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: bitNot r%u, r%u",
-             sl.frRes.index(),
-             sl.frInput1.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.loadFrameAddr(a64::x1, sl.frInput1);
-         EMIT_RUNTIME_CALL(
-             em,
-             SHLegacyValue (*)(SHRuntime *, const SHLegacyValue *),
-             _sh_ljs_bit_not_rjs);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [frRes, frInput, hwRes](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: bitNot r%u, r%u", frRes.index(), frInput.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.loadFrameAddr(a64::x1, frInput);
+        EMIT_RUNTIME_CALL(
+            em,
+            SHLegacyValue (*)(SHRuntime *, const SHLegacyValue *),
+            _sh_ljs_bit_not_rjs);
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::typeOf(FR frRes, FR frInput) {
@@ -503,32 +471,28 @@ void Emitter::mod(bool forceNumber, FR frRes, FR frLeft, FR frRight) {
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .frInput1 = frLeft,
-       .frInput2 = frRight,
-       .hwRes = hwRes,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// mod r%u, r%u, r%u",
-             sl.frRes.index(),
-             sl.frInput1.index(),
-             sl.frInput2.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.loadFrameAddr(a64::x1, sl.frInput1);
-         em.loadFrameAddr(a64::x2, sl.frInput2);
-         EMIT_RUNTIME_CALL(
-             em,
-             SHLegacyValue (*)(
-                 SHRuntime *, const SHLegacyValue *, const SHLegacyValue *),
-             _sh_ljs_mod_rjs);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [frRes, frLeft, frRight, hwRes](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// mod r%u, r%u, r%u",
+            frRes.index(),
+            frLeft.index(),
+            frRight.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.loadFrameAddr(a64::x1, frLeft);
+        em.loadFrameAddr(a64::x2, frRight);
+        EMIT_RUNTIME_CALL(
+            em,
+            SHLegacyValue (*)(
+                SHRuntime *, const SHLegacyValue *, const SHLegacyValue *),
+            _sh_ljs_mod_rjs);
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::arithBinOp(
@@ -598,32 +562,26 @@ void Emitter::arithBinOp(
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .name = name,
-       .frRes = frRes,
-       .frInput1 = frLeft,
-       .frInput2 = frRight,
-       .hwRes = hwRes,
-       .slowCall = slowCall,
-       .slowCallName = slowCallName,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// %s r%u, r%u, r%u",
-             sl.name,
-             sl.frRes.index(),
-             sl.frInput1.index(),
-             sl.frInput2.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.loadFrameAddr(a64::x1, sl.frInput1);
-         em.loadFrameAddr(a64::x2, sl.frInput2);
-         em.callThunkWithSavedIP(sl.slowCall, sl.slowCallName);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [name, frRes, frLeft, frRight, hwRes, slowCall, slowCallName](
+          Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// %s r%u, r%u, r%u",
+            name,
+            frRes.index(),
+            frLeft.index(),
+            frRight.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.loadFrameAddr(a64::x1, frLeft);
+        em.loadFrameAddr(a64::x2, frRight);
+        em.callThunkWithSavedIP(slowCall, slowCallName);
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::bitBinOp(
@@ -699,32 +657,26 @@ void Emitter::bitBinOp(
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .name = name,
-       .frRes = frRes,
-       .frInput1 = frLeft,
-       .frInput2 = frRight,
-       .hwRes = hwRes,
-       .slowCall = (void *)slowCall,
-       .slowCallName = slowCallName,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// %s r%u, r%u, r%u",
-             sl.name,
-             sl.frRes.index(),
-             sl.frInput1.index(),
-             sl.frInput2.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.loadFrameAddr(a64::x1, sl.frInput1);
-         em.loadFrameAddr(a64::x2, sl.frInput2);
-         em.callThunkWithSavedIP(sl.slowCall, sl.slowCallName);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [name, frRes, frLeft, frRight, hwRes, slowCall, slowCallName](
+          Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// %s r%u, r%u, r%u",
+            name,
+            frRes.index(),
+            frLeft.index(),
+            frRight.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.loadFrameAddr(a64::x1, frLeft);
+        em.loadFrameAddr(a64::x2, frRight);
+        em.callThunkWithSavedIP((void *)slowCall, slowCallName);
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::strictEqualImpl(bool invert, FR frRes, FR frLeft, FR frRight) {
@@ -873,47 +825,34 @@ void Emitter::strictEqualImpl(bool invert, FR frRes, FR frLeft, FR frRight) {
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .name = !invert ? "StrictEq" : "StrictNEq",
-       .frRes = frRes,
-       .frInput1 = frLeft,
-       .frInput2 = frRight,
-       .hwRes = hwRes,
-       .invert = invert,
-       .passArgsByVal = true,
-       .slowCall = (void *)_sh_ljs_strict_equal,
-       .slowCallName = "_sh_ljs_strict_equal",
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: %s r%u, r%u, r%u",
-             sl.name,
-             sl.frRes.index(),
-             sl.frInput1.index(),
-             sl.frInput2.index());
-         em.a.bind(sl.slowPathLab);
-         if (sl.passArgsByVal) {
-           em._loadFrame(HWReg::gpX(0), sl.frInput1);
-           em._loadFrame(HWReg::gpX(1), sl.frInput2);
-         } else {
-           em.a.mov(a64::x0, xRuntime);
-           em.loadFrameAddr(a64::x1, sl.frInput1);
-           em.loadFrameAddr(a64::x2, sl.frInput2);
-         }
-         em.callThunkWithSavedIP(sl.slowCall, sl.slowCallName);
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [invert, frRes, frLeft, frRight, hwRes](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: %s r%u, r%u, r%u",
+            !invert ? "StrictEq" : "StrictNEq",
+            frRes.index(),
+            frLeft.index(),
+            frRight.index());
+        em.a.bind(sp.slowPathLab);
+        // _sh_ljs_strict_equal takes its arguments by value.
+        em._loadFrame(HWReg::gpX(0), frLeft);
+        em._loadFrame(HWReg::gpX(1), frRight);
+        em.callThunkWithSavedIP(
+            (void *)_sh_ljs_strict_equal, "_sh_ljs_strict_equal");
 
-         // Invert the slow path result if needed.
-         if (sl.invert)
-           em.a.eor(sl.hwRes.a64GpX(), a64::x0, 1);
-         else
-           em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
+        // Invert the slow path result if needed.
+        if (invert)
+          em.a.eor(hwRes.a64GpX(), a64::x0, 1);
+        else
+          em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
 
-         // Comparison functions return bool, so encode it.
-         emit_sh_ljs_bool(em.a, sl.hwRes.a64GpX());
-         em.a.b(sl.contLab);
-       }});
+        // Comparison functions return bool, so encode it.
+        emit_sh_ljs_bool(em.a, hwRes.a64GpX());
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::compareImpl(
@@ -979,47 +918,46 @@ void Emitter::compareImpl(
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .name = name,
-       .frRes = frRes,
-       .frInput1 = frLeft,
-       .frInput2 = frRight,
-       .hwRes = hwRes,
-       .invert = invSlow,
-       .passArgsByVal = passArgsByVal,
-       .slowCall = slowCall,
-       .slowCallName = slowCallName,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: j_%s r%u, r%u, r%u",
-             sl.name,
-             sl.frRes.index(),
-             sl.frInput1.index(),
-             sl.frInput2.index());
-         em.a.bind(sl.slowPathLab);
-         if (sl.passArgsByVal) {
-           em._loadFrame(HWReg::gpX(0), sl.frInput1);
-           em._loadFrame(HWReg::gpX(1), sl.frInput2);
-         } else {
-           em.a.mov(a64::x0, xRuntime);
-           em.loadFrameAddr(a64::x1, sl.frInput1);
-           em.loadFrameAddr(a64::x2, sl.frInput2);
-         }
-         em.callThunkWithSavedIP(sl.slowCall, sl.slowCallName);
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [name,
+       frRes,
+       frLeft,
+       frRight,
+       hwRes,
+       invSlow,
+       passArgsByVal,
+       slowCall,
+       slowCallName](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: j_%s r%u, r%u, r%u",
+            name,
+            frRes.index(),
+            frLeft.index(),
+            frRight.index());
+        em.a.bind(sp.slowPathLab);
+        if (passArgsByVal) {
+          em._loadFrame(HWReg::gpX(0), frLeft);
+          em._loadFrame(HWReg::gpX(1), frRight);
+        } else {
+          em.a.mov(a64::x0, xRuntime);
+          em.loadFrameAddr(a64::x1, frLeft);
+          em.loadFrameAddr(a64::x2, frRight);
+        }
+        em.callThunkWithSavedIP(slowCall, slowCallName);
 
-         // Invert the slow path result if needed.
-         if (sl.invert)
-           em.a.eor(sl.hwRes.a64GpX(), a64::x0, 1);
-         else
-           em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
+        // Invert the slow path result if needed.
+        if (invSlow)
+          em.a.eor(hwRes.a64GpX(), a64::x0, 1);
+        else
+          em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
 
-         // Comparison functions return bool, so encode it.
-         emit_sh_ljs_bool(em.a, sl.hwRes.a64GpX());
-         em.a.b(sl.contLab);
-       }});
+        // Comparison functions return bool, so encode it.
+        emit_sh_ljs_bool(em.a, hwRes.a64GpX());
+        em.a.b(sp.contLab);
+      });
 }
 
 } // namespace hermes::vm::arm64

--- a/lib/VM/JIT/arm64/JitEmitter-arith.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-arith.cpp
@@ -164,7 +164,7 @@ void Emitter::toInt32(FR frRes, FR frInput, bool isSigned) {
         em.a.bind(sp.slowPathLab);
         em.a.mov(a64::x0, xRuntime);
         em.loadFrameAddr(a64::x1, frInput);
-        em.callThunkWithSavedIP(
+        em.callRuntimeWithSavedIP(
             isSigned ? (void *)_sh_ljs_to_int32_rjs
                      : (void *)_sh_ljs_to_uint32_rjs,
             isSigned ? "_sh_ljs_to_int32_rjs" : "_sh_ljs_to_uint32_rjs");
@@ -289,7 +289,7 @@ void Emitter::arithUnop(
         em.a.bind(sp.slowPathLab);
         em.a.mov(a64::x0, xRuntime);
         em.loadFrameAddr(a64::x1, frInput);
-        em.callThunkWithSavedIP(slowCall, slowCallName);
+        em.callRuntimeWithSavedIP(slowCall, slowCallName);
         em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
         em.a.b(sp.contLab);
       });
@@ -578,7 +578,7 @@ void Emitter::arithBinOp(
         em.a.mov(a64::x0, xRuntime);
         em.loadFrameAddr(a64::x1, frLeft);
         em.loadFrameAddr(a64::x2, frRight);
-        em.callThunkWithSavedIP(slowCall, slowCallName);
+        em.callRuntimeWithSavedIP(slowCall, slowCallName);
         em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
         em.a.b(sp.contLab);
       });
@@ -673,7 +673,7 @@ void Emitter::bitBinOp(
         em.a.mov(a64::x0, xRuntime);
         em.loadFrameAddr(a64::x1, frLeft);
         em.loadFrameAddr(a64::x2, frRight);
-        em.callThunkWithSavedIP((void *)slowCall, slowCallName);
+        em.callRuntimeWithSavedIP((void *)slowCall, slowCallName);
         em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
         em.a.b(sp.contLab);
       });
@@ -840,7 +840,7 @@ void Emitter::strictEqualImpl(bool invert, FR frRes, FR frLeft, FR frRight) {
         // _sh_ljs_strict_equal takes its arguments by value.
         em._loadFrame(HWReg::gpX(0), frLeft);
         em._loadFrame(HWReg::gpX(1), frRight);
-        em.callThunkWithSavedIP(
+        em.callRuntimeWithSavedIP(
             (void *)_sh_ljs_strict_equal, "_sh_ljs_strict_equal");
 
         // Invert the slow path result if needed.
@@ -946,7 +946,7 @@ void Emitter::compareImpl(
           em.loadFrameAddr(a64::x1, frLeft);
           em.loadFrameAddr(a64::x2, frRight);
         }
-        em.callThunkWithSavedIP(slowCall, slowCallName);
+        em.callRuntimeWithSavedIP(slowCall, slowCallName);
 
         // Invert the slow path result if needed.
         if (invSlow)

--- a/lib/VM/JIT/arm64/JitEmitter-array.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-array.cpp
@@ -542,7 +542,7 @@ void Emitter::getArgumentsPropByValImpl(
         em.a.mov(a64::x1, xFrame);
         em.loadFrameAddr(a64::x2, frIndex);
         em.loadFrameAddr(a64::x3, frLazyReg);
-        em.callThunkWithSavedIP((void *)shImpl, shImplName);
+        em.callRuntimeWithSavedIP((void *)shImpl, shImplName);
         em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
         em.a.b(sp.contLab);
       });
@@ -583,7 +583,7 @@ void Emitter::reifyArgumentsImpl(FR frLazyReg, bool strict, const char *name) {
         em.a.mov(a64::x0, xRuntime);
         em.a.mov(a64::x1, xFrame);
         em.loadFrameAddr(a64::x2, frLazyReg);
-        em.callThunkWithSavedIP(
+        em.callRuntimeWithSavedIP(
             strict ? (void *)_sh_ljs_reify_arguments_strict
                    : (void *)_sh_ljs_reify_arguments_loose,
             strict ? "_sh_ljs_reify_arguments_strict"

--- a/lib/VM/JIT/arm64/JitEmitter-array.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-array.cpp
@@ -179,23 +179,20 @@ void Emitter::fastArrayLoad(FR frRes, FR frArr, FR frIdx) {
       a64::Mem(hwTmpStorage.a64GpX(), hwTmpIdxGpX.a64GpX(), a64::lsl(3)));
   frUpdatedWithHW(frRes, hwRes);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .frRes = frRes,
-       .frInput1 = frArr,
-       .frInput2 = frIdx,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: FastArrayLoad r%u, r%u, r%u",
-             sl.frRes.index(),
-             sl.frInput1.index(),
-             sl.frInput2.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         EMIT_RUNTIME_CALL(em, void (*)(SHRuntime *), _sh_throw_array_oob);
-         // Call does not return.
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      emittingIP,
+      [frRes, frArr, frIdx](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: FastArrayLoad r%u, r%u, r%u",
+            frRes.index(),
+            frArr.index(),
+            frIdx.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        EMIT_RUNTIME_CALL(em, void (*)(SHRuntime *), _sh_throw_array_oob);
+        // Call does not return.
+      });
 #endif
 }
 
@@ -284,29 +281,26 @@ void Emitter::getArgumentsLength(FR frRes, FR frLazyReg) {
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .frInput1 = frLazyReg,
-       .hwRes = hwRes,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: GetArgumentsLength r%u, r%u",
-             sl.frRes.index(),
-             sl.frInput1.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.a.mov(a64::x1, xFrame);
-         em.loadFrameAddr(a64::x2, sl.frInput1);
-         EMIT_RUNTIME_CALL(
-             em,
-             SHLegacyValue (*)(SHRuntime *, SHLegacyValue *, SHLegacyValue *),
-             _sh_ljs_get_arguments_length);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [frRes, frLazyReg, hwRes](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: GetArgumentsLength r%u, r%u",
+            frRes.index(),
+            frLazyReg.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.a.mov(a64::x1, xFrame);
+        em.loadFrameAddr(a64::x2, frLazyReg);
+        EMIT_RUNTIME_CALL(
+            em,
+            SHLegacyValue (*)(SHRuntime *, SHLegacyValue *, SHLegacyValue *),
+            _sh_ljs_get_arguments_length);
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::iteratorBegin(FR frRes, FR frSource) {
@@ -536,28 +530,22 @@ void Emitter::getArgumentsPropByValImpl(
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .name = name,
-       .frRes = frRes,
-       .frInput1 = frIndex,
-       .frInput2 = frLazyReg,
-       .hwRes = hwRes,
-       .slowCall = (void *)shImpl,
-       .slowCallName = shImplName,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment("// Slow path: %s r%u", sl.name, sl.frInput1.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.a.mov(a64::x1, xFrame);
-         em.loadFrameAddr(a64::x2, sl.frInput1);
-         em.loadFrameAddr(a64::x3, sl.frInput2);
-         em.callThunkWithSavedIP(sl.slowCall, sl.slowCallName);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [name, frIndex, frLazyReg, hwRes, shImpl, shImplName](
+          Emitter &em, SlowPath &sp) {
+        em.comment("// Slow path: %s r%u", name, frIndex.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.a.mov(a64::x1, xFrame);
+        em.loadFrameAddr(a64::x2, frIndex);
+        em.loadFrameAddr(a64::x3, frLazyReg);
+        em.callThunkWithSavedIP((void *)shImpl, shImplName);
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::reifyArgumentsImpl(FR frLazyReg, bool strict, const char *name) {
@@ -581,32 +569,32 @@ void Emitter::reifyArgumentsImpl(FR frLazyReg, bool strict, const char *name) {
   // Fast path: do nothing.
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .name = name,
-       .frInput1 = frLazyReg,
-       // Use hwRes field to pass the global reg for the in/out param.
-       .hwRes = frameRegs_[frLazyReg.index()].globalReg,
-       .slowCall = strict ? (void *)_sh_ljs_reify_arguments_strict
-                          : (void *)_sh_ljs_reify_arguments_loose,
-       .slowCallName = strict ? "_sh_ljs_reify_arguments_strict"
-                              : "_sh_ljs_reify_arguments_loose",
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment("// Slow path: %s r%u", sl.name, sl.frInput1.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.a.mov(a64::x1, xFrame);
-         em.loadFrameAddr(a64::x2, sl.frInput1);
-         em.callThunkWithSavedIP(sl.slowCall, sl.slowCallName);
-         // Slow path modifies the frame so we need to sync it if there's a
-         // global reg.
-         if (sl.hwRes.isValid()) {
-           em._loadFrame(sl.hwRes, sl.frInput1);
-         }
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [name,
+       frLazyReg,
+       strict,
+       hwGlobalReg = frameRegs_[frLazyReg.index()].globalReg](
+          Emitter &em, SlowPath &sp) {
+        em.comment("// Slow path: %s r%u", name, frLazyReg.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.a.mov(a64::x1, xFrame);
+        em.loadFrameAddr(a64::x2, frLazyReg);
+        em.callThunkWithSavedIP(
+            strict ? (void *)_sh_ljs_reify_arguments_strict
+                   : (void *)_sh_ljs_reify_arguments_loose,
+            strict ? "_sh_ljs_reify_arguments_strict"
+                   : "_sh_ljs_reify_arguments_loose");
+        // Slow path modifies the frame so we need to sync it if there's a
+        // global reg.
+        if (hwGlobalReg.isValid()) {
+          em._loadFrame(hwGlobalReg, frLazyReg);
+        }
+        em.a.b(sp.contLab);
+      });
 }
 
 } // namespace hermes::vm::arm64

--- a/lib/VM/JIT/arm64/JitEmitter-call.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-call.cpp
@@ -108,28 +108,26 @@ void Emitter::loadThisNS(FR frRes) {
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .hwRes = hwRes,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment("// Slow path: LoadThisNS r%u", sl.frRes.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.a.ldur(
-             a64::x1,
-             a64::Mem(
-                 xFrame,
-                 StackFrameLayout::ThisArg * (int)sizeof(SHLegacyValue)));
-         EMIT_RUNTIME_CALL(
-             em,
-             SHLegacyValue (*)(SHRuntime *, SHLegacyValue),
-             _sh_ljs_coerce_this_ns);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [frRes, hwRes](Emitter &em, SlowPath &sp) {
+        em.comment("// Slow path: LoadThisNS r%u", frRes.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.a.ldur(
+            a64::x1,
+            a64::Mem(
+                xFrame,
+                StackFrameLayout::ThisArg * (int)sizeof(SHLegacyValue)));
+        EMIT_RUNTIME_CALL(
+            em,
+            SHLegacyValue (*)(SHRuntime *, SHLegacyValue),
+            _sh_ljs_coerce_this_ns);
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::coerceThisNS(FR frRes, FR frThis) {
@@ -162,28 +160,23 @@ void Emitter::coerceThisNS(FR frRes, FR frThis) {
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .frInput1 = frThis,
-       .hwRes = hwRes,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: CoerceThis r%u, r%u",
-             sl.frRes.index(),
-             sl.frInput1.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em._loadFrame(HWReg(a64::x1), sl.frInput1);
-         EMIT_RUNTIME_CALL(
-             em,
-             SHLegacyValue (*)(SHRuntime *, SHLegacyValue),
-             _sh_ljs_coerce_this_ns);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [frRes, frThis, hwRes](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: CoerceThis r%u, r%u", frRes.index(), frThis.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em._loadFrame(HWReg(a64::x1), frThis);
+        EMIT_RUNTIME_CALL(
+            em,
+            SHLegacyValue (*)(SHRuntime *, SHLegacyValue),
+            _sh_ljs_coerce_this_ns);
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::getNewTarget(FR frRes) {
@@ -267,18 +260,19 @@ void Emitter::callImpl(FR frRes, FR frCallee) {
   // If we have not already created a slow path for non-object calls, do so now.
   if (!nonObjCallLabel_.isValid()) {
     nonObjCallLabel_ = newSlowPathLabel();
-    slowPaths_.push_back(
-        {.slowPathLab = nonObjCallLabel_,
-         .emit = [](Emitter &em, SlowPath &sl) {
-           em.comment("// Throw on non-object call");
-           em.a.bind(sl.slowPathLab);
-           em.a.mov(a64::x0, xRuntime);
-           // The IP is already saved by the call setup, no need to save it
-           // again.
-           EMIT_RUNTIME_CALL_WITHOUT_SAVED_IP(
-               em, void (*)(SHRuntime *), _jit_throw_non_object_call);
-           // The call does not return.
-         }});
+    slowPaths_.emplace_back(
+        nonObjCallLabel_,
+        /* emittingIP */ nullptr,
+        [](Emitter &em, SlowPath &sp) {
+          em.comment("// Throw on non-object call");
+          em.a.bind(sp.slowPathLab);
+          em.a.mov(a64::x0, xRuntime);
+          // The IP is already saved by the call setup, no need to save it
+          // again.
+          EMIT_RUNTIME_CALL_WITHOUT_SAVED_IP(
+              em, void (*)(SHRuntime *), _jit_throw_non_object_call);
+          // The call does not return.
+        });
   }
 
   auto slowPathLab = newSlowPathLabel();
@@ -316,28 +310,25 @@ void Emitter::callImpl(FR frRes, FR frCallee) {
   a.blr(a64::x2);
   movHWFromHW<false>(hwRes, HWReg::gpX(0));
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .frInput1 = frCallee,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: CallImpl r%u, r%u",
-             sl.frRes.index(),
-             sl.frInput1.index());
-         em.a.bind(sl.slowPathLab);
-         em.emitIncrementCounter(JitCounter::NumCallSlow);
-         em.loadBits64InGp(
-             a64::x2, (uint64_t)&VTable::jitCallArray, "VTable::jitCallArray");
-         // Load the jitCall function. x0 still contains the callee CellKind
-         // from the fast path.
-         em.a.ldr(
-             a64::x2,
-             a64::Mem(a64::x2, a64::x0, a64::Shift(a64::ShiftOp::kLSL, 3)));
-         // x1 already contains the Callable* from the fast path.
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      /* emittingIP */ nullptr,
+      [frRes, frCallee](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: CallImpl r%u, r%u", frRes.index(), frCallee.index());
+        em.a.bind(sp.slowPathLab);
+        em.emitIncrementCounter(JitCounter::NumCallSlow);
+        em.loadBits64InGp(
+            a64::x2, (uint64_t)&VTable::jitCallArray, "VTable::jitCallArray");
+        // Load the jitCall function. x0 still contains the callee CellKind
+        // from the fast path.
+        em.a.ldr(
+            a64::x2,
+            a64::Mem(a64::x2, a64::x0, a64::Shift(a64::ShiftOp::kLSL, 3)));
+        // x1 already contains the Callable* from the fast path.
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::call(FR frRes, FR frCallee, uint32_t argc) {

--- a/lib/VM/JIT/arm64/JitEmitter-control.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-control.cpp
@@ -80,23 +80,20 @@ void Emitter::throwIfEmptyUndefinedImpl(FR frRes, FR frInput, bool empty) {
   movHWFromHW<false>(hwRes, hwInput);
   frUpdatedWithHW(frRes, hwRes);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .name = empty ? "ThrowIfEmpty" : "ThrowIfUndefined",
-       .frRes = frRes,
-       .frInput1 = frInput,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: %s r%u, r%u",
-             sl.name,
-             sl.frRes.index(),
-             sl.frInput1.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         EMIT_RUNTIME_CALL(em, void (*)(SHRuntime *), _sh_throw_empty);
-         // Call does not return.
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      emittingIP,
+      [empty, frRes, frInput](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: %s r%u, r%u",
+            empty ? "ThrowIfEmpty" : "ThrowIfUndefined",
+            frRes.index(),
+            frInput.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        EMIT_RUNTIME_CALL(em, void (*)(SHRuntime *), _sh_throw_empty);
+        // Call does not return.
+      });
 }
 
 void Emitter::throwIfThisInitialized(FR frInput) {
@@ -129,19 +126,15 @@ void Emitter::throwIfThisInitialized(FR frInput) {
   emit_sh_ljs_is_empty(a, hwTemp.a64GpX(), hwInput.a64GpX());
   a.b_ne(slowPathLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .frInput1 = frInput,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: ThrowIfThisInitialized r%u", sl.frInput1.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         EMIT_RUNTIME_CALL(
-             em, void (*)(SHRuntime *), _sh_throw_this_already_initialized);
-         // Call does not return.
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab, emittingIP, [frInput](Emitter &em, SlowPath &sp) {
+        em.comment("// Slow path: ThrowIfThisInitialized r%u", frInput.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        EMIT_RUNTIME_CALL(
+            em, void (*)(SHRuntime *), _sh_throw_this_already_initialized);
+        // Call does not return.
+      });
 }
 
 void Emitter::jmpTypeOfIs(
@@ -811,41 +804,40 @@ void Emitter::jCond(
   // Do this always, since this is the end of the BB.
   freeAllFRTempExcept(FR());
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .target = target,
-       .name = name,
-       .frInput1 = frLeft,
-       .frInput2 = frRight,
-       .invert = invert,
-       .passArgsByVal = passArgsByVal,
-       .slowCall = slowCall,
-       .slowCallName = slowCallName,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: j_%s%s Lx, r%u, r%u",
-             sl.invert ? "not_" : "",
-             sl.name,
-             sl.frInput1.index(),
-             sl.frInput2.index());
-         em.a.bind(sl.slowPathLab);
-         if (sl.passArgsByVal) {
-           em._loadFrame(HWReg::gpX(0), sl.frInput1);
-           em._loadFrame(HWReg::gpX(1), sl.frInput2);
-         } else {
-           em.a.mov(a64::x0, xRuntime);
-           em.loadFrameAddr(a64::x1, sl.frInput1);
-           em.loadFrameAddr(a64::x2, sl.frInput2);
-         }
-         em.callThunkWithSavedIP(sl.slowCall, sl.slowCallName);
-         if (!sl.invert)
-           em.a.cbnz(a64::w0, sl.target);
-         else
-           em.a.cbz(a64::w0, sl.target);
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [name,
+       slowCall,
+       slowCallName,
+       target,
+       frLeft,
+       frRight,
+       invert,
+       passArgsByVal](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: j_%s%s Lx, r%u, r%u",
+            invert ? "not_" : "",
+            name,
+            frLeft.index(),
+            frRight.index());
+        em.a.bind(sp.slowPathLab);
+        if (passArgsByVal) {
+          em._loadFrame(HWReg::gpX(0), frLeft);
+          em._loadFrame(HWReg::gpX(1), frRight);
+        } else {
+          em.a.mov(a64::x0, xRuntime);
+          em.loadFrameAddr(a64::x1, frLeft);
+          em.loadFrameAddr(a64::x2, frRight);
+        }
+        em.callThunkWithSavedIP(slowCall, slowCallName);
+        if (!invert)
+          em.a.cbnz(a64::w0, target);
+        else
+          em.a.cbz(a64::w0, target);
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::jStrictEqual(
@@ -985,33 +977,27 @@ void Emitter::jStrictEqual(
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .target = target,
-       .name = invert ? "j_strict_not_eq" : "j_strict_eq",
-       .frInput1 = frLeft,
-       .frInput2 = frRight,
-       .invert = invert,
-       .slowCall = (void *)_sh_ljs_strict_equal,
-       .slowCallName = "_sh_ljs_strict_equal",
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: %s Lx, r%u, r%u",
-             sl.name,
-             sl.frInput1.index(),
-             sl.frInput2.index());
-         em.a.bind(sl.slowPathLab);
-         em._loadFrame(HWReg::gpX(0), sl.frInput1);
-         em._loadFrame(HWReg::gpX(1), sl.frInput2);
-         em.callThunkWithSavedIP(sl.slowCall, sl.slowCallName);
-         if (!sl.invert)
-           em.a.cbnz(a64::w0, sl.target);
-         else
-           em.a.cbz(a64::w0, sl.target);
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [target, frLeft, frRight, invert](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: %s Lx, r%u, r%u",
+            invert ? "j_strict_not_eq" : "j_strict_eq",
+            frLeft.index(),
+            frRight.index());
+        em.a.bind(sp.slowPathLab);
+        em._loadFrame(HWReg::gpX(0), frLeft);
+        em._loadFrame(HWReg::gpX(1), frRight);
+        em.callThunkWithSavedIP(
+            (void *)_sh_ljs_strict_equal, "_sh_ljs_strict_equal");
+        if (!invert)
+          em.a.cbnz(a64::w0, target);
+        else
+          em.a.cbz(a64::w0, target);
+        em.a.b(sp.contLab);
+      });
 }
 
 } // namespace hermes::vm::arm64

--- a/lib/VM/JIT/arm64/JitEmitter-control.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-control.cpp
@@ -501,7 +501,9 @@ void Emitter::uintSwitchImm(
   comment(
       "// uintSwitchImm r%u, min %u, max %u", frInput.index(), minVal, maxVal);
 
-  asmjit::Error err;
+  // minVal is compared against and subtracted below; both are add/sub
+  // immediate forms with the same encoding limit.
+  const bool minValIsImm = a64::Utils::isAddSubImm(minVal);
 
   // End of the basic block.
   syncAllFRTempExcept({});
@@ -527,8 +529,9 @@ void Emitter::uintSwitchImm(
 
   // Check if the integer value in xTemp is in range.
   // First check minVal.
-  EXPECT_ERROR(asmjit::kErrorInvalidImmediate, err = a.cmp(wTempInput, minVal));
-  if (err) {
+  if (minValIsImm) {
+    a.cmp(wTempInput, minVal);
+  } else {
     a.mov(hwTempTarget.a64GpX().w(), minVal);
     a.cmp(wTempInput, hwTempTarget.a64GpX().w());
   }
@@ -536,8 +539,9 @@ void Emitter::uintSwitchImm(
   a.b_lo(defaultLabel);
 
   // Now check maxVal.
-  EXPECT_ERROR(asmjit::kErrorInvalidImmediate, err = a.cmp(wTempInput, maxVal));
-  if (err) {
+  if (a64::Utils::isAddSubImm(maxVal)) {
+    a.cmp(wTempInput, maxVal);
+  } else {
     a.mov(hwTempTarget.a64GpX().w(), maxVal);
     a.cmp(wTempInput, hwTempTarget.a64GpX().w());
   }
@@ -547,10 +551,9 @@ void Emitter::uintSwitchImm(
   // Compute the offset into the jump table, dereference, and jump.
   // Offset by the minVal if necessary.
   if (minVal != 0) {
-    EXPECT_ERROR(
-        asmjit::kErrorInvalidImmediate,
-        err = a.sub(wTempInput, wTempInput, minVal));
-    if (err) {
+    if (minValIsImm) {
+      a.sub(wTempInput, wTempInput, minVal);
+    } else {
       a.mov(hwTempTarget.a64GpX().w(), minVal);
       a.sub(wTempInput, wTempInput, hwTempTarget.a64GpX().w());
     }

--- a/lib/VM/JIT/arm64/JitEmitter-control.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-control.cpp
@@ -831,7 +831,7 @@ void Emitter::jCond(
           em.loadFrameAddr(a64::x1, frLeft);
           em.loadFrameAddr(a64::x2, frRight);
         }
-        em.callThunkWithSavedIP(slowCall, slowCallName);
+        em.callRuntimeWithSavedIP(slowCall, slowCallName);
         if (!invert)
           em.a.cbnz(a64::w0, target);
         else
@@ -990,7 +990,7 @@ void Emitter::jStrictEqual(
         em.a.bind(sp.slowPathLab);
         em._loadFrame(HWReg::gpX(0), frLeft);
         em._loadFrame(HWReg::gpX(1), frRight);
-        em.callThunkWithSavedIP(
+        em.callRuntimeWithSavedIP(
             (void *)_sh_ljs_strict_equal, "_sh_ljs_strict_equal");
         if (!invert)
           em.a.cbnz(a64::w0, target);

--- a/lib/VM/JIT/arm64/JitEmitter-env.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-env.cpp
@@ -87,28 +87,25 @@ void Emitter::createFunctionEnvironment(FR frRes, uint32_t size) {
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .hwRes = hwRes,
-       .sizeOrIdx = size,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: CreateFunctionEnvironment r%u", sl.frRes.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.a.mov(a64::x1, xFrame);
-         em.a.mov(a64::w2, sl.sizeOrIdx);
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [frRes, hwRes, size](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: CreateFunctionEnvironment r%u", frRes.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.a.mov(a64::x1, xFrame);
+        em.a.mov(a64::w2, size);
 
-         EMIT_RUNTIME_CALL(
-             em,
-             SHLegacyValue (*)(SHRuntime *, SHLegacyValue *, uint32_t),
-             _sh_ljs_create_function_environment);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+        EMIT_RUNTIME_CALL(
+            em,
+            SHLegacyValue (*)(SHRuntime *, SHLegacyValue *, uint32_t),
+            _sh_ljs_create_function_environment);
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::createEnvironment(FR frRes, FR frParent, uint32_t size) {
@@ -164,33 +161,29 @@ void Emitter::createEnvironment(FR frRes, FR frParent, uint32_t size) {
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .frInput1 = frParent,
-       .hwRes = hwRes,
-       .sizeOrIdx = size,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: CreateEnvironment r%u, r%u",
-             sl.frRes.index(),
-             sl.frInput1.index());
-         em.a.bind(sl.slowPathLab);
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [frRes, frParent, hwRes, size](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: CreateEnvironment r%u, r%u",
+            frRes.index(),
+            frParent.index());
+        em.a.bind(sp.slowPathLab);
 
-         em.a.mov(a64::x0, xRuntime);
-         em.loadFrameAddr(a64::x1, sl.frInput1);
-         em.a.mov(a64::w2, sl.sizeOrIdx);
+        em.a.mov(a64::x0, xRuntime);
+        em.loadFrameAddr(a64::x1, frParent);
+        em.a.mov(a64::w2, size);
 
-         EMIT_RUNTIME_CALL(
-             em,
-             SHLegacyValue (*)(SHRuntime *, const SHLegacyValue *, uint32_t),
-             _sh_ljs_create_environment);
+        EMIT_RUNTIME_CALL(
+            em,
+            SHLegacyValue (*)(SHRuntime *, const SHLegacyValue *, uint32_t),
+            _sh_ljs_create_environment);
 
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::getParentEnvironment(FR frRes, uint32_t level) {

--- a/lib/VM/JIT/arm64/JitEmitter-internal.h
+++ b/lib/VM/JIT/arm64/JitEmitter-internal.h
@@ -16,14 +16,6 @@
 
 namespace hermes::vm::arm64 {
 
-// Disable warnings about missing designated initializers since they occur often
-// when we construct SlowPaths.
-#ifdef __clang__
-#if __has_warning("-Wmissing-designated-field-initializers")
-#pragma clang diagnostic ignored "-Wmissing-designated-field-initializers"
-#endif
-#endif
-
 // Ensure that HermesValue tags are handled correctly by updating this every
 // time the HERMESVALUE_VERSION changes, and going through the JIT and updating
 // any relevant code.

--- a/lib/VM/JIT/arm64/JitEmitter-internal.h
+++ b/lib/VM/JIT/arm64/JitEmitter-internal.h
@@ -742,12 +742,12 @@ inline bool isStpGpXImm(int i) {
 /// Save the current IP and emit a call to a runtime function. This should be
 /// used in most cases when invoking slow paths and handlers for complex
 /// functionality.
-#define EMIT_RUNTIME_CALL(em, type, func)           \
-  do {                                              \
-    using _FnT = type;                              \
-    _FnT _fn = func;                                \
-    (void)_fn;                                      \
-    (em).callThunkWithSavedIP((void *)func, #func); \
+#define EMIT_RUNTIME_CALL(em, type, func)             \
+  do {                                                \
+    using _FnT = type;                                \
+    _FnT _fn = func;                                  \
+    (void)_fn;                                        \
+    (em).callRuntimeWithSavedIP((void *)func, #func); \
   } while (0)
 
 /// Call a runtime function without saving the IP. This is intended for special
@@ -758,19 +758,7 @@ inline bool isStpGpXImm(int i) {
     using _FnT = type;                                     \
     _FnT _fn = func;                                       \
     (void)_fn;                                             \
-    (em).callThunk((void *)func, #func);                   \
-  } while (0)
-
-/// Make call without creating a thunk for it or saving the IP. This is useful
-/// for specific functionality where saving the IP is either unnecessary or
-/// incorrect, and where the call target is only going to be invoked at most
-/// once in the function.
-#define EMIT_RUNTIME_CALL_WITHOUT_THUNK_AND_SAVED_IP(em, type, func) \
-  do {                                                               \
-    using _FnT = type;                                               \
-    _FnT _fn = func;                                                 \
-    (void)_fn;                                                       \
-    (em).callWithoutThunk((void *)func, #func);                      \
+    (em).callRuntime((void *)func, #func);                 \
   } while (0)
 
 /// Load the lengthAndFlags of a HermesValue that contains a StringPrimitive

--- a/lib/VM/JIT/arm64/JitEmitter-object.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-object.cpp
@@ -60,21 +60,19 @@ void Emitter::newObject(FR frRes) {
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .hwRes = hwRes,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment("// Slow path: NewObject r%u", sl.frRes.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         EMIT_RUNTIME_CALL(
-             em, SHLegacyValue (*)(SHRuntime *), _sh_ljs_new_object);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [frRes, hwRes](Emitter &em, SlowPath &sp) {
+        em.comment("// Slow path: NewObject r%u", frRes.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        EMIT_RUNTIME_CALL(
+            em, SHLegacyValue (*)(SHRuntime *), _sh_ljs_new_object);
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::newObjectWithParent(FR frRes, FR frParent) {
@@ -150,29 +148,26 @@ void Emitter::newObjectWithParent(FR frRes, FR frParent) {
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .frInput1 = frParent,
-       .hwRes = hwRes,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: NewObjectWithParent r%u, r%u",
-             sl.frRes.index(),
-             sl.frInput1.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.loadFrameAddr(a64::x1, sl.frInput1);
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [frRes, frParent, hwRes](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: NewObjectWithParent r%u, r%u",
+            frRes.index(),
+            frParent.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.loadFrameAddr(a64::x1, frParent);
 
-         EMIT_RUNTIME_CALL(
-             em,
-             SHLegacyValue (*)(SHRuntime *, const SHLegacyValue *),
-             _sh_ljs_new_object_with_parent);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+        EMIT_RUNTIME_CALL(
+            em,
+            SHLegacyValue (*)(SHRuntime *, const SHLegacyValue *),
+            _sh_ljs_new_object_with_parent);
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::newObjectWithBuffer(
@@ -472,33 +467,31 @@ void Emitter::newObjectWithBuffer(
   // This slow path only allocates the new object.
   // Property population is always done in JIT-emitted code specialized for this
   // shape table entry.
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .hwRes = hwObj,
-       .sizeOrIdx = shapeTableIndex,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: NewObjectWithBuffer r%u, %u, %u",
-             sl.frRes.index(),
-             sl.sizeOrIdx,
-             sl.sizeOrIdx2);
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.loadBits64InGp(a64::x1, (uint64_t)em.codeBlock_, "CodeBlock");
-         em.a.mov(a64::w2, sl.sizeOrIdx);
-         em.loadFrameAddr(a64::x3, sl.frRes);
-         EMIT_RUNTIME_CALL(
-             em,
-             JSObject *
-                 (*)(Runtime &, CodeBlock *, uint32_t, PinnedHermesValue *),
-             _jit_new_empty_object_for_buffer);
-         // Move into xObj.
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [frRes, hwObj, shapeTableIndex, valBufferOffset](
+          Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: NewObjectWithBuffer r%u, %u, %u",
+            frRes.index(),
+            shapeTableIndex,
+            valBufferOffset);
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.loadBits64InGp(a64::x1, (uint64_t)em.codeBlock_, "CodeBlock");
+        em.a.mov(a64::w2, shapeTableIndex);
+        em.loadFrameAddr(a64::x3, frRes);
+        EMIT_RUNTIME_CALL(
+            em,
+            JSObject *
+                (*)(Runtime &, CodeBlock *, uint32_t, PinnedHermesValue *),
+            _jit_new_empty_object_for_buffer);
+        // Move into xObj.
+        em.movHWFromHW<false>(hwObj, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::newObjectWithBufferSlow(

--- a/lib/VM/JIT/arm64/JitEmitter-property.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-property.cpp
@@ -50,7 +50,7 @@ void Emitter::putByValImpl(
   loadFrameAddr(a64::x1, frTarget);
   loadFrameAddr(a64::x2, frKey);
   loadFrameAddr(a64::x3, frValue);
-  callThunkWithSavedIP((void *)shImpl, shImplName);
+  callRuntimeWithSavedIP((void *)shImpl, shImplName);
 }
 
 void Emitter::putByValWithReceiver(
@@ -318,7 +318,7 @@ class HERMES_ATTRIBUTE_INTERNAL_LINKAGE Emitter::GetByIdImpl {
         emit_add_imm_u24(
             a, a64::x3, sizeof(SHReadPropertyCacheEntry) * cacheIdx);
     }
-    _.callThunkWithSavedIP((void *)shImpl, shImplName);
+    _.callRuntimeWithSavedIP((void *)shImpl, shImplName);
 
     _.movHWFromHW<false>(hwRes, HWReg::gpX(0));
     _.frUpdatedWithHW(frRes, hwRes);

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -769,9 +769,10 @@ void Emitter::loadParam(FR frRes, uint32_t paramIndex) {
           xFrame,
           (int)StackFrameLayout::ArgCount * (int)sizeof(SHLegacyValue)));
 
-  EXPECT_ERROR(asmjit::kErrorInvalidImmediate, err = a.cmp(wTmp, paramIndex));
   // Does paramIndex fit in the 12-bit unsigned immediate?
-  if (err) {
+  if (a64::Utils::isAddSubImm(paramIndex)) {
+    a.cmp(wTmp, paramIndex);
+  } else {
     HWReg hwTmp2 = allocAndLogTempGpX();
     a64::GpW wTmp2(hwTmp2.indexInClass());
     loadBits64InGp(wTmp2, paramIndex, "paramIndex");

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -27,6 +27,14 @@
 
 namespace hermes::vm::arm64 {
 
+// Disable warnings about missing designated initializers, which the
+// roDataDesc_ entries below rely on.
+#ifdef __clang__
+#if __has_warning("-Wmissing-designated-field-initializers")
+#pragma clang diagnostic ignored "-Wmissing-designated-field-initializers"
+#endif
+#endif
+
 llvh::raw_ostream &operator<<(
     llvh::raw_ostream &os,
     const hermes::vm::arm64::HWReg &hwReg) {
@@ -321,20 +329,21 @@ void Emitter::frameSetup(
   // check if the bounds have changed.
   a.b_hi(nativeOverflowLab);
   a.bind(nativeOverflowContLab);
-  slowPaths_.push_back(
-      {.slowPathLab = nativeOverflowLab,
-       .contLab = nativeOverflowContLab,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment("// Slow path: _sh_check_native_stack_overflow");
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         // Do not save the IP because we have not yet set up the stack frame
-         // for this function. If this throws, the exception should appear in
-         // the caller.
-         EMIT_RUNTIME_CALL_WITHOUT_THUNK_AND_SAVED_IP(
-             em, void (*)(SHRuntime *), _sh_check_native_stack_overflow);
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      nativeOverflowLab,
+      nativeOverflowContLab,
+      /* emittingIP */ nullptr,
+      [](Emitter &em, SlowPath &sp) {
+        em.comment("// Slow path: _sh_check_native_stack_overflow");
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        // Do not save the IP because we have not yet set up the stack frame
+        // for this function. If this throws, the exception should appear in
+        // the caller.
+        EMIT_RUNTIME_CALL_WITHOUT_THUNK_AND_SAVED_IP(
+            em, void (*)(SHRuntime *), _sh_check_native_stack_overflow);
+        em.a.b(sp.contLab);
+      });
 
   comment("// xFrame");
   a.ldr(xFrame, a64::Mem(xRuntime, RuntimeOffsets::stackPointer));
@@ -375,20 +384,19 @@ void Emitter::frameSetup(
       slowCallName = "_sh_throw_invalid_construct";
     }
 
-    slowPaths_.push_back(
-        {.slowPathLab = throwInvalidInvokeLab,
-         .slowCall = (void *)slowCall,
-         .slowCallName = slowCallName,
-         .emit = [](Emitter &em, SlowPath &sl) {
-           em.comment("// Slow path: %s", sl.slowCallName);
-           em.a.bind(sl.slowPathLab);
-           em.a.mov(a64::x0, xRuntime);
-           // We don't register a thunk since there will only be a single call
-           // to this. Note that we also don't save the IP, because this is
-           // being thrown in the caller's context.
-           em.callWithoutThunk(sl.slowCall, sl.slowCallName);
-           // Function does not return.
-         }});
+    slowPaths_.emplace_back(
+        throwInvalidInvokeLab,
+        /* emittingIP */ nullptr,
+        [slowCall, slowCallName](Emitter &em, SlowPath &sp) {
+          em.comment("// Slow path: %s", slowCallName);
+          em.a.bind(sp.slowPathLab);
+          em.a.mov(a64::x0, xRuntime);
+          // We don't register a thunk since there will only be a single call
+          // to this. Note that we also don't save the IP, because this is
+          // being thrown in the caller's context.
+          em.callWithoutThunk((void *)slowCall, slowCallName);
+          // Function does not return.
+        });
   }
 
   // NOTE: Unlike _sh_enter, we do not push an SHLocals object.
@@ -465,17 +473,18 @@ void Emitter::frameSetup(
   }
 
   // Create the slow path for throwing a register stack overflow.
-  slowPaths_.push_back(
-      {.slowPathLab = registerOverflowLab,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment("// Slow path: _sh_throw_register_stack_overflow");
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         // Do not save the IP because we have not yet set up the stack frame
-         // for this function. The exception should appear in the caller.
-         EMIT_RUNTIME_CALL_WITHOUT_THUNK_AND_SAVED_IP(
-             em, void (*)(SHRuntime *), _sh_throw_register_stack_overflow);
-       }});
+  slowPaths_.emplace_back(
+      registerOverflowLab,
+      /* emittingIP */ nullptr,
+      [](Emitter &em, SlowPath &sp) {
+        em.comment("// Slow path: _sh_throw_register_stack_overflow");
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        // Do not save the IP because we have not yet set up the stack frame
+        // for this function. The exception should appear in the caller.
+        EMIT_RUNTIME_CALL_WITHOUT_THUNK_AND_SAVED_IP(
+            em, void (*)(SHRuntime *), _sh_throw_register_stack_overflow);
+      });
 
   if (catchTableLabel_.isValid()) {
     comment("// _sh_try");
@@ -825,19 +834,16 @@ void Emitter::loadParam(FR frRes, uint32_t paramIndex) {
   a.bind(contLab);
   frUpdatedWithHW(frRes, hwRes);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .hwRes = hwRes,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment("// Slow path: LoadParam r%u", sl.frRes.index());
-         em.a.bind(sl.slowPathLab);
-         em.loadBits64InGp(
-             sl.hwRes.a64GpX(), _sh_ljs_undefined().raw, "undefined");
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [frRes, hwRes](Emitter &em, SlowPath &sp) {
+        em.comment("// Slow path: LoadParam r%u", frRes.index());
+        em.a.bind(sp.slowPathLab);
+        em.loadBits64InGp(hwRes.a64GpX(), _sh_ljs_undefined().raw, "undefined");
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::getGlobalObject(FR frRes) {
@@ -997,7 +1003,7 @@ void Emitter::emitSlowPaths() {
   while (!slowPaths_.empty()) {
     SlowPath &sp = slowPaths_.front();
     emittingIP = sp.emittingIP;
-    sp.emit(*this, sp);
+    sp.emit(*this);
     slowPaths_.pop_front();
   }
   emittingIP = nullptr;

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -340,7 +340,7 @@ void Emitter::frameSetup(
         // Do not save the IP because we have not yet set up the stack frame
         // for this function. If this throws, the exception should appear in
         // the caller.
-        EMIT_RUNTIME_CALL_WITHOUT_THUNK_AND_SAVED_IP(
+        EMIT_RUNTIME_CALL_WITHOUT_SAVED_IP(
             em, void (*)(SHRuntime *), _sh_check_native_stack_overflow);
         em.a.b(sp.contLab);
       });
@@ -391,10 +391,9 @@ void Emitter::frameSetup(
           em.comment("// Slow path: %s", slowCallName);
           em.a.bind(sp.slowPathLab);
           em.a.mov(a64::x0, xRuntime);
-          // We don't register a thunk since there will only be a single call
-          // to this. Note that we also don't save the IP, because this is
-          // being thrown in the caller's context.
-          em.callWithoutThunk((void *)slowCall, slowCallName);
+          // We don't save the IP, because this is being thrown in the
+          // caller's context.
+          em.callRuntime((void *)slowCall, slowCallName);
           // Function does not return.
         });
   }
@@ -482,7 +481,7 @@ void Emitter::frameSetup(
         em.a.mov(a64::x0, xRuntime);
         // Do not save the IP because we have not yet set up the stack frame
         // for this function. The exception should appear in the caller.
-        EMIT_RUNTIME_CALL_WITHOUT_THUNK_AND_SAVED_IP(
+        EMIT_RUNTIME_CALL_WITHOUT_SAVED_IP(
             em, void (*)(SHRuntime *), _sh_throw_register_stack_overflow);
       });
 
@@ -499,9 +498,8 @@ void Emitter::frameSetup(
 
     // _setjmp(buf->buf);
     a.add(a64::x0, a64::sp, jmpBufOffset + offsetof(SHJmpBuf, buf));
-    // setjmp can't throw and it'll be called once, so don't use a thunk.
-    EMIT_RUNTIME_CALL_WITHOUT_THUNK_AND_SAVED_IP(
-        *this, int (*)(jmp_buf), _sh_setjmp);
+    // setjmp can't throw, so the IP does not need to be saved.
+    EMIT_RUNTIME_CALL_WITHOUT_SAVED_IP(*this, int (*)(jmp_buf), _sh_setjmp);
     // If this a catch, go to the catch table to jump to either a handler BB or
     // rethrow.
     a.cbnz(a64::x0, catchTableLabel_);
@@ -575,28 +573,16 @@ void Emitter::leave(llvh::ArrayRef<const asmjit::Label *> exceptionHandlers) {
 
   emitCatchTable(exceptionHandlers);
   emitSlowPaths();
-  emitThunks();
   emitROData();
 }
 
-void Emitter::callThunk(void *fn, const char *name) {
-  // Using thunks leads to 0.27% more branch mispredicts and 2.8% performance
-  // regression on an important React benchmark. So, disable them for now.
-  if constexpr (false) {
-    comment("// call %s", name);
-    a.bl(registerThunk(fn, name));
-  } else {
-    callWithoutThunk(fn, name);
-  }
-}
-
-void Emitter::callThunkWithSavedIP(void *fn, const char *name) {
+void Emitter::callRuntimeWithSavedIP(void *fn, const char *name) {
   // Save the current IP in the runtime.
   getBytecodeIP(xScratch);
   a.str(xScratch, a64::Mem(xRuntime, RuntimeOffsets::currentIP));
 
   // Call the passed function.
-  callThunk(fn, name);
+  callRuntime(fn, name);
 
   if (emitAsserts_) {
     // Invalidate the current IP to make sure it is set before the next call.
@@ -605,7 +591,7 @@ void Emitter::callThunkWithSavedIP(void *fn, const char *name) {
   }
 }
 
-void Emitter::callWithoutThunk(void *fn, const char *name) {
+void Emitter::callRuntime(void *fn, const char *name) {
   comment("// call %s", name);
   loadBits64InGp(xScratch, (uint64_t)fn, name);
   a.blr(xScratch);
@@ -948,20 +934,6 @@ int32_t Emitter::uint64Const(uint64_t bits, const char *comment) {
   return it->second;
 }
 
-asmjit::Label Emitter::registerThunk(void *fn, const char *name) {
-  auto [it, inserted] = thunkMap_.try_emplace(fn, 0);
-  // Is this a new thunk?
-  if (inserted) {
-    it->second = thunks_.size();
-    int32_t dataOfs =
-        reserveData(sizeof(fn), sizeof(fn), asmjit::TypeId::kUInt64, 1, name);
-    memcpy(roData_.data() + dataOfs, &fn, sizeof(fn));
-    thunks_.emplace_back(name ? a.newNamedLabel(name) : a.newLabel(), dataOfs);
-  }
-
-  return thunks_[it->second].first;
-}
-
 void Emitter::emitCatchTable(
     llvh::ArrayRef<const asmjit::Label *> exceptionHandlers) {
   // No trys in the function, nothing to do here.
@@ -979,7 +951,7 @@ void Emitter::emitCatchTable(
   a.add(a64::x3, a64::sp, getJmpBufOffset());
   a.ldr(a64::x4, a64::Mem(a64::sp, getSavedSHLocalsOffset()));
   a.adr(a64::x5, addressTableLab);
-  EMIT_RUNTIME_CALL_WITHOUT_THUNK_AND_SAVED_IP(
+  EMIT_RUNTIME_CALL_WITHOUT_SAVED_IP(
       *this,
       void *(*)(SHRuntime *,
                 SHCodeBlock *,
@@ -1007,15 +979,6 @@ void Emitter::emitSlowPaths() {
     slowPaths_.pop_front();
   }
   emittingIP = nullptr;
-}
-
-void Emitter::emitThunks() {
-  comment("// Thunks");
-  for (const auto &th : thunks_) {
-    a.bind(th.first);
-    a.ldr(xScratch, a64::Mem(roDataLabel_, th.second));
-    a.br(xScratch);
-  }
 }
 
 void Emitter::emitROData() {

--- a/lib/VM/JIT/arm64/JitEmitter.h
+++ b/lib/VM/JIT/arm64/JitEmitter.h
@@ -25,6 +25,9 @@
 
 #include <cstdarg>
 #include <deque>
+#include <new>
+#include <type_traits>
+#include <utility>
 
 namespace hermes::vm::arm64 {
 
@@ -320,41 +323,79 @@ class Emitter {
   /// VecD temp registers.
   TempRegAlloc vecTemp_{kVecTemp1, kVecTemp2};
 
-  /// Keep enough information to generate a slow path at the end of the
-  /// function.
-  struct SlowPath {
+  /// A deferred slow path, emitted at the end of the function.
+  ///
+  /// Everything the slow path needs beyond the common fields below is held in
+  /// the lambda passed to the constructor, stored inline in \c storage_. This
+  /// keeps each slow path's state private to the one place that produces and
+  /// consumes it, instead of a shared set of fields that any slow path could
+  /// read whether or not its producer set them.
+  class SlowPath {
+   public:
     /// Label of the slow path.
     asmjit::Label slowPathLab;
     /// Label to jump to after the slow path.
     asmjit::Label contLab;
-    /// Target if this is a branch.
-    asmjit::Label target;
-
-    /// Name of the slow path.
-    const char *name;
-    /// Frame register indexes;
-    FR frRes, frInput1, frInput2;
-    /// Optional hardware register for the result.
-    HWReg hwRes;
-    /// Whether to invert a condition.
-    bool invert;
-    /// Whether to pass arguments by value to the slow path.
-    bool passArgsByVal;
-    /// Some number or index that needs to be passed to the slow path.
-    unsigned sizeOrIdx;
-    /// Another number or index that needs to be passed to the slow path.
-    unsigned sizeOrIdx2;
-
-    /// Pointer to the slow path function that must be called.
-    void *slowCall;
-    /// The name of the slow path function.
-    const char *slowCallName;
-
     /// Bytecode IP of the instruction that this is a slow path for.
     const inst::Inst *emittingIP;
 
-    /// Callback to actually emit.
-    void (*emit)(Emitter &em, SlowPath &sl);
+    /// \param l is invoked as l(Emitter &, SlowPath &) to emit the slow path.
+    /// Its captures are copied into \c storage_ and never destroyed, so they
+    /// must be trivially destructible and must fit.
+    template <typename L>
+    SlowPath(
+        asmjit::Label slowPathLab,
+        asmjit::Label contLab,
+        const inst::Inst *emittingIP,
+        L &&l)
+        : slowPathLab(slowPathLab),
+          contLab(contLab),
+          emittingIP(emittingIP),
+          emit_([](Emitter &em, SlowPath &sp) {
+            (*reinterpret_cast<std::decay_t<L> *>(sp.storage_))(em, sp);
+          }) {
+      using Lambda = std::decay_t<L>;
+      static_assert(
+          sizeof(Lambda) <= sizeof(storage_),
+          "slow path captures too much; enlarge storage_ or capture less");
+      static_assert(
+          alignof(Lambda) <= alignof(void *),
+          "slow path captures are over-aligned");
+      static_assert(
+          std::is_trivially_destructible_v<Lambda>,
+          "slow path captures must be trivially destructible");
+      ::new (storage_) Lambda(std::forward<L>(l));
+    }
+
+    /// Overload for slow paths that do not branch back to a continuation.
+    template <typename L>
+    SlowPath(asmjit::Label slowPathLab, const inst::Inst *emittingIP, L &&l)
+        : SlowPath(
+              slowPathLab,
+              asmjit::Label(),
+              emittingIP,
+              std::forward<L>(l)) {}
+
+    /// Non-copyable and non-movable: \c storage_ holds a type-erased lambda
+    /// that cannot be relocated by the implicit memberwise copy. std::deque
+    /// never relocates existing elements, so emplace_back and pop_front are
+    /// all that is needed.
+    SlowPath(const SlowPath &) = delete;
+    SlowPath &operator=(const SlowPath &) = delete;
+
+    /// Emit this slow path.
+    void emit(Emitter &em) {
+      emit_(em, *this);
+    }
+
+   private:
+    void (*emit_)(Emitter &em, SlowPath &sp);
+    /// Inline storage for the lambda's captures. Sized to the largest current
+    /// slow path, jCond, whose captures include an asmjit::Label (16 bytes, an
+    /// Operand) plus three pointers, two FRs and two bools. Raising this is
+    /// fine; the static_assert above is what keeps a too-large capture from
+    /// becoming a silent heap allocation.
+    alignas(void *) char storage_[56];
   };
   /// Queue of slow paths.
   std::deque<SlowPath> slowPaths_{};

--- a/lib/VM/JIT/arm64/JitEmitter.h
+++ b/lib/VM/JIT/arm64/JitEmitter.h
@@ -201,7 +201,7 @@ static constexpr auto xRuntime = a64::x19;
 static constexpr auto xFrame = a64::x20;
 
 /// Scratch register. x16/x17 sit outside the register allocator and are used
-/// as scratch (thunk targets, IP materialization); nothing holds a value in
+/// as scratch (call targets, IP materialization); nothing holds a value in
 /// them across an emitter call.
 static constexpr auto xScratch = a64::x16;
 
@@ -414,10 +414,6 @@ class Emitter {
   std::vector<uint8_t> roData_{};
   asmjit::Label roDataLabel_{};
 
-  /// Each thunk contains the offset of the function pointer in roData.
-  std::vector<std::pair<asmjit::Label, int32_t>> thunks_{};
-  llvh::DenseMap<void *, size_t> thunkMap_{};
-
   /// Map from the bit pattern of a double value to offset in constant pool.
   llvh::DenseMap<hermes::DenseUInt64, int32_t> fp64ConstMap_{};
 
@@ -497,7 +493,7 @@ class Emitter {
   /// line so that vsnprintf is not duplicated into every caller.
   void commentV(const char *fmt, va_list args);
 
-  /// Emit the catch table, slow paths, thunks and RO data,
+  /// Emit the catch table, slow paths and RO data,
   /// then reset the stack, end any try, and return.
   /// \param exceptionHandlers the labels for the exception handler table.
   void leave(llvh::ArrayRef<const asmjit::Label *> exceptionHandlers);
@@ -1238,25 +1234,15 @@ class Emitter {
   /// Register a 64-bit constant in RO DATA and return its offset.
   int32_t uint64Const(uint64_t bits, const char *comment);
 
-  /// Register \p fn as a thunk and return its label.
-  /// \param name is an optional name for the thunk.
-  asmjit::Label registerThunk(void *fn, const char *name = nullptr);
+  /// Emit a call to \p fn, saving the bytecode IP to Runtime::currentIP
+  /// before making the call. This should be used for all calls that may
+  /// observe the IP, such as calls that may throw exceptions, or perform
+  /// allocations.
+  void callRuntimeWithSavedIP(void *fn, const char *name);
 
-  /// Register a call as a thunk and emit a call to it. Note that most calls
-  /// into runtime functions should use \c callThunkWithSavedIP below.
-  void callThunk(void *fn, const char *name);
-
-  /// Register a call as a thunk and emit a call to it, saving the bytecode IP
-  /// to Runtime::currentIP before making the call. This should be used for all
-  /// calls that may observe the IP, such as calls that may throw exceptions, or
-  /// perform allocations.
-  void callThunkWithSavedIP(void *fn, const char *name);
-
-  /// Call a function without registering it as a thunk. This should be used for
-  /// functions that will only have a single call site in the emitted function,
-  /// and therefore do not benefit from a thunk. Note that like \c callThunk,
-  /// this does not save the IP.
-  void callWithoutThunk(void *fn, const char *name);
+  /// Emit a call to \p fn without saving the IP. This should be used only
+  /// where saving the IP is unnecessary or incorrect.
+  void callRuntime(void *fn, const char *name);
 
   /// Emit the code that runs when this function is longjmped to.
   /// Performs the catch table lookup and jumps to the appropriate catch block,
@@ -1264,7 +1250,6 @@ class Emitter {
   /// exception.
   void emitCatchTable(llvh::ArrayRef<const asmjit::Label *> exceptionHandlers);
   void emitSlowPaths();
-  void emitThunks();
   void emitROData();
 
  private:

--- a/utils/jit/README.md
+++ b/utils/jit/README.md
@@ -1,0 +1,134 @@
+# JIT dump tools
+
+Tools for checking that a change to the arm64 JIT emitter did not change the
+code it emits.
+
+- `jit-dump.sh` — capture a canonicalized dump of all JIT-emitted code from
+  one `hermes` binary.
+- `jit-diff.sh` — capture from two binaries and compare, reporting comment
+  changes separately from instruction changes.
+
+## Why not just diff `-Xdump-jitcode` output?
+
+Because two runs of an **unchanged** binary produce different dumps.
+
+`Emitter::loadBits64InGp` asks `isCheapConst()` whether a 64-bit value has at
+most two non-zero 16-bit halfwords. If it does, the value is materialized
+inline with `mov`/`movk`; if not, it is spilled to the read-only data section
+and loaded with `ldr`. JIT-emitted code bakes in runtime pointers, and ASLR
+moves those every run. So the emitter genuinely selects *different
+instructions* from one run to the next, and every subsequent RO-data offset
+shifts along with them.
+
+You can see this for yourself:
+
+```sh
+utils/jit/jit-dump.sh --raw -o /tmp/a.txt build/bin/hermes
+utils/jit/jit-dump.sh --raw -o /tmp/b.txt build/bin/hermes
+diff -u /tmp/a.txt /tmp/b.txt | grep -cE '^[-+]'
+```
+
+That reports roughly 3,500 changed lines out of about 90,000 — from the same
+binary, twice, with no code change at all. Disabling ASLR (running under lldb)
+cuts it to a few dozen but does not eliminate it, because the contiguous
+heap's base address comes from a separate randomized mmap.
+
+`jit-dump.sh` therefore collapses constant materialization to a `CONST` token,
+drops the RO-data contents, and normalizes any remaining wide hex literal to
+`ADDR`. What survives is compared verbatim: instructions, registers, branches,
+labels, ordering, and the emitter's own comments. In practice that is about
+92% of the dump, and the same command without `--raw` reports zero
+differences.
+
+## Usage
+
+Both tools take **binaries**, not a build directory, so they work regardless
+of how you built.
+
+```sh
+# Build the "before" binary and stash it somewhere.
+cmake --build build --target hermes
+cp build/bin/hermes /tmp/hermes-before
+
+# Make your change, rebuild, and compare.
+utils/jit/jit-diff.sh /tmp/hermes-before build/bin/hermes
+```
+
+Typical output for a refactor that should be behaviour-preserving:
+
+```
+jit-diff: dumps are identical
+```
+
+and for one that touches only `Emitter::comment()` strings:
+
+```
+jit-diff: 20 changed lines (+10 / -10)
+  comment lines:     20
+  instruction lines: 0
+RESULT: comments only, no instruction changed
+```
+
+`--comments-ok` makes that second case exit 0, which is useful when a change
+deliberately edits a comment string.
+
+If the "before" binary is gone but you kept its capture, compare the dumps
+directly:
+
+```sh
+utils/jit/jit-diff.sh --dumps /tmp/before.txt /tmp/after.txt
+```
+
+To capture a single dump, for example to read one function by hand:
+
+```sh
+utils/jit/jit-dump.sh --raw -c test/jit/binops.js build/bin/hermes | less
+```
+
+`--raw` skips canonicalization. Use it for reading, never for comparing.
+
+## Corpus
+
+By default the corpus is every `test/jit/*.js` plus three typed tests that
+exercise paths the JIT tests do not:
+
+- `test/shermes/array-typed.js`
+- `test/hermes/flow/array-for-of.js`
+- `test/hermes/flow/nbody.js`
+
+Each `test/jit` file is run typed if and only if its own lit `RUN:` line
+passes `-typed`. That matters more than it sounds: running a typed test
+untyped does not just lose coverage, it fails to compile, so the file
+contributes a syntax error to the dump instead of any JIT code.
+
+Override with `-c FILE` (untyped) and `-t FILE` (compiled with `-typed`),
+both repeatable. Supplying either replaces the whole default corpus.
+
+A corpus file that exits nonzero aborts the capture. Its diagnostics would
+otherwise land in the dump, where they are indistinguishable from emitted
+code and will happily compare equal between two runs.
+
+## Limitations
+
+**Canonicalized lines are not compared.** A change that alters *which*
+instruction form is chosen for a constant is invisible to these tools, because
+that is exactly what gets collapsed to `CONST`. If your change touches
+`isCheapConst`, `loadBits64InGp`, `uint64Const`, or RO-data layout, these tools
+cannot verify it.
+
+**Coverage is only as good as the corpus.** An emitter path no test reaches
+will not appear in the dump. Notably, every function in the default corpus has
+well under 4 KB of bytecode, so paths gated on large bytecode offsets — such as
+the two-instruction `add` in `Emitter::getBytecodeIP` — are never exercised.
+Add a targeted file with `-c` when working on one of those.
+
+**A clean diff is not a correctness proof.** It shows the emitted code did not
+change, which is the right check for a refactor. It says nothing about whether
+the code was correct to begin with, and nothing about the emitter's own runtime
+behaviour. Run the lit suite too.
+
+**The JIT must be enabled** in the binaries under test
+(`-DHERMESVM_ALLOW_JIT=1`); the tools force it on per-run with `-Xjit=force
+-Xjit-threshold=1`, but cannot enable a compile-time-disabled JIT. If a binary
+was built without it, `jit-dump.sh` fails with a message saying so rather than
+silently producing an empty dump.

--- a/utils/jit/jit-diff.sh
+++ b/utils/jit/jit-diff.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Compare the JIT-emitted code of two hermes binaries over the same corpus.
+#
+# Takes binaries rather than driving a build, so it works the same whether the
+# binaries came from CMake, buck2, or anywhere else.
+#
+# Reports whether any *instruction* changed, separately from comment lines,
+# because that is usually the question being asked of a refactor.
+
+set -u
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+  cat <<'EOF'
+Usage: jit-diff.sh [options] <hermes-before> <hermes-after>
+
+Captures a canonicalized JIT dump from each binary and compares them,
+reporting comment-line changes separately from instruction changes.
+
+Options:
+  -k DIR         Keep the captures and the diff in DIR instead of a temp dir.
+  -c FILE        Add FILE to the corpus, run untyped. Repeatable.
+  -t FILE        Add FILE to the corpus, run with -typed. Repeatable.
+  -n N           Show at most N lines of the diff (default 40, 0 for all).
+  --comments-ok  Exit 0 when only comment lines differ.
+  --dumps        The two arguments are existing jit-dump.sh outputs rather
+                 than binaries. Useful when the "before" binary is gone but
+                 its capture was kept.
+  -h, --help     Show this help.
+
+Exit status:
+  0  dumps identical (or only comments differ, with --comments-ok)
+  1  dumps differ
+  2  usage or capture error
+
+Example:
+  git stash && cmake --build build --target hermes && cp build/bin/hermes /tmp/h-before
+  git stash pop && cmake --build build --target hermes
+  utils/jit/jit-diff.sh /tmp/h-before build/bin/hermes
+EOF
+}
+
+KEEP=""
+MAXLINES=40
+COMMENTS_OK=0
+DUMPS=0
+CORPUS=()
+
+# Abort rather than loop forever when an option is given without its operand.
+need_arg() {
+  if [ "$2" -lt 2 ]; then
+    echo "jit-diff: option $1 requires an argument" >&2
+    exit 2
+  fi
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -k) need_arg -k $#; KEEP="$2"; shift 2 ;;
+    -c) need_arg -c $#; CORPUS+=(-c "$2"); shift 2 ;;
+    -t) need_arg -t $#; CORPUS+=(-t "$2"); shift 2 ;;
+    -n) need_arg -n $#; MAXLINES="$2"; shift 2 ;;
+    --comments-ok) COMMENTS_OK=1; shift ;;
+    --dumps) DUMPS=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    -*) echo "jit-diff: unknown option: $1" >&2; usage >&2; exit 2 ;;
+    *) break ;;
+  esac
+done
+
+if [ $# -ne 2 ]; then
+  echo "jit-diff: expected two ${DUMPS:+dump files}${DUMPS:-hermes binaries}" >&2
+  usage >&2
+  exit 2
+fi
+BEFORE="$1"
+AFTER="$2"
+
+if [ -n "$KEEP" ]; then
+  mkdir -p "$KEEP" || exit 2
+  D="$KEEP"
+else
+  D="$(mktemp -d)"
+  trap 'rm -rf "$D"' EXIT
+fi
+
+if [ "$DUMPS" -eq 1 ]; then
+  for f in "$BEFORE" "$AFTER"; do
+    if [ ! -f "$f" ] || [ ! -r "$f" ]; then
+      echo "jit-diff: cannot read dump file: $f" >&2
+      exit 2
+    fi
+  done
+  cp "$BEFORE" "$D/before.txt" || exit 2
+  cp "$AFTER" "$D/after.txt" || exit 2
+else
+  echo "jit-diff: capturing 'before' from $BEFORE" >&2
+  "$SCRIPT_DIR/jit-dump.sh" ${CORPUS[@]+"${CORPUS[@]}"} -o "$D/before.txt" "$BEFORE" || exit 2
+  echo "jit-diff: capturing 'after'  from $AFTER" >&2
+  "$SCRIPT_DIR/jit-dump.sh" ${CORPUS[@]+"${CORPUS[@]}"} -o "$D/after.txt" "$AFTER" || exit 2
+fi
+
+# diff exits 0 for same, 1 for differing, >1 for trouble. Treating trouble as
+# "differing" would report a misleading result for an unreadable capture.
+diff -u "$D/before.txt" "$D/after.txt" > "$D/jit.diff"
+DSTATUS=$?
+if [ "$DSTATUS" -eq 0 ]; then
+  echo "jit-diff: dumps are identical"
+  exit 0
+elif [ "$DSTATUS" -gt 1 ]; then
+  echo "jit-diff: diff failed with status $DSTATUS" >&2
+  exit 2
+fi
+
+# Classify each changed line. A line that begins with '//' after the diff
+# marker is a comment emitted by Emitter::comment(); anything else is a label
+# or an instruction.
+changed=$(grep -cE '^[-+]' "$D/jit.diff")
+headers=$(grep -cE '^(\+\+\+|---)' "$D/jit.diff")
+changed=$((changed - headers))
+added=$(grep -cE '^\+' "$D/jit.diff")
+removed=$(grep -cE '^-' "$D/jit.diff")
+added=$((added - 1))
+removed=$((removed - 1))
+comments=$(grep -E '^[-+]' "$D/jit.diff" | grep -vE '^(\+\+\+|---)' \
+           | sed -E 's/^[-+][[:space:]]*//' | grep -cE '^//' || true)
+insns=$((changed - comments))
+
+echo "jit-diff: $changed changed lines (+$added / -$removed)"
+echo "  comment lines:     $comments"
+echo "  instruction lines: $insns"
+if [ "$insns" -eq 0 ]; then
+  echo "RESULT: comments only, no instruction changed"
+else
+  echo "RESULT: INSTRUCTIONS CHANGED"
+fi
+[ -n "$KEEP" ] && echo "captures and diff kept in $D"
+
+if [ "$MAXLINES" -ne 0 ]; then
+  echo "--- first $MAXLINES diff lines ---"
+  head -n "$MAXLINES" "$D/jit.diff"
+else
+  cat "$D/jit.diff"
+fi
+
+if [ "$insns" -eq 0 ] && [ "$COMMENTS_OK" -eq 1 ]; then
+  exit 0
+fi
+exit 1

--- a/utils/jit/jit-dump.sh
+++ b/utils/jit/jit-dump.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Capture a canonicalized dump of all JIT-emitted code over a corpus of JS
+# files, suitable for byte-for-byte comparison between two builds.
+#
+# The canonicalization is not optional for comparison purposes; see
+# utils/jit/README.md for why two runs of an *unchanged* binary produce
+# different raw dumps.
+
+set -u
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+usage() {
+  cat <<'EOF'
+Usage: jit-dump.sh [options] <hermes-binary>
+
+Runs <hermes-binary> over a corpus of JS files with the JIT forced on,
+dumping every emitted function, and canonicalizes the output so that two
+captures can be compared byte for byte.
+
+Options:
+  -o FILE        Write the dump to FILE (default: stdout).
+  -c FILE        Add FILE to the corpus, run untyped. Repeatable.
+  -t FILE        Add FILE to the corpus, run with -typed. Repeatable.
+                 If neither -c nor -t is given, the default corpus is used:
+                 test/jit/*.js plus a few typed tests.
+  --raw          Skip canonicalization. Useful for reading a single dump,
+                 useless for comparing two.
+  -q             Do not print the summary line to stderr.
+  -h, --help     Show this help.
+
+Examples:
+  # Capture from a CMake build.
+  utils/jit/jit-dump.sh -o /tmp/before.txt ~/build/bin/hermes
+
+  # Compare two builds (see also jit-diff.sh).
+  utils/jit/jit-dump.sh -o /tmp/after.txt ./bin/hermes
+  diff -u /tmp/before.txt /tmp/after.txt
+
+  # Just one file, raw, to read by hand.
+  utils/jit/jit-dump.sh --raw -c test/jit/binops.js ./bin/hermes
+EOF
+}
+
+OUT=""
+RAW=0
+QUIET=0
+UNTYPED=()
+TYPED=()
+
+# Abort rather than loop forever when an option is given without its operand.
+need_arg() {
+  if [ "$2" -lt 2 ]; then
+    echo "jit-dump: option $1 requires an argument" >&2
+    exit 2
+  fi
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) need_arg -o $#; OUT="$2"; shift 2 ;;
+    -c) need_arg -c $#; UNTYPED+=("$2"); shift 2 ;;
+    -t) need_arg -t $#; TYPED+=("$2"); shift 2 ;;
+    --raw) RAW=1; shift ;;
+    -q) QUIET=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    -*) echo "jit-dump: unknown option: $1" >&2; usage >&2; exit 2 ;;
+    *) break ;;
+  esac
+done
+
+if [ $# -ne 1 ]; then
+  echo "jit-dump: expected exactly one hermes binary" >&2
+  usage >&2
+  exit 2
+fi
+HERMES="$1"
+
+if [ ! -x "$HERMES" ]; then
+  echo "jit-dump: not an executable: $HERMES" >&2
+  exit 2
+fi
+
+# Default corpus: every JIT test, plus a few typed tests that exercise paths
+# the JIT tests do not.
+#
+# A JIT test is run typed iff its own lit RUN line passes -typed. Running a
+# typed test untyped does not merely reduce coverage: it fails to compile, and
+# the corpus then contributes a syntax error instead of any JIT code.
+if [ ${#UNTYPED[@]} -eq 0 ] && [ ${#TYPED[@]} -eq 0 ]; then
+  while IFS= read -r f; do
+    if grep -qE '^// *RUN:.*[[:space:]]-typed([[:space:]]|$)' "$f"; then
+      TYPED+=("$f")
+    else
+      UNTYPED+=("$f")
+    fi
+  done < <(ls "$ROOT"/test/jit/*.js 2>/dev/null)
+  TYPED+=("$ROOT/test/shermes/array-typed.js")
+  TYPED+=("$ROOT/test/hermes/flow/array-for-of.js")
+  TYPED+=("$ROOT/test/hermes/flow/nbody.js")
+  if [ ${#UNTYPED[@]} -eq 0 ] && [ ${#TYPED[@]} -eq 3 ]; then
+    echo "jit-dump: default corpus is empty; no $ROOT/test/jit/*.js found" >&2
+    exit 2
+  fi
+fi
+
+for f in ${UNTYPED[@]+"${UNTYPED[@]}"} ${TYPED[@]+"${TYPED[@]}"}; do
+  [ -f "$f" ] || { echo "jit-dump: no such corpus file: $f" >&2; exit 2; }
+done
+
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+# Canonicalize:
+#  - Collapse constant materialization to a CONST token. isCheapConst() picks
+#    between mov/movk and an RO-data load based on the *value*, and JIT code
+#    bakes in runtime pointers that ASLR moves every run.
+#  - Drop the RO_DATA contents, whose layout shifts with the above.
+#  - Normalize any remaining wide hex literal to ADDR.
+canonicalize() {
+  if [ "$RAW" -eq 1 ]; then
+    cat
+    return
+  fi
+  sed -E \
+      -e 's/^( *)mov (x[0-9]+), 0x[0-9A-Fa-f]+$/\1CONST \2/' \
+      -e 's/^( *)ldr (x[0-9]+), \[RO_DATA(, [0-9]+)?\]$/\1CONST \2/' \
+      -e 's/^( *)ldr (d[0-9]+), \[RO_DATA(, [0-9]+)?\]$/\1CONST \2/' \
+      -e '/JIT total memory usage/d' \
+      -e '/^\.xword /d' \
+      -e '/^\/\/ Bytecode start$/d' \
+      -e '/^\/\/ RuntimeModule$/d' \
+      -e 's/0x[0-9A-Fa-f]{8,}/ADDR/g' \
+  | awk '/^RO_DATA:$/ {inro=1; next} inro && /^\/\// {next} inro {inro=0} {print}'
+}
+
+run_one() {
+  local label="$1" file="$2"; shift 2
+  local before after
+  # Snapshot the whole pipeline status: hermes failing and canonicalization
+  # failing both yield a dump that is wrong but looks plausible.
+  local -a pstatus
+  echo "===== $label =====" >> "$TMP"
+  before=$(wc -l < "$TMP")
+  "$HERMES" "$@" -Xjit=force -Xjit-threshold=1 -Xdump-jitcode=3 "$file" 2>&1 \
+    | canonicalize >> "$TMP"
+  pstatus=("${PIPESTATUS[@]}")
+  after=$(wc -l < "$TMP")
+  # A failing run still writes its diagnostics into the dump, where they are
+  # indistinguishable from emitted code. Never let that pass silently.
+  if [ "${pstatus[0]}" -ne 0 ]; then
+    echo "jit-dump: '$label' exited with status ${pstatus[0]}" >&2
+    echo "  Its diagnostics, not JIT output, would have gone into the dump." >&2
+    echo "  Last lines captured:" >&2
+    tail -n 3 "$TMP" | sed 's/^/    /' >&2
+    exit 1
+  fi
+  # Canonicalization is sed|awk writing to $TMP, so this catches a write
+  # failure (full disk, unwritable temp) that would silently truncate.
+  if [ "${pstatus[1]}" -ne 0 ]; then
+    echo "jit-dump: canonicalizing '$label' failed with status ${pstatus[1]}" >&2
+    echo "  The dump is likely truncated; refusing to continue." >&2
+    exit 1
+  fi
+  if [ "$after" -le "$((before + 2))" ]; then
+    echo "jit-dump: '$label' emitted almost nothing." >&2
+    echo "  Is $HERMES built with the JIT enabled (HERMESVM_ALLOW_JIT)?" >&2
+    exit 1
+  fi
+}
+
+for f in ${UNTYPED[@]+"${UNTYPED[@]}"}; do run_one "$(basename "$f")" "$f"; done
+for f in ${TYPED[@]+"${TYPED[@]}"}; do run_one "typed $(basename "$f")" "$f" -typed; done
+
+if [ "$QUIET" -eq 0 ]; then
+  total=$(wc -l < "$TMP" | tr -d ' ')
+  const=$(grep -c 'CONST ' "$TMP" || true)
+  pct=$(( total > 0 ? (total - const) * 100 / total : 0 ))
+  echo "jit-dump: $total lines, $const canonicalized (${pct}% compared verbatim)" >&2
+fi
+
+if [ -n "$OUT" ]; then
+  cp "$TMP" "$OUT"
+else
+  cat "$TMP"
+fi


### PR DESCRIPTION
Summary:

Promote the throwaway scripts used to verify the JitEmitter split into
`utils/jit/`, reworked to take hermes binaries rather than drive a
build, so they work in both the internal and open-source checkouts. The
README covers why raw `-Xdump-jitcode` output cannot be compared
directly.

Reviewed By: micleo2

Differential Revision: D116842078


