### PR TITLE
JIT: assert values match their register class (#2155)

### DIFF
--- a/doc/superpowers/plans/2026-08-20-jit-type-asserts.md
+++ b/doc/superpowers/plans/2026-08-20-jit-type-asserts.md
@@ -1,0 +1,969 @@
+# JIT FR Type Assertions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Emit runtime checks into arm64 JIT'ed code, under a new default-off
+flag, that verify the FR type facts the emitters rely on when they elide tag
+checks and when they place values in class-restricted callee-saved registers.
+
+**Architecture:** One check primitive (`Emitter::emitTypeAssert`) that uses
+only the two reserved scratch registers and never touches `TempRegAlloc`,
+plus one out-of-line fail stub per site riding the existing `slowPaths_`
+deque, plus one shared per-function tail that calls a noreturn C++ handler.
+Consumption-side checks (Classes A and B) go where the fast path has already
+materialized its operand and before that fast path's own compare. The
+producer-side check (Class C) runs from a hook at the bytecode instruction
+boundary in `compileBB`, not from inside the register-file helpers.
+
+**Tech Stack:** C++17 (no exceptions, no RTTI), asmjit, buck2 (the build and
+test path for all work), CMake + Ninja (must stay green, out-of-tree only),
+LLVM lit + FileCheck, Sapling.
+
+**Design:** `doc/superpowers/specs/2026-08-20-jit-type-asserts-design.md`.
+Read it before Task 1; this plan does not restate its motivation or its
+justification for any of the choices below.
+
+## Global Constraints
+
+- **Emitted code must be byte-identical with the flag off.** After every
+  task, `utils/jit/jit-diff.sh <before> <after>` must report
+  `dumps are identical`. This is the single most important constraint: a
+  debugging feature that perturbs production codegen is worse than none.
+- **The flag is a runtime flag, not a build-time one.** Gate everything on
+  `emitTypeAsserts_`. Never gate emitted-code paths on `#ifndef NDEBUG` —
+  a release build with `-Xjit-emit-type-asserts` must emit the checks.
+  (`assert()` on compile-time bookkeeping is still fine and encouraged.)
+- **Check sequences use `x16`/`x17` only.** Never call `allocTempGpX`,
+  `allocTempVecD`, `getOrAllocFRIn*`, `syncToFrame`, or `freeReg` from
+  check-emission code. No new spills, no LRU state changes.
+- **Every insertion point must be verified flags-dead by the author.** This
+  is not a property arm64 emitters have in general; `selectObject` holds
+  NZCV across `getOrAllocFRInGpX` and consumes it in `csel`. State the
+  verification for each site in the task report.
+- 80-column lines, 2-space indent, doc comment on every declaration, Meta
+  copyright header on every new file, trailing newline, `\n` line endings.
+- **Build and test with buck2. Never create a CMake build directory inside
+  `fbsource`.** This checkout is on EdenFS, which does not support CMake
+  build trees (`facebook/CLAUDE-meta.md`). CMake must stay green, but it is
+  verified from a build directory outside `fbsource` — the controller
+  supplies the path in each dispatch — and never by configuring one here.
+- `arc f` and `arc lint` clean.
+
+## Design points this plan resolves
+
+The design doc leaves four things implicit that turn into concrete decisions
+here. They are listed once, up front, rather than argued inside each task.
+
+1. **The Class C hook is a sibling of `assertPostInstructionInvariants`, not
+   an addition to its body.** That function is `{}` under `NDEBUG`
+   (`JitEmitter.h:473`), so putting emitted-code generation inside it would
+   silently disable Class C in release builds where the flag is on.
+2. **The leaked object is the `std::vector`, not its buffer.** The design
+   says to leak a `TypeAssertSite[]` and store its address in RO data, but
+   the array's address is not known until every site is registered, which
+   is after the RO-data constant must be emitted. Leaking the vector
+   *object* gives a stable address at first use and needs no back-patching.
+3. **The handler does not take `SHRuntime *`.** It formats from the site
+   record alone (`CodeBlock::getFunctionID`, `getNameString`), so the fail
+   tail is one instruction shorter and the stubs pass the site index in
+   `w0` rather than `w1`.
+4. **`TypeAssertSite` stores a bytecode offset, not an `inst::Inst *`.**
+   Computed at emit time with `codeBlock_->getOffsetOf(emittingIP)`, the
+   same call `getBytecodeIP` makes.
+
+## Verification harness
+
+Everything here is buck2. `jit-diff.sh` and `jit-dump.sh` take **binaries**,
+not a build directory, so they work with buck2 output unchanged — resolve
+the binary once and reuse it:
+
+```bash
+HERMES=$(buck2 build //xplat/static_h:hermes --show-full-output | awk '{print $2}')
+```
+
+Capture the baseline binary once, in Task 1, from a pristine tree before any
+edit. Both sides of every later comparison must come from the same build
+system, so a baseline built any other way is not usable:
+
+```bash
+cp "$HERMES" /tmp/hermes-typeassert-base
+```
+
+Then after each task:
+
+```bash
+HERMES=$(buck2 build //xplat/static_h:hermes --show-full-output | awk '{print $2}')
+utils/jit/jit-diff.sh /tmp/hermes-typeassert-base "$HERMES"
+buck2 test //xplat/static_h:lit
+arc lint
+```
+
+`jit-diff.sh` defaults to running without the new flag, so
+`dumps are identical` is the expected result for every task including the
+last one. To see what a task *added*, capture with the flag explicitly:
+
+```bash
+utils/jit/jit-dump.sh --raw -c test/jit/type-asserts.js "$HERMES" | less
+```
+
+Note that `jit-dump.sh` does not pass `-Xjit-emit-type-asserts`; add it to
+the invocation by hand when inspecting, or run the binary directly.
+
+**CMake must also stay green**, but from a build directory *outside*
+`fbsource`; the controller supplies the path in each dispatch. Never
+configure one inside the repository — EdenFS does not support CMake build
+trees, and a 4 GB build directory in the source tree is a real cost even
+though `.gitignore` hides it.
+
+`buck2 test //xplat/static_h:testsuite_tests` (and `:testsuite_tests_jit`)
+are the heavyweight suites. Do not run them per task; they are for the final
+review, and only when the human asks.
+
+---
+
+### Task 1: Add the `-Xjit-emit-type-asserts` flag
+
+Plumbing only. No emitted-code change, which makes this the task that
+establishes the byte-identical baseline.
+
+The chain mirrors `jitEmitAsserts` exactly, at five sites. Do not reuse
+`emitAsserts_`: it defaults to **true** under `!NDEBUG`
+(`include/hermes/VM/RuntimeFlags.h:286`), so the checks would be emitted
+in every debug lit run.
+
+**Files:**
+- Modify: `include/hermes/VM/RuntimeFlags.h:286` (add after `JITEmitAsserts`)
+- Modify: `include/hermes/ConsoleHost/ConsoleHost.h:171`
+- Modify: `tools/hermes/hermes.cpp:150`
+- Modify: `lib/ConsoleHost/ConsoleHost.cpp:969`
+- Modify: `include/hermes/VM/JIT/JIT.h:127` (no-op stubs for the non-JIT build)
+- Modify: `include/hermes/VM/JIT/arm64/JIT.h:143,161,191`
+- Modify: `lib/VM/JIT/arm64/JIT.cpp:117` (`Compiler` ctor init list)
+- Modify: `lib/VM/JIT/arm64/JitEmitter.h:307,460` (member + ctor param)
+- Modify: `lib/VM/JIT/arm64/JitEmitter.cpp:64` (ctor init list)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `Emitter::emitTypeAsserts_` (`bool const`, private),
+  `JITContext::setEmitTypeAsserts(bool)`,
+  `JITContext::getEmitTypeAsserts()`, and the
+  `-Xjit-emit-type-asserts` command-line flag.
+
+- [ ] **Step 1: Capture the baseline binary**
+
+```bash
+HERMES=$(buck2 build //xplat/static_h:hermes --show-full-output | awk '{print $2}')
+cp "$HERMES" /tmp/hermes-typeassert-base
+```
+
+- [ ] **Step 2: Add the command-line flag**
+
+In `include/hermes/VM/RuntimeFlags.h`, immediately after the
+`JITEmitAsserts` option. Unlike that one, it is unconditionally
+`init(false)`:
+
+```cpp
+  llvh::cl::opt<bool> JITEmitTypeAsserts{
+      "Xjit-emit-type-asserts",
+      llvh::cl::Hidden,
+      llvh::cl::cat(RuntimeCategory),
+      llvh::cl::desc(
+          "(default false) Whether to verify FR type assumptions in JIT "
+          "compiled code"),
+      llvh::cl::init(false)};
+```
+
+- [ ] **Step 3: Thread it to the JIT context**
+
+`include/hermes/ConsoleHost/ConsoleHost.h`, after `jitEmitAsserts`:
+
+```cpp
+  /// Verify FR type assumptions in JIT'ed code.
+  bool jitEmitTypeAsserts{false};
+```
+
+`tools/hermes/hermes.cpp`, after line 150:
+
+```cpp
+  options.jitEmitTypeAsserts = flags.JITEmitTypeAsserts;
+```
+
+`lib/ConsoleHost/ConsoleHost.cpp`, after line 969:
+
+```cpp
+  runtime->getJITContext().setEmitTypeAsserts(options.jitEmitTypeAsserts);
+```
+
+- [ ] **Step 4: Add the JITContext accessors**
+
+`include/hermes/VM/JIT/arm64/JIT.h`, beside `setEmitAsserts`/`getEmitAsserts`
+and the `emitAsserts_` member:
+
+```cpp
+  /// Set the flag to verify FR type assumptions in the JIT'ed code.
+  void setEmitTypeAsserts(bool emitTypeAsserts) {
+    emitTypeAsserts_ = emitTypeAsserts;
+  }
+```
+
+```cpp
+  /// \return true if we should verify FR type assumptions in JIT'ed code.
+  bool getEmitTypeAsserts() {
+    return emitTypeAsserts_;
+  }
+```
+
+```cpp
+  /// Whether to verify FR type assumptions in the JIT'ed code.
+  bool emitTypeAsserts_{false};
+```
+
+`include/hermes/VM/JIT/JIT.h` gets the matching no-ops, beside the existing
+ones at lines 127 and 136:
+
+```cpp
+  void setEmitTypeAsserts(bool emitTypeAsserts) {}
+```
+
+```cpp
+  bool getEmitTypeAsserts() {
+    return false;
+  }
+```
+
+- [ ] **Step 5: Thread it into the Emitter**
+
+`JitEmitter.h`, after the `emitAsserts_` member at line 307:
+
+```cpp
+  /// Whether to verify FR type assumptions in the JIT'ed code.
+  bool const emitTypeAsserts_;
+```
+
+Add a `bool emitTypeAsserts` parameter to the `Emitter` constructor
+declaration (line 460) directly after `emitAsserts`, mirror it in the
+definition's init list (`JitEmitter.cpp:64`), and pass
+`jc.getEmitTypeAsserts()` from the `Compiler` ctor (`JIT.cpp:117`).
+
+- [ ] **Step 6: Verify the flag exists and changes nothing**
+
+```bash
+HERMES=$(buck2 build //xplat/static_h:hermes --show-full-output | awk '{print $2}')
+"$HERMES" -Xjit=force -Xjit-emit-type-asserts test/jit/binops.js
+utils/jit/jit-diff.sh /tmp/hermes-typeassert-base "$HERMES"
+```
+
+Expected: the script exits 0 with `jit-diff: dumps are identical`, and the
+run with the flag produces identical program output to a run without it.
+
+- [ ] **Step 7: Commit**
+
+```bash
+sl commit include/hermes/VM/RuntimeFlags.h \
+  include/hermes/ConsoleHost/ConsoleHost.h tools/hermes/hermes.cpp \
+  lib/ConsoleHost/ConsoleHost.cpp include/hermes/VM/JIT/JIT.h \
+  include/hermes/VM/JIT/arm64/JIT.h lib/VM/JIT/arm64/JIT.cpp \
+  lib/VM/JIT/arm64/JitEmitter.h lib/VM/JIT/arm64/JitEmitter.cpp \
+  --reason "commit type assert flag - sl help commit" \
+  -m "..."
+```
+
+---
+
+### Task 2: The check primitive, the failure path, and the first site
+
+The primitive is not independently testable, so this task also converts one
+Class A site — `arithBinOp` under `forceNumber` — which makes the whole
+chain observable end to end.
+
+**Files:**
+- Modify: `lib/VM/JIT/arm64/JitEmitter.h`
+- Modify: `lib/VM/JIT/arm64/JitEmitter.cpp`
+- Modify: `lib/VM/JIT/arm64/JitEmitter-arith.cpp`
+- Create: `test/jit/type-asserts.js`
+
+**Interfaces:**
+- Consumes: `Emitter::emitTypeAsserts_` from Task 1.
+- Produces, in `namespace hermes::vm::arm64`:
+  - `enum class TypePred : uint8_t` with `IsNumber`, `IsBool`,
+    `NotPointer`, `BitComparable`, `IsObject`
+  - `const char *typePredName(TypePred)`
+  - `struct TypeAssertSite { CodeBlock *codeBlock; uint32_t bytecodeOfs;
+    uint16_t frIndex; TypePred pred; }`
+  - `void Emitter::emitTypeAssert(FR fr, HWReg hwVal, TypePred pred)`
+  - `void Emitter::emitTypeAssertGpX(FR fr, const a64::GpX &xVal,
+    TypePred pred)` (private)
+  - `void Emitter::emitTypeAssertFailTail()` (private)
+  - `[[noreturn]] void _jit_type_assert_failed(uint32_t siteIdx,
+    const std::vector<TypeAssertSite> *sites)`
+  - `static constexpr auto xScratch2 = a64::x17;`
+
+- [ ] **Step 1: Declare the second scratch register**
+
+`JitEmitter.h`, at the `xScratch` definition (line 203). Replace the
+existing comment and add the second register:
+
+```cpp
+/// Scratch registers. x16/x17 sit outside the register allocator and are
+/// used as scratch (call targets, IP materialization, type assert check
+/// sequences); nothing holds a value in them across an emitter call.
+static constexpr auto xScratch = a64::x16;
+static constexpr auto xScratch2 = a64::x17;
+```
+
+- [ ] **Step 2: Add the predicate enum and the site record**
+
+`JitEmitter.h`, above `class Emitter`:
+
+```cpp
+/// A property of an FR's value that a fast path relies on. These are the
+/// predicates the emitters actually exploit, which is narrower and more
+/// useful than the declared FRType.
+enum class TypePred : uint8_t {
+  /// Unsigned-below (HVTag_First << kHV_NumDataBits).
+  IsNumber,
+  /// ETag == HVETag_Bool.
+  IsBool,
+  /// Tag unsigned-below the pointer range. This is the GC-safety predicate.
+  NotPointer,
+  /// NotPointer && !IsNumber: comparable by raw bits.
+  BitComparable,
+  /// Tag == HVTag_Object.
+  IsObject,
+};
+
+/// \return a human-readable name for \p pred, for diagnostics.
+const char *typePredName(TypePred pred);
+
+/// One emitted type check, recorded so the failure handler can name it.
+struct TypeAssertSite {
+  CodeBlock *codeBlock;
+  uint32_t bytecodeOfs;
+  uint16_t frIndex;
+  TypePred pred;
+};
+
+/// Report a failed JIT type assertion and abort. Called only from JIT'ed
+/// code, and never returns, so it needs no register or frame preservation.
+[[noreturn]] void _jit_type_assert_failed(
+    uint32_t siteIdx,
+    const std::vector<TypeAssertSite> *sites);
+```
+
+- [ ] **Step 3: Add the Emitter members**
+
+`JitEmitter.h`, in the private data of `class Emitter`, near `slowPaths_`:
+
+```cpp
+  /// Records for every emitted type check, in site-index order. Allocated
+  /// on first use and deliberately leaked: its address is baked into the
+  /// emitted code, the handler that reads it never returns, and JIT'ed
+  /// code is never freed.
+  std::vector<TypeAssertSite> *typeAssertSites_ = nullptr;
+  /// The shared failure tail, bound only if there is at least one site.
+  asmjit::Label typeAssertFailLab_{};
+```
+
+And the public/private methods:
+
+```cpp
+  /// Emit, only when emitTypeAsserts_ is set, a trap-on-violation check
+  /// that the value of \p fr, currently held in \p hwVal, satisfies
+  /// \p pred.
+  ///
+  /// Uses only xScratch/xScratch2 and never touches the register
+  /// allocator, so it is a pure insertion. It clobbers NZCV, so the caller
+  /// must have verified that flags are dead at the insertion point. That
+  /// is an obligation, not a property emitters have in general: see
+  /// selectObject, which holds flags across getOrAllocFRInGpX.
+  void emitTypeAssert(FR fr, HWReg hwVal, TypePred pred);
+```
+
+- [ ] **Step 4: Implement the primitive**
+
+`JitEmitter.cpp`:
+
+```cpp
+const char *typePredName(TypePred pred) {
+  switch (pred) {
+    case TypePred::IsNumber:
+      return "number";
+    case TypePred::IsBool:
+      return "bool";
+    case TypePred::NotPointer:
+      return "non-pointer";
+    case TypePred::BitComparable:
+      return "non-pointer non-number";
+    case TypePred::IsObject:
+      return "object";
+  }
+  return "<invalid>";
+}
+
+void Emitter::emitTypeAssert(FR fr, HWReg hwVal, TypePred pred) {
+  if (LLVM_LIKELY(!emitTypeAsserts_))
+    return;
+  if (hwVal.isVecD()) {
+    a.fmov(xScratch, hwVal.a64VecD());
+    emitTypeAssertGpX(fr, xScratch, pred);
+  } else {
+    emitTypeAssertGpX(fr, hwVal.a64GpX(), pred);
+  }
+}
+
+void Emitter::emitTypeAssertGpX(
+    FR fr,
+    const a64::GpX &xVal,
+    TypePred pred) {
+  assert(emitTypeAsserts_ && "caller must check emitTypeAsserts_");
+  if (!typeAssertSites_) {
+    typeAssertSites_ = new std::vector<TypeAssertSite>();
+    typeAssertFailLab_ = newPrefLabel("TYPEASSERT_FAIL", 0);
+  }
+
+  uint32_t idx = (uint32_t)typeAssertSites_->size();
+  typeAssertSites_->push_back(TypeAssertSite{
+      codeBlock_,
+      codeBlock_->getOffsetOf(emittingIP),
+      (uint16_t)fr.index(),
+      pred});
+
+  comment("// type assert r%u is %s", fr.index(), typePredName(pred));
+  asmjit::Label failLab = newPrefLabel("TYPEASSERT_", idx);
+
+  // The helpers below tolerate xTemp == xVal; every such use is the last
+  // read of xVal in the sequence.
+  switch (pred) {
+    case TypePred::IsNumber:
+      emit_sh_ljs_is_double(a, xVal, xScratch2);
+      a.b_hs(failLab);
+      break;
+    case TypePred::IsBool:
+      emit_sh_ljs_is_bool(a, xScratch, xVal);
+      a.b_ne(failLab);
+      break;
+    case TypePred::NotPointer:
+      emit_sh_ljs_get_tag(a, xScratch, xVal);
+      emit_sh_ljs_tag_is_pointer(a, xScratch);
+      a.b_hs(failLab);
+      break;
+    case TypePred::BitComparable:
+      emit_sh_ljs_is_double(a, xVal, xScratch2);
+      a.b_lo(failLab);
+      emit_sh_ljs_get_tag(a, xScratch, xVal);
+      emit_sh_ljs_tag_is_pointer(a, xScratch);
+      a.b_hs(failLab);
+      break;
+    case TypePred::IsObject:
+      emit_sh_ljs_is_object(a, xScratch, xVal);
+      a.b_ne(failLab);
+      break;
+  }
+
+  slowPaths_.emplace_back(
+      failLab, emittingIP, [idx](Emitter &em, SlowPath &sp) {
+        em.comment("// Type assert failure %u", idx);
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::w0, idx);
+        em.a.b(em.typeAssertFailLab_);
+      });
+}
+```
+
+Condition codes, for review: `emit_sh_ljs_is_double` leaves number ⟺ LO, so
+not-a-number is HS. `emit_sh_ljs_tag_is_pointer` leaves pointer ⟺ HS.
+`emit_sh_ljs_is_bool` and `emit_sh_ljs_is_object` leave the property ⟺ EQ.
+
+- [ ] **Step 5: Implement the shared tail and the handler**
+
+`JitEmitter.cpp`:
+
+```cpp
+void Emitter::emitTypeAssertFailTail() {
+  if (!typeAssertSites_)
+    return;
+  comment("// Type assert failure tail");
+  a.bind(typeAssertFailLab_);
+  // w0 already holds the site index, set by the per-site stub.
+  a.ldr(
+      a64::x1,
+      a64::Mem(
+          roDataLabel_,
+          uint64Const(
+              (uint64_t)typeAssertSites_, "type assert site table")));
+  // Not EMIT_RUNTIME_CALL: that saves the current IP, and emitSlowPaths()
+  // has already cleared emittingIP by the time this runs. The handler does
+  // not need the IP anyway — the site record carries the bytecode offset.
+  EMIT_RUNTIME_CALL_WITHOUT_SAVED_IP(
+      *this,
+      void (*)(uint32_t, const std::vector<TypeAssertSite> *),
+      _jit_type_assert_failed);
+}
+
+void _jit_type_assert_failed(
+    uint32_t siteIdx,
+    const std::vector<TypeAssertSite> *sites) {
+  const TypeAssertSite &site = (*sites)[siteIdx];
+  std::string message;
+  llvh::raw_string_ostream os(message);
+  os << "JIT type assert failed: function "
+     << site.codeBlock->getFunctionID() << "("
+     << site.codeBlock->getNameString() << "), bytecode offset "
+     << site.bytecodeOfs << ", r" << site.frIndex << ", expected "
+     << typePredName(site.pred);
+  os.flush();
+  hermes_fatal(message);
+}
+```
+
+Call the tail between the two existing calls at the end of the function
+emission (`JitEmitter.cpp:575`), because it allocates an RO-data constant
+and must therefore precede `emitROData`, and it is a branch target of slow
+paths so it must follow `emitSlowPaths`:
+
+```cpp
+  emitSlowPaths();
+  emitTypeAssertFailTail();
+  emitROData();
+```
+
+- [ ] **Step 6: Convert the first site — `arithBinOp` under `forceNumber`**
+
+In `lib/VM/JIT/arm64/JitEmitter-arith.cpp`, in `arithBinOp`, after both
+operands have been materialized by `getOrAllocFRInVecD` and before the
+fast path's own `fcmp`:
+
+```cpp
+  if (forceNumber) {
+    emitTypeAssert(frLeft, hwLeft, TypePred::IsNumber);
+    emitTypeAssert(frRight, hwRight, TypePred::IsNumber);
+  }
+```
+
+Flags-dead verification for this site: the two `getOrAllocFRInVecD` calls
+are the first flag-relevant emissions in the fast path, and the first
+consumer of NZCV (`fcmp`/`b.vs`) is emitted strictly after. Record this in
+the task report.
+
+- [ ] **Step 7: Write the lit test**
+
+`test/jit/type-asserts.js`. It runs the same code twice, once with the flag
+and once without, and checks that behaviour is unchanged. It deliberately
+does **not** FileCheck emitted code: pinning the check sequences line by
+line would turn every future emitter change into a test edit, and the
+property under test is that behaviour and flag-off codegen do not move.
+
+```js
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+// RUN: %hermes -Xjit=force %s | %FileCheck --match-full-lines %s
+// RUN: %hermes -Xjit=force -Xjit-emit-type-asserts %s | %FileCheck --match-full-lines %s
+
+function addNumbers(a, b) {
+  var sum = 0;
+  for (var i = 0; i < 100; ++i)
+    sum += a * b - i;
+  return sum;
+}
+
+print(addNumbers(3, 4));
+// CHECK: -3750
+```
+
+- [ ] **Step 8: Verify**
+
+```bash
+HERMES=$(buck2 build //xplat/static_h:hermes --show-full-output | awk '{print $2}')
+utils/jit/jit-diff.sh /tmp/hermes-typeassert-base "$HERMES"
+buck2 test //xplat/static_h:lit
+```
+
+Expected: `dumps are identical`, all jit tests pass. Then confirm the checks
+really are emitted:
+
+```bash
+"$HERMES" -Xjit=force -Xjit-emit-type-asserts \
+  -Xdump-jitcode=1 test/jit/type-asserts.js | grep -c "type assert"
+```
+
+Expected: a nonzero count.
+
+- [ ] **Step 9: Commit**
+
+---
+
+### Task 3: The remaining Class A sites
+
+`forceNumber` promises number operands and the emitters skip both the check
+and the slow path, so these are the sites where a front-end type-inference
+bug is invisible today.
+
+**Files:**
+- Modify: `lib/VM/JIT/arm64/JitEmitter-arith.cpp` (`arithUnop`, `mod`)
+- Modify: `lib/VM/JIT/arm64/JitEmitter-control.cpp` (`jCond`)
+- Modify: `lib/VM/JIT/arm64/JitEmitter-call.cpp` (`callWithNewTargetLong`)
+
+**Interfaces:**
+- Consumes: `emitTypeAssert`, `TypePred` from Task 2.
+- Produces: nothing new.
+
+- [ ] **Step 1: `arithUnop`**
+
+After `hwInput = getOrAllocFRInVecD(frInput, true);` and before the
+`if (!inputIsNum)` block's `fcmp`:
+
+```cpp
+  if (forceNumber)
+    emitTypeAssert(frInput, hwInput, TypePred::IsNumber);
+```
+
+- [ ] **Step 2: `mod`, `jCond`, `callWithNewTargetLong`**
+
+Same shape in each: immediately after the last operand is materialized,
+before that emitter's first flag-setting instruction. For
+`callWithNewTargetLong` the operand is `frArgc` and the reliance is the
+`fcvtzu` that assumes a number, so the check goes immediately before it.
+
+For each site, verify flags-dead and record the verification.
+
+- [ ] **Step 3: Verify and commit**
+
+Run the harness. `dumps are identical` is still required.
+
+---
+
+### Task 4: `readFRForAssert` and the Class B sites
+
+Class B covers the fast paths that skip a check because `isFRKnownNumber`,
+`isFRKnownBool` or `isFRKnownOtherNonPtr` returned true. Note that those
+predicates consult `globalType` as well as `localType`
+(`JitEmitter.h:1157`), so they test the bytecode header's classification,
+not only the JIT's own bookkeeping.
+
+`jmpUndefined` needs a read helper: when the operand is known Number or
+Bool it emits *nothing*, so there is no materialized register to check.
+
+**Files:**
+- Modify: `lib/VM/JIT/arm64/JitEmitter.h`
+- Modify: `lib/VM/JIT/arm64/JitEmitter.cpp`
+- Modify: `lib/VM/JIT/arm64/JitEmitter-arith.cpp` (`arithBinOp`,
+  `arithUnop`, `compareImpl`, `strictEqualImpl`, `toNumber`, `toNumeric`)
+- Modify: `lib/VM/JIT/arm64/JitEmitter-control.cpp` (`jCond`,
+  `jmpTrueFalse`, `jmpUndefined`, `jStrictEqual`)
+
+**Interfaces:**
+- Consumes: `emitTypeAssert`, `TypePred`.
+- Produces: `void Emitter::readFRForAssert(FR fr)`.
+
+- [ ] **Step 1: Implement `readFRForAssert`**
+
+The location priority must honour the `FRState` up-to-date invariants, not
+just the location order. Reading a stale location would make the assert
+report phantom violations, which is the worst failure mode a checking
+feature can have.
+
+```cpp
+void Emitter::readFRForAssert(FR fr) {
+  assert(emitTypeAsserts_ && "caller must check emitTypeAsserts_");
+  FRState &frState = frameRegs_[fr.index()];
+  assert(!frState.regIsDirty && "reading an FR that is about to be written");
+
+  // Locals always hold the latest value; a global reg holds it only if
+  // globalRegUpToDate; otherwise the frame must be up to date.
+  if (frState.localGpX) {
+    a.mov(xScratch, frState.localGpX.a64GpX());
+  } else if (frState.localVecD) {
+    a.fmov(xScratch, frState.localVecD.a64VecD());
+  } else if (frState.globalReg && frState.globalRegUpToDate) {
+    if (frState.globalReg.isGpX())
+      a.mov(xScratch, frState.globalReg.a64GpX());
+    else
+      a.fmov(xScratch, frState.globalReg.a64VecD());
+  } else {
+    assert(frState.frameUpToDate && "FR has no up-to-date location");
+    // The encoding fallback in _loadFrame also uses xScratch, but sequences
+    // that use before xScratch receives the loaded value.
+    _loadFrame(HWReg(xScratch), fr);
+  }
+}
+```
+
+Declare it in `JitEmitter.h` beside `emitTypeAssert`, private, with the doc
+comment from the design.
+
+- [ ] **Step 2: The materialized-operand sites**
+
+For each row of the design's Class B table except `jmpUndefined`, insert the
+check right after the operand the elision applies to is materialized:
+
+| Emitter | Guard | Check |
+|---|---|---|
+| `arithBinOp`, `arithUnop` | `isFRKnownNumber(fr)` | `IsNumber` on that operand |
+| `compareImpl`, `jCond` | both known Number | `IsNumber` on both |
+| `jmpTrueFalse` | known Number / known Bool | `IsNumber` / `IsBool` |
+| `strictEqualImpl` (`arith.cpp:692`) | known Bool or OtherNonPtr / known Number | `BitComparable` / `IsNumber` on the known side |
+| `jStrictEqual` (`control.cpp:858`) | same two elisions, separate emitter | `BitComparable` / `IsNumber` on the known side |
+
+`jStrictEqual` is a distinct emitter from `strictEqualImpl`, not a caller
+of it, and carries its own copy of both tiers. Convert both.
+
+Note that `arithBinOp`'s `forceNumber` path from Task 2 already sets
+`localType = FRType::Number`, so guard the Class B insertion on
+`!forceNumber` to avoid emitting the same check twice.
+
+- [ ] **Step 3: The early-return elisions**
+
+Three sites elide by returning before anything is materialized, so there is
+no operand register to check and `readFRForAssert` is required. Flags are
+trivially dead at all three: the insertion point is an otherwise empty
+emission.
+
+`jmpUndefined` (`control.cpp:685`) returns early when the input is known
+Number **or** known Bool. Assert the fact that was actually relied on, in
+the same order the emitter tests it:
+
+```cpp
+  if (emitTypeAsserts_) {
+    readFRForAssert(frInput);
+    emitTypeAssertGpX(
+        frInput,
+        xScratch,
+        isFRKnownType(frInput, FRType::Number) ? TypePred::IsNumber
+                                               : TypePred::IsBool);
+  }
+```
+
+Do **not** use `BitComparable` here. It is `NotPointer && !IsNumber`, so it
+would trap on every legitimate number reaching this path, and it accepts
+`undefined` — inverted in both directions.
+
+`toNumber` (`arith.cpp:20`) and `toNumeric` (`arith.cpp:68`) elide with
+`return mov(frRes, frInput, false)` when the input is known Number. The
+check goes immediately before that early return, on `frInput`:
+
+```cpp
+  if (isFRKnownNumber(frInput)) {
+    if (emitTypeAsserts_) {
+      readFRForAssert(frInput);
+      emitTypeAssertGpX(frInput, xScratch, TypePred::IsNumber);
+    }
+    return mov(frRes, frInput, false);
+  }
+```
+
+`toInt32` is **not** a Class B site and must not be converted: it has no
+`isFRKnownNumber` elision at all — it always emits its check and slow
+path.
+
+- [ ] **Step 4: Verify and commit**
+
+---
+
+### Task 5: Class C — producer-side global-class checks
+
+A value stored into an FR that owns a callee-saved global register must
+match that register's class, or the GC will either miss a pointer or
+misread one. Consumption checks cannot cover this, because the GC's
+"consumption" is register residency rather than an emitted instruction.
+
+The hook runs at the bytecode instruction boundary. Do not hook the tail of
+`frUpdatedWithHW`: many emitters call it *before* emitting the write
+(`catchInst`, `callImpl`'s SavedCodeBlock, `bitNot`, `booleanNot`,
+`loadThisNS`, `selectObject`), so it would check a register the value has
+not reached — and because `frUpdatedWithHW` clears `regIsDirty`, it could
+not even detect that it was in that window. A third write path,
+`syncFrameOutParam`, reaches neither `frUpdatedWithHW` nor `movFRFromHW`.
+
+**Files:**
+- Modify: `lib/VM/JIT/arm64/JitEmitter.h`
+- Modify: `lib/VM/JIT/arm64/JitEmitter.cpp`
+- Modify: `lib/VM/JIT/arm64/JitEmitter-regalloc.cpp`
+- Modify: `lib/VM/JIT/arm64/JIT.cpp:157`
+
+**Interfaces:**
+- Consumes: `emitTypeAssertGpX`, `readFRForAssert`, `TypePred`.
+- Produces: `void Emitter::recordFRWriteForAssert(FR fr)` (private),
+  `void Emitter::emitPendingTypeAsserts()` (public, called from
+  `compileBB`).
+
+- [ ] **Step 1: Add the per-instruction written set**
+
+`JitEmitter.h`, in the private data:
+
+```cpp
+  /// FRs written by the bytecode instruction currently being emitted whose
+  /// global register class requires a check. Drained at each instruction
+  /// boundary by emitPendingTypeAsserts().
+  llvh::SmallVector<FR, 4> typeAssertPendingWrites_{};
+```
+
+```cpp
+  /// Record that \p fr was written, so that the instruction boundary can
+  /// check the value against its global register class. Records nothing
+  /// unless the FR owns a global register. The callers gate on
+  /// emitTypeAsserts_.
+  void recordFRWriteForAssert(FR fr);
+```
+
+- [ ] **Step 2: Record from all three write paths**
+
+`JitEmitter-regalloc.cpp`. In `frUpdatedWithHW`, at the top (before it
+clears `regIsDirty`, though the position does not matter — only the
+recording does); in `movFRFromHW`'s direct-to-frame `else` branch; and in
+`syncFrameOutParam`:
+
+```cpp
+  if (LLVM_UNLIKELY(emitTypeAsserts_))
+    recordFRWriteForAssert(fr);
+```
+
+```cpp
+void Emitter::recordFRWriteForAssert(FR fr) {
+  FRState &frState = frameRegs_[fr.index()];
+  // The two conditions coincide today only because enter()'s allocation
+  // loops set globalReg and globalType together and stop together. Pin it,
+  // because the check below relies on it.
+  assert(
+      (frState.globalType != FRType::UnknownPtr) ==
+          frState.globalReg.isValid() &&
+      "globalType and globalReg must agree");
+  if (frState.globalType == FRType::UnknownPtr)
+    return;
+  if (llvh::is_contained(typeAssertPendingWrites_, fr))
+    return;
+  typeAssertPendingWrites_.push_back(fr);
+}
+```
+
+- [ ] **Step 3: Emit at the instruction boundary**
+
+`JitEmitter.cpp`:
+
+```cpp
+void Emitter::emitPendingTypeAsserts() {
+  if (LLVM_LIKELY(typeAssertPendingWrites_.empty()))
+    return;
+  for (FR fr : typeAssertPendingWrites_) {
+    FRState &frState = frameRegs_[fr.index()];
+    TypePred pred = frState.globalType == FRType::Number
+        ? TypePred::IsNumber
+        : TypePred::NotPointer;
+    readFRForAssert(fr);
+    emitTypeAssertGpX(fr, xScratch, pred);
+  }
+  typeAssertPendingWrites_.clear();
+}
+```
+
+`JIT.cpp`, in `compileBB`, as a sibling of the existing call — **not**
+inside `assertPostInstructionInvariants`, whose body is `{}` under
+`NDEBUG`:
+
+```cpp
+    while (ip != to) {
+      em_.emittingIP = ip;
+      ip = dispatch(ip);
+      em_.assertPostInstructionInvariants();
+      em_.emitPendingTypeAsserts();
+    }
+```
+
+`emittingIP` still names the instruction just emitted, which is what the
+site record should carry.
+
+Add to `newBasicBlock`:
+
+```cpp
+  assert(
+      typeAssertPendingWrites_.empty() &&
+      "pending type asserts must be drained at each instruction");
+```
+
+- [ ] **Step 4: Verify and commit**
+
+Beyond the standard harness, run a program that exercises number-classed
+global registers under the flag and confirm no trap:
+
+```bash
+"$HERMES" -Xjit=force -Xjit-emit-type-asserts test/hermes/flow/nbody.js
+```
+
+---
+
+### Task 6: Prove the checks can fail
+
+A green run proves only that the suite ran. Each mutation below is applied
+to a throwaway working copy, observed, and reverted; none of them is
+committed.
+
+**This task produces no commit.** Its deliverable is the three recorded
+failure messages, which go into the task report and into the Test Plan of
+Task 5's commit. There is no `doc/JIT.md` or any other user-facing document
+describing the JIT's `-X` flags in this repository — the `cl::desc` string
+added in Task 1 is the documentation. Do not create one as part of this
+feature.
+
+**Files:**
+- None. Mutations are applied and reverted, never committed.
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-5.
+- Produces: nothing.
+
+- [ ] **Step 1: Class C — a lying emitter**
+
+Change `loadConstString` to declare `FRType::Number`, rebuild, and run any
+test that stores a string into a number-classed FR under the flag. Expect a
+fatal naming that FR and `expected number`. Record the exact message.
+
+- [ ] **Step 2: Class B — a weakened elision**
+
+Force `isFRKnownNumber` to return true for one FR in `arithBinOp`, rebuild,
+run `test/jit/binops.js` under the flag. Expect a trap at the consumption
+site. Record the message.
+
+- [ ] **Step 3: Class A — the `*N` contract**
+
+Apply the Step 2 mutation to the `jLessN` path and run a typed test that
+reaches it. Record the message.
+
+- [ ] **Step 4: Revert all mutations and confirm the tree is clean**
+
+```bash
+sl status --reason "confirm mutations reverted - sl help status"
+```
+
+- [ ] **Step 5: Final verification**
+
+```bash
+buck2 test //xplat/static_h:lit
+utils/jit/jit-diff.sh /tmp/hermes-typeassert-base "$HERMES"
+```
+
+`buck2 test //xplat/static_h:testsuite_tests_jit` is the run that would
+actually certify the existing type plumbing, and the design's rollout order
+asks for it here. It is heavyweight, so ask the human before running it
+rather than starting it unprompted.
+
+---
+
+## Out of scope
+
+- **Class D (typed-mode invariants).** `typedLoadParent`, the `fastArray*`
+  element assumptions, and `AddS`'s both-strings contract. Cheap once the
+  primitive exists, but they validate the typed front-end rather than the
+  JIT, and typed mode has its own checking story. Revisit after Class A/B/C
+  have run clean against test262 and the benchmark suite.
+- **The x86-64 side.** The design's register-convention requirement — a
+  reserved caller-saved scratch (r11, and a second for the `IsNumber`
+  bound, which genuinely cannot be done with one register) — belongs in the
+  port plan's register-convention section, which must be written before the
+  temp allocator's range is fixed.
+- **Sharing Class C across backends.** It lives in
+  `JitEmitter-regalloc.cpp`, the piece proposed for cross-arch extraction
+  (cleanup item A3). If that extraction lands first, Class C is written
+  once for both backends; this plan does not depend on it either way.

--- a/doc/superpowers/specs/2026-08-20-jit-type-asserts-design.md
+++ b/doc/superpowers/specs/2026-08-20-jit-type-asserts-design.md
@@ -1,0 +1,360 @@
+# Design: runtime verification of FR type assumptions (`-Xjit-emit-type-asserts`)
+
+## Motivation
+
+The JIT elides tag checks and decides GC register residency based on FR type
+facts (`FRState::globalType` / `localType`) that come from three unverified
+sources: the bytecode header's number/non-pointer register counts (i.e. the
+whole front-end pipeline), each emitter's hand-written result-type claims
+(~150 `frUpdatedWithHW` sites), and the `*N` instruction contract
+(`forceNumber`). A wrong fact produces silently wrong JS values (a mistyped
+object NaN-boxes as NaN and flows through `fadd`) or delayed heap corruption
+(a pointer in a NonPtr-class callee-saved register is invisible to the GC).
+Nothing checks any of this at run time; `assertPostInstructionInvariants`
+audits only compile-time bookkeeping.
+
+This design adds emitted-code verification of those assumptions under the
+new `emitTypeAsserts_` flag (`-Xjit-emit-type-asserts`, see Configuration), so a violation traps at
+the first instruction that relies on it, with enough metadata to name the
+site. Primary consumer: validating the arm64 backend before the x86-64 port,
+then keeping x86-64 bring-up honest while every emitter is rewritten.
+
+## Goals / non-goals
+
+Goals:
+
+- Trap at the **first consumption** of a value that violates the type fact
+  the fast path relied on, and at the **end of the instruction** that
+  leaves a global-register-class fact violated (see Class C).
+- **Pure insertion**: the build with the flag on must make byte-identical
+  allocation and code-shape decisions to the run with it off, plus
+  inserted check sequences. No interaction with `TempRegAlloc`, no new
+  spills, no changed LRU state.
+- Actionable diagnostics: failure names the function, bytecode offset, FR,
+  and violated predicate.
+
+Non-goals:
+
+- Not a general verifier. A wrong claim that is never consumed (and not
+  covered by the write-side global-class checks) is not caught.
+- Class C validates the front-end's number/non-pointer classification only
+  for the FRs that actually received a global register (~16 per function):
+  `enter()` records `globalType` only for those, so class claims for the
+  overflow FRs are neither used by the JIT nor checkable here. (They are
+  also harmless while unused — but a future backend that consumes them
+  must extend the recording.)
+- The tag-test helpers themselves (`emit_sh_ljs_is_*`) are trusted; they are
+  already covered by static_asserts against the HV encoding.
+- No attempt to keep flags/registers alive across a *failed* check — the
+  failure path is noreturn.
+
+## Design principles
+
+1. **Assert the predicate the fast path relies on, not the declared FRType.**
+   Consumption sites know exactly what they exploit: `arithBinOp` relies on
+   "is a double", the strict-equality raw-bit tier relies on "not a pointer
+   and not a double", global-reg residency relies on "not a pointer". The
+   API therefore takes a predicate, not an `FRType`:
+
+   ```cpp
+   enum class TypePred : uint8_t {
+     IsNumber,     // unsigned-below (HVTag_First << kHV_NumDataBits)
+     IsBool,       // ETag == HVETag_Bool
+     NotPointer,   // tag unsigned-below the pointer range (GC-safety)
+     BitComparable, // NotPointer && !IsNumber: bits are the === identity
+     IsObject,     // tag == HVTag_Object (typed-invariant sites, phase 2)
+   };
+   ```
+
+2. **Reserved scratch only.** All check sequences use x16/x17 (already
+   outside `TempRegAlloc`'s x0–x15 domain, already used as raw scratch by
+   `callRuntime`/`callRuntimeWithSavedIP` and by the `_loadFrame`/
+   `_storeFrame` encoding fallbacks). Never `allocTempGpX`.
+
+3. **Flags-dead placement — a per-site obligation, not a given.** Checks
+   clobber NZCV, so each insertion point must be verified flags-dead by the
+   author; it is *not* a property emitters have in general. Counterexample:
+   `selectObject` sets flags via `emit_sh_ljs_is_object`, then calls
+   `getOrAllocFRInGpX`, then consumes the flags in `csel` — flags live
+   across an allocation call. None of the Class A/B sites below have that
+   shape (their operand materialization precedes their own compare), and
+   the Class C hook runs at bytecode-instruction boundaries where NZCV is
+   dead by construction, but any future site (Class D especially) must be
+   checked, and `emitTypeAssert`'s doc comment must state the obligation.
+   Checks are never inserted inside a window where x16 is live; all such
+   windows (call-target/IP materialization, the frame-access encoding
+   fallbacks) are contained within single helper emissions, so no
+   insertion point in this design ever lands inside one.
+   `readFRForAssert`'s own frame load may itself take the encoding
+   fallback; that is fine — the fallback's x16 use is sequenced before x16
+   receives the loaded value.
+
+## The check primitive
+
+```cpp
+/// Emit (only when emitTypeAsserts_) a trap-on-violation check that the value
+/// of \p fr, currently available in \p hwVal, satisfies \p pred.
+/// Uses only x16/x17. Clobbers NZCV. Must be called when flags are dead.
+void Emitter::emitTypeAssert(FR fr, HWReg hwVal, TypePred pred);
+```
+
+Sequences (input first normalized to a GpX: if `hwVal` is a VecD, emit
+`fmov x16, dN` and check x16; helpers tolerate temp == input):
+
+- `IsNumber`: `mov x17, #(HVTag_First << kHV_NumDataBits)` ; `cmp xIn, x17` ;
+  `b.hs fail`. (Reuses the `emit_sh_ljs_is_double` shape; the only predicate
+  needing both scratch registers when the input is already a GpX.)
+- `IsBool`: `asr x16, xIn, #(kHV_NumDataBits - 1)` ; `cmn x16, #-HVETag_Bool`
+  ; `b.ne fail` (existing `emit_sh_ljs_is_bool`).
+- `NotPointer`: `asr x16, xIn, #kHV_NumDataBits` ; `cmn x16,
+  #-HVTag_FirstPointer` ; `b.hs fail` (inverted `emit_sh_ljs_tag_is_pointer`).
+- `BitComparable`: `IsNumber`-style bound check with inverted branch
+  (`b.lo fail`) followed by `NotPointer`.
+- `IsObject`: existing `emit_sh_ljs_is_object` with x16 as temp; `b.ne fail`.
+
+For sites where no operand is materialized at all (see `jmpUndefined`
+below), a small read helper loads the FR's current value into x16 directly
+from its best location per `FRState` (local reg → global reg → frame slot),
+again without touching the allocator:
+
+```cpp
+/// Read the current value of \p fr into x16 for assertion purposes,
+/// without allocating or perturbing any state.
+void Emitter::readFRForAssert(FR fr);
+```
+
+`readFRForAssert` must honor the FRState up-to-date invariants, not just
+the location priority: read the local reg if one exists (locals always
+hold the latest value), else the global reg **only if
+`globalRegUpToDate`**, else the frame slot (asserting `frameUpToDate`),
+and assert `!regIsDirty` on entry. Reading a stale location would make
+the assert itself report phantom violations — the worst failure mode a
+checking feature can have.
+
+## Insertion sites
+
+### Class A — `forceNumber` contract sites (highest value)
+
+The `*N` bytecodes promise number operands; the emitters skip both checks
+and slow paths. Assert `IsNumber` on every operand. This validates the
+front-end's type inference, not merely the JIT's bookkeeping.
+
+| Emitter | Condition | Operands asserted |
+|---|---|---|
+| `arithBinOp` | `forceNumber` (`AddN`, `SubN`, `MulN`, `DivN`) | left, right |
+| `arithUnop` | `forceNumber`, **unreachable today** | input |
+| `jCond` | `forceNumber` (`JLessN`, `JNotLessN`, `JLessEqualN`, `JNotLessEqualN`) | left, right |
+| `mod` | `forceNumber`, **unreachable today** | left, right |
+| `callWithNewTargetLong` | argc `fcvtzu` assumes number | frArgc |
+
+The `*N` family is exactly those eight opcodes: there is no `NegateN` or
+`ModN`, every `DECL_UNOP` hardcodes `forceNum = false`, and `mod`'s only
+caller passes `false`. The `arithUnop` and `mod` rows are therefore
+contracts the current bytecode never exercises; they cost nothing to
+assert and cover a future `*N` opcode for free.
+
+### Class B — `isFRKnown*` elisions
+
+Wherever a fast path skips a check because `isFRKnownNumber/Bool/
+OtherNonPtr` returned true, emit the skipped predicate anyway:
+
+| Emitter | Elision | Predicate |
+|---|---|---|
+| `arithBinOp` / `arithUnop` | operand known Number → no NaN-box check, possibly no slow path | `IsNumber` per known operand |
+| `compareImpl` / `jCond` | both known Number → no `b.vs` slow path | `IsNumber` per known operand |
+| `mod` | both known Number → no `fcmp`/`b.vs` slow path | `IsNumber` per known operand |
+| `jmpTrueFalse` | known Number → fcmp-only path; known Bool → tst-only path | `IsNumber` / `IsBool` |
+| `jmpUndefined` | known Number/Bool → **emits nothing** | `IsNumber` or `IsBool`, whichever was relied on, via `readFRForAssert` (no operand is otherwise loaded) |
+| `strictEqualImpl` | side known Bool/OtherNonPtr → raw-bit tier; side known Number → fcmp-only tier | `BitComparable` / `IsNumber` on the known side |
+| `jStrictEqual` | separate emitter, same two tiers as `strictEqualImpl` | `BitComparable` / `IsNumber` on the known side |
+| `toNumber` / `toNumeric` | known Number → early `return mov(...)`, no operand materialized | `IsNumber` via `readFRForAssert` |
+
+Where an emitter computes one known-type boolean per operand
+(`arithBinOp`, `mod`, `compareImpl`, `jCond`, `strictEqualImpl`,
+`jStrictEqual`), guard each operand's check on that operand's own
+boolean, never on the emitter's combined fast-path condition (`!slow`).
+Per-operand asserts every fact the JIT holds, at its first appearance,
+rather than only the facts that happen to be load-bearing for the shape
+the emitter chose; with `leftIsNum && !rightIsNum`, `!slow` would assert
+nothing at all.
+
+`jmpUndefined` must **not** use `BitComparable` (`NotPointer && !IsNumber`):
+it would trap on every legitimate number reaching the elided path, and it
+accepts `undefined`. Assert the fact the emitter actually tested.
+
+`toInt32` is deliberately absent: it has no `isFRKnownNumber` elision, and
+always emits its own check and slow path.
+
+### Class C — producer-side checks for global-class FRs (GC direction)
+
+Consumption checks cannot cover the GC, whose "consumption" is implicit in
+register residency. Instead, verify on the **producer side**: whenever a
+value is stored into an FR whose `globalType` is `Number` or
+`UnknownNonPtr` (equivalently: any FR that is *eligible* for a
+callee-saved global register), assert the value matches the class:
+
+- `globalType == Number` → `IsNumber`
+- `globalType == UnknownNonPtr` → `NotPointer`
+
+"Producer side", not "write time": the check is emitted at the *next
+bytecode instruction boundary*, for the reasons argued below, so what it
+validates is the value the FR holds once the writing instruction has
+finished. An instruction that stores a non-conforming value, makes a
+runtime call (a GC safepoint), and then overwrites it with a conforming
+one before it ends passes the check. That gap is not a bug in the
+recording; it follows from the boundary placement, which is the only
+sound hook available.
+
+Insertion point: a **post-instruction hook**, not a tail hook in
+`frUpdatedWithHW`. A tail hook there is unsound: many emitters call
+`frUpdatedWithHW` *before* emitting the write into the register (the
+declare-then-write pattern that `FRState::regIsDirty` exists to model —
+e.g. `catchInst` declares the result FR updated and only then emits the
+`ldr` from `thrownValue_`; `callImpl`'s SavedCodeBlock reg, `bitNot`,
+`booleanNot` and `loadThisNS` have the same shape), so the hook would
+check a register that does not yet hold the value — and since
+`frUpdatedWithHW` clears `regIsDirty`, the hook cannot even detect that it
+is in that window. A third write path, `syncFrameOutParam` (the runtime
+wrote the frame slot directly; seven callers), reaches neither
+`frUpdatedWithHW` nor `movFRFromHW` at all.
+
+Instead: `frUpdatedWithHW`/`movFRFromHW`/`syncFrameOutParam` merely
+*record* the FR in a small per-instruction written-set (compile-time
+bookkeeping, done only when the flag is on), and a hook invoked at each
+bytecode instruction boundary — alongside the existing compile-time
+`assertPostInstructionInvariants` call in `compileBB` — emits the checks
+for the recorded FRs whose class requires one, then clears the set. At an
+instruction boundary the value is definitionally materialized (that is
+the post-instruction invariant), NZCV is dead by construction, x16/x17
+are free, and all three write paths are covered by a single call site.
+
+Guard the check on the *class claim* (`globalType == Number` /
+`UnknownNonPtr`), and separately assert the expected equivalence
+`(globalType != UnknownPtr) == globalReg.isValid()` — today the two
+coincide only because `enter()`'s allocation loops set both together and
+break together; that is a load-bearing coincidence worth pinning with an
+assert rather than silently relying on.
+
+### Class D (phase 2, optional) — typed-mode invariants
+
+`typedLoadParent`, `fastArray*` element assumptions, and
+`AddS`'s both-strings contract rely on typed-bytecode guarantees. Assert
+`IsObject` / string tag on the inputs. Lower priority: these validate the
+typed front-end rather than the JIT, and typed mode has its own checking
+story, but the hooks are cheap once the primitive exists.
+
+## Failure path and diagnostics
+
+Each `emitTypeAssert` call registers a compile-time record and embeds its
+index:
+
+```cpp
+struct TypeAssertSite {   // one entry per emitted check
+  CodeBlock *codeBlock;
+  uint32_t bytecodeOfs;   // codeBlock_->getOffsetOf(emittingIP)
+  uint16_t frIndex;
+  TypePred pred;
+};
+```
+
+Emitted failure sequence per site (placed with the slow paths, out of
+line — the inline cost is one conditional branch per predicate leg):
+
+```
+fail_N:  mov  w0, #N
+         b    typeAssertFailLab
+```
+
+There is no per-function metadata mechanism to hang the table on —
+`addToRuntime` returns a bare `JITCompiledFunctionPtr` into
+`setJITCompiled` — and inventing a registry for a fatal-only debugging
+feature is overkill. Instead: **leak** the per-function
+`std::vector<TypeAssertSite>` *object* (the handler never returns, and
+JIT code is never freed anyway), store its address as one RO-data 64-bit
+constant, and have the shared per-function tail materialize it:
+
+```
+typeAssertFailLab:
+         ldr  x1, [RO_DATA + siteTableOfs]   // w0 = site idx, set per stub
+         bl   _jit_type_assert_failed        // noreturn
+```
+
+Leak the vector object, not its buffer: the buffer's address is not final
+until the last site is registered, which is long after the RO-data
+constant has to be emitted, whereas the object's address is stable from
+first use and needs no back-patching.
+
+`_jit_type_assert_failed(uint32_t siteIdx, const
+std::vector<TypeAssertSite> *sites)` formats "JIT type assert failed:
+function F, bytecode offset O, rN, expected <pred>", and `hermes_fatal`s.
+It takes no `SHRuntime *`: the site record alone names the function, via
+`CodeBlock::getFunctionID` and `getNameString`. Being noreturn, it needs
+no register/frame preservation, and the call may safely use the normal
+`callRuntime` shape; no change to `addToRuntime`.
+(A bare `brk #N` is an acceptable fallback first implementation — the
+site index in the brk immediate plus the dump-jitcode listing already
+localizes the failure — but the C++ handler costs little and removes the
+need for a debugger to triage.)
+
+## Configuration and rollout
+
+- **A separate flag, default off** (`-Xjit-emit-type-asserts`, its own
+  `emitTypeAsserts_` bool), *not* a rider on `emitAsserts_`:
+  `-Xjit-emit-asserts` defaults to **true in debug builds**
+  (`RuntimeFlags.h`), so piggybacking would emit the checks in every debug
+  lit run, in a feature whose whole premise is that it perturbs nothing
+  until asked. A separate opt-in bit also lets a bring-up failure be
+  bisected by check class. (Consider subdividing further — A/B vs. C — if
+  that bisection proves useful in practice.)
+- Rollout order: land the primitive + Class A/B/C on arm64; run `test/jit`
+  (with `HERMESVM_ALLOW_JIT=2`), test262, and the benchmark suite under
+  `-Xjit-emit-type-asserts` to certify the *existing* type plumbing; then treat
+  a clean assert run as a gating check during x86-64 bring-up.
+
+## Verifying the checks can fail
+
+A green run proves only that the suite ran. Before trusting the feature,
+mutate and observe the trap (throwaway build):
+
+1. Flip one emitter's claim — e.g. make `loadConstString` declare
+   `FRType::Number` — and confirm a Class C trap naming that FR.
+2. Weaken one elision — e.g. force `isFRKnownNumber` to return true for one
+   FR in `arithBinOp` — and confirm a Class B trap at the consumption site.
+3. Run one `*N` test with the mutation in (2) applied to the `jLessN` path
+   to confirm Class A coverage.
+
+These three mutations cover the three insertion classes; record the
+expected trap message for each in the commit message of the feature.
+
+## Cost
+
+- Production builds: zero (everything is behind `emitTypeAsserts_`, which is a
+  compile-of-the-JS-function-time flag, not a build-time flag; the checks
+  simply are not emitted).
+- With the flag on (in any build): 2-5 instructions per elided check plus
+  2 per out-of-line fail stub; site-table memory proportional to check
+  count. JIT compile time impact negligible.
+- One new invariant on emitter authors: `emitTypeAssert` must be placed
+  while flags are dead. This is enforced socially (it is called from ~10
+  central places, not per-emitter) and documented at the primitive.
+
+## x86-64 notes
+
+- The design requires one (occasionally two) non-allocated scratch GPRs.
+  x86-64 has no ABI-reserved analogue of x16/x17, so the port's register
+  convention must reserve a caller-saved scratch (r11, optionally r10)
+  outside the temp allocator — for this, and for the call-target/IP
+  materialization duties x16/x17 already serve on arm64. Decide this up
+  front; retrofitting a reserved scratch after the allocator hands out all
+  16 GPRs is painful.
+- Predicate sequences translate directly: `sar $47/$48` + `cmp` for tag
+  tests, `mov r11, imm64` + `cmp` for the double bound; `ucomisd`-based
+  shapes are not needed (all checks are integer tag tests on the raw bits,
+  via `movq r11←xmm` for vector-resident values).
+- Class C's write recording (`frUpdatedWithHW`, `movFRFromHW`,
+  `syncFrameOutParam`) lives in `JitEmitter-regalloc.cpp` — the
+  register-file engine the file split isolated, and the piece proposed for
+  cross-arch sharing (cleanup item A3). If that extraction lands first,
+  the recording half of Class C is written once for both backends. The
+  emission half is the instruction-boundary hook, which each backend calls
+  from its own `compileBB` dispatch loop.

