### PR TITLE
fix(hermes-parser): make single-node AST replacement O(1) instead of O(siblings)

### DIFF
--- a/tools/hermes-parser/js/hermes-parser/__tests__/transform/SimpleTransform-test.js
+++ b/tools/hermes-parser/js/hermes-parser/__tests__/transform/SimpleTransform-test.js
@@ -119,5 +119,91 @@ describe('SimpleTransform', () => {
         },
       });
     });
+    it('Array element at each position', () => {
+      // A replacement must land correctly at the start, middle and end of the
+      // sibling array.
+      for (const target of [1, 2, 3]) {
+        expectTransformToEqual({
+          code: `[1, 2, 3];`,
+          result: `[${[1, 2, 3].map(v => (v === target ? 9 : v)).join(', ')}];`,
+          transform(node) {
+            if (node.type === 'Literal' && node.value === target) {
+              // $FlowFixMe[incompatible-type]
+              return {
+                type: 'Literal',
+                value: 9,
+                raw: '9',
+                literalType: 'numeric',
+              };
+            }
+            return node;
+          },
+        });
+      }
+    });
+    it('Nested array element', () => {
+      expectTransformToEqual({
+        code: `[[1, 2], [3]];`,
+        result: `[[1, 9], [3]];`,
+        transform(node) {
+          if (node.type === 'Literal' && node.value === 2) {
+            // $FlowFixMe[incompatible-type]
+            return {
+              type: 'Literal',
+              value: 9,
+              raw: '9',
+              literalType: 'numeric',
+            };
+          }
+          return node;
+        },
+      });
+    });
+    it('One node with many nodes inside an array', () => {
+      // Array-valued replacements change the sibling count, so they must keep
+      // going through `replaceInArray` instead of any in-place assignment.
+      expectTransformToEqual({
+        code: `[1, 2, 3];`,
+        result: `[1, 9, 8, 3];`,
+        transform(node) {
+          if (node.type === 'Literal' && node.value === 2) {
+            // $FlowFixMe[incompatible-type]
+            return [
+              {type: 'Literal', value: 9, raw: '9', literalType: 'numeric'},
+              {type: 'Literal', value: 8, raw: '8', literalType: 'numeric'},
+            ];
+          }
+          return node;
+        },
+      });
+    });
+    it('Keeps the sibling array identity for a single-node replacement', () => {
+      // Regression guard for the O(1) replacement path: swapping one node for
+      // one node must write into the existing array rather than rebuild it.
+      // Rebuilding is O(siblings) per replacement, which made the `babel: true`
+      // AST conversion quadratic in sibling count.
+      const ast: $FlowFixMe = parse(`[1, 2, 3];`);
+      const elementsBefore = ast.body[0].expression.elements;
+
+      const result = SimpleTransform.transform(ast, {
+        transform(node) {
+          if (node.type === 'Literal' && node.value === 2) {
+            // $FlowFixMe[incompatible-type]
+            return {
+              type: 'Literal',
+              value: 9,
+              raw: '9',
+              literalType: 'numeric',
+            };
+          }
+          return node;
+        },
+      });
+
+      const resultAST: $FlowFixMe = result;
+      const elementsAfter = resultAST.body[0].expression.elements;
+      expect(elementsAfter).toBe(elementsBefore);
+      expect(elementsAfter.map(element => element.value)).toEqual([1, 9, 3]);
+    });
   });
 });

--- a/tools/hermes-parser/js/hermes-parser/__tests__/traverse/SimpleTraverser-test.js
+++ b/tools/hermes-parser/js/hermes-parser/__tests__/traverse/SimpleTraverser-test.js
@@ -13,6 +13,36 @@
 import {SimpleTraverser} from '../../src/traverse/SimpleTraverser';
 
 describe('SimpleTraverser', () => {
+  it('passes the parent key and array index to the callbacks', () => {
+    const traverser = new SimpleTraverser();
+
+    const fakeAst: $FlowFixMe = {
+      type: 'Program',
+      body: [
+        {
+          type: 'ExpressionStatement',
+          expression: {type: 'Identifier', name: 'a'},
+        },
+      ],
+    };
+
+    const entered: Array<string> = [];
+    traverser.traverse(fakeAst, {
+      enter(node, _parent, parentKey, parentIndex) {
+        entered.push(`${node.type}:${String(parentKey)}:${String(parentIndex)}`);
+      },
+      leave() {},
+    });
+
+    expect(entered).toEqual([
+      'Program:undefined:undefined',
+      // array child: both the key and the index are known
+      'ExpressionStatement:body:0',
+      // single child: the key is known, there is no index
+      'Identifier:expression:null',
+    ]);
+  });
+
   it("traverses all keys except 'parent', 'loc', 'range', 'leadingComments', and 'trailingComments'", () => {
     const traverser = new SimpleTraverser();
 

--- a/tools/hermes-parser/js/hermes-parser/src/transform/SimpleTransform.js
+++ b/tools/hermes-parser/js/hermes-parser/src/transform/SimpleTransform.js
@@ -71,7 +71,12 @@ export class SimpleTransform {
   transform(rootNode: ESNode, options: TransformOptions): ESNode | null {
     let resultRootNode: ESNode | null = rootNode;
     SimpleTraverser.traverse(rootNode, {
-      enter: (node: ESNode, parent: ?ESNode) => {
+      enter: (
+        node: ESNode,
+        parent: ?ESNode,
+        parentKey?: ?string,
+        parentIndex?: ?number,
+      ) => {
         // Ensure the parent pointers are correctly set before entering the node.
         setParentPointer(node, parent);
 
@@ -114,6 +119,8 @@ export class SimpleTransform {
               parent,
               traversedResultNode,
               options.visitorKeys,
+              parentKey,
+              parentIndex,
             );
             setParentPointer(traversedResultNode, parent);
           }

--- a/tools/hermes-parser/js/hermes-parser/src/transform/astNodeMutationHelpers.js
+++ b/tools/hermes-parser/js/hermes-parser/src/transform/astNodeMutationHelpers.js
@@ -83,7 +83,37 @@ export function replaceNodeOnParent(
   originalNodeParent: ESNode,
   nodeToReplaceWith: ESNode | ReadonlyArray<ESNode>,
   visitorKeys?: ?VisitorKeysType,
+  parentKey?: ?string,
+  parentIndex?: ?number,
 ): void {
+  // Fast path: a caller that already knows where `originalNode` sits (e.g. a
+  // traversal that just walked to it) can pass that position, which lets us skip
+  // both the O(siblings) `getParentKey` scan and the O(siblings) array rebuild in
+  // `replaceInArray`. Without it, replacing every element of an N-element array
+  // costs O(N^2) -- exactly what the `babel: true` AST conversion does when it
+  // maps each literal node to a fresh object.
+  //
+  // The hint is only trusted after an O(1) identity probe, so a stale or
+  // incorrect hint falls through to the slow path instead of corrupting the AST.
+  // Replacements with an array change the sibling count, so they must still go
+  // through `replaceInArray`.
+  if (
+    parentKey != null &&
+    parentIndex != null &&
+    !Array.isArray(nodeToReplaceWith)
+  ) {
+    // $FlowExpectedError[prop-missing]
+    const siblings = originalNodeParent[parentKey];
+    if (Array.isArray(siblings)) {
+      // $FlowFixMe[invalid-compare]
+      const hintIsValid = siblings[parentIndex] === originalNode;
+      if (hintIsValid) {
+        siblings[parentIndex] = nodeToReplaceWith;
+        return;
+      }
+    }
+  }
+
   const replacementParent = getParentKey(
     originalNode,
     originalNodeParent,

--- a/tools/hermes-parser/js/hermes-parser/src/traverse/SimpleTraverser.js
+++ b/tools/hermes-parser/js/hermes-parser/src/traverse/SimpleTraverser.js
@@ -15,7 +15,12 @@ import type {ESNode} from 'hermes-estree';
 
 import {getVisitorKeys, isNode} from './getVisitorKeys';
 
-export type TraverserCallback = (node: ESNode, parent: ?ESNode) => void;
+export type TraverserCallback = (
+  node: ESNode,
+  parent: ?ESNode,
+  parentKey?: ?string,
+  parentIndex?: ?number,
+) => void;
 export type TraverserOptions = Readonly<{
   /** The callback function which is called on entering each node. */
   enter: TraverserCallback,
@@ -66,13 +71,19 @@ export class SimpleTraverser {
    * @param parent The parent node.
    * @private
    */
-  _traverse(node: ESNode, parent: ?ESNode, options: TraverserOptions): void {
+  _traverse(
+    node: ESNode,
+    parent: ?ESNode,
+    options: TraverserOptions,
+    parentKey?: ?string,
+    parentIndex?: ?number,
+  ): void {
     if (!isNode(node)) {
       return;
     }
 
     try {
-      options.enter(node, parent);
+      options.enter(node, parent, parentKey, parentIndex);
     } catch (ex) {
       if (ex === SimpleTraverserSkip) {
         return;
@@ -89,15 +100,15 @@ export class SimpleTraverser {
 
       if (Array.isArray(child)) {
         for (let j = 0; j < child.length; ++j) {
-          this._traverse(child[j], node, options);
+          this._traverse(child[j], node, options, lookupKey, j);
         }
       } else {
-        this._traverse(child, node, options);
+        this._traverse(child, node, options, lookupKey, null);
       }
     }
 
     try {
-      options.leave(node, parent);
+      options.leave(node, parent, parentKey, parentIndex);
     } catch (ex) {
       if (ex === SimpleTraverserSkip) {
         return;


### PR DESCRIPTION
## Summary

`parse(src, {babel: true})` is quadratic in sibling count. A 502 KB prebuilt file takes 88 seconds where the parse itself takes 0.1 (#2158), which put a 94 second floor on every cold build for a downstream bundler (callstack/repack#1447).

Each single-node replacement runs two independent O(siblings) operations. `getParentKey` (`astNodeMutationHelpers.js:24`) rescans the parent array to rebuild an index the traversal already had, then `replaceInArray` (`astArrayMutationHelpers.js:61`) rebuilds the whole array. `_traverse` holds that index in `j`, but `TraverserCallback` is typed `(node, parent) => void`, so it never reaches the callback.

This threads the position down as two optional trailing parameters and uses it in `replaceNodeOnParent` after an O(1) identity probe, falling back to the existing scan when the hint does not match. Array-valued replacements change sibling count and still go through `replaceInArray`. At 32,000 elements: 21,187ms to 225ms.

Both halves are needed. The issue suggests either change alone removes most of the cost. Measured separately, the index alone leaves 9,664ms and the in-place write alone leaves 12,649ms, against 21,187ms baseline and 225ms with both.

`TraverserCallback` and `replaceNodeOnParent` are exported from `index.js`, so this touches public API. No existing caller changes behaviour, because the fast path only engages when the new parameters are passed. `replaceInArray` is deliberately untouched, since `hermes-transform` calls it directly and relies on its copy-on-write result.

## Test Plan

From `tools/hermes-parser/js`: `yarn test` gives 2,615 passing and 456 snapshots, against 2,610 on a pristine checkout. The difference is the five tests added here. `yarn flow` and `yarn lint` are clean.

The new tests cover replacement at the first, middle and last array position, inside a nested array, and one node replaced by many so the length-changing path stays covered. A guard asserts the sibling array keeps its object identity, and both mechanism tests fail without the fix.
