### PR TITLE
StaticH: fix typed string and FastArray builtins

### DIFF
--- a/lib/TypedLib/02-string.js
+++ b/lib/TypedLib/02-string.js
@@ -9,3 +9,8 @@ function charAt(this: string, pos: number): string {
   return this[pos];
 }
 Hermes.decorate(charAt, Hermes.builtin);
+
+function charCodeAt(this: string, pos: number): number {
+  return globalThis.String.prototype.charCodeAt.call(this, pos) as number;
+}
+Hermes.decorate(charCodeAt, Hermes.builtin);

--- a/lib/VM/JSLib/GlobalObject.cpp
+++ b/lib/VM/JSLib/GlobalObject.cpp
@@ -461,8 +461,10 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
   // Declare the array class.
   runtime.arrayClass = JSArray::createClass(runtime, runtime.arrayPrototype);
 
-  // TODO: Give FastArray its own prototype so methods like push will work.
-  runtime.fastArrayPrototype = *runtime.objectPrototype;
+  // FastArray needs its own prototype for methods that bridge typed arrays to
+  // dynamic JavaScript without adding those methods to Object.prototype.
+  runtime.fastArrayPrototype =
+      JSObject::create(runtime, runtime.objectPrototype);
 
   // Declare the fast array class.
   runtime.fastArrayClass =
@@ -595,6 +597,19 @@ void initGlobalObject(Runtime &runtime, const JSLibFlags &jsLibFlags) {
   // Array constructor.
   runtime.arrayConstructor.castAndSetHermesValue<NativeConstructor>(
       createArrayConstructor(runtime));
+
+  // FastArray uses the standard generic array iterator when it crosses into
+  // dynamic JavaScript. FastArray instances are sealed, so the method lives on
+  // their shared prototype.
+  DefinePropertyFlags fastArrayIteratorDPF =
+      DefinePropertyFlags::getNewNonEnumerableFlags();
+  runtime.ignoreAllocationFailure(
+      JSObject::defineOwnProperty(
+          Handle<JSObject>::vmcast(&runtime.fastArrayPrototype),
+          runtime,
+          Predefined::getSymbolID(Predefined::SymbolIterator),
+          fastArrayIteratorDPF,
+          runtime.arrayPrototypeValues));
 
   // ArrayBuffer constructor.
   runtime.arrayBufferConstructor.castAndSetHermesValue<NativeConstructor>(

--- a/test/Sema/flow/builtin-string-charCodeAt.js
+++ b/test/Sema/flow/builtin-string-charCodeAt.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %shermes -typed -dump-sema %s | %FileCheckOrRegen %s --match-full-lines
+
+// Test that string.charCodeAt builtin method is correctly typechecked.
+
+function test(s: string): number {
+  return s.charCodeAt(0);
+}
+
+// Auto-generated content below. Please do not modify manually.
+
+// CHECK:%untyped_function.1 = untyped_function()
+// CHECK-NEXT:%function.2 = function(s: string): number
+// CHECK-NEXT:%function.3 = function(this: string, pos: number): number
+
+// CHECK:SemContext
+// CHECK-NEXT:Func strict
+// CHECK-NEXT:    Scope %s.1
+// CHECK-NEXT:        Decl %d.1 'exports' Parameter : any
+// CHECK-NEXT:        Decl %d.2 'test' Var : %function.2
+// CHECK-NEXT:        Decl %d.3 'arguments' Var Arguments
+// CHECK-NEXT:        hoistedFunction test
+// CHECK-NEXT:    Func strict
+// CHECK-NEXT:        Scope %s.2
+// CHECK-NEXT:            Decl %d.4 's' Parameter : string
+// CHECK-NEXT:            Decl %d.5 'arguments' Var Arguments
+
+// CHECK:FunctionExpression : %untyped_function.1
+// CHECK-NEXT:    Id 'exports' [D:E:%d.1 'exports']
+// CHECK-NEXT:    BlockStatement
+// CHECK-NEXT:        FunctionDeclaration : %function.2
+// CHECK-NEXT:            Id 'test' [D:E:%d.2 'test']
+// CHECK-NEXT:            Id 's' [D:E:%d.4 's']
+// CHECK-NEXT:            BlockStatement
+// CHECK-NEXT:                ReturnStatement
+// CHECK-NEXT:                    CallExpression : number
+// CHECK-NEXT:                        MemberExpression : %function.3
+// CHECK-NEXT:                            Id 's' [D:E:%d.4 's'] : string
+// CHECK-NEXT:                            Id 'charCodeAt'
+// CHECK-NEXT:                        NumericLiteral : number

--- a/test/shermes/array-spread-fast-array.js
+++ b/test/shermes/array-spread-fast-array.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %shermes -typed -exec %s | %FileCheck --match-full-lines %s
+
+'use strict';
+
+const pathSymbol: any = Symbol.for('path');
+
+function createPath(pathParts: Array<string> = []): any {
+  const handler: any = {
+    get(_target: any, property: any): any {
+      if (typeof property === 'string') {
+        return createPath([...pathParts, property]);
+      }
+      if (property === pathSymbol) {
+        return pathParts.join('.');
+      }
+      return undefined;
+    },
+  };
+  return new Proxy({}, handler);
+}
+
+function resolvePath(): string {
+  return createPath().first.second[pathSymbol];
+}
+
+print(resolvePath());
+// CHECK: first.second
+print(resolvePath());
+// CHECK-NEXT: first.second
+
+function joinDynamic(values: any): string {
+  let result = '';
+  for (const value of values) {
+    result += value;
+  }
+  return result;
+}
+
+const values: Array<string> = ['third', '.', 'fourth'];
+print(joinDynamic(values));
+// CHECK-NEXT: third.fourth
+
+function collectRest(...values: Array<string>): Array<string> {
+  return values;
+}
+
+print(joinDynamic(collectRest('fifth', '.', 'sixth')));
+// CHECK-NEXT: fifth.sixth


### PR DESCRIPTION
## Summary

- Expose `String.prototype.charCodeAt` to the typed library.
- Give Static Hermes `FastArray` values a dedicated prototype and standard array iterator when they cross into dynamic JavaScript.

The typed builtin delegates to the existing dynamic implementation. The FastArray prototype avoids extending `Object.prototype` and keeps iterator behavior local to FastArray instances.

## Test plan

- `shermes -typed -exec -O0 test/shermes/array-spread-fast-array.js`
- `shermes -typed -exec -O0 test/hermes/flow/computed-class-method.js` (regression smoke check)
- `shermes -typed -exec -O0 test/shermes/typed-class-expression.js` (regression smoke check)
- `shermes -typed -dump-sema test/Sema/flow/builtin-string-charCodeAt.js`