--- a/include/hermes/ConsoleHost/ConsoleHost.h
+++ b/include/hermes/ConsoleHost/ConsoleHost.h
@@ -170,6 +170,9 @@ struct ExecuteOptions {
   /// Emit asserts in JIT'ed code
   bool jitEmitAsserts{false};
 
+  /// Verify FR type assumptions in JIT'ed code.
+  bool jitEmitTypeAsserts{false};
+
   /// Emit counters in JIT'ed code.
   bool jitEmitCounters{false};
 

--- a/include/hermes/VM/JIT/JIT.h
+++ b/include/hermes/VM/JIT/JIT.h
@@ -126,6 +126,9 @@ class JITContext {
   /// Set the flag to emit asserts in the JIT'ed code.
   void setEmitAsserts(bool emitAsserts) {}
 
+  /// Set the flag to verify FR type assumptions in the JIT'ed code.
+  void setEmitTypeAsserts(bool emitTypeAsserts) {}
+
   /// Set whether we should emit counters in the JIT'ed code.
   void setEmitCounters(bool emitCounters) {}
 
@@ -134,6 +137,11 @@ class JITContext {
 
   /// \return true if we should emit asserts in the JIT'ed code.
   bool getEmitAsserts() {
+    return false;
+  }
+
+  /// \return true if we should verify FR type assumptions in JIT'ed code.
+  bool getEmitTypeAsserts() {
     return false;
   }
 

--- a/include/hermes/VM/JIT/arm64/JIT.h
+++ b/include/hermes/VM/JIT/arm64/JIT.h
@@ -144,6 +144,11 @@ class JITContext {
     emitAsserts_ = emitAsserts;
   }
 
+  /// Set the flag to verify FR type assumptions in the JIT'ed code.
+  void setEmitTypeAsserts(bool emitTypeAsserts) {
+    emitTypeAsserts_ = emitTypeAsserts;
+  }
+
   /// Set whether we should emit counters in the JIT'ed code.
   void setEmitCounters(bool emitCounters) {
     assert(
@@ -160,6 +165,11 @@ class JITContext {
   /// \return true if we should emit asserts in the JIT'ed code.
   bool getEmitAsserts() {
     return emitAsserts_;
+  }
+
+  /// \return true if we should verify FR type assumptions in JIT'ed code.
+  bool getEmitTypeAsserts() {
+    return emitTypeAsserts_;
   }
 
   /// Called by the GC at the beginning of a collection. This method informs the
@@ -189,6 +199,8 @@ class JITContext {
   bool crashOnError_{false};
   /// Whether to emit asserts in the JIT'ed code.
   bool emitAsserts_{false};
+  /// Whether to verify FR type assumptions in the JIT'ed code.
+  bool emitTypeAsserts_{false};
   /// Whether to force jitting of all functions.
   /// If true, ignores the default exec threshold completely.
   bool forceJIT_{false};

--- a/include/hermes/VM/RuntimeFlags.h
+++ b/include/hermes/VM/RuntimeFlags.h
@@ -298,6 +298,15 @@ struct VMOnlyRuntimeFlags {
 #endif
   };
 
+  llvh::cl::opt<bool> JITEmitTypeAsserts{
+      "Xjit-emit-type-asserts",
+      llvh::cl::Hidden,
+      llvh::cl::cat(RuntimeCategory),
+      llvh::cl::desc(
+          "(default false) Whether to verify FR type assumptions in JIT "
+          "compiled code"),
+      llvh::cl::init(false)};
+
   llvh::cl::opt<bool> JITEmitCounters{
       "Xjit-emit-counters",
       llvh::cl::Hidden,

--- a/lib/ConsoleHost/ConsoleHost.cpp
+++ b/lib/ConsoleHost/ConsoleHost.cpp
@@ -967,6 +967,7 @@ bool executeHBCBytecodeImpl(
   runtime->getJITContext().setDumpJITCode(options.dumpJITCode);
   runtime->getJITContext().setCrashOnError(options.jitCrashOnError);
   runtime->getJITContext().setEmitAsserts(options.jitEmitAsserts);
+  runtime->getJITContext().setEmitTypeAsserts(options.jitEmitTypeAsserts);
   runtime->getJITContext().setEmitCounters(options.jitEmitCounters);
   runtime->getJITContext().setHCIdLimit(options.jitHCIdLimit);
 

--- a/lib/VM/JIT/arm64/JIT.cpp
+++ b/lib/VM/JIT/arm64/JIT.cpp
@@ -156,6 +156,7 @@ class JITContext::Compiler {
       em_.emittingIP = ip;
       ip = dispatch(ip);
       em_.assertPostInstructionInvariants();
+      em_.emitPendingTypeAsserts();
     }
     em_.emittingIP = nullptr;
   }

--- a/lib/VM/JIT/arm64/JIT.cpp
+++ b/lib/VM/JIT/arm64/JIT.cpp
@@ -121,6 +121,7 @@ class JITContext::Compiler {
             *jc.impl_,
             jc.getDumpJITCode(),
             jc.getEmitAsserts(),
+            jc.getEmitTypeAsserts(),
             jc.counters_.get() != nullptr,
             jc.perfJitDump_.get(),
             codeBlock,

--- a/lib/VM/JIT/arm64/JitEmitter-alloc.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-alloc.cpp
@@ -44,7 +44,7 @@ void Emitter::bumpAllocAndUnpoison(
   a.mov(a64::x0, xOut);
   a.mov(a64::x1, sz);
   // Unpoison the newly allocated memory.
-  EMIT_RUNTIME_CALL_WITHOUT_THUNK_AND_SAVED_IP(
+  EMIT_RUNTIME_CALL_WITHOUT_SAVED_IP(
       *this,
       void (*)(void const volatile *, size_t),
       __asan_unpoison_memory_region);

--- a/lib/VM/JIT/arm64/JitEmitter-arith.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-arith.cpp
@@ -533,6 +533,11 @@ void Emitter::arithBinOp(
   hwLeft = getOrAllocFRInVecD(frLeft, true);
   hwRight = getOrAllocFRInVecD(frRight, true);
 
+  if (forceNumber) {
+    emitTypeAssert(frLeft, hwLeft, TypePred::IsNumber);
+    emitTypeAssert(frRight, hwRight, TypePred::IsNumber);
+  }
+
   if (slow) {
     slowPathLab = newSlowPathLabel();
     contLab = newContLabel();

--- a/lib/VM/JIT/arm64/JitEmitter-arith.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-arith.cpp
@@ -17,8 +17,10 @@ namespace hermes::vm::arm64 {
 
 void Emitter::toNumber(FR frRes, FR frInput) {
   comment("// %s r%u, r%u", "toNumber", frRes.index(), frInput.index());
-  if (isFRKnownNumber(frInput))
+  if (isFRKnownNumber(frInput)) {
+    emitTypeAssertFR(frInput, TypePred::IsNumber);
     return mov(frRes, frInput, false);
+  }
 
   HWReg hwRes, hwInput;
   asmjit::Label slowPathLab = newSlowPathLabel();
@@ -65,8 +67,10 @@ void Emitter::toNumber(FR frRes, FR frInput) {
 
 void Emitter::toNumeric(FR frRes, FR frInput) {
   comment("// %s r%u, r%u", "toNumeric", frRes.index(), frInput.index());
-  if (isFRKnownNumber(frInput))
+  if (isFRKnownNumber(frInput)) {
+    emitTypeAssertFR(frInput, TypePred::IsNumber);
     return mov(frRes, frInput, false);
+  }
 
   HWReg hwRes, hwInput;
   asmjit::Label slowPathLab = newSlowPathLabel();
@@ -249,7 +253,7 @@ void Emitter::arithUnop(
   }
 
   hwInput = getOrAllocFRInVecD(frInput, true);
-  if (forceNumber)
+  if (inputIsNum)
     emitTypeAssert(frInput, hwInput, TypePred::IsNumber);
   if (!inputIsNum) {
     slowPathLab = newSlowPathLabel();
@@ -446,10 +450,10 @@ void Emitter::mod(bool forceNumber, FR frRes, FR frLeft, FR frRight) {
   hwLeft = getOrAllocFRInVecD(frLeft, true);
   hwRight = getOrAllocFRInVecD(frRight, true);
 
-  if (forceNumber) {
+  if (leftIsNum)
     emitTypeAssert(frLeft, hwLeft, TypePred::IsNumber);
+  if (rightIsNum)
     emitTypeAssert(frRight, hwRight, TypePred::IsNumber);
-  }
 
   if (slow) {
     // Since HermesValue is NaN-boxed we know that all non-number values will be
@@ -540,10 +544,10 @@ void Emitter::arithBinOp(
   hwLeft = getOrAllocFRInVecD(frLeft, true);
   hwRight = getOrAllocFRInVecD(frRight, true);
 
-  if (forceNumber) {
+  if (leftIsNum)
     emitTypeAssert(frLeft, hwLeft, TypePred::IsNumber);
+  if (rightIsNum)
     emitTypeAssert(frRight, hwRight, TypePred::IsNumber);
-  }
 
   if (slow) {
     slowPathLab = newSlowPathLabel();
@@ -705,6 +709,17 @@ void Emitter::strictEqualImpl(bool invert, FR frRes, FR frLeft, FR frRight) {
       isFRKnownOtherNonPtr(frLeft) || isFRKnownOtherNonPtr(frRight)) {
     HWReg hwLeft = getOrAllocFRInGpX(frLeft, true);
     HWReg hwRight = getOrAllocFRInGpX(frRight, true);
+
+    // Evaluate and check the guards before frRes is declared updated below:
+    // frRes may alias frLeft/frRight, and frUpdatedWithHW would otherwise
+    // make isFRKnownBool/isFRKnownOtherNonPtr true only because of the
+    // result declaration, asserting a predicate against a register that
+    // still holds the (differently-typed) original operand.
+    if (isFRKnownBool(frLeft) || isFRKnownOtherNonPtr(frLeft))
+      emitTypeAssert(frLeft, hwLeft, TypePred::BitComparable);
+    if (isFRKnownBool(frRight) || isFRKnownOtherNonPtr(frRight))
+      emitTypeAssert(frRight, hwRight, TypePred::BitComparable);
+
     HWReg hwRes = getOrAllocFRInGpX(frRes, false);
     frUpdatedWithHW(frRes, hwRes, FRType::Bool);
 
@@ -723,6 +738,15 @@ void Emitter::strictEqualImpl(bool invert, FR frRes, FR frLeft, FR frRight) {
     // Do this always, since this could be the end of the BB.
     HWReg hwLeftD = getOrAllocFRInVecD(frLeft, true);
     HWReg hwRightD = getOrAllocFRInVecD(frRight, true);
+
+    // See the raw-bit tier above: evaluate and check the guards before
+    // frRes is declared updated, since frRes may alias frLeft/frRight and
+    // frUpdatedWithHW would otherwise perturb isFRKnownNumber's answer.
+    if (isFRKnownNumber(frLeft))
+      emitTypeAssert(frLeft, hwLeftD, TypePred::IsNumber);
+    if (isFRKnownNumber(frRight))
+      emitTypeAssert(frRight, hwRightD, TypePred::IsNumber);
+
     HWReg hwRes = getOrAllocFRInGpX(frRes, false);
     frUpdatedWithHW(frRes, hwRes, FRType::Bool);
 
@@ -894,6 +918,10 @@ void Emitter::compareImpl(
 
   hwLeft = getOrAllocFRInVecD(frLeft, true);
   hwRight = getOrAllocFRInVecD(frRight, true);
+  if (leftIsNum)
+    emitTypeAssert(frLeft, hwLeft, TypePred::IsNumber);
+  if (rightIsNum)
+    emitTypeAssert(frRight, hwRight, TypePred::IsNumber);
   if (slow) {
     slowPathLab = newSlowPathLabel();
     contLab = newContLabel();

--- a/lib/VM/JIT/arm64/JitEmitter-arith.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-arith.cpp
@@ -249,6 +249,8 @@ void Emitter::arithUnop(
   }
 
   hwInput = getOrAllocFRInVecD(frInput, true);
+  if (forceNumber)
+    emitTypeAssert(frInput, hwInput, TypePred::IsNumber);
   if (!inputIsNum) {
     slowPathLab = newSlowPathLabel();
     contLab = newContLabel();
@@ -443,6 +445,11 @@ void Emitter::mod(bool forceNumber, FR frRes, FR frLeft, FR frRight) {
 
   hwLeft = getOrAllocFRInVecD(frLeft, true);
   hwRight = getOrAllocFRInVecD(frRight, true);
+
+  if (forceNumber) {
+    emitTypeAssert(frLeft, hwLeft, TypePred::IsNumber);
+    emitTypeAssert(frRight, hwRight, TypePred::IsNumber);
+  }
 
   if (slow) {
     // Since HermesValue is NaN-boxed we know that all non-number values will be

--- a/lib/VM/JIT/arm64/JitEmitter-arith.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-arith.cpp
@@ -44,28 +44,23 @@ void Emitter::toNumber(FR frRes, FR frInput) {
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .frInput1 = frInput,
-       .hwRes = hwRes,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: toNumber r%u, r%u",
-             sl.frRes.index(),
-             sl.frInput1.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.loadFrameAddr(a64::x1, sl.frInput1);
-         EMIT_RUNTIME_CALL(
-             em,
-             double (*)(SHRuntime *, const SHLegacyValue *),
-             _sh_ljs_to_double_rjs);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::vecD(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [frRes, frInput, hwRes](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: toNumber r%u, r%u", frRes.index(), frInput.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.loadFrameAddr(a64::x1, frInput);
+        EMIT_RUNTIME_CALL(
+            em,
+            double (*)(SHRuntime *, const SHLegacyValue *),
+            _sh_ljs_to_double_rjs);
+        em.movHWFromHW<false>(hwRes, HWReg::vecD(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::toNumeric(FR frRes, FR frInput) {
@@ -97,28 +92,23 @@ void Emitter::toNumeric(FR frRes, FR frInput) {
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .frInput1 = frInput,
-       .hwRes = hwRes,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: toNumeric r%u, r%u",
-             sl.frRes.index(),
-             sl.frInput1.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.loadFrameAddr(a64::x1, sl.frInput1);
-         EMIT_RUNTIME_CALL(
-             em,
-             SHLegacyValue (*)(SHRuntime *, const SHLegacyValue *),
-             _sh_ljs_to_numeric_rjs);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [frRes, frInput, hwRes](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: toNumeric r%u, r%u", frRes.index(), frInput.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.loadFrameAddr(a64::x1, frInput);
+        EMIT_RUNTIME_CALL(
+            em,
+            SHLegacyValue (*)(SHRuntime *, const SHLegacyValue *),
+            _sh_ljs_to_numeric_rjs);
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::toInt32(FR frRes, FR frInput, bool isSigned) {
@@ -161,32 +151,26 @@ void Emitter::toInt32(FR frRes, FR frInput, bool isSigned) {
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .name = isSigned ? "ToInt32" : "ToUint32",
-       .frRes = frRes,
-       .frInput1 = frInput,
-       .hwRes = hwRes,
-       .slowCall = isSigned ? (void *)_sh_ljs_to_int32_rjs
-                            : (void *)_sh_ljs_to_uint32_rjs,
-       .slowCallName =
-           isSigned ? "_sh_ljs_to_int32_rjs" : "_sh_ljs_to_uint32_rjs",
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: %s, r%u, r%u, r%u",
-             sl.name,
-             sl.frRes.index(),
-             sl.frInput1.index(),
-             sl.frInput2.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.loadFrameAddr(a64::x1, sl.frInput1);
-         em.callThunkWithSavedIP((void *)sl.slowCall, sl.slowCallName);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::vecD(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [isSigned, frRes, frInput, hwRes](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: %s, r%u, r%u",
+            isSigned ? "ToInt32" : "ToUint32",
+            frRes.index(),
+            frInput.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.loadFrameAddr(a64::x1, frInput);
+        em.callThunkWithSavedIP(
+            isSigned ? (void *)_sh_ljs_to_int32_rjs
+                     : (void *)_sh_ljs_to_uint32_rjs,
+            isSigned ? "_sh_ljs_to_int32_rjs" : "_sh_ljs_to_uint32_rjs");
+        em.movHWFromHW<false>(hwRes, HWReg::vecD(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::addEmptyString(FR frRes, FR frInput) {
@@ -217,28 +201,25 @@ void Emitter::addEmptyString(FR frRes, FR frInput) {
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .frInput1 = frInput,
-       .hwRes = hwRes,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: AddEmptyString r%u, r%u",
-             sl.frRes.index(),
-             sl.frInput1.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.loadFrameAddr(a64::x1, sl.frInput1);
-         EMIT_RUNTIME_CALL(
-             em,
-             SHLegacyValue (*)(SHRuntime *, const SHLegacyValue *),
-             _sh_ljs_add_empty_string_rjs);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [frRes, frInput, hwRes](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: AddEmptyString r%u, r%u",
+            frRes.index(),
+            frInput.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.loadFrameAddr(a64::x1, frInput);
+        EMIT_RUNTIME_CALL(
+            em,
+            SHLegacyValue (*)(SHRuntime *, const SHLegacyValue *),
+            _sh_ljs_add_empty_string_rjs);
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::arithUnop(
@@ -297,29 +278,21 @@ void Emitter::arithUnop(
   freeAllFRTempExcept(frRes);
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .name = name,
-       .frRes = frRes,
-       .frInput1 = frInput,
-       .hwRes = hwRes,
-       .slowCall = slowCall,
-       .slowCallName = slowCallName,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: %s r%u, r%u",
-             sl.name,
-             sl.frRes.index(),
-             sl.frInput1.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.loadFrameAddr(a64::x1, sl.frInput1);
-         em.callThunkWithSavedIP(sl.slowCall, sl.slowCallName);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [name, frRes, frInput, hwRes, slowCall, slowCallName](
+          Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: %s r%u, r%u", name, frRes.index(), frInput.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.loadFrameAddr(a64::x1, frInput);
+        em.callThunkWithSavedIP(slowCall, slowCallName);
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::booleanNot(FR frRes, FR frInput) {
@@ -378,28 +351,23 @@ void Emitter::bitNot(FR frRes, FR frInput) {
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .frInput1 = frInput,
-       .hwRes = hwRes,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: bitNot r%u, r%u",
-             sl.frRes.index(),
-             sl.frInput1.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.loadFrameAddr(a64::x1, sl.frInput1);
-         EMIT_RUNTIME_CALL(
-             em,
-             SHLegacyValue (*)(SHRuntime *, const SHLegacyValue *),
-             _sh_ljs_bit_not_rjs);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [frRes, frInput, hwRes](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: bitNot r%u, r%u", frRes.index(), frInput.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.loadFrameAddr(a64::x1, frInput);
+        EMIT_RUNTIME_CALL(
+            em,
+            SHLegacyValue (*)(SHRuntime *, const SHLegacyValue *),
+            _sh_ljs_bit_not_rjs);
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::typeOf(FR frRes, FR frInput) {
@@ -503,32 +471,28 @@ void Emitter::mod(bool forceNumber, FR frRes, FR frLeft, FR frRight) {
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .frInput1 = frLeft,
-       .frInput2 = frRight,
-       .hwRes = hwRes,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// mod r%u, r%u, r%u",
-             sl.frRes.index(),
-             sl.frInput1.index(),
-             sl.frInput2.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.loadFrameAddr(a64::x1, sl.frInput1);
-         em.loadFrameAddr(a64::x2, sl.frInput2);
-         EMIT_RUNTIME_CALL(
-             em,
-             SHLegacyValue (*)(
-                 SHRuntime *, const SHLegacyValue *, const SHLegacyValue *),
-             _sh_ljs_mod_rjs);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [frRes, frLeft, frRight, hwRes](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// mod r%u, r%u, r%u",
+            frRes.index(),
+            frLeft.index(),
+            frRight.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.loadFrameAddr(a64::x1, frLeft);
+        em.loadFrameAddr(a64::x2, frRight);
+        EMIT_RUNTIME_CALL(
+            em,
+            SHLegacyValue (*)(
+                SHRuntime *, const SHLegacyValue *, const SHLegacyValue *),
+            _sh_ljs_mod_rjs);
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::arithBinOp(
@@ -598,32 +562,26 @@ void Emitter::arithBinOp(
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .name = name,
-       .frRes = frRes,
-       .frInput1 = frLeft,
-       .frInput2 = frRight,
-       .hwRes = hwRes,
-       .slowCall = slowCall,
-       .slowCallName = slowCallName,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// %s r%u, r%u, r%u",
-             sl.name,
-             sl.frRes.index(),
-             sl.frInput1.index(),
-             sl.frInput2.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.loadFrameAddr(a64::x1, sl.frInput1);
-         em.loadFrameAddr(a64::x2, sl.frInput2);
-         em.callThunkWithSavedIP(sl.slowCall, sl.slowCallName);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [name, frRes, frLeft, frRight, hwRes, slowCall, slowCallName](
+          Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// %s r%u, r%u, r%u",
+            name,
+            frRes.index(),
+            frLeft.index(),
+            frRight.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.loadFrameAddr(a64::x1, frLeft);
+        em.loadFrameAddr(a64::x2, frRight);
+        em.callThunkWithSavedIP(slowCall, slowCallName);
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::bitBinOp(
@@ -699,32 +657,26 @@ void Emitter::bitBinOp(
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .name = name,
-       .frRes = frRes,
-       .frInput1 = frLeft,
-       .frInput2 = frRight,
-       .hwRes = hwRes,
-       .slowCall = (void *)slowCall,
-       .slowCallName = slowCallName,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// %s r%u, r%u, r%u",
-             sl.name,
-             sl.frRes.index(),
-             sl.frInput1.index(),
-             sl.frInput2.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.loadFrameAddr(a64::x1, sl.frInput1);
-         em.loadFrameAddr(a64::x2, sl.frInput2);
-         em.callThunkWithSavedIP(sl.slowCall, sl.slowCallName);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [name, frRes, frLeft, frRight, hwRes, slowCall, slowCallName](
+          Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// %s r%u, r%u, r%u",
+            name,
+            frRes.index(),
+            frLeft.index(),
+            frRight.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.loadFrameAddr(a64::x1, frLeft);
+        em.loadFrameAddr(a64::x2, frRight);
+        em.callThunkWithSavedIP((void *)slowCall, slowCallName);
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::strictEqualImpl(bool invert, FR frRes, FR frLeft, FR frRight) {
@@ -873,47 +825,34 @@ void Emitter::strictEqualImpl(bool invert, FR frRes, FR frLeft, FR frRight) {
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .name = !invert ? "StrictEq" : "StrictNEq",
-       .frRes = frRes,
-       .frInput1 = frLeft,
-       .frInput2 = frRight,
-       .hwRes = hwRes,
-       .invert = invert,
-       .passArgsByVal = true,
-       .slowCall = (void *)_sh_ljs_strict_equal,
-       .slowCallName = "_sh_ljs_strict_equal",
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: %s r%u, r%u, r%u",
-             sl.name,
-             sl.frRes.index(),
-             sl.frInput1.index(),
-             sl.frInput2.index());
-         em.a.bind(sl.slowPathLab);
-         if (sl.passArgsByVal) {
-           em._loadFrame(HWReg::gpX(0), sl.frInput1);
-           em._loadFrame(HWReg::gpX(1), sl.frInput2);
-         } else {
-           em.a.mov(a64::x0, xRuntime);
-           em.loadFrameAddr(a64::x1, sl.frInput1);
-           em.loadFrameAddr(a64::x2, sl.frInput2);
-         }
-         em.callThunkWithSavedIP(sl.slowCall, sl.slowCallName);
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [invert, frRes, frLeft, frRight, hwRes](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: %s r%u, r%u, r%u",
+            !invert ? "StrictEq" : "StrictNEq",
+            frRes.index(),
+            frLeft.index(),
+            frRight.index());
+        em.a.bind(sp.slowPathLab);
+        // _sh_ljs_strict_equal takes its arguments by value.
+        em._loadFrame(HWReg::gpX(0), frLeft);
+        em._loadFrame(HWReg::gpX(1), frRight);
+        em.callThunkWithSavedIP(
+            (void *)_sh_ljs_strict_equal, "_sh_ljs_strict_equal");
 
-         // Invert the slow path result if needed.
-         if (sl.invert)
-           em.a.eor(sl.hwRes.a64GpX(), a64::x0, 1);
-         else
-           em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
+        // Invert the slow path result if needed.
+        if (invert)
+          em.a.eor(hwRes.a64GpX(), a64::x0, 1);
+        else
+          em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
 
-         // Comparison functions return bool, so encode it.
-         emit_sh_ljs_bool(em.a, sl.hwRes.a64GpX());
-         em.a.b(sl.contLab);
-       }});
+        // Comparison functions return bool, so encode it.
+        emit_sh_ljs_bool(em.a, hwRes.a64GpX());
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::compareImpl(
@@ -979,47 +918,46 @@ void Emitter::compareImpl(
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .name = name,
-       .frRes = frRes,
-       .frInput1 = frLeft,
-       .frInput2 = frRight,
-       .hwRes = hwRes,
-       .invert = invSlow,
-       .passArgsByVal = passArgsByVal,
-       .slowCall = slowCall,
-       .slowCallName = slowCallName,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: j_%s r%u, r%u, r%u",
-             sl.name,
-             sl.frRes.index(),
-             sl.frInput1.index(),
-             sl.frInput2.index());
-         em.a.bind(sl.slowPathLab);
-         if (sl.passArgsByVal) {
-           em._loadFrame(HWReg::gpX(0), sl.frInput1);
-           em._loadFrame(HWReg::gpX(1), sl.frInput2);
-         } else {
-           em.a.mov(a64::x0, xRuntime);
-           em.loadFrameAddr(a64::x1, sl.frInput1);
-           em.loadFrameAddr(a64::x2, sl.frInput2);
-         }
-         em.callThunkWithSavedIP(sl.slowCall, sl.slowCallName);
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [name,
+       frRes,
+       frLeft,
+       frRight,
+       hwRes,
+       invSlow,
+       passArgsByVal,
+       slowCall,
+       slowCallName](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: j_%s r%u, r%u, r%u",
+            name,
+            frRes.index(),
+            frLeft.index(),
+            frRight.index());
+        em.a.bind(sp.slowPathLab);
+        if (passArgsByVal) {
+          em._loadFrame(HWReg::gpX(0), frLeft);
+          em._loadFrame(HWReg::gpX(1), frRight);
+        } else {
+          em.a.mov(a64::x0, xRuntime);
+          em.loadFrameAddr(a64::x1, frLeft);
+          em.loadFrameAddr(a64::x2, frRight);
+        }
+        em.callThunkWithSavedIP(slowCall, slowCallName);
 
-         // Invert the slow path result if needed.
-         if (sl.invert)
-           em.a.eor(sl.hwRes.a64GpX(), a64::x0, 1);
-         else
-           em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
+        // Invert the slow path result if needed.
+        if (invSlow)
+          em.a.eor(hwRes.a64GpX(), a64::x0, 1);
+        else
+          em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
 
-         // Comparison functions return bool, so encode it.
-         emit_sh_ljs_bool(em.a, sl.hwRes.a64GpX());
-         em.a.b(sl.contLab);
-       }});
+        // Comparison functions return bool, so encode it.
+        emit_sh_ljs_bool(em.a, hwRes.a64GpX());
+        em.a.b(sp.contLab);
+      });
 }
 
 } // namespace hermes::vm::arm64

--- a/lib/VM/JIT/arm64/JitEmitter-arith.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-arith.cpp
@@ -164,7 +164,7 @@ void Emitter::toInt32(FR frRes, FR frInput, bool isSigned) {
         em.a.bind(sp.slowPathLab);
         em.a.mov(a64::x0, xRuntime);
         em.loadFrameAddr(a64::x1, frInput);
-        em.callThunkWithSavedIP(
+        em.callRuntimeWithSavedIP(
             isSigned ? (void *)_sh_ljs_to_int32_rjs
                      : (void *)_sh_ljs_to_uint32_rjs,
             isSigned ? "_sh_ljs_to_int32_rjs" : "_sh_ljs_to_uint32_rjs");
@@ -289,7 +289,7 @@ void Emitter::arithUnop(
         em.a.bind(sp.slowPathLab);
         em.a.mov(a64::x0, xRuntime);
         em.loadFrameAddr(a64::x1, frInput);
-        em.callThunkWithSavedIP(slowCall, slowCallName);
+        em.callRuntimeWithSavedIP(slowCall, slowCallName);
         em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
         em.a.b(sp.contLab);
       });
@@ -578,7 +578,7 @@ void Emitter::arithBinOp(
         em.a.mov(a64::x0, xRuntime);
         em.loadFrameAddr(a64::x1, frLeft);
         em.loadFrameAddr(a64::x2, frRight);
-        em.callThunkWithSavedIP(slowCall, slowCallName);
+        em.callRuntimeWithSavedIP(slowCall, slowCallName);
         em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
         em.a.b(sp.contLab);
       });
@@ -673,7 +673,7 @@ void Emitter::bitBinOp(
         em.a.mov(a64::x0, xRuntime);
         em.loadFrameAddr(a64::x1, frLeft);
         em.loadFrameAddr(a64::x2, frRight);
-        em.callThunkWithSavedIP((void *)slowCall, slowCallName);
+        em.callRuntimeWithSavedIP((void *)slowCall, slowCallName);
         em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
         em.a.b(sp.contLab);
       });
@@ -840,7 +840,7 @@ void Emitter::strictEqualImpl(bool invert, FR frRes, FR frLeft, FR frRight) {
         // _sh_ljs_strict_equal takes its arguments by value.
         em._loadFrame(HWReg::gpX(0), frLeft);
         em._loadFrame(HWReg::gpX(1), frRight);
-        em.callThunkWithSavedIP(
+        em.callRuntimeWithSavedIP(
             (void *)_sh_ljs_strict_equal, "_sh_ljs_strict_equal");
 
         // Invert the slow path result if needed.
@@ -946,7 +946,7 @@ void Emitter::compareImpl(
           em.loadFrameAddr(a64::x1, frLeft);
           em.loadFrameAddr(a64::x2, frRight);
         }
-        em.callThunkWithSavedIP(slowCall, slowCallName);
+        em.callRuntimeWithSavedIP(slowCall, slowCallName);
 
         // Invert the slow path result if needed.
         if (invSlow)

--- a/lib/VM/JIT/arm64/JitEmitter-array.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-array.cpp
@@ -542,7 +542,7 @@ void Emitter::getArgumentsPropByValImpl(
         em.a.mov(a64::x1, xFrame);
         em.loadFrameAddr(a64::x2, frIndex);
         em.loadFrameAddr(a64::x3, frLazyReg);
-        em.callThunkWithSavedIP((void *)shImpl, shImplName);
+        em.callRuntimeWithSavedIP((void *)shImpl, shImplName);
         em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
         em.a.b(sp.contLab);
       });
@@ -583,7 +583,7 @@ void Emitter::reifyArgumentsImpl(FR frLazyReg, bool strict, const char *name) {
         em.a.mov(a64::x0, xRuntime);
         em.a.mov(a64::x1, xFrame);
         em.loadFrameAddr(a64::x2, frLazyReg);
-        em.callThunkWithSavedIP(
+        em.callRuntimeWithSavedIP(
             strict ? (void *)_sh_ljs_reify_arguments_strict
                    : (void *)_sh_ljs_reify_arguments_loose,
             strict ? "_sh_ljs_reify_arguments_strict"

--- a/lib/VM/JIT/arm64/JitEmitter-array.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-array.cpp
@@ -179,23 +179,20 @@ void Emitter::fastArrayLoad(FR frRes, FR frArr, FR frIdx) {
       a64::Mem(hwTmpStorage.a64GpX(), hwTmpIdxGpX.a64GpX(), a64::lsl(3)));
   frUpdatedWithHW(frRes, hwRes);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .frRes = frRes,
-       .frInput1 = frArr,
-       .frInput2 = frIdx,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: FastArrayLoad r%u, r%u, r%u",
-             sl.frRes.index(),
-             sl.frInput1.index(),
-             sl.frInput2.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         EMIT_RUNTIME_CALL(em, void (*)(SHRuntime *), _sh_throw_array_oob);
-         // Call does not return.
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      emittingIP,
+      [frRes, frArr, frIdx](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: FastArrayLoad r%u, r%u, r%u",
+            frRes.index(),
+            frArr.index(),
+            frIdx.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        EMIT_RUNTIME_CALL(em, void (*)(SHRuntime *), _sh_throw_array_oob);
+        // Call does not return.
+      });
 #endif
 }
 
@@ -284,29 +281,26 @@ void Emitter::getArgumentsLength(FR frRes, FR frLazyReg) {
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .frInput1 = frLazyReg,
-       .hwRes = hwRes,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: GetArgumentsLength r%u, r%u",
-             sl.frRes.index(),
-             sl.frInput1.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.a.mov(a64::x1, xFrame);
-         em.loadFrameAddr(a64::x2, sl.frInput1);
-         EMIT_RUNTIME_CALL(
-             em,
-             SHLegacyValue (*)(SHRuntime *, SHLegacyValue *, SHLegacyValue *),
-             _sh_ljs_get_arguments_length);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [frRes, frLazyReg, hwRes](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: GetArgumentsLength r%u, r%u",
+            frRes.index(),
+            frLazyReg.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.a.mov(a64::x1, xFrame);
+        em.loadFrameAddr(a64::x2, frLazyReg);
+        EMIT_RUNTIME_CALL(
+            em,
+            SHLegacyValue (*)(SHRuntime *, SHLegacyValue *, SHLegacyValue *),
+            _sh_ljs_get_arguments_length);
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::iteratorBegin(FR frRes, FR frSource) {
@@ -536,28 +530,22 @@ void Emitter::getArgumentsPropByValImpl(
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .name = name,
-       .frRes = frRes,
-       .frInput1 = frIndex,
-       .frInput2 = frLazyReg,
-       .hwRes = hwRes,
-       .slowCall = (void *)shImpl,
-       .slowCallName = shImplName,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment("// Slow path: %s r%u", sl.name, sl.frInput1.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.a.mov(a64::x1, xFrame);
-         em.loadFrameAddr(a64::x2, sl.frInput1);
-         em.loadFrameAddr(a64::x3, sl.frInput2);
-         em.callThunkWithSavedIP(sl.slowCall, sl.slowCallName);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [name, frIndex, frLazyReg, hwRes, shImpl, shImplName](
+          Emitter &em, SlowPath &sp) {
+        em.comment("// Slow path: %s r%u", name, frIndex.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.a.mov(a64::x1, xFrame);
+        em.loadFrameAddr(a64::x2, frIndex);
+        em.loadFrameAddr(a64::x3, frLazyReg);
+        em.callThunkWithSavedIP((void *)shImpl, shImplName);
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::reifyArgumentsImpl(FR frLazyReg, bool strict, const char *name) {
@@ -581,32 +569,32 @@ void Emitter::reifyArgumentsImpl(FR frLazyReg, bool strict, const char *name) {
   // Fast path: do nothing.
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .name = name,
-       .frInput1 = frLazyReg,
-       // Use hwRes field to pass the global reg for the in/out param.
-       .hwRes = frameRegs_[frLazyReg.index()].globalReg,
-       .slowCall = strict ? (void *)_sh_ljs_reify_arguments_strict
-                          : (void *)_sh_ljs_reify_arguments_loose,
-       .slowCallName = strict ? "_sh_ljs_reify_arguments_strict"
-                              : "_sh_ljs_reify_arguments_loose",
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment("// Slow path: %s r%u", sl.name, sl.frInput1.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.a.mov(a64::x1, xFrame);
-         em.loadFrameAddr(a64::x2, sl.frInput1);
-         em.callThunkWithSavedIP(sl.slowCall, sl.slowCallName);
-         // Slow path modifies the frame so we need to sync it if there's a
-         // global reg.
-         if (sl.hwRes.isValid()) {
-           em._loadFrame(sl.hwRes, sl.frInput1);
-         }
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [name,
+       frLazyReg,
+       strict,
+       hwGlobalReg = frameRegs_[frLazyReg.index()].globalReg](
+          Emitter &em, SlowPath &sp) {
+        em.comment("// Slow path: %s r%u", name, frLazyReg.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.a.mov(a64::x1, xFrame);
+        em.loadFrameAddr(a64::x2, frLazyReg);
+        em.callThunkWithSavedIP(
+            strict ? (void *)_sh_ljs_reify_arguments_strict
+                   : (void *)_sh_ljs_reify_arguments_loose,
+            strict ? "_sh_ljs_reify_arguments_strict"
+                   : "_sh_ljs_reify_arguments_loose");
+        // Slow path modifies the frame so we need to sync it if there's a
+        // global reg.
+        if (hwGlobalReg.isValid()) {
+          em._loadFrame(hwGlobalReg, frLazyReg);
+        }
+        em.a.b(sp.contLab);
+      });
 }
 
 } // namespace hermes::vm::arm64

--- a/lib/VM/JIT/arm64/JitEmitter-call.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-call.cpp
@@ -510,6 +510,7 @@ void Emitter::callWithNewTargetLong(
   HWReg hwArgcArg = getOrAllocFRInGpX(argcFrameArg, false);
   frUpdatedWithHW(argcFrameArg, hwArgcArg, FRType::OtherNonPtr);
 
+  emitTypeAssert(frArgc, hwArgc, TypePred::IsNumber);
   static_assert(HERMESVALUE_VERSION == 2, "Native u32 must not need encoding");
   a.fcvtzu(hwArgcArg.a64GpX(), hwArgc.a64VecD());
   // The bytecode arg count includes "this", but the frame one does not, so

--- a/lib/VM/JIT/arm64/JitEmitter-call.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-call.cpp
@@ -108,28 +108,26 @@ void Emitter::loadThisNS(FR frRes) {
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .hwRes = hwRes,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment("// Slow path: LoadThisNS r%u", sl.frRes.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.a.ldur(
-             a64::x1,
-             a64::Mem(
-                 xFrame,
-                 StackFrameLayout::ThisArg * (int)sizeof(SHLegacyValue)));
-         EMIT_RUNTIME_CALL(
-             em,
-             SHLegacyValue (*)(SHRuntime *, SHLegacyValue),
-             _sh_ljs_coerce_this_ns);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [frRes, hwRes](Emitter &em, SlowPath &sp) {
+        em.comment("// Slow path: LoadThisNS r%u", frRes.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.a.ldur(
+            a64::x1,
+            a64::Mem(
+                xFrame,
+                StackFrameLayout::ThisArg * (int)sizeof(SHLegacyValue)));
+        EMIT_RUNTIME_CALL(
+            em,
+            SHLegacyValue (*)(SHRuntime *, SHLegacyValue),
+            _sh_ljs_coerce_this_ns);
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::coerceThisNS(FR frRes, FR frThis) {
@@ -162,28 +160,23 @@ void Emitter::coerceThisNS(FR frRes, FR frThis) {
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .frInput1 = frThis,
-       .hwRes = hwRes,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: CoerceThis r%u, r%u",
-             sl.frRes.index(),
-             sl.frInput1.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em._loadFrame(HWReg(a64::x1), sl.frInput1);
-         EMIT_RUNTIME_CALL(
-             em,
-             SHLegacyValue (*)(SHRuntime *, SHLegacyValue),
-             _sh_ljs_coerce_this_ns);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [frRes, frThis, hwRes](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: CoerceThis r%u, r%u", frRes.index(), frThis.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em._loadFrame(HWReg(a64::x1), frThis);
+        EMIT_RUNTIME_CALL(
+            em,
+            SHLegacyValue (*)(SHRuntime *, SHLegacyValue),
+            _sh_ljs_coerce_this_ns);
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::getNewTarget(FR frRes) {
@@ -267,18 +260,19 @@ void Emitter::callImpl(FR frRes, FR frCallee) {
   // If we have not already created a slow path for non-object calls, do so now.
   if (!nonObjCallLabel_.isValid()) {
     nonObjCallLabel_ = newSlowPathLabel();
-    slowPaths_.push_back(
-        {.slowPathLab = nonObjCallLabel_,
-         .emit = [](Emitter &em, SlowPath &sl) {
-           em.comment("// Throw on non-object call");
-           em.a.bind(sl.slowPathLab);
-           em.a.mov(a64::x0, xRuntime);
-           // The IP is already saved by the call setup, no need to save it
-           // again.
-           EMIT_RUNTIME_CALL_WITHOUT_SAVED_IP(
-               em, void (*)(SHRuntime *), _jit_throw_non_object_call);
-           // The call does not return.
-         }});
+    slowPaths_.emplace_back(
+        nonObjCallLabel_,
+        /* emittingIP */ nullptr,
+        [](Emitter &em, SlowPath &sp) {
+          em.comment("// Throw on non-object call");
+          em.a.bind(sp.slowPathLab);
+          em.a.mov(a64::x0, xRuntime);
+          // The IP is already saved by the call setup, no need to save it
+          // again.
+          EMIT_RUNTIME_CALL_WITHOUT_SAVED_IP(
+              em, void (*)(SHRuntime *), _jit_throw_non_object_call);
+          // The call does not return.
+        });
   }
 
   auto slowPathLab = newSlowPathLabel();
@@ -316,28 +310,25 @@ void Emitter::callImpl(FR frRes, FR frCallee) {
   a.blr(a64::x2);
   movHWFromHW<false>(hwRes, HWReg::gpX(0));
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .frInput1 = frCallee,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: CallImpl r%u, r%u",
-             sl.frRes.index(),
-             sl.frInput1.index());
-         em.a.bind(sl.slowPathLab);
-         em.emitIncrementCounter(JitCounter::NumCallSlow);
-         em.loadBits64InGp(
-             a64::x2, (uint64_t)&VTable::jitCallArray, "VTable::jitCallArray");
-         // Load the jitCall function. x0 still contains the callee CellKind
-         // from the fast path.
-         em.a.ldr(
-             a64::x2,
-             a64::Mem(a64::x2, a64::x0, a64::Shift(a64::ShiftOp::kLSL, 3)));
-         // x1 already contains the Callable* from the fast path.
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      /* emittingIP */ nullptr,
+      [frRes, frCallee](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: CallImpl r%u, r%u", frRes.index(), frCallee.index());
+        em.a.bind(sp.slowPathLab);
+        em.emitIncrementCounter(JitCounter::NumCallSlow);
+        em.loadBits64InGp(
+            a64::x2, (uint64_t)&VTable::jitCallArray, "VTable::jitCallArray");
+        // Load the jitCall function. x0 still contains the callee CellKind
+        // from the fast path.
+        em.a.ldr(
+            a64::x2,
+            a64::Mem(a64::x2, a64::x0, a64::Shift(a64::ShiftOp::kLSL, 3)));
+        // x1 already contains the Callable* from the fast path.
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::call(FR frRes, FR frCallee, uint32_t argc) {

--- a/lib/VM/JIT/arm64/JitEmitter-control.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-control.cpp
@@ -633,6 +633,7 @@ void Emitter::jmpTrueFalse(
 
   if (isFRKnownType(frInput, FRType::Number)) {
     HWReg hwInput = getOrAllocFRInVecD(frInput, true);
+    emitTypeAssert(frInput, hwInput, TypePred::IsNumber);
     a.fcmp(hwInput.a64VecD(), 0.0);
     if (onTrue) {
       // Branch on < 0 and > 0. All that remains is 0 and NaN.
@@ -648,6 +649,7 @@ void Emitter::jmpTrueFalse(
   } else if (isFRKnownType(frInput, FRType::Bool)) {
     HWReg hwInput = getOrAllocFRInGpX(frInput, true);
     a64::GpX xInput = hwInput.a64GpX();
+    emitTypeAssert(frInput, hwInput, TypePred::IsBool);
 
     static_assert(
         HERMESVALUE_VERSION == 2, "bool is encoded as a bit at kHV_BoolBitIdx");
@@ -684,6 +686,10 @@ void Emitter::jmpUndefined(const asmjit::Label &target, FR frInput) {
 
   if (isFRKnownType(frInput, FRType::Number) ||
       isFRKnownType(frInput, FRType::Bool)) {
+    emitTypeAssertFR(
+        frInput,
+        isFRKnownType(frInput, FRType::Number) ? TypePred::IsNumber
+                                               : TypePred::IsBool);
     return;
   }
 
@@ -775,10 +781,10 @@ void Emitter::jCond(
   hwLeft = getOrAllocFRInVecD(frLeft, true);
   hwRight = getOrAllocFRInVecD(frRight, true);
 
-  if (forceNumber) {
+  if (leftIsNum)
     emitTypeAssert(frLeft, hwLeft, TypePred::IsNumber);
+  if (rightIsNum)
     emitTypeAssert(frRight, hwRight, TypePred::IsNumber);
-  }
 
   a.fcmp(hwLeft.a64VecD(), hwRight.a64VecD());
 
@@ -869,6 +875,11 @@ void Emitter::jStrictEqual(
     HWReg hwRight = getOrAllocFRInGpX(frRight, true);
     freeAllFRTempExcept({});
 
+    if (isFRKnownBool(frLeft) || isFRKnownOtherNonPtr(frLeft))
+      emitTypeAssert(frLeft, hwLeft, TypePred::BitComparable);
+    if (isFRKnownBool(frRight) || isFRKnownOtherNonPtr(frRight))
+      emitTypeAssert(frRight, hwRight, TypePred::BitComparable);
+
     a.cmp(hwLeft.a64GpX(), hwRight.a64GpX());
     a.b(!invert ? a64::CondCode::kEQ : a64::CondCode::kNE, target);
     return;
@@ -885,6 +896,12 @@ void Emitter::jStrictEqual(
     HWReg hwLeftD = getOrAllocFRInVecD(frLeft, true);
     HWReg hwRightD = getOrAllocFRInVecD(frRight, true);
     freeAllFRTempExcept({});
+
+    if (isFRKnownNumber(frLeft))
+      emitTypeAssert(frLeft, hwLeftD, TypePred::IsNumber);
+    if (isFRKnownNumber(frRight))
+      emitTypeAssert(frRight, hwRightD, TypePred::IsNumber);
+
     a.fcmp(hwLeftD.a64VecD(), hwRightD.a64VecD());
     a.b(!invert ? a64::CondCode::kEQ : a64::CondCode::kNE, target);
     return;

--- a/lib/VM/JIT/arm64/JitEmitter-control.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-control.cpp
@@ -80,23 +80,20 @@ void Emitter::throwIfEmptyUndefinedImpl(FR frRes, FR frInput, bool empty) {
   movHWFromHW<false>(hwRes, hwInput);
   frUpdatedWithHW(frRes, hwRes);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .name = empty ? "ThrowIfEmpty" : "ThrowIfUndefined",
-       .frRes = frRes,
-       .frInput1 = frInput,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: %s r%u, r%u",
-             sl.name,
-             sl.frRes.index(),
-             sl.frInput1.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         EMIT_RUNTIME_CALL(em, void (*)(SHRuntime *), _sh_throw_empty);
-         // Call does not return.
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      emittingIP,
+      [empty, frRes, frInput](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: %s r%u, r%u",
+            empty ? "ThrowIfEmpty" : "ThrowIfUndefined",
+            frRes.index(),
+            frInput.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        EMIT_RUNTIME_CALL(em, void (*)(SHRuntime *), _sh_throw_empty);
+        // Call does not return.
+      });
 }
 
 void Emitter::throwIfThisInitialized(FR frInput) {
@@ -129,19 +126,15 @@ void Emitter::throwIfThisInitialized(FR frInput) {
   emit_sh_ljs_is_empty(a, hwTemp.a64GpX(), hwInput.a64GpX());
   a.b_ne(slowPathLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .frInput1 = frInput,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: ThrowIfThisInitialized r%u", sl.frInput1.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         EMIT_RUNTIME_CALL(
-             em, void (*)(SHRuntime *), _sh_throw_this_already_initialized);
-         // Call does not return.
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab, emittingIP, [frInput](Emitter &em, SlowPath &sp) {
+        em.comment("// Slow path: ThrowIfThisInitialized r%u", frInput.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        EMIT_RUNTIME_CALL(
+            em, void (*)(SHRuntime *), _sh_throw_this_already_initialized);
+        // Call does not return.
+      });
 }
 
 void Emitter::jmpTypeOfIs(
@@ -811,41 +804,40 @@ void Emitter::jCond(
   // Do this always, since this is the end of the BB.
   freeAllFRTempExcept(FR());
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .target = target,
-       .name = name,
-       .frInput1 = frLeft,
-       .frInput2 = frRight,
-       .invert = invert,
-       .passArgsByVal = passArgsByVal,
-       .slowCall = slowCall,
-       .slowCallName = slowCallName,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: j_%s%s Lx, r%u, r%u",
-             sl.invert ? "not_" : "",
-             sl.name,
-             sl.frInput1.index(),
-             sl.frInput2.index());
-         em.a.bind(sl.slowPathLab);
-         if (sl.passArgsByVal) {
-           em._loadFrame(HWReg::gpX(0), sl.frInput1);
-           em._loadFrame(HWReg::gpX(1), sl.frInput2);
-         } else {
-           em.a.mov(a64::x0, xRuntime);
-           em.loadFrameAddr(a64::x1, sl.frInput1);
-           em.loadFrameAddr(a64::x2, sl.frInput2);
-         }
-         em.callThunkWithSavedIP(sl.slowCall, sl.slowCallName);
-         if (!sl.invert)
-           em.a.cbnz(a64::w0, sl.target);
-         else
-           em.a.cbz(a64::w0, sl.target);
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [name,
+       slowCall,
+       slowCallName,
+       target,
+       frLeft,
+       frRight,
+       invert,
+       passArgsByVal](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: j_%s%s Lx, r%u, r%u",
+            invert ? "not_" : "",
+            name,
+            frLeft.index(),
+            frRight.index());
+        em.a.bind(sp.slowPathLab);
+        if (passArgsByVal) {
+          em._loadFrame(HWReg::gpX(0), frLeft);
+          em._loadFrame(HWReg::gpX(1), frRight);
+        } else {
+          em.a.mov(a64::x0, xRuntime);
+          em.loadFrameAddr(a64::x1, frLeft);
+          em.loadFrameAddr(a64::x2, frRight);
+        }
+        em.callThunkWithSavedIP(slowCall, slowCallName);
+        if (!invert)
+          em.a.cbnz(a64::w0, target);
+        else
+          em.a.cbz(a64::w0, target);
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::jStrictEqual(
@@ -985,33 +977,27 @@ void Emitter::jStrictEqual(
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .target = target,
-       .name = invert ? "j_strict_not_eq" : "j_strict_eq",
-       .frInput1 = frLeft,
-       .frInput2 = frRight,
-       .invert = invert,
-       .slowCall = (void *)_sh_ljs_strict_equal,
-       .slowCallName = "_sh_ljs_strict_equal",
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: %s Lx, r%u, r%u",
-             sl.name,
-             sl.frInput1.index(),
-             sl.frInput2.index());
-         em.a.bind(sl.slowPathLab);
-         em._loadFrame(HWReg::gpX(0), sl.frInput1);
-         em._loadFrame(HWReg::gpX(1), sl.frInput2);
-         em.callThunkWithSavedIP(sl.slowCall, sl.slowCallName);
-         if (!sl.invert)
-           em.a.cbnz(a64::w0, sl.target);
-         else
-           em.a.cbz(a64::w0, sl.target);
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [target, frLeft, frRight, invert](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: %s Lx, r%u, r%u",
+            invert ? "j_strict_not_eq" : "j_strict_eq",
+            frLeft.index(),
+            frRight.index());
+        em.a.bind(sp.slowPathLab);
+        em._loadFrame(HWReg::gpX(0), frLeft);
+        em._loadFrame(HWReg::gpX(1), frRight);
+        em.callThunkWithSavedIP(
+            (void *)_sh_ljs_strict_equal, "_sh_ljs_strict_equal");
+        if (!invert)
+          em.a.cbnz(a64::w0, target);
+        else
+          em.a.cbz(a64::w0, target);
+        em.a.b(sp.contLab);
+      });
 }
 
 } // namespace hermes::vm::arm64

--- a/lib/VM/JIT/arm64/JitEmitter-control.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-control.cpp
@@ -501,7 +501,9 @@ void Emitter::uintSwitchImm(
   comment(
       "// uintSwitchImm r%u, min %u, max %u", frInput.index(), minVal, maxVal);
 
-  asmjit::Error err;
+  // minVal is compared against and subtracted below; both are add/sub
+  // immediate forms with the same encoding limit.
+  const bool minValIsImm = a64::Utils::isAddSubImm(minVal);
 
   // End of the basic block.
   syncAllFRTempExcept({});
@@ -527,8 +529,9 @@ void Emitter::uintSwitchImm(
 
   // Check if the integer value in xTemp is in range.
   // First check minVal.
-  EXPECT_ERROR(asmjit::kErrorInvalidImmediate, err = a.cmp(wTempInput, minVal));
-  if (err) {
+  if (minValIsImm) {
+    a.cmp(wTempInput, minVal);
+  } else {
     a.mov(hwTempTarget.a64GpX().w(), minVal);
     a.cmp(wTempInput, hwTempTarget.a64GpX().w());
   }
@@ -536,8 +539,9 @@ void Emitter::uintSwitchImm(
   a.b_lo(defaultLabel);
 
   // Now check maxVal.
-  EXPECT_ERROR(asmjit::kErrorInvalidImmediate, err = a.cmp(wTempInput, maxVal));
-  if (err) {
+  if (a64::Utils::isAddSubImm(maxVal)) {
+    a.cmp(wTempInput, maxVal);
+  } else {
     a.mov(hwTempTarget.a64GpX().w(), maxVal);
     a.cmp(wTempInput, hwTempTarget.a64GpX().w());
   }
@@ -547,10 +551,9 @@ void Emitter::uintSwitchImm(
   // Compute the offset into the jump table, dereference, and jump.
   // Offset by the minVal if necessary.
   if (minVal != 0) {
-    EXPECT_ERROR(
-        asmjit::kErrorInvalidImmediate,
-        err = a.sub(wTempInput, wTempInput, minVal));
-    if (err) {
+    if (minValIsImm) {
+      a.sub(wTempInput, wTempInput, minVal);
+    } else {
       a.mov(hwTempTarget.a64GpX().w(), minVal);
       a.sub(wTempInput, wTempInput, hwTempTarget.a64GpX().w());
     }

--- a/lib/VM/JIT/arm64/JitEmitter-control.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-control.cpp
@@ -831,7 +831,7 @@ void Emitter::jCond(
           em.loadFrameAddr(a64::x1, frLeft);
           em.loadFrameAddr(a64::x2, frRight);
         }
-        em.callThunkWithSavedIP(slowCall, slowCallName);
+        em.callRuntimeWithSavedIP(slowCall, slowCallName);
         if (!invert)
           em.a.cbnz(a64::w0, target);
         else
@@ -990,7 +990,7 @@ void Emitter::jStrictEqual(
         em.a.bind(sp.slowPathLab);
         em._loadFrame(HWReg::gpX(0), frLeft);
         em._loadFrame(HWReg::gpX(1), frRight);
-        em.callThunkWithSavedIP(
+        em.callRuntimeWithSavedIP(
             (void *)_sh_ljs_strict_equal, "_sh_ljs_strict_equal");
         if (!invert)
           em.a.cbnz(a64::w0, target);

--- a/lib/VM/JIT/arm64/JitEmitter-control.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-control.cpp
@@ -775,6 +775,11 @@ void Emitter::jCond(
   hwLeft = getOrAllocFRInVecD(frLeft, true);
   hwRight = getOrAllocFRInVecD(frRight, true);
 
+  if (forceNumber) {
+    emitTypeAssert(frLeft, hwLeft, TypePred::IsNumber);
+    emitTypeAssert(frRight, hwRight, TypePred::IsNumber);
+  }
+
   a.fcmp(hwLeft.a64VecD(), hwRight.a64VecD());
 
   // If the condition is not inverted, then it can only produce true if both

--- a/lib/VM/JIT/arm64/JitEmitter-env.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-env.cpp
@@ -87,28 +87,25 @@ void Emitter::createFunctionEnvironment(FR frRes, uint32_t size) {
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .hwRes = hwRes,
-       .sizeOrIdx = size,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: CreateFunctionEnvironment r%u", sl.frRes.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.a.mov(a64::x1, xFrame);
-         em.a.mov(a64::w2, sl.sizeOrIdx);
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [frRes, hwRes, size](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: CreateFunctionEnvironment r%u", frRes.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.a.mov(a64::x1, xFrame);
+        em.a.mov(a64::w2, size);
 
-         EMIT_RUNTIME_CALL(
-             em,
-             SHLegacyValue (*)(SHRuntime *, SHLegacyValue *, uint32_t),
-             _sh_ljs_create_function_environment);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+        EMIT_RUNTIME_CALL(
+            em,
+            SHLegacyValue (*)(SHRuntime *, SHLegacyValue *, uint32_t),
+            _sh_ljs_create_function_environment);
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::createEnvironment(FR frRes, FR frParent, uint32_t size) {
@@ -164,33 +161,29 @@ void Emitter::createEnvironment(FR frRes, FR frParent, uint32_t size) {
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .frInput1 = frParent,
-       .hwRes = hwRes,
-       .sizeOrIdx = size,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: CreateEnvironment r%u, r%u",
-             sl.frRes.index(),
-             sl.frInput1.index());
-         em.a.bind(sl.slowPathLab);
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [frRes, frParent, hwRes, size](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: CreateEnvironment r%u, r%u",
+            frRes.index(),
+            frParent.index());
+        em.a.bind(sp.slowPathLab);
 
-         em.a.mov(a64::x0, xRuntime);
-         em.loadFrameAddr(a64::x1, sl.frInput1);
-         em.a.mov(a64::w2, sl.sizeOrIdx);
+        em.a.mov(a64::x0, xRuntime);
+        em.loadFrameAddr(a64::x1, frParent);
+        em.a.mov(a64::w2, size);
 
-         EMIT_RUNTIME_CALL(
-             em,
-             SHLegacyValue (*)(SHRuntime *, const SHLegacyValue *, uint32_t),
-             _sh_ljs_create_environment);
+        EMIT_RUNTIME_CALL(
+            em,
+            SHLegacyValue (*)(SHRuntime *, const SHLegacyValue *, uint32_t),
+            _sh_ljs_create_environment);
 
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::getParentEnvironment(FR frRes, uint32_t level) {

--- a/lib/VM/JIT/arm64/JitEmitter-internal.h
+++ b/lib/VM/JIT/arm64/JitEmitter-internal.h
@@ -16,14 +16,6 @@
 
 namespace hermes::vm::arm64 {
 
-// Disable warnings about missing designated initializers since they occur often
-// when we construct SlowPaths.
-#ifdef __clang__
-#if __has_warning("-Wmissing-designated-field-initializers")
-#pragma clang diagnostic ignored "-Wmissing-designated-field-initializers"
-#endif
-#endif
-
 // Ensure that HermesValue tags are handled correctly by updating this every
 // time the HERMESVALUE_VERSION changes, and going through the JIT and updating
 // any relevant code.

--- a/lib/VM/JIT/arm64/JitEmitter-internal.h
+++ b/lib/VM/JIT/arm64/JitEmitter-internal.h
@@ -742,12 +742,12 @@ inline bool isStpGpXImm(int i) {
 /// Save the current IP and emit a call to a runtime function. This should be
 /// used in most cases when invoking slow paths and handlers for complex
 /// functionality.
-#define EMIT_RUNTIME_CALL(em, type, func)           \
-  do {                                              \
-    using _FnT = type;                              \
-    _FnT _fn = func;                                \
-    (void)_fn;                                      \
-    (em).callThunkWithSavedIP((void *)func, #func); \
+#define EMIT_RUNTIME_CALL(em, type, func)             \
+  do {                                                \
+    using _FnT = type;                                \
+    _FnT _fn = func;                                  \
+    (void)_fn;                                        \
+    (em).callRuntimeWithSavedIP((void *)func, #func); \
   } while (0)
 
 /// Call a runtime function without saving the IP. This is intended for special
@@ -758,19 +758,7 @@ inline bool isStpGpXImm(int i) {
     using _FnT = type;                                     \
     _FnT _fn = func;                                       \
     (void)_fn;                                             \
-    (em).callThunk((void *)func, #func);                   \
-  } while (0)
-
-/// Make call without creating a thunk for it or saving the IP. This is useful
-/// for specific functionality where saving the IP is either unnecessary or
-/// incorrect, and where the call target is only going to be invoked at most
-/// once in the function.
-#define EMIT_RUNTIME_CALL_WITHOUT_THUNK_AND_SAVED_IP(em, type, func) \
-  do {                                                               \
-    using _FnT = type;                                               \
-    _FnT _fn = func;                                                 \
-    (void)_fn;                                                       \
-    (em).callWithoutThunk((void *)func, #func);                      \
+    (em).callRuntime((void *)func, #func);                 \
   } while (0)
 
 /// Load the lengthAndFlags of a HermesValue that contains a StringPrimitive

--- a/lib/VM/JIT/arm64/JitEmitter-object.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-object.cpp
@@ -60,21 +60,19 @@ void Emitter::newObject(FR frRes) {
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .hwRes = hwRes,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment("// Slow path: NewObject r%u", sl.frRes.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         EMIT_RUNTIME_CALL(
-             em, SHLegacyValue (*)(SHRuntime *), _sh_ljs_new_object);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [frRes, hwRes](Emitter &em, SlowPath &sp) {
+        em.comment("// Slow path: NewObject r%u", frRes.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        EMIT_RUNTIME_CALL(
+            em, SHLegacyValue (*)(SHRuntime *), _sh_ljs_new_object);
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::newObjectWithParent(FR frRes, FR frParent) {
@@ -150,29 +148,26 @@ void Emitter::newObjectWithParent(FR frRes, FR frParent) {
 
   a.bind(contLab);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .frInput1 = frParent,
-       .hwRes = hwRes,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: NewObjectWithParent r%u, r%u",
-             sl.frRes.index(),
-             sl.frInput1.index());
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.loadFrameAddr(a64::x1, sl.frInput1);
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [frRes, frParent, hwRes](Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: NewObjectWithParent r%u, r%u",
+            frRes.index(),
+            frParent.index());
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.loadFrameAddr(a64::x1, frParent);
 
-         EMIT_RUNTIME_CALL(
-             em,
-             SHLegacyValue (*)(SHRuntime *, const SHLegacyValue *),
-             _sh_ljs_new_object_with_parent);
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+        EMIT_RUNTIME_CALL(
+            em,
+            SHLegacyValue (*)(SHRuntime *, const SHLegacyValue *),
+            _sh_ljs_new_object_with_parent);
+        em.movHWFromHW<false>(hwRes, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::newObjectWithBuffer(
@@ -472,33 +467,31 @@ void Emitter::newObjectWithBuffer(
   // This slow path only allocates the new object.
   // Property population is always done in JIT-emitted code specialized for this
   // shape table entry.
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .hwRes = hwObj,
-       .sizeOrIdx = shapeTableIndex,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment(
-             "// Slow path: NewObjectWithBuffer r%u, %u, %u",
-             sl.frRes.index(),
-             sl.sizeOrIdx,
-             sl.sizeOrIdx2);
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         em.loadBits64InGp(a64::x1, (uint64_t)em.codeBlock_, "CodeBlock");
-         em.a.mov(a64::w2, sl.sizeOrIdx);
-         em.loadFrameAddr(a64::x3, sl.frRes);
-         EMIT_RUNTIME_CALL(
-             em,
-             JSObject *
-                 (*)(Runtime &, CodeBlock *, uint32_t, PinnedHermesValue *),
-             _jit_new_empty_object_for_buffer);
-         // Move into xObj.
-         em.movHWFromHW<false>(sl.hwRes, HWReg::gpX(0));
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [frRes, hwObj, shapeTableIndex, valBufferOffset](
+          Emitter &em, SlowPath &sp) {
+        em.comment(
+            "// Slow path: NewObjectWithBuffer r%u, %u, %u",
+            frRes.index(),
+            shapeTableIndex,
+            valBufferOffset);
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        em.loadBits64InGp(a64::x1, (uint64_t)em.codeBlock_, "CodeBlock");
+        em.a.mov(a64::w2, shapeTableIndex);
+        em.loadFrameAddr(a64::x3, frRes);
+        EMIT_RUNTIME_CALL(
+            em,
+            JSObject *
+                (*)(Runtime &, CodeBlock *, uint32_t, PinnedHermesValue *),
+            _jit_new_empty_object_for_buffer);
+        // Move into xObj.
+        em.movHWFromHW<false>(hwObj, HWReg::gpX(0));
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::newObjectWithBufferSlow(

--- a/lib/VM/JIT/arm64/JitEmitter-property.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-property.cpp
@@ -50,7 +50,7 @@ void Emitter::putByValImpl(
   loadFrameAddr(a64::x1, frTarget);
   loadFrameAddr(a64::x2, frKey);
   loadFrameAddr(a64::x3, frValue);
-  callThunkWithSavedIP((void *)shImpl, shImplName);
+  callRuntimeWithSavedIP((void *)shImpl, shImplName);
 }
 
 void Emitter::putByValWithReceiver(
@@ -318,7 +318,7 @@ class HERMES_ATTRIBUTE_INTERNAL_LINKAGE Emitter::GetByIdImpl {
         emit_add_imm_u24(
             a, a64::x3, sizeof(SHReadPropertyCacheEntry) * cacheIdx);
     }
-    _.callThunkWithSavedIP((void *)shImpl, shImplName);
+    _.callRuntimeWithSavedIP((void *)shImpl, shImplName);
 
     _.movHWFromHW<false>(hwRes, HWReg::gpX(0));
     _.frUpdatedWithHW(frRes, hwRes);

--- a/lib/VM/JIT/arm64/JitEmitter-regalloc.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter-regalloc.cpp
@@ -10,6 +10,8 @@
 #include "JitEmitter-internal.h"
 #include "JitEmitter.h"
 
+#include "llvh/ADT/STLExtras.h"
+
 namespace hermes::vm::arm64 {
 
 void Emitter::_storeHWToFrame(FR fr, HWReg src) {
@@ -52,6 +54,12 @@ void Emitter::movFRFromHW(FR dst, HWReg src, FRType type) {
     frUpdatedWithHW(dst, frState.globalReg, type);
   } else {
     // Otherwise store it directly to the frame.
+    // This branch is reached only when the FR has no global register, so
+    // the call can never record anything today. It is here for the
+    // globalType/globalReg equivalence assert, and so that the path stays
+    // covered if that ever changes.
+    if (LLVM_UNLIKELY(emitTypeAsserts_))
+      recordFRWriteForAssert(dst);
     _storeHWToFrame(dst, src);
     frUpdateType(dst, type);
     frState.frameUpToDate = true;
@@ -60,6 +68,9 @@ void Emitter::movFRFromHW(FR dst, HWReg src, FRType type) {
 
 void Emitter::syncFrameOutParam(FR fr, FRType type) {
   auto &frState = frameRegs_[fr.index()];
+
+  if (LLVM_UNLIKELY(emitTypeAsserts_))
+    recordFRWriteForAssert(fr);
 
   frState.frameUpToDate = true;
 
@@ -443,6 +454,9 @@ HWReg Emitter::getOrAllocFRInAnyReg(
 void Emitter::frUpdatedWithHW(FR fr, HWReg hwReg, FRType localType) {
   FRState &frState = frameRegs_[fr.index()];
 
+  if (LLVM_UNLIKELY(emitTypeAsserts_))
+    recordFRWriteForAssert(fr);
+
   frState.frameUpToDate = false;
 #ifndef NDEBUG
   frState.regIsDirty = false;
@@ -471,6 +485,22 @@ void Emitter::frUpdatedWithHW(FR fr, HWReg hwReg, FRType localType) {
 
 void Emitter::frUpdateType(FR fr, FRType type) {
   frameRegs_[fr.index()].localType = type;
+}
+
+void Emitter::recordFRWriteForAssert(FR fr) {
+  FRState &frState = frameRegs_[fr.index()];
+  // The two conditions coincide today only because enter()'s allocation
+  // loops set globalReg and globalType together and stop together. Pin it,
+  // because the check below relies on it.
+  assert(
+      (frState.globalType != FRType::UnknownPtr) ==
+          frState.globalReg.isValid() &&
+      "globalType and globalReg must agree");
+  if (frState.globalType == FRType::UnknownPtr)
+    return;
+  if (llvh::is_contained(typeAssertPendingWrites_, fr))
+    return;
+  typeAssertPendingWrites_.push_back(fr);
 }
 
 } // namespace hermes::vm::arm64

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -208,6 +208,9 @@ void Emitter::assertPostInstructionInvariants() {
 #endif
 
 void Emitter::newBasicBlock(const asmjit::Label &label) {
+  assert(
+      typeAssertPendingWrites_.empty() &&
+      "pending type asserts must be drained at each instruction");
   syncAllFRTempExcept({});
   freeAllFRTempExcept({});
 
@@ -1024,6 +1027,17 @@ void Emitter::emitTypeAssertFR(FR fr, TypePred pred) {
   comment("// type assert r%u is %s", fr.index(), typePredName(pred));
   readFRForAssert(fr);
   emitTypeAssertGpX(fr, xScratch, pred);
+}
+
+void Emitter::emitPendingTypeAssertsSlow() {
+  assert(!typeAssertPendingWrites_.empty() && "nothing to emit");
+  for (FR fr : typeAssertPendingWrites_) {
+    FRState &frState = frameRegs_[fr.index()];
+    TypePred pred = frState.globalType == FRType::Number ? TypePred::IsNumber
+                                                         : TypePred::NotPointer;
+    emitTypeAssertFR(fr, pred);
+  }
+  typeAssertPendingWrites_.clear();
 }
 
 void Emitter::emitTypeAssertGpX(FR fr, const a64::GpX &xVal, TypePred pred) {

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -769,9 +769,10 @@ void Emitter::loadParam(FR frRes, uint32_t paramIndex) {
           xFrame,
           (int)StackFrameLayout::ArgCount * (int)sizeof(SHLegacyValue)));
 
-  EXPECT_ERROR(asmjit::kErrorInvalidImmediate, err = a.cmp(wTmp, paramIndex));
   // Does paramIndex fit in the 12-bit unsigned immediate?
-  if (err) {
+  if (a64::Utils::isAddSubImm(paramIndex)) {
+    a.cmp(wTmp, paramIndex);
+  } else {
     HWReg hwTmp2 = allocAndLogTempGpX();
     a64::GpW wTmp2(hwTmp2.indexInClass());
     loadBits64InGp(wTmp2, paramIndex, "paramIndex");

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -689,20 +689,21 @@ void Emitter::loadFrameAddr(a64::GpX dst, FR frameReg) {
 }
 
 void Emitter::getBytecodeIP(const a64::GpX &xOut) {
-  auto ofs = codeBlock_->getOffsetOf(emittingIP);
+  uint32_t ofs = codeBlock_->getOffsetOf(emittingIP);
+  // ADD's immediate is 12 bits, optionally shifted left by 12, so an offset
+  // of 16MB or above cannot be reached by adding to the base at all.
+  // Materialize the whole address instead. That costs a constant pool entry
+  // per call site rather than one shared for the function, which is why it is
+  // not the general case.
+  if (LLVM_UNLIKELY(ofs > 0xFFFFFF)) {
+    loadBits64InGp(xOut, (uint64_t)codeBlock_->begin() + ofs, "Bytecode IP");
+    return;
+  }
   loadBits64InGp(xOut, (uint64_t)codeBlock_->begin(), "Bytecode start");
   // The first instruction of a function is at offset zero, which needs no
   // add at all.
-  if (!ofs)
-    return;
-  // The add instruction takes a 12 bit immediate optionally shifted by 12 bits.
-  // So we do the add as up to two 12 bit steps. Note that this means that it
-  // will currently fail on any function that is larger than 16MB.
-  auto low12Bits = ofs & llvh::maskTrailingOnes<uint32_t>(12);
-  assert(a64::Utils::isAddSubImm(low12Bits) && "immediate should be 12 bits");
-  a.add(xOut, xOut, low12Bits);
-  if (auto restBits = ofs - low12Bits)
-    a.add(xOut, xOut, restBits);
+  if (ofs)
+    emit_add_imm_u24(a, xOut, ofs);
 }
 
 void Emitter::unreachable() {

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -27,6 +27,14 @@
 
 namespace hermes::vm::arm64 {
 
+// Disable warnings about missing designated initializers, which the
+// roDataDesc_ entries below rely on.
+#ifdef __clang__
+#if __has_warning("-Wmissing-designated-field-initializers")
+#pragma clang diagnostic ignored "-Wmissing-designated-field-initializers"
+#endif
+#endif
+
 llvh::raw_ostream &operator<<(
     llvh::raw_ostream &os,
     const hermes::vm::arm64::HWReg &hwReg) {
@@ -321,20 +329,21 @@ void Emitter::frameSetup(
   // check if the bounds have changed.
   a.b_hi(nativeOverflowLab);
   a.bind(nativeOverflowContLab);
-  slowPaths_.push_back(
-      {.slowPathLab = nativeOverflowLab,
-       .contLab = nativeOverflowContLab,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment("// Slow path: _sh_check_native_stack_overflow");
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         // Do not save the IP because we have not yet set up the stack frame
-         // for this function. If this throws, the exception should appear in
-         // the caller.
-         EMIT_RUNTIME_CALL_WITHOUT_THUNK_AND_SAVED_IP(
-             em, void (*)(SHRuntime *), _sh_check_native_stack_overflow);
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      nativeOverflowLab,
+      nativeOverflowContLab,
+      /* emittingIP */ nullptr,
+      [](Emitter &em, SlowPath &sp) {
+        em.comment("// Slow path: _sh_check_native_stack_overflow");
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        // Do not save the IP because we have not yet set up the stack frame
+        // for this function. If this throws, the exception should appear in
+        // the caller.
+        EMIT_RUNTIME_CALL_WITHOUT_THUNK_AND_SAVED_IP(
+            em, void (*)(SHRuntime *), _sh_check_native_stack_overflow);
+        em.a.b(sp.contLab);
+      });
 
   comment("// xFrame");
   a.ldr(xFrame, a64::Mem(xRuntime, RuntimeOffsets::stackPointer));
@@ -375,20 +384,19 @@ void Emitter::frameSetup(
       slowCallName = "_sh_throw_invalid_construct";
     }
 
-    slowPaths_.push_back(
-        {.slowPathLab = throwInvalidInvokeLab,
-         .slowCall = (void *)slowCall,
-         .slowCallName = slowCallName,
-         .emit = [](Emitter &em, SlowPath &sl) {
-           em.comment("// Slow path: %s", sl.slowCallName);
-           em.a.bind(sl.slowPathLab);
-           em.a.mov(a64::x0, xRuntime);
-           // We don't register a thunk since there will only be a single call
-           // to this. Note that we also don't save the IP, because this is
-           // being thrown in the caller's context.
-           em.callWithoutThunk(sl.slowCall, sl.slowCallName);
-           // Function does not return.
-         }});
+    slowPaths_.emplace_back(
+        throwInvalidInvokeLab,
+        /* emittingIP */ nullptr,
+        [slowCall, slowCallName](Emitter &em, SlowPath &sp) {
+          em.comment("// Slow path: %s", slowCallName);
+          em.a.bind(sp.slowPathLab);
+          em.a.mov(a64::x0, xRuntime);
+          // We don't register a thunk since there will only be a single call
+          // to this. Note that we also don't save the IP, because this is
+          // being thrown in the caller's context.
+          em.callWithoutThunk((void *)slowCall, slowCallName);
+          // Function does not return.
+        });
   }
 
   // NOTE: Unlike _sh_enter, we do not push an SHLocals object.
@@ -465,17 +473,18 @@ void Emitter::frameSetup(
   }
 
   // Create the slow path for throwing a register stack overflow.
-  slowPaths_.push_back(
-      {.slowPathLab = registerOverflowLab,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment("// Slow path: _sh_throw_register_stack_overflow");
-         em.a.bind(sl.slowPathLab);
-         em.a.mov(a64::x0, xRuntime);
-         // Do not save the IP because we have not yet set up the stack frame
-         // for this function. The exception should appear in the caller.
-         EMIT_RUNTIME_CALL_WITHOUT_THUNK_AND_SAVED_IP(
-             em, void (*)(SHRuntime *), _sh_throw_register_stack_overflow);
-       }});
+  slowPaths_.emplace_back(
+      registerOverflowLab,
+      /* emittingIP */ nullptr,
+      [](Emitter &em, SlowPath &sp) {
+        em.comment("// Slow path: _sh_throw_register_stack_overflow");
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::x0, xRuntime);
+        // Do not save the IP because we have not yet set up the stack frame
+        // for this function. The exception should appear in the caller.
+        EMIT_RUNTIME_CALL_WITHOUT_THUNK_AND_SAVED_IP(
+            em, void (*)(SHRuntime *), _sh_throw_register_stack_overflow);
+      });
 
   if (catchTableLabel_.isValid()) {
     comment("// _sh_try");
@@ -825,19 +834,16 @@ void Emitter::loadParam(FR frRes, uint32_t paramIndex) {
   a.bind(contLab);
   frUpdatedWithHW(frRes, hwRes);
 
-  slowPaths_.push_back(
-      {.slowPathLab = slowPathLab,
-       .contLab = contLab,
-       .frRes = frRes,
-       .hwRes = hwRes,
-       .emittingIP = emittingIP,
-       .emit = [](Emitter &em, SlowPath &sl) {
-         em.comment("// Slow path: LoadParam r%u", sl.frRes.index());
-         em.a.bind(sl.slowPathLab);
-         em.loadBits64InGp(
-             sl.hwRes.a64GpX(), _sh_ljs_undefined().raw, "undefined");
-         em.a.b(sl.contLab);
-       }});
+  slowPaths_.emplace_back(
+      slowPathLab,
+      contLab,
+      emittingIP,
+      [frRes, hwRes](Emitter &em, SlowPath &sp) {
+        em.comment("// Slow path: LoadParam r%u", frRes.index());
+        em.a.bind(sp.slowPathLab);
+        em.loadBits64InGp(hwRes.a64GpX(), _sh_ljs_undefined().raw, "undefined");
+        em.a.b(sp.contLab);
+      });
 }
 
 void Emitter::getGlobalObject(FR frRes) {
@@ -997,7 +1003,7 @@ void Emitter::emitSlowPaths() {
   while (!slowPaths_.empty()) {
     SlowPath &sp = slowPaths_.front();
     emittingIP = sp.emittingIP;
-    sp.emit(*this, sp);
+    sp.emit(*this);
     slowPaths_.pop_front();
   }
   emittingIP = nullptr;

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -1009,12 +1009,21 @@ const char *typePredName(TypePred pred) {
 void Emitter::emitTypeAssert(FR fr, HWReg hwVal, TypePred pred) {
   if (LLVM_LIKELY(!emitTypeAsserts_))
     return;
+  comment("// type assert r%u is %s", fr.index(), typePredName(pred));
   if (hwVal.isVecD()) {
     a.fmov(xScratch, hwVal.a64VecD());
     emitTypeAssertGpX(fr, xScratch, pred);
   } else {
     emitTypeAssertGpX(fr, hwVal.a64GpX(), pred);
   }
+}
+
+void Emitter::emitTypeAssertFR(FR fr, TypePred pred) {
+  if (LLVM_LIKELY(!emitTypeAsserts_))
+    return;
+  comment("// type assert r%u is %s", fr.index(), typePredName(pred));
+  readFRForAssert(fr);
+  emitTypeAssertGpX(fr, xScratch, pred);
 }
 
 void Emitter::emitTypeAssertGpX(FR fr, const a64::GpX &xVal, TypePred pred) {
@@ -1032,7 +1041,6 @@ void Emitter::emitTypeAssertGpX(FR fr, const a64::GpX &xVal, TypePred pred) {
           (uint16_t)fr.index(),
           pred});
 
-  comment("// type assert r%u is %s", fr.index(), typePredName(pred));
   asmjit::Label failLab = newPrefLabel("TYPEASSERT_", idx);
 
   // The helpers below tolerate xTemp == xVal; every such use is the last
@@ -1071,6 +1079,32 @@ void Emitter::emitTypeAssertGpX(FR fr, const a64::GpX &xVal, TypePred pred) {
         em.a.mov(a64::w0, idx);
         em.a.b(em.typeAssertFailLab_);
       });
+}
+
+void Emitter::readFRForAssert(FR fr) {
+  assert(emitTypeAsserts_ && "caller must check emitTypeAsserts_");
+  FRState &frState = frameRegs_[fr.index()];
+  assert(!frState.regIsDirty && "reading an FR that is about to be written");
+
+  // Locals always hold the latest value; a global reg holds it only if
+  // globalRegUpToDate; otherwise the frame must be up to date.
+  if (frState.localGpX) {
+    a.mov(xScratch, frState.localGpX.a64GpX());
+  } else if (frState.localVecD) {
+    a.fmov(xScratch, frState.localVecD.a64VecD());
+  } else if (frState.globalReg && frState.globalRegUpToDate) {
+    if (frState.globalReg.isGpX())
+      a.mov(xScratch, frState.globalReg.a64GpX());
+    else
+      a.fmov(xScratch, frState.globalReg.a64VecD());
+  } else {
+    assert(frState.frameUpToDate && "FR has no up-to-date location");
+    // _loadFrame's large-offset encoding fallback also uses xScratch, but
+    // only as the address index in its mov/ldr pair, which is read before
+    // the ldr writes the loaded value into it, so passing xScratch as the
+    // destination here is safe.
+    _loadFrame(HWReg(xScratch), fr);
+  }
 }
 
 void Emitter::emitTypeAssertFailTail() {

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -575,6 +575,7 @@ void Emitter::leave(llvh::ArrayRef<const asmjit::Label *> exceptionHandlers) {
 
   emitCatchTable(exceptionHandlers);
   emitSlowPaths();
+  emitTypeAssertFailTail();
   emitROData();
 }
 
@@ -987,6 +988,123 @@ void Emitter::emitSlowPaths() {
     slowPaths_.pop_front();
   }
   emittingIP = nullptr;
+}
+
+const char *typePredName(TypePred pred) {
+  switch (pred) {
+    case TypePred::IsNumber:
+      return "number";
+    case TypePred::IsBool:
+      return "bool";
+    case TypePred::NotPointer:
+      return "non-pointer";
+    case TypePred::BitComparable:
+      return "non-pointer non-number";
+    case TypePred::IsObject:
+      return "object";
+  }
+  return "<invalid>";
+}
+
+void Emitter::emitTypeAssert(FR fr, HWReg hwVal, TypePred pred) {
+  if (LLVM_LIKELY(!emitTypeAsserts_))
+    return;
+  if (hwVal.isVecD()) {
+    a.fmov(xScratch, hwVal.a64VecD());
+    emitTypeAssertGpX(fr, xScratch, pred);
+  } else {
+    emitTypeAssertGpX(fr, hwVal.a64GpX(), pred);
+  }
+}
+
+void Emitter::emitTypeAssertGpX(FR fr, const a64::GpX &xVal, TypePred pred) {
+  assert(emitTypeAsserts_ && "caller must check emitTypeAsserts_");
+  if (!typeAssertSites_) {
+    typeAssertSites_ = &jitImpl_.typeAssertSites.emplace_back();
+    typeAssertFailLab_ = newPrefLabel("TYPEASSERT_FAIL", 0);
+  }
+
+  uint32_t idx = (uint32_t)typeAssertSites_->size();
+  typeAssertSites_->push_back(
+      TypeAssertSite{
+          codeBlock_,
+          codeBlock_->getOffsetOf(emittingIP),
+          (uint16_t)fr.index(),
+          pred});
+
+  comment("// type assert r%u is %s", fr.index(), typePredName(pred));
+  asmjit::Label failLab = newPrefLabel("TYPEASSERT_", idx);
+
+  // The helpers below tolerate xTemp == xVal; every such use is the last
+  // read of xVal in the sequence.
+  switch (pred) {
+    case TypePred::IsNumber:
+      emit_sh_ljs_is_double(a, xVal, xScratch2);
+      a.b_hs(failLab);
+      break;
+    case TypePred::IsBool:
+      emit_sh_ljs_is_bool(a, xScratch, xVal);
+      a.b_ne(failLab);
+      break;
+    case TypePred::NotPointer:
+      emit_sh_ljs_get_tag(a, xScratch, xVal);
+      emit_sh_ljs_tag_is_pointer(a, xScratch);
+      a.b_hs(failLab);
+      break;
+    case TypePred::BitComparable:
+      emit_sh_ljs_is_double(a, xVal, xScratch2);
+      a.b_lo(failLab);
+      emit_sh_ljs_get_tag(a, xScratch, xVal);
+      emit_sh_ljs_tag_is_pointer(a, xScratch);
+      a.b_hs(failLab);
+      break;
+    case TypePred::IsObject:
+      emit_sh_ljs_is_object(a, xScratch, xVal);
+      a.b_ne(failLab);
+      break;
+  }
+
+  slowPaths_.emplace_back(
+      failLab, emittingIP, [idx](Emitter &em, SlowPath &sp) {
+        em.comment("// Type assert failure %u", idx);
+        em.a.bind(sp.slowPathLab);
+        em.a.mov(a64::w0, idx);
+        em.a.b(em.typeAssertFailLab_);
+      });
+}
+
+void Emitter::emitTypeAssertFailTail() {
+  if (!typeAssertSites_)
+    return;
+  comment("// Type assert failure tail");
+  a.bind(typeAssertFailLab_);
+  // w0 already holds the site index, set by the per-site stub.
+  a.ldr(
+      a64::x1,
+      a64::Mem(
+          roDataLabel_,
+          uint64Const((uint64_t)typeAssertSites_, "type assert site table")));
+  // Not EMIT_RUNTIME_CALL: that saves the current IP, and emitSlowPaths()
+  // has already cleared emittingIP by the time this runs. The handler does
+  // not need the IP anyway - the site record carries the bytecode offset.
+  EMIT_RUNTIME_CALL_WITHOUT_SAVED_IP(
+      *this,
+      void (*)(uint32_t, const std::vector<TypeAssertSite> *),
+      _jit_type_assert_failed);
+}
+
+void _jit_type_assert_failed(
+    uint32_t siteIdx,
+    const std::vector<TypeAssertSite> *sites) {
+  const TypeAssertSite &site = (*sites)[siteIdx];
+  std::string message;
+  llvh::raw_string_ostream os(message);
+  os << "JIT type assert failed: function " << site.codeBlock->getFunctionID()
+     << "(" << site.codeBlock->getNameString() << "), bytecode offset "
+     << site.bytecodeOfs << ", r" << site.frIndex << ", expected "
+     << typePredName(site.pred);
+  os.flush();
+  hermes_fatal(message);
 }
 
 void Emitter::emitROData() {

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -54,6 +54,7 @@ Emitter::Emitter(
     JITContext::Impl &jitImpl,
     unsigned dumpJitCode,
     bool emitAsserts,
+    bool emitTypeAsserts,
     bool emitCounters,
     PerfJitDump *perfJitDump,
     CodeBlock *codeBlock,
@@ -62,6 +63,7 @@ Emitter::Emitter(
       jitImpl_(jitImpl),
       dumpJitCode_(dumpJitCode),
       emitAsserts_(emitAsserts),
+      emitTypeAsserts_(emitTypeAsserts),
       emitCounters_(emitCounters),
       frameRegs_(codeBlock->getFrameSize()),
       codeBlock_(codeBlock) {

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -340,7 +340,7 @@ void Emitter::frameSetup(
         // Do not save the IP because we have not yet set up the stack frame
         // for this function. If this throws, the exception should appear in
         // the caller.
-        EMIT_RUNTIME_CALL_WITHOUT_THUNK_AND_SAVED_IP(
+        EMIT_RUNTIME_CALL_WITHOUT_SAVED_IP(
             em, void (*)(SHRuntime *), _sh_check_native_stack_overflow);
         em.a.b(sp.contLab);
       });
@@ -391,10 +391,9 @@ void Emitter::frameSetup(
           em.comment("// Slow path: %s", slowCallName);
           em.a.bind(sp.slowPathLab);
           em.a.mov(a64::x0, xRuntime);
-          // We don't register a thunk since there will only be a single call
-          // to this. Note that we also don't save the IP, because this is
-          // being thrown in the caller's context.
-          em.callWithoutThunk((void *)slowCall, slowCallName);
+          // We don't save the IP, because this is being thrown in the
+          // caller's context.
+          em.callRuntime((void *)slowCall, slowCallName);
           // Function does not return.
         });
   }
@@ -482,7 +481,7 @@ void Emitter::frameSetup(
         em.a.mov(a64::x0, xRuntime);
         // Do not save the IP because we have not yet set up the stack frame
         // for this function. The exception should appear in the caller.
-        EMIT_RUNTIME_CALL_WITHOUT_THUNK_AND_SAVED_IP(
+        EMIT_RUNTIME_CALL_WITHOUT_SAVED_IP(
             em, void (*)(SHRuntime *), _sh_throw_register_stack_overflow);
       });
 
@@ -499,9 +498,8 @@ void Emitter::frameSetup(
 
     // _setjmp(buf->buf);
     a.add(a64::x0, a64::sp, jmpBufOffset + offsetof(SHJmpBuf, buf));
-    // setjmp can't throw and it'll be called once, so don't use a thunk.
-    EMIT_RUNTIME_CALL_WITHOUT_THUNK_AND_SAVED_IP(
-        *this, int (*)(jmp_buf), _sh_setjmp);
+    // setjmp can't throw, so the IP does not need to be saved.
+    EMIT_RUNTIME_CALL_WITHOUT_SAVED_IP(*this, int (*)(jmp_buf), _sh_setjmp);
     // If this a catch, go to the catch table to jump to either a handler BB or
     // rethrow.
     a.cbnz(a64::x0, catchTableLabel_);
@@ -575,28 +573,16 @@ void Emitter::leave(llvh::ArrayRef<const asmjit::Label *> exceptionHandlers) {
 
   emitCatchTable(exceptionHandlers);
   emitSlowPaths();
-  emitThunks();
   emitROData();
 }
 
-void Emitter::callThunk(void *fn, const char *name) {
-  // Using thunks leads to 0.27% more branch mispredicts and 2.8% performance
-  // regression on an important React benchmark. So, disable them for now.
-  if constexpr (false) {
-    comment("// call %s", name);
-    a.bl(registerThunk(fn, name));
-  } else {
-    callWithoutThunk(fn, name);
-  }
-}
-
-void Emitter::callThunkWithSavedIP(void *fn, const char *name) {
+void Emitter::callRuntimeWithSavedIP(void *fn, const char *name) {
   // Save the current IP in the runtime.
   getBytecodeIP(xScratch);
   a.str(xScratch, a64::Mem(xRuntime, RuntimeOffsets::currentIP));
 
   // Call the passed function.
-  callThunk(fn, name);
+  callRuntime(fn, name);
 
   if (emitAsserts_) {
     // Invalidate the current IP to make sure it is set before the next call.
@@ -605,7 +591,7 @@ void Emitter::callThunkWithSavedIP(void *fn, const char *name) {
   }
 }
 
-void Emitter::callWithoutThunk(void *fn, const char *name) {
+void Emitter::callRuntime(void *fn, const char *name) {
   comment("// call %s", name);
   loadBits64InGp(xScratch, (uint64_t)fn, name);
   a.blr(xScratch);
@@ -948,20 +934,6 @@ int32_t Emitter::uint64Const(uint64_t bits, const char *comment) {
   return it->second;
 }
 
-asmjit::Label Emitter::registerThunk(void *fn, const char *name) {
-  auto [it, inserted] = thunkMap_.try_emplace(fn, 0);
-  // Is this a new thunk?
-  if (inserted) {
-    it->second = thunks_.size();
-    int32_t dataOfs =
-        reserveData(sizeof(fn), sizeof(fn), asmjit::TypeId::kUInt64, 1, name);
-    memcpy(roData_.data() + dataOfs, &fn, sizeof(fn));
-    thunks_.emplace_back(name ? a.newNamedLabel(name) : a.newLabel(), dataOfs);
-  }
-
-  return thunks_[it->second].first;
-}
-
 void Emitter::emitCatchTable(
     llvh::ArrayRef<const asmjit::Label *> exceptionHandlers) {
   // No trys in the function, nothing to do here.
@@ -979,7 +951,7 @@ void Emitter::emitCatchTable(
   a.add(a64::x3, a64::sp, getJmpBufOffset());
   a.ldr(a64::x4, a64::Mem(a64::sp, getSavedSHLocalsOffset()));
   a.adr(a64::x5, addressTableLab);
-  EMIT_RUNTIME_CALL_WITHOUT_THUNK_AND_SAVED_IP(
+  EMIT_RUNTIME_CALL_WITHOUT_SAVED_IP(
       *this,
       void *(*)(SHRuntime *,
                 SHCodeBlock *,
@@ -1007,15 +979,6 @@ void Emitter::emitSlowPaths() {
     slowPaths_.pop_front();
   }
   emittingIP = nullptr;
-}
-
-void Emitter::emitThunks() {
-  comment("// Thunks");
-  for (const auto &th : thunks_) {
-    a.bind(th.first);
-    a.ldr(xScratch, a64::Mem(roDataLabel_, th.second));
-    a.br(xScratch);
-  }
 }
 
 void Emitter::emitROData() {

--- a/lib/VM/JIT/arm64/JitEmitter.cpp
+++ b/lib/VM/JIT/arm64/JitEmitter.cpp
@@ -691,6 +691,10 @@ void Emitter::loadFrameAddr(a64::GpX dst, FR frameReg) {
 void Emitter::getBytecodeIP(const a64::GpX &xOut) {
   auto ofs = codeBlock_->getOffsetOf(emittingIP);
   loadBits64InGp(xOut, (uint64_t)codeBlock_->begin(), "Bytecode start");
+  // The first instruction of a function is at offset zero, which needs no
+  // add at all.
+  if (!ofs)
+    return;
   // The add instruction takes a 12 bit immediate optionally shifted by 12 bits.
   // So we do the add as up to two 12 bit steps. Note that this means that it
   // will currently fail on any function that is larger than 16MB.

--- a/lib/VM/JIT/arm64/JitEmitter.h
+++ b/lib/VM/JIT/arm64/JitEmitter.h
@@ -22,6 +22,7 @@
 #include "hermes/VMLayouts/StackFrameLayout.h"
 
 #include "llvh/ADT/DenseMap.h"
+#include "llvh/ADT/SmallVector.h"
 
 #include <cstdarg>
 #include <deque>
@@ -447,6 +448,11 @@ class Emitter {
   std::vector<TypeAssertSite> *typeAssertSites_ = nullptr;
   /// The shared failure tail, bound only if there is at least one site.
   asmjit::Label typeAssertFailLab_{};
+
+  /// FRs written by the bytecode instruction currently being emitted whose
+  /// global register class requires a check. Drained at each instruction
+  /// boundary by emitPendingTypeAsserts().
+  llvh::SmallVector<FR, 4> typeAssertPendingWrites_{};
 
   /// Descriptor for a single RO data entry.
   struct DataDesc {
@@ -1029,6 +1035,25 @@ class Emitter {
   /// the ones the chosen code shape happens to rely on.
   void emitTypeAssert(FR fr, HWReg hwVal, TypePred pred);
 
+  /// Emit, at a bytecode instruction boundary, the global-register-class
+  /// checks for every FR recorded by recordFRWriteForAssert() since the
+  /// last call, then clear the recorded set. Called from compileBB as a
+  /// sibling of assertPostInstructionInvariants(), never from inside it:
+  /// that function's body is compiled out under NDEBUG, and emitting
+  /// checks from within it would silently disable Class C in
+  /// release-with-flag builds.
+  ///
+  /// This checks the value each FR holds at the boundary, not at the
+  /// instruction's write to it. An instruction that writes a
+  /// non-conforming value, calls the runtime (a GC safepoint), and then
+  /// overwrites it with a conforming one is not caught; only the value
+  /// that survives the instruction is.
+  void emitPendingTypeAsserts() {
+    if (LLVM_LIKELY(typeAssertPendingWrites_.empty()))
+      return;
+    emitPendingTypeAssertsSlow();
+  }
+
  private:
   /// \return the byte offset of \p fr's slot from xFrame.
   static constexpr inline uint32_t frByteOffset(FR fr) {
@@ -1338,9 +1363,19 @@ class Emitter {
   /// \pre \p fr is not dirty (regIsDirty).
   void readFRForAssert(FR fr);
 
+  /// The out-of-line body of \c emitPendingTypeAsserts.
+  /// \pre the pending set is not empty.
+  void emitPendingTypeAssertsSlow();
+
   /// Emit the shared out-of-line tail that all type assert failure stubs
   /// jump to, if any type assert was emitted for this function.
   void emitTypeAssertFailTail();
+
+  /// Record that \p fr was written, so that the instruction boundary can
+  /// check the value against its global register class. Records nothing
+  /// unless the FR owns a global register. Callers must check
+  /// emitTypeAsserts_ themselves; this does not.
+  void recordFRWriteForAssert(FR fr);
 
  private:
   /// Set up the call frame and perform the call. The caller should have already

--- a/lib/VM/JIT/arm64/JitEmitter.h
+++ b/lib/VM/JIT/arm64/JitEmitter.h
@@ -25,6 +25,9 @@
 
 #include <cstdarg>
 #include <deque>
+#include <new>
+#include <type_traits>
+#include <utility>
 
 namespace hermes::vm::arm64 {
 
@@ -320,41 +323,79 @@ class Emitter {
   /// VecD temp registers.
   TempRegAlloc vecTemp_{kVecTemp1, kVecTemp2};
 
-  /// Keep enough information to generate a slow path at the end of the
-  /// function.
-  struct SlowPath {
+  /// A deferred slow path, emitted at the end of the function.
+  ///
+  /// Everything the slow path needs beyond the common fields below is held in
+  /// the lambda passed to the constructor, stored inline in \c storage_. This
+  /// keeps each slow path's state private to the one place that produces and
+  /// consumes it, instead of a shared set of fields that any slow path could
+  /// read whether or not its producer set them.
+  class SlowPath {
+   public:
     /// Label of the slow path.
     asmjit::Label slowPathLab;
     /// Label to jump to after the slow path.
     asmjit::Label contLab;
-    /// Target if this is a branch.
-    asmjit::Label target;
-
-    /// Name of the slow path.
-    const char *name;
-    /// Frame register indexes;
-    FR frRes, frInput1, frInput2;
-    /// Optional hardware register for the result.
-    HWReg hwRes;
-    /// Whether to invert a condition.
-    bool invert;
-    /// Whether to pass arguments by value to the slow path.
-    bool passArgsByVal;
-    /// Some number or index that needs to be passed to the slow path.
-    unsigned sizeOrIdx;
-    /// Another number or index that needs to be passed to the slow path.
-    unsigned sizeOrIdx2;
-
-    /// Pointer to the slow path function that must be called.
-    void *slowCall;
-    /// The name of the slow path function.
-    const char *slowCallName;
-
     /// Bytecode IP of the instruction that this is a slow path for.
     const inst::Inst *emittingIP;
 
-    /// Callback to actually emit.
-    void (*emit)(Emitter &em, SlowPath &sl);
+    /// \param l is invoked as l(Emitter &, SlowPath &) to emit the slow path.
+    /// Its captures are copied into \c storage_ and never destroyed, so they
+    /// must be trivially destructible and must fit.
+    template <typename L>
+    SlowPath(
+        asmjit::Label slowPathLab,
+        asmjit::Label contLab,
+        const inst::Inst *emittingIP,
+        L &&l)
+        : slowPathLab(slowPathLab),
+          contLab(contLab),
+          emittingIP(emittingIP),
+          emit_([](Emitter &em, SlowPath &sp) {
+            (*reinterpret_cast<std::decay_t<L> *>(sp.storage_))(em, sp);
+          }) {
+      using Lambda = std::decay_t<L>;
+      static_assert(
+          sizeof(Lambda) <= sizeof(storage_),
+          "slow path captures too much; enlarge storage_ or capture less");
+      static_assert(
+          alignof(Lambda) <= alignof(void *),
+          "slow path captures are over-aligned");
+      static_assert(
+          std::is_trivially_destructible_v<Lambda>,
+          "slow path captures must be trivially destructible");
+      ::new (storage_) Lambda(std::forward<L>(l));
+    }
+
+    /// Overload for slow paths that do not branch back to a continuation.
+    template <typename L>
+    SlowPath(asmjit::Label slowPathLab, const inst::Inst *emittingIP, L &&l)
+        : SlowPath(
+              slowPathLab,
+              asmjit::Label(),
+              emittingIP,
+              std::forward<L>(l)) {}
+
+    /// Non-copyable and non-movable: \c storage_ holds a type-erased lambda
+    /// that cannot be relocated by the implicit memberwise copy. std::deque
+    /// never relocates existing elements, so emplace_back and pop_front are
+    /// all that is needed.
+    SlowPath(const SlowPath &) = delete;
+    SlowPath &operator=(const SlowPath &) = delete;
+
+    /// Emit this slow path.
+    void emit(Emitter &em) {
+      emit_(em, *this);
+    }
+
+   private:
+    void (*emit_)(Emitter &em, SlowPath &sp);
+    /// Inline storage for the lambda's captures. Sized to the largest current
+    /// slow path, jCond, whose captures include an asmjit::Label (16 bytes, an
+    /// Operand) plus three pointers, two FRs and two bools. Raising this is
+    /// fine; the static_assert above is what keeps a too-large capture from
+    /// becoming a silent heap allocation.
+    alignas(void *) char storage_[56];
   };
   /// Queue of slow paths.
   std::deque<SlowPath> slowPaths_{};

--- a/lib/VM/JIT/arm64/JitEmitter.h
+++ b/lib/VM/JIT/arm64/JitEmitter.h
@@ -305,6 +305,8 @@ class Emitter {
   unsigned const dumpJitCode_;
   /// Whether to emit asserts in the JIT'ed code.
   bool const emitAsserts_;
+  /// Whether to verify FR type assumptions in the JIT'ed code.
+  bool const emitTypeAsserts_;
   /// Whether to emit counters in the JIT'ed code.
   bool const emitCounters_;
 
@@ -462,6 +464,7 @@ class Emitter {
       JITContext::Impl &jitImpl,
       unsigned dumpJitCode,
       bool emitAsserts,
+      bool emitTypeAsserts,
       bool emitCounters,
       PerfJitDump *perfJitDump,
       CodeBlock *codeBlock,

--- a/lib/VM/JIT/arm64/JitEmitter.h
+++ b/lib/VM/JIT/arm64/JitEmitter.h
@@ -201,7 +201,7 @@ static constexpr auto xRuntime = a64::x19;
 static constexpr auto xFrame = a64::x20;
 
 /// Scratch register. x16/x17 sit outside the register allocator and are used
-/// as scratch (thunk targets, IP materialization); nothing holds a value in
+/// as scratch (call targets, IP materialization); nothing holds a value in
 /// them across an emitter call.
 static constexpr auto xScratch = a64::x16;
 
@@ -414,10 +414,6 @@ class Emitter {
   std::vector<uint8_t> roData_{};
   asmjit::Label roDataLabel_{};
 
-  /// Each thunk contains the offset of the function pointer in roData.
-  std::vector<std::pair<asmjit::Label, int32_t>> thunks_{};
-  llvh::DenseMap<void *, size_t> thunkMap_{};
-
   /// Map from the bit pattern of a double value to offset in constant pool.
   llvh::DenseMap<hermes::DenseUInt64, int32_t> fp64ConstMap_{};
 
@@ -497,7 +493,7 @@ class Emitter {
   /// line so that vsnprintf is not duplicated into every caller.
   void commentV(const char *fmt, va_list args);
 
-  /// Emit the catch table, slow paths, thunks and RO data,
+  /// Emit the catch table, slow paths and RO data,
   /// then reset the stack, end any try, and return.
   /// \param exceptionHandlers the labels for the exception handler table.
   void leave(llvh::ArrayRef<const asmjit::Label *> exceptionHandlers);
@@ -1238,25 +1234,15 @@ class Emitter {
   /// Register a 64-bit constant in RO DATA and return its offset.
   int32_t uint64Const(uint64_t bits, const char *comment);
 
-  /// Register \p fn as a thunk and return its label.
-  /// \param name is an optional name for the thunk.
-  asmjit::Label registerThunk(void *fn, const char *name = nullptr);
+  /// Emit a call to \p fn, saving the bytecode IP to Runtime::currentIP
+  /// before making the call. This should be used for all calls that may
+  /// observe the IP, such as calls that may throw exceptions, or perform
+  /// allocations.
+  void callRuntimeWithSavedIP(void *fn, const char *name);
 
-  /// Register a call as a thunk and emit a call to it. Note that most calls
-  /// into runtime functions should use \c callThunkWithSavedIP below.
-  void callThunk(void *fn, const char *name);
-
-  /// Register a call as a thunk and emit a call to it, saving the bytecode IP
-  /// to Runtime::currentIP before making the call. This should be used for all
-  /// calls that may observe the IP, such as calls that may throw exceptions, or
-  /// perform allocations.
-  void callThunkWithSavedIP(void *fn, const char *name);
-
-  /// Call a function without registering it as a thunk. This should be used for
-  /// functions that will only have a single call site in the emitted function,
-  /// and therefore do not benefit from a thunk. Note that like \c callThunk,
-  /// this does not save the IP.
-  void callWithoutThunk(void *fn, const char *name);
+  /// Emit a call to \p fn without saving the IP. This should be used only
+  /// where saving the IP is unnecessary or incorrect.
+  void callRuntime(void *fn, const char *name);
 
   /// Emit the code that runs when this function is longjmped to.
   /// Performs the catch table lookup and jumps to the appropriate catch block,
@@ -1264,7 +1250,6 @@ class Emitter {
   /// exception.
   void emitCatchTable(llvh::ArrayRef<const asmjit::Label *> exceptionHandlers);
   void emitSlowPaths();
-  void emitThunks();
   void emitROData();
 
  private:

--- a/lib/VM/JIT/arm64/JitEmitter.h
+++ b/lib/VM/JIT/arm64/JitEmitter.h
@@ -1022,6 +1022,11 @@ class Emitter {
   /// must have verified that flags are dead at the insertion point. That
   /// is an obligation, not a property emitters have in general: see
   /// selectObject, which holds flags across getOrAllocFRInGpX.
+  ///
+  /// Where an emitter knows a type fact per operand, guard each check on
+  /// that operand's own fact, never on the emitter's combined fast-path
+  /// condition: the point is to assert every fact the JIT holds, not only
+  /// the ones the chosen code shape happens to rely on.
   void emitTypeAssert(FR fr, HWReg hwVal, TypePred pred);
 
  private:
@@ -1314,7 +1319,24 @@ class Emitter {
 
   /// Emit \c emitTypeAssert's check sequence for \p pred against \p xVal,
   /// which holds the current value of \p fr, recording a TypeAssertSite.
+  /// The caller emits the dump comment, so that it precedes any load it
+  /// had to emit to produce \p xVal.
   void emitTypeAssertGpX(FR fr, const a64::GpX &xVal, TypePred pred);
+
+  /// Like \c emitTypeAssert, but for an \p fr that the fast path never
+  /// materializes into a register: reads it with \c readFRForAssert first.
+  /// Like \c emitTypeAssert, it does nothing unless emitTypeAsserts_ is
+  /// set, so callers need not check it themselves.
+  void emitTypeAssertFR(FR fr, TypePred pred);
+
+  /// Read the current value of \p fr into xScratch, for use immediately
+  /// before an \c emitTypeAssertGpX call, without allocating or perturbing
+  /// any FRState. Honors the FRState up-to-date invariants rather than
+  /// merely the location priority: the local register if any (locals are
+  /// always current), else the global register only if
+  /// globalRegUpToDate, else the frame slot (asserting frameUpToDate).
+  /// \pre \p fr is not dirty (regIsDirty).
+  void readFRForAssert(FR fr);
 
   /// Emit the shared out-of-line tail that all type assert failure stubs
   /// jump to, if any type assert was emitted for this function.

--- a/lib/VM/JIT/arm64/JitEmitter.h
+++ b/lib/VM/JIT/arm64/JitEmitter.h
@@ -28,6 +28,7 @@
 #include <new>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 namespace hermes::vm::arm64 {
 
@@ -200,10 +201,11 @@ static constexpr auto xRuntime = a64::x19;
 // x20 is frame
 static constexpr auto xFrame = a64::x20;
 
-/// Scratch register. x16/x17 sit outside the register allocator and are used
-/// as scratch (call targets, IP materialization); nothing holds a value in
-/// them across an emitter call.
+/// Scratch registers. x16/x17 sit outside the register allocator and are
+/// used as scratch (call targets, IP materialization, type assert check
+/// sequences); nothing holds a value in them across an emitter call.
 static constexpr auto xScratch = a64::x16;
+static constexpr auto xScratch2 = a64::x17;
 
 /// GP arg registers (inclusive).
 // static constexpr std::pair<uint8_t, uint8_t> kGPArgs(0, 7);
@@ -296,6 +298,43 @@ class TempRegAlloc {
 
  private:
 };
+
+/// A property of an FR's value that a fast path relies on. These are the
+/// predicates the emitters actually exploit, which is narrower and more
+/// useful than the declared FRType.
+enum class TypePred : uint8_t {
+  /// Unsigned-below (HVTag_First << kHV_NumDataBits).
+  IsNumber,
+  /// ETag == HVETag_Bool.
+  IsBool,
+  /// Tag unsigned-below the pointer range. This is the GC-safety predicate.
+  NotPointer,
+  /// NotPointer && !IsNumber: the raw bits are the value's identity under
+  /// strict equality, so `===` is a bit compare. Doubles are excluded
+  /// because NaN is not equal to itself while its bits are, and -0 and +0
+  /// are equal while their bits are not; pointers because strings compare
+  /// by content rather than address.
+  BitComparable,
+  /// Tag == HVTag_Object.
+  IsObject,
+};
+
+/// \return a human-readable name for \p pred, for diagnostics.
+const char *typePredName(TypePred pred);
+
+/// One emitted type check, recorded so the failure handler can name it.
+struct TypeAssertSite {
+  CodeBlock *codeBlock;
+  uint32_t bytecodeOfs;
+  uint16_t frIndex;
+  TypePred pred;
+};
+
+/// Report a failed JIT type assertion and abort. Called only from JIT'ed
+/// code, and never returns, so it needs no register or frame preservation.
+[[noreturn]] void _jit_type_assert_failed(
+    uint32_t siteIdx,
+    const std::vector<TypeAssertSite> *sites);
 
 class Emitter {
   Runtime &runtime_;
@@ -401,6 +440,13 @@ class Emitter {
   };
   /// Queue of slow paths.
   std::deque<SlowPath> slowPaths_{};
+
+  /// Records for every emitted type check, in site-index order. Owned by
+  /// JITContext::Impl, which outlives the emitted code that refers to it;
+  /// this is only a pointer to that entry, claimed on first use.
+  std::vector<TypeAssertSite> *typeAssertSites_ = nullptr;
+  /// The shared failure tail, bound only if there is at least one site.
+  asmjit::Label typeAssertFailLab_{};
 
   /// Descriptor for a single RO data entry.
   struct DataDesc {
@@ -967,6 +1013,17 @@ class Emitter {
   void loadParentNoTraps(FR frRes, FR frObj);
   void typedLoadParent(FR frRes, FR frObj);
 
+  /// Emit, only when emitTypeAsserts_ is set, a trap-on-violation check
+  /// that the value of \p fr, currently held in \p hwVal, satisfies
+  /// \p pred.
+  ///
+  /// Uses only xScratch/xScratch2 and never touches the register
+  /// allocator, so it is a pure insertion. It clobbers NZCV, so the caller
+  /// must have verified that flags are dead at the insertion point. That
+  /// is an obligation, not a property emitters have in general: see
+  /// selectObject, which holds flags across getOrAllocFRInGpX.
+  void emitTypeAssert(FR fr, HWReg hwVal, TypePred pred);
+
  private:
   /// \return the byte offset of \p fr's slot from xFrame.
   static constexpr inline uint32_t frByteOffset(FR fr) {
@@ -1254,6 +1311,14 @@ class Emitter {
   void emitCatchTable(llvh::ArrayRef<const asmjit::Label *> exceptionHandlers);
   void emitSlowPaths();
   void emitROData();
+
+  /// Emit \c emitTypeAssert's check sequence for \p pred against \p xVal,
+  /// which holds the current value of \p fr, recording a TypeAssertSite.
+  void emitTypeAssertGpX(FR fr, const a64::GpX &xVal, TypePred pred);
+
+  /// Emit the shared out-of-line tail that all type assert failure stubs
+  /// jump to, if any type assert was emitted for this function.
+  void emitTypeAssertFailTail();
 
  private:
   /// Set up the call frame and perform the call. The caller should have already

--- a/lib/VM/JIT/arm64/JitImpl.h
+++ b/lib/VM/JIT/arm64/JitImpl.h
@@ -9,6 +9,11 @@
 
 #include "asmjit/a64.h"
 
+#include "JitEmitter.h"
+
+#include <deque>
+#include <vector>
+
 namespace hermes::vm::arm64 {
 
 class JITContext::Impl {
@@ -25,6 +30,15 @@ class JITContext::Impl {
   /// that the exhaustion path can be reached without interning 65535 hidden
   /// classes; the true ceiling is the width of HiddenClass::lazyJITId_.
   uint16_t hcIdLimit{kHCIdOverflow};
+
+  /// Type assert site tables, one per function compiled with
+  /// -Xjit-emit-type-asserts. Each table's address is baked into that
+  /// function's failure tail, so entries must keep their addresses as more
+  /// functions are compiled; a deque never moves an existing element. Empty
+  /// unless the flag is set. A function whose compilation is abandoned
+  /// leaves its table behind, which costs a little memory but does not
+  /// outlive the runtime.
+  std::deque<std::vector<TypeAssertSite>> typeAssertSites{};
 
   /// Hidden classes that we used by the emitted JIT code. Since we never
   /// throw away code, they can never be freed.

--- a/test/jit/type-asserts.js
+++ b/test/jit/type-asserts.js
@@ -81,3 +81,25 @@ print(eqNullAlias({p: {}}));
 // CHECK-NEXT: false
 print(eqNullAlias({p: null}));
 // CHECK-NEXT: true
+
+// Class C: the boolean-typed values here earn a non-pointer-classed
+// global register (FRType::UnknownNonPtr), whose write is checked against
+// TypePred::NotPointer at the following instruction boundary. Under -O
+// the loop is rotated and `flag` is folded into the branch, so exactly
+// one such check survives, in the loop pre-header. The numbers earn
+// Number-classed global registers, checked the same way at many more
+// sites, including inside the loop body. The -O0 RUN line contributes no
+// Class C coverage at all: without optimization no FR gets a global
+// register.
+function nonPtrGlobalReg(n) {
+  var flag = false;
+  var total = 0;
+  for (var i = 0; i < n; ++i) {
+    flag = (i % 2) === 0;
+    if (flag)
+      total += i;
+  }
+  return total;
+}
+print(nonPtrGlobalReg(10));
+// CHECK-NEXT: 20

--- a/test/jit/type-asserts.js
+++ b/test/jit/type-asserts.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -Xjit=force -Xjit-crash-on-error %s | %FileCheck --match-full-lines %s
+// RUN: %hermes -Xjit=force -Xjit-crash-on-error -Xjit-emit-type-asserts %s | %FileCheck --match-full-lines %s
+// REQUIRES: jit
+
+function addNumbers(a, b) {
+  var sum = 0;
+  for (var i = 0; i < 100; ++i)
+    sum += a * b - i;
+  return sum;
+}
+
+print(addNumbers(3, 4));
+// CHECK: -3750

--- a/test/jit/type-asserts.js
+++ b/test/jit/type-asserts.js
@@ -7,6 +7,7 @@
 
 // RUN: %hermes -Xjit=force -Xjit-crash-on-error %s | %FileCheck --match-full-lines %s
 // RUN: %hermes -Xjit=force -Xjit-crash-on-error -Xjit-emit-type-asserts %s | %FileCheck --match-full-lines %s
+// RUN: %hermes -O0 -Xjit=force -Xjit-crash-on-error -Xjit-emit-type-asserts %s | %FileCheck --match-full-lines %s
 // REQUIRES: jit
 
 function addNumbers(a, b) {
@@ -18,3 +19,65 @@ function addNumbers(a, b) {
 
 print(addNumbers(3, 4));
 // CHECK: -3750
+
+// Materializes a genuine boolean value (the print() use stops it from being
+// fused into the comparison's own branch), then branches on it, exercising
+// jmpTrueFalse's known-Bool tier (TypePred::IsBool).
+function boolCond(x, y) {
+  var b = (x === y);
+  print(b);
+  if (b)
+    print("eq");
+  else
+    print("neq");
+}
+boolCond(3, 3);
+// CHECK-NEXT: true
+// CHECK-NEXT: eq
+boolCond(3, 4);
+// CHECK-NEXT: false
+// CHECK-NEXT: neq
+
+// The `null` operand is a compile-time-known OtherNonPtr constant, driving
+// strictEqualImpl's raw-bit tier (TypePred::BitComparable).
+function eqNull(x) {
+  return x === null;
+}
+print(eqNull(null));
+// CHECK-NEXT: true
+print(eqNull(3));
+// CHECK-NEXT: false
+
+// Same elision, but as a conditional jump: the `true` operand is a
+// compile-time-known Bool constant, driving jStrictEqual's raw-bit tier
+// (TypePred::BitComparable), a distinct emitter from strictEqualImpl.
+function eqTrue(x) {
+  if (x === true)
+    return 1;
+  return 0;
+}
+print(eqTrue(true));
+// CHECK-NEXT: 1
+print(eqTrue(false));
+// CHECK-NEXT: 0
+print(eqTrue(3));
+// CHECK-NEXT: 0
+
+// Regression: under -O0, HBC's register allocator can coalesce
+// StrictEqual's result register with the register of the *unknown*
+// operand (x.p here), not just the known constant's, since coalescing is
+// just lowest-free-register reuse and has no notion of which operand is
+// "known". strictEqualImpl's per-operand guards must be evaluated before
+// frUpdatedWithHW(frRes, ...) overwrites that shared register's
+// localType, or the guard goes spuriously true (or false) against a
+// register that still holds the original, differently-typed operand.
+// Under -O0 this compiles to `StrictEq rX, rX, rY` with rX = x.p, and
+// previously crashed here with a bogus "expected non-pointer non-number"
+// type assert failure on x.p's own (non-null) value.
+function eqNullAlias(x) {
+  return x.p === null;
+}
+print(eqNullAlias({p: {}}));
+// CHECK-NEXT: false
+print(eqNullAlias({p: null}));
+// CHECK-NEXT: true

--- a/tools/hermes/hermes.cpp
+++ b/tools/hermes/hermes.cpp
@@ -148,6 +148,7 @@ static int executeHBCBytecodeFromCL(
   options.dumpJITCode = flags.DumpJITCode;
   options.jitCrashOnError = flags.JITCrashOnError;
   options.jitEmitAsserts = flags.JITEmitAsserts;
+  options.jitEmitTypeAsserts = flags.JITEmitTypeAsserts;
   options.jitEmitCounters = flags.JITEmitCounters;
   options.jitHCIdLimit = flags.JITHCIdLimit;
   options.stopAfterInit = flags.StopAfterInit;

--- a/utils/jit/README.md
+++ b/utils/jit/README.md
@@ -1,0 +1,134 @@
+# JIT dump tools
+
+Tools for checking that a change to the arm64 JIT emitter did not change the
+code it emits.
+
+- `jit-dump.sh` — capture a canonicalized dump of all JIT-emitted code from
+  one `hermes` binary.
+- `jit-diff.sh` — capture from two binaries and compare, reporting comment
+  changes separately from instruction changes.
+
+## Why not just diff `-Xdump-jitcode` output?
+
+Because two runs of an **unchanged** binary produce different dumps.
+
+`Emitter::loadBits64InGp` asks `isCheapConst()` whether a 64-bit value has at
+most two non-zero 16-bit halfwords. If it does, the value is materialized
+inline with `mov`/`movk`; if not, it is spilled to the read-only data section
+and loaded with `ldr`. JIT-emitted code bakes in runtime pointers, and ASLR
+moves those every run. So the emitter genuinely selects *different
+instructions* from one run to the next, and every subsequent RO-data offset
+shifts along with them.
+
+You can see this for yourself:
+
+```sh
+utils/jit/jit-dump.sh --raw -o /tmp/a.txt build/bin/hermes
+utils/jit/jit-dump.sh --raw -o /tmp/b.txt build/bin/hermes
+diff -u /tmp/a.txt /tmp/b.txt | grep -cE '^[-+]'
+```
+
+That reports roughly 3,500 changed lines out of about 90,000 — from the same
+binary, twice, with no code change at all. Disabling ASLR (running under lldb)
+cuts it to a few dozen but does not eliminate it, because the contiguous
+heap's base address comes from a separate randomized mmap.
+
+`jit-dump.sh` therefore collapses constant materialization to a `CONST` token,
+drops the RO-data contents, and normalizes any remaining wide hex literal to
+`ADDR`. What survives is compared verbatim: instructions, registers, branches,
+labels, ordering, and the emitter's own comments. In practice that is about
+92% of the dump, and the same command without `--raw` reports zero
+differences.
+
+## Usage
+
+Both tools take **binaries**, not a build directory, so they work regardless
+of how you built.
+
+```sh
+# Build the "before" binary and stash it somewhere.
+cmake --build build --target hermes
+cp build/bin/hermes /tmp/hermes-before
+
+# Make your change, rebuild, and compare.
+utils/jit/jit-diff.sh /tmp/hermes-before build/bin/hermes
+```
+
+Typical output for a refactor that should be behaviour-preserving:
+
+```
+jit-diff: dumps are identical
+```
+
+and for one that touches only `Emitter::comment()` strings:
+
+```
+jit-diff: 20 changed lines (+10 / -10)
+  comment lines:     20
+  instruction lines: 0
+RESULT: comments only, no instruction changed
+```
+
+`--comments-ok` makes that second case exit 0, which is useful when a change
+deliberately edits a comment string.
+
+If the "before" binary is gone but you kept its capture, compare the dumps
+directly:
+
+```sh
+utils/jit/jit-diff.sh --dumps /tmp/before.txt /tmp/after.txt
+```
+
+To capture a single dump, for example to read one function by hand:
+
+```sh
+utils/jit/jit-dump.sh --raw -c test/jit/binops.js build/bin/hermes | less
+```
+
+`--raw` skips canonicalization. Use it for reading, never for comparing.
+
+## Corpus
+
+By default the corpus is every `test/jit/*.js` plus three typed tests that
+exercise paths the JIT tests do not:
+
+- `test/shermes/array-typed.js`
+- `test/hermes/flow/array-for-of.js`
+- `test/hermes/flow/nbody.js`
+
+Each `test/jit` file is run typed if and only if its own lit `RUN:` line
+passes `-typed`. That matters more than it sounds: running a typed test
+untyped does not just lose coverage, it fails to compile, so the file
+contributes a syntax error to the dump instead of any JIT code.
+
+Override with `-c FILE` (untyped) and `-t FILE` (compiled with `-typed`),
+both repeatable. Supplying either replaces the whole default corpus.
+
+A corpus file that exits nonzero aborts the capture. Its diagnostics would
+otherwise land in the dump, where they are indistinguishable from emitted
+code and will happily compare equal between two runs.
+
+## Limitations
+
+**Canonicalized lines are not compared.** A change that alters *which*
+instruction form is chosen for a constant is invisible to these tools, because
+that is exactly what gets collapsed to `CONST`. If your change touches
+`isCheapConst`, `loadBits64InGp`, `uint64Const`, or RO-data layout, these tools
+cannot verify it.
+
+**Coverage is only as good as the corpus.** An emitter path no test reaches
+will not appear in the dump. Notably, every function in the default corpus has
+well under 4 KB of bytecode, so paths gated on large bytecode offsets — such as
+the two-instruction `add` in `Emitter::getBytecodeIP` — are never exercised.
+Add a targeted file with `-c` when working on one of those.
+
+**A clean diff is not a correctness proof.** It shows the emitted code did not
+change, which is the right check for a refactor. It says nothing about whether
+the code was correct to begin with, and nothing about the emitter's own runtime
+behaviour. Run the lit suite too.
+
+**The JIT must be enabled** in the binaries under test
+(`-DHERMESVM_ALLOW_JIT=1`); the tools force it on per-run with `-Xjit=force
+-Xjit-threshold=1`, but cannot enable a compile-time-disabled JIT. If a binary
+was built without it, `jit-dump.sh` fails with a message saying so rather than
+silently producing an empty dump.

--- a/utils/jit/jit-diff.sh
+++ b/utils/jit/jit-diff.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Compare the JIT-emitted code of two hermes binaries over the same corpus.
+#
+# Takes binaries rather than driving a build, so it works the same whether the
+# binaries came from CMake, buck2, or anywhere else.
+#
+# Reports whether any *instruction* changed, separately from comment lines,
+# because that is usually the question being asked of a refactor.
+
+set -u
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+  cat <<'EOF'
+Usage: jit-diff.sh [options] <hermes-before> <hermes-after>
+
+Captures a canonicalized JIT dump from each binary and compares them,
+reporting comment-line changes separately from instruction changes.
+
+Options:
+  -k DIR         Keep the captures and the diff in DIR instead of a temp dir.
+  -c FILE        Add FILE to the corpus, run untyped. Repeatable.
+  -t FILE        Add FILE to the corpus, run with -typed. Repeatable.
+  -n N           Show at most N lines of the diff (default 40, 0 for all).
+  --comments-ok  Exit 0 when only comment lines differ.
+  --dumps        The two arguments are existing jit-dump.sh outputs rather
+                 than binaries. Useful when the "before" binary is gone but
+                 its capture was kept.
+  -h, --help     Show this help.
+
+Exit status:
+  0  dumps identical (or only comments differ, with --comments-ok)
+  1  dumps differ
+  2  usage or capture error
+
+Example:
+  git stash && cmake --build build --target hermes && cp build/bin/hermes /tmp/h-before
+  git stash pop && cmake --build build --target hermes
+  utils/jit/jit-diff.sh /tmp/h-before build/bin/hermes
+EOF
+}
+
+KEEP=""
+MAXLINES=40
+COMMENTS_OK=0
+DUMPS=0
+CORPUS=()
+
+# Abort rather than loop forever when an option is given without its operand.
+need_arg() {
+  if [ "$2" -lt 2 ]; then
+    echo "jit-diff: option $1 requires an argument" >&2
+    exit 2
+  fi
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -k) need_arg -k $#; KEEP="$2"; shift 2 ;;
+    -c) need_arg -c $#; CORPUS+=(-c "$2"); shift 2 ;;
+    -t) need_arg -t $#; CORPUS+=(-t "$2"); shift 2 ;;
+    -n) need_arg -n $#; MAXLINES="$2"; shift 2 ;;
+    --comments-ok) COMMENTS_OK=1; shift ;;
+    --dumps) DUMPS=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    -*) echo "jit-diff: unknown option: $1" >&2; usage >&2; exit 2 ;;
+    *) break ;;
+  esac
+done
+
+if [ $# -ne 2 ]; then
+  echo "jit-diff: expected two ${DUMPS:+dump files}${DUMPS:-hermes binaries}" >&2
+  usage >&2
+  exit 2
+fi
+BEFORE="$1"
+AFTER="$2"
+
+if [ -n "$KEEP" ]; then
+  mkdir -p "$KEEP" || exit 2
+  D="$KEEP"
+else
+  D="$(mktemp -d)"
+  trap 'rm -rf "$D"' EXIT
+fi
+
+if [ "$DUMPS" -eq 1 ]; then
+  for f in "$BEFORE" "$AFTER"; do
+    if [ ! -f "$f" ] || [ ! -r "$f" ]; then
+      echo "jit-diff: cannot read dump file: $f" >&2
+      exit 2
+    fi
+  done
+  cp "$BEFORE" "$D/before.txt" || exit 2
+  cp "$AFTER" "$D/after.txt" || exit 2
+else
+  echo "jit-diff: capturing 'before' from $BEFORE" >&2
+  "$SCRIPT_DIR/jit-dump.sh" ${CORPUS[@]+"${CORPUS[@]}"} -o "$D/before.txt" "$BEFORE" || exit 2
+  echo "jit-diff: capturing 'after'  from $AFTER" >&2
+  "$SCRIPT_DIR/jit-dump.sh" ${CORPUS[@]+"${CORPUS[@]}"} -o "$D/after.txt" "$AFTER" || exit 2
+fi
+
+# diff exits 0 for same, 1 for differing, >1 for trouble. Treating trouble as
+# "differing" would report a misleading result for an unreadable capture.
+diff -u "$D/before.txt" "$D/after.txt" > "$D/jit.diff"
+DSTATUS=$?
+if [ "$DSTATUS" -eq 0 ]; then
+  echo "jit-diff: dumps are identical"
+  exit 0
+elif [ "$DSTATUS" -gt 1 ]; then
+  echo "jit-diff: diff failed with status $DSTATUS" >&2
+  exit 2
+fi
+
+# Classify each changed line. A line that begins with '//' after the diff
+# marker is a comment emitted by Emitter::comment(); anything else is a label
+# or an instruction.
+changed=$(grep -cE '^[-+]' "$D/jit.diff")
+headers=$(grep -cE '^(\+\+\+|---)' "$D/jit.diff")
+changed=$((changed - headers))
+added=$(grep -cE '^\+' "$D/jit.diff")
+removed=$(grep -cE '^-' "$D/jit.diff")
+added=$((added - 1))
+removed=$((removed - 1))
+comments=$(grep -E '^[-+]' "$D/jit.diff" | grep -vE '^(\+\+\+|---)' \
+           | sed -E 's/^[-+][[:space:]]*//' | grep -cE '^//' || true)
+insns=$((changed - comments))
+
+echo "jit-diff: $changed changed lines (+$added / -$removed)"
+echo "  comment lines:     $comments"
+echo "  instruction lines: $insns"
+if [ "$insns" -eq 0 ]; then
+  echo "RESULT: comments only, no instruction changed"
+else
+  echo "RESULT: INSTRUCTIONS CHANGED"
+fi
+[ -n "$KEEP" ] && echo "captures and diff kept in $D"
+
+if [ "$MAXLINES" -ne 0 ]; then
+  echo "--- first $MAXLINES diff lines ---"
+  head -n "$MAXLINES" "$D/jit.diff"
+else
+  cat "$D/jit.diff"
+fi
+
+if [ "$insns" -eq 0 ] && [ "$COMMENTS_OK" -eq 1 ]; then
+  exit 0
+fi
+exit 1

--- a/utils/jit/jit-dump.sh
+++ b/utils/jit/jit-dump.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Capture a canonicalized dump of all JIT-emitted code over a corpus of JS
+# files, suitable for byte-for-byte comparison between two builds.
+#
+# The canonicalization is not optional for comparison purposes; see
+# utils/jit/README.md for why two runs of an *unchanged* binary produce
+# different raw dumps.
+
+set -u
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+usage() {
+  cat <<'EOF'
+Usage: jit-dump.sh [options] <hermes-binary>
+
+Runs <hermes-binary> over a corpus of JS files with the JIT forced on,
+dumping every emitted function, and canonicalizes the output so that two
+captures can be compared byte for byte.
+
+Options:
+  -o FILE        Write the dump to FILE (default: stdout).
+  -c FILE        Add FILE to the corpus, run untyped. Repeatable.
+  -t FILE        Add FILE to the corpus, run with -typed. Repeatable.
+                 If neither -c nor -t is given, the default corpus is used:
+                 test/jit/*.js plus a few typed tests.
+  --raw          Skip canonicalization. Useful for reading a single dump,
+                 useless for comparing two.
+  -q             Do not print the summary line to stderr.
+  -h, --help     Show this help.
+
+Examples:
+  # Capture from a CMake build.
+  utils/jit/jit-dump.sh -o /tmp/before.txt ~/build/bin/hermes
+
+  # Compare two builds (see also jit-diff.sh).
+  utils/jit/jit-dump.sh -o /tmp/after.txt ./bin/hermes
+  diff -u /tmp/before.txt /tmp/after.txt
+
+  # Just one file, raw, to read by hand.
+  utils/jit/jit-dump.sh --raw -c test/jit/binops.js ./bin/hermes
+EOF
+}
+
+OUT=""
+RAW=0
+QUIET=0
+UNTYPED=()
+TYPED=()
+
+# Abort rather than loop forever when an option is given without its operand.
+need_arg() {
+  if [ "$2" -lt 2 ]; then
+    echo "jit-dump: option $1 requires an argument" >&2
+    exit 2
+  fi
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) need_arg -o $#; OUT="$2"; shift 2 ;;
+    -c) need_arg -c $#; UNTYPED+=("$2"); shift 2 ;;
+    -t) need_arg -t $#; TYPED+=("$2"); shift 2 ;;
+    --raw) RAW=1; shift ;;
+    -q) QUIET=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    -*) echo "jit-dump: unknown option: $1" >&2; usage >&2; exit 2 ;;
+    *) break ;;
+  esac
+done
+
+if [ $# -ne 1 ]; then
+  echo "jit-dump: expected exactly one hermes binary" >&2
+  usage >&2
+  exit 2
+fi
+HERMES="$1"
+
+if [ ! -x "$HERMES" ]; then
+  echo "jit-dump: not an executable: $HERMES" >&2
+  exit 2
+fi
+
+# Default corpus: every JIT test, plus a few typed tests that exercise paths
+# the JIT tests do not.
+#
+# A JIT test is run typed iff its own lit RUN line passes -typed. Running a
+# typed test untyped does not merely reduce coverage: it fails to compile, and
+# the corpus then contributes a syntax error instead of any JIT code.
+if [ ${#UNTYPED[@]} -eq 0 ] && [ ${#TYPED[@]} -eq 0 ]; then
+  while IFS= read -r f; do
+    if grep -qE '^// *RUN:.*[[:space:]]-typed([[:space:]]|$)' "$f"; then
+      TYPED+=("$f")
+    else
+      UNTYPED+=("$f")
+    fi
+  done < <(ls "$ROOT"/test/jit/*.js 2>/dev/null)
+  TYPED+=("$ROOT/test/shermes/array-typed.js")
+  TYPED+=("$ROOT/test/hermes/flow/array-for-of.js")
+  TYPED+=("$ROOT/test/hermes/flow/nbody.js")
+  if [ ${#UNTYPED[@]} -eq 0 ] && [ ${#TYPED[@]} -eq 3 ]; then
+    echo "jit-dump: default corpus is empty; no $ROOT/test/jit/*.js found" >&2
+    exit 2
+  fi
+fi
+
+for f in ${UNTYPED[@]+"${UNTYPED[@]}"} ${TYPED[@]+"${TYPED[@]}"}; do
+  [ -f "$f" ] || { echo "jit-dump: no such corpus file: $f" >&2; exit 2; }
+done
+
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+# Canonicalize:
+#  - Collapse constant materialization to a CONST token. isCheapConst() picks
+#    between mov/movk and an RO-data load based on the *value*, and JIT code
+#    bakes in runtime pointers that ASLR moves every run.
+#  - Drop the RO_DATA contents, whose layout shifts with the above.
+#  - Normalize any remaining wide hex literal to ADDR.
+canonicalize() {
+  if [ "$RAW" -eq 1 ]; then
+    cat
+    return
+  fi
+  sed -E \
+      -e 's/^( *)mov (x[0-9]+), 0x[0-9A-Fa-f]+$/\1CONST \2/' \
+      -e 's/^( *)ldr (x[0-9]+), \[RO_DATA(, [0-9]+)?\]$/\1CONST \2/' \
+      -e 's/^( *)ldr (d[0-9]+), \[RO_DATA(, [0-9]+)?\]$/\1CONST \2/' \
+      -e '/JIT total memory usage/d' \
+      -e '/^\.xword /d' \
+      -e '/^\/\/ Bytecode start$/d' \
+      -e '/^\/\/ RuntimeModule$/d' \
+      -e 's/0x[0-9A-Fa-f]{8,}/ADDR/g' \
+  | awk '/^RO_DATA:$/ {inro=1; next} inro && /^\/\// {next} inro {inro=0} {print}'
+}
+
+run_one() {
+  local label="$1" file="$2"; shift 2
+  local before after
+  # Snapshot the whole pipeline status: hermes failing and canonicalization
+  # failing both yield a dump that is wrong but looks plausible.
+  local -a pstatus
+  echo "===== $label =====" >> "$TMP"
+  before=$(wc -l < "$TMP")
+  "$HERMES" "$@" -Xjit=force -Xjit-threshold=1 -Xdump-jitcode=3 "$file" 2>&1 \
+    | canonicalize >> "$TMP"
+  pstatus=("${PIPESTATUS[@]}")
+  after=$(wc -l < "$TMP")
+  # A failing run still writes its diagnostics into the dump, where they are
+  # indistinguishable from emitted code. Never let that pass silently.
+  if [ "${pstatus[0]}" -ne 0 ]; then
+    echo "jit-dump: '$label' exited with status ${pstatus[0]}" >&2
+    echo "  Its diagnostics, not JIT output, would have gone into the dump." >&2
+    echo "  Last lines captured:" >&2
+    tail -n 3 "$TMP" | sed 's/^/    /' >&2
+    exit 1
+  fi
+  # Canonicalization is sed|awk writing to $TMP, so this catches a write
+  # failure (full disk, unwritable temp) that would silently truncate.
+  if [ "${pstatus[1]}" -ne 0 ]; then
+    echo "jit-dump: canonicalizing '$label' failed with status ${pstatus[1]}" >&2
+    echo "  The dump is likely truncated; refusing to continue." >&2
+    exit 1
+  fi
+  if [ "$after" -le "$((before + 2))" ]; then
+    echo "jit-dump: '$label' emitted almost nothing." >&2
+    echo "  Is $HERMES built with the JIT enabled (HERMESVM_ALLOW_JIT)?" >&2
+    exit 1
+  fi
+}
+
+for f in ${UNTYPED[@]+"${UNTYPED[@]}"}; do run_one "$(basename "$f")" "$f"; done
+for f in ${TYPED[@]+"${TYPED[@]}"}; do run_one "typed $(basename "$f")" "$f" -typed; done
+
+if [ "$QUIET" -eq 0 ]; then
+  total=$(wc -l < "$TMP" | tr -d ' ')
+  const=$(grep -c 'CONST ' "$TMP" || true)
+  pct=$(( total > 0 ? (total - const) * 100 / total : 0 ))
+  echo "jit-dump: $total lines, $const canonicalized (${pct}% compared verbatim)" >&2
+fi
+
+if [ -n "$OUT" ]; then
+  cp "$TMP" "$OUT"
+else
+  cat "$TMP"
+fi


### PR DESCRIPTION
Summary:

When the bytecode header classifies one of a function's registers as a
number, the JIT parks it in a callee-saved register such as d8 for the
whole function and stops writing it back to the frame -- numbers never
need scanning, so there is no reason to. But the frame is what the GC
scans. If a pointer ever lands in that register, the collector cannot
see it: it is never marked, and a moving collector never updates it.
The damage shows up later and somewhere else.

There is no consumption site to hang a check on, because the
"consumption" is the value merely sitting there. So the check goes on
the producing side.

It fires at the next bytecode instruction boundary rather than at the
write, because several emitters announce a write before performing it.
`catchInst` is the clearest case:

    hwRes = getOrAllocFRInGpX(frRes, false);
    frUpdatedWithHW(frRes, hwRes, ...);   // "r3 holds the result now"
    a.ldr(hwRes, [thrownValue]);          // ...and only here does it

A check at the end of `frUpdatedWithHW` would read r3 one instruction
too early, and could not tell that it had: `FRState::regIsDirty` marks
exactly this window, and `frUpdatedWithHW` clears it.

Deferring costs something. Only the value left in the register when the
instruction finishes is checked, so an instruction that puts a pointer
there, calls a runtime helper that could collect, and then overwrites it
with a number will pass.

Differential Revision: D116976061
