### PR TITLE
Support inline SerialExecutor tasks without Emscripten pthreads

### DIFF
--- a/lib/Support/SerialExecutor.cpp
+++ b/lib/Support/SerialExecutor.cpp
@@ -32,6 +32,11 @@ SerialExecutor::~SerialExecutor() {
 }
 
 void SerialExecutor::add(std::function<void()> task) {
+#if defined(__EMSCRIPTEN__) && !defined(__EMSCRIPTEN_PTHREADS__)
+  task();
+  return;
+#endif
+
   std::unique_lock<std::mutex> lock(mutex_);
   assert(
       threadState_ != ThreadState::Terminating &&


### PR DESCRIPTION
## Summary

When Hermes is built for Emscripten without pthreads, run `SerialExecutor` tasks inline instead of attempting to create an executor thread.

This keeps task ordering and finalizer execution available in the single-threaded runtime while leaving the threaded path unchanged.

## Test plan

- Reviewed the guarded `__EMSCRIPTEN__ && !__EMSCRIPTEN_PTHREADS__` path and existing SerialExecutor contract.
- Native tests are unchanged because this branch is specific to the single-threaded Emscripten configuration.
