### PR TITLE
Bail out early when expanding $-substitutions in String.prototype.replace

### DIFF
--- a/lib/VM/JSLib/RegExp.cpp
+++ b/lib/VM/JSLib/RegExp.cpp
@@ -1475,6 +1475,12 @@ CallResult<HermesValue> getSubstitution(
   // Don't use a StringView iterator, as any calls to createStringView can
   // allocate and move the underlying char storage.
   for (size_t i = 0, e = replacementView.length(); i < e;) {
+    // A single $ substitution can expand to the whole input string, so result
+    // can grow past MAX_STRING_LENGTH before the bounds check in
+    // StringPrimitive::create() below runs. Bail out early with a RangeError
+    // instead, as overflowing the intermediate SmallVector would crash.
+    if (LLVM_UNLIKELY(result.size() > StringPrimitive::MAX_STRING_LENGTH))
+      return runtime.raiseRangeError("String length exceeds limit");
     // Go character by character and account for $ replacement strings.
     char16_t c0 = replacementView[i];
     if (c0 != u'$' || i + 1 == e) {

--- a/test/hermes/string-replace-substitution-overflow.js
+++ b/test/hermes/string-replace-substitution-overflow.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -O -target=HBC -gc-sanitize-handles=0 %s | %FileCheck --match-full-lines %s
+// RUN: %hermes -O -target=HBC -gc-sanitize-handles=0 -emit-binary -out %t.hbc %s && %hermes %t.hbc | %FileCheck --match-full-lines %s
+// RUN: %shermes -exec %s -Wx,-gc-sanitize-handles=0 | %FileCheck --match-full-lines %s
+
+// Regression test for an integer overflow when expanding $-substitutions in
+// String.prototype.replace. Each `$`` expands to the portion of the input
+// string before the match, so a long input string with a long replacement
+// template can build a result larger than MAX_STRING_LENGTH. The intermediate
+// SmallVector used to grow past its capacity limit and abort the process
+// ("SmallVector capacity overflow during allocation") instead of throwing. The
+// result is now bounded and a RangeError is thrown instead.
+
+var s = "x".repeat(1024 * 1024) + "a";
+var t = "$`".repeat(300);
+try {
+  s.replace("a", t);
+  print("no error");
+} catch (e) {
+  print("caught", e.name);
+}
+//CHECK: caught RangeError


### PR DESCRIPTION
# Summary

`String.prototype.replace` can crash the engine instead of throwing a `RangeError` when the replacement template expands to an oversized result.

`getSubstitution()` builds the replacement string in an intermediate `SmallU16String`. A replacement template containing many `$`-substitutions (e.g. ``$` ``) that each expand to a large portion of the input string can grow this intermediate buffer past 2^31 code units. `SmallVector`'s capacity doubling then wraps the 32-bit capacity and aborts with `SmallVector capacity overflow during allocation` (issue #1033) *before* the bounds check in `StringPrimitive::create()` can raise the expected `RangeError`.

## The fix

Check the result length at the top of the substitution loop and raise `RangeError("String length exceeds limit")` as soon as the result exceeds `MAX_STRING_LENGTH` (256 MiB), matching the bounds check `StringPrimitive::create()` would apply.

With this bound the intermediate result can never exceed `2 * MAX_STRING_LENGTH < 2^31` code units, so the `SmallVector` capacity doubling can no longer overflow.

## Test

Added `test/hermes/string-replace-substitution-overflow.js`, which builds a replacement result larger than `MAX_STRING_LENGTH` via ``$` `` substitutions and asserts that a `RangeError` is thrown. It mirrors the memory scale of the existing `test/hermes/large-string.js` and the range-error pattern of `test/hermes/regexp-replace-truncation.js`.

Fixes #1033.