### PR TITLE
Graft "[SH] Fix: races and dead lock in SerialExecutor between add() and run()" to shermes/stable

### DIFF
--- a/include/hermes/Support/SerialExecutor.h
+++ b/include/hermes/Support/SerialExecutor.h
@@ -8,6 +8,8 @@
 #ifndef HERMES_SERIALEXECUTOR_SERIALEXECUTOR_H
 #define HERMES_SERIALEXECUTOR_SERIALEXECUTOR_H
 
+#include "llvh/ADT/FunctionExtras.h"
+
 #include <atomic>
 #include <cassert>
 #include <chrono>
@@ -16,10 +18,9 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <thread>
 #if !defined(_WINDOWS) && !defined(__EMSCRIPTEN__)
 #include <pthread.h>
-#else
-#include <thread>
 #endif
 
 namespace hermes {
@@ -63,8 +64,21 @@ class SerialExecutor {
   std::thread workerThread_;
 #endif
 
-  /// A list of functions to execute on the worker thread.
-  std::deque<std::function<void()>> tasks_;
+  /// Id of the worker thread currently executing run(), or a default
+  /// constructed id when none is. run() sets it on entry and clears it before
+  /// returning, both under mutex_, so it is never a thread that has exited:
+  /// note that a worker is spawned before it reaches run(), and that an id is
+  /// free to be reused once its thread is gone. This exists so that add() can
+  /// tell an enqueue coming from the running worker apart from one coming from
+  /// any other thread.
+  std::thread::id workerThreadId_;
+
+  /// A list of functions to execute on the worker thread. These are
+  /// llvh::unique_function rather than std::function because moving a
+  /// unique_function always empties the source, which lets the queue take sole
+  /// ownership of a task before the worker can dequeue it. std::function makes
+  /// no such guarantee: libc++ copies small inlined callables on move.
+  std::deque<llvh::unique_function<void()>> tasks_;
 
   /// Mutex guarding state shared with the worker thread.
   std::mutex mutex_;
@@ -125,7 +139,16 @@ class SerialExecutor {
 
   /// Push a task to the back of the queue, lazily creating the worker thread if
   /// it does not exist.
-  void add(std::function<void()> task);
+  ///
+  /// Ownership of \p task transfers to the queue before this returns, so the
+  /// task and everything it captures are destroyed on the worker thread after
+  /// the task has run, never on the calling thread.
+  ///
+  /// Destroying a task runs caller code, so a task's captured state may itself
+  /// call add(). Once ~SerialExecutor has begun draining, only the worker
+  /// thread may do so: the drain loop picks up whatever it enqueues, whereas a
+  /// task enqueued from another thread at that point may never run at all.
+  void add(llvh::unique_function<void()> task);
 };
 } // namespace hermes
 

--- a/lib/Support/SerialExecutor.cpp
+++ b/lib/Support/SerialExecutor.cpp
@@ -31,15 +31,25 @@ SerialExecutor::~SerialExecutor() {
   assert(tasks_.empty() && "Thread should have drained all tasks.");
 }
 
-void SerialExecutor::add(std::function<void()> task) {
+void SerialExecutor::add(llvh::unique_function<void()> task) {
   std::unique_lock<std::mutex> lock(mutex_);
+  // Draining inside ~SerialExecutor destroys tasks, and a task's captured
+  // state may enqueue more work from its destructor. That is fine: the drain
+  // loop runs until the queue is empty, so it picks the new task up. Enqueuing
+  // from any other thread once teardown has begun is a lifetime bug, because
+  // the worker may already have passed the drain loop.
   assert(
-      threadState_ != ThreadState::Terminating &&
-      "Adding tasks during teardown.");
+      (threadState_ != ThreadState::Terminating ||
+       workerThreadId_ == std::this_thread::get_id()) &&
+      "Adding tasks during teardown from outside the worker thread.");
 
   // If the thread is exiting or has already exited, we need to create a new
-  // one.
-  if (threadState_ != ThreadState::Initialized) {
+  // one. Terminating is the exception: the worker is still draining and will
+  // pick this task up itself. Spawning another one there would overwrite tid_
+  // out from under the join in ~SerialExecutor and reset threadState_, so the
+  // drain loop would never see Terminating and both workers would park.
+  if (threadState_ != ThreadState::Initialized &&
+      threadState_ != ThreadState::Terminating) {
     assert(tasks_.empty() && "Exited thread should have drained tasks.");
 
 #if !defined(_WINDOWS) && !defined(__EMSCRIPTEN__)
@@ -73,15 +83,23 @@ void SerialExecutor::add(std::function<void()> task) {
     threadState_ = ThreadState::Initialized;
   }
 
-  tasks_.push_back(task);
+  // Moving a unique_function always empties the source, so the queue is the
+  // sole owner of the task before we release the lock. Otherwise the caller
+  // could drop the last reference to the task's captured state -- for
+  // finalizers, the object being finalized -- after the worker has already
+  // run, destroying it on the calling thread instead of the worker.
+  tasks_.push_back(std::move(task));
   wakeUpSig_.notify_one();
 }
 
 void SerialExecutor::run() {
   std::unique_lock<std::mutex> lock(mutex_);
+  workerThreadId_ = std::this_thread::get_id();
   while (true) {
     while (!tasks_.empty()) {
-      std::function<void()> task = std::move(tasks_.front());
+      // The move empties the queue element, so pop_front() destroys an empty
+      // shell and cannot run the task's captured destructors under the lock.
+      llvh::unique_function<void()> task = std::move(tasks_.front());
       tasks_.pop_front();
       // Make sure we do *NOT* hold a lock to mutex_ as we execute the given
       // task. Otherwise, this can lead to a deadlock if the given task calls
@@ -89,9 +107,16 @@ void SerialExecutor::run() {
       // hold the lock anytime that we interact with the tasks queue.
       lock.unlock();
       task();
+      // Destroy the task before re-acquiring the lock. Its captured state
+      // belongs to the caller and destroying it runs caller code, which may
+      // call add() just as the task body may.
+      task = nullptr;
       lock.lock();
     }
     if (threadState_ == ThreadState::Terminating) {
+      // This thread is on its way out, so stop claiming to be the worker.
+      // Both exits do this while still holding the lock.
+      workerThreadId_ = std::thread::id{};
       return;
     }
 
@@ -103,6 +128,7 @@ void SerialExecutor::run() {
     // Timed out and there is nothing to do, exit.
     if (waitRes == std::cv_status::timeout && tasks_.empty()) {
       threadState_ = ThreadState::TimedOut;
+      workerThreadId_ = std::thread::id{};
       return;
     }
   }

--- a/unittests/Support/SerialExecutorTest.cpp
+++ b/unittests/Support/SerialExecutorTest.cpp
@@ -10,9 +10,51 @@
 
 #include "gtest/gtest.h"
 
+#include <atomic>
+#include <future>
+#include <memory>
 #include <thread>
 
 namespace {
+
+/// Captured state that enqueues a follow-up task when it is destroyed.
+class EnqueueOnDestruction {
+ public:
+  EnqueueOnDestruction(
+      hermes::SerialExecutor &executor,
+      std::atomic<bool> &followUpRan)
+      : executor_(executor), followUpRan_(followUpRan) {}
+
+  ~EnqueueOnDestruction() {
+    executor_.add([&followUpRan = followUpRan_] { followUpRan = true; });
+  }
+
+ private:
+  hermes::SerialExecutor &executor_;
+  std::atomic<bool> &followUpRan_;
+};
+
+/// Destroy \p executor on another thread, giving up after \p limit. Returns
+/// false if the destructor is still running by then, which means it
+/// deadlocked. The caller must not touch \p executor afterwards: the wedged
+/// thread is detached and the executor leaked, because joining either one
+/// would hang the whole test binary instead of reporting a failure.
+bool destroyWithin(
+    hermes::SerialExecutor *executor,
+    std::chrono::seconds limit) {
+  auto destroyed = std::make_shared<std::promise<void>>();
+  auto finished = destroyed->get_future();
+  std::thread destroyer([executor, destroyed] {
+    delete executor;
+    destroyed->set_value();
+  });
+  if (finished.wait_for(limit) == std::future_status::timeout) {
+    destroyer.detach();
+    return false;
+  }
+  destroyer.join();
+  return true;
+}
 
 /// Wait until \p predicate holds, giving up after a deadline so that a broken
 /// executor fails the test instead of hanging it.
@@ -102,6 +144,133 @@ TEST(SerialExecutorTest, ThreadRunnerWrapsEachWorker) {
 
   EXPECT_EQ(starts, 5);
   EXPECT_EQ(exits, 5);
+}
+
+TEST(SerialExecutorTest, TaskDestructorCanEnqueue) {
+  // A task's captured state belongs to the caller, so destroying a finished
+  // task runs caller code that may enqueue more work -- a JSI finalizer that
+  // releases another host object does exactly this. The worker must therefore
+  // drop the task before re-acquiring mutex_, which is not recursive.
+  auto executor = std::make_unique<hermes::SerialExecutor>();
+  std::atomic<bool> releaseTask{false};
+  std::atomic<bool> followUpRan{false};
+
+  // The state is held through a shared_ptr so that its destructor runs exactly
+  // once, when the last copy dies.
+  auto owner = std::make_shared<EnqueueOnDestruction>(*executor, followUpRan);
+  executor->add([owner, &releaseTask] {
+    // Stay in the task body until the test has dropped its own reference, so
+    // that the worker is the one holding the last one.
+    while (!releaseTask)
+      std::this_thread::yield();
+  });
+  owner.reset();
+  releaseTask = true;
+
+  const bool ranFollowUp =
+      waitFor([&followUpRan] { return followUpRan.load(); });
+  if (!ranFollowUp) {
+    // The worker is wedged waiting on a mutex it already holds, so joining it
+    // would hang the whole binary. Leak the executor so the failure is
+    // reported instead.
+    (void)executor.release();
+  }
+  ASSERT_TRUE(ranFollowUp) << "a task destructor could not call add()";
+}
+
+TEST(SerialExecutorTest, TaskDestructorCanEnqueueWhileDraining) {
+  // ~SerialExecutor sets Terminating before the worker drains, so tasks
+  // destroyed during the drain enqueue their follow-up work with teardown
+  // already under way. That is legal from the worker itself, because the drain
+  // loop runs until the queue is empty.
+  //
+  // Whether the drain or the worker wins the race is not controlled here, so
+  // this only sometimes exercises the Terminating branch. It never reports a
+  // false failure: the follow-up has to run either way.
+  std::atomic<bool> followUpRan{false};
+  {
+    hermes::SerialExecutor executor;
+    auto owner = std::make_shared<EnqueueOnDestruction>(executor, followUpRan);
+    executor.add([owner] {});
+    owner.reset();
+  }
+  EXPECT_TRUE(followUpRan) << "a follow-up enqueued while draining never ran";
+}
+
+TEST(SerialExecutorTest, TaskCanEnqueueWhileDraining) {
+  // The general form of the case above, with no destructors involved: a task
+  // that is still running when ~SerialExecutor begins enqueues its follow-up
+  // with threadState_ already Terminating. add() must not read that as "the
+  // worker is gone" and spawn a second one. Doing so overwrites tid_ out from
+  // under the join, and resets threadState_ so the drain loop never sees
+  // Terminating, leaving both workers parked on the condition variable.
+  //
+  // The timeout is finite on purpose. With the default of milliseconds::max()
+  // the wait overflows to a deadline in the past and returns immediately, so
+  // stranded workers exit by accident and hide the deadlock.
+  std::atomic<bool> release{false};
+  std::atomic<bool> followUpRan{false};
+  auto *executor = new hermes::SerialExecutor(0, std::chrono::hours(1));
+
+  executor->add([executor, &release, &followUpRan] {
+    // Stay in the body until teardown has plausibly begun, so the add() below
+    // runs while Terminating. Losing that race only costs coverage; it cannot
+    // produce a false failure.
+    while (!release)
+      std::this_thread::yield();
+    executor->add([&followUpRan] { followUpRan = true; });
+  });
+
+  std::thread releaser([&release] {
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    release = true;
+  });
+
+  const bool destroyed = destroyWithin(executor, std::chrono::seconds(10));
+  releaser.join();
+  ASSERT_TRUE(destroyed) << "~SerialExecutor deadlocked while draining";
+  EXPECT_TRUE(followUpRan) << "a follow-up enqueued while draining never ran";
+}
+
+TEST(SerialExecutorTest, TaskDestroyedOnWorkerThread) {
+  // add() must leave the queue as the sole owner of the task, so that the
+  // task's captured state is destroyed on the worker rather than on whichever
+  // thread called add(). JSI finalizers depend on this: keeping clean-up off
+  // the calling thread is the entire point of the executor.
+  //
+  // The capture below is move-only, which is what makes the transfer
+  // structural. Copying the task, or going back to std::function, would stop
+  // compiling rather than silently reintroduce the race.
+  std::atomic<std::thread::id> ranOn{std::thread::id{}};
+  std::atomic<std::thread::id> destroyedOn{std::thread::id{}};
+
+  /// Records the thread that destroys it.
+  class RecordDestroyingThread {
+   public:
+    explicit RecordDestroyingThread(std::atomic<std::thread::id> &destroyedOn)
+        : destroyedOn_(destroyedOn) {}
+
+    ~RecordDestroyingThread() {
+      destroyedOn_ = std::this_thread::get_id();
+    }
+
+   private:
+    std::atomic<std::thread::id> &destroyedOn_;
+  };
+
+  {
+    hermes::SerialExecutor executor;
+    executor.add([&ranOn,
+                  recorder = std::make_unique<RecordDestroyingThread>(
+                      destroyedOn)] { ranOn = std::this_thread::get_id(); });
+    // ~SerialExecutor drains and joins, so both ids are set once it returns.
+  }
+
+  ASSERT_NE(ranOn.load(), std::thread::id{}) << "the task never ran";
+  EXPECT_EQ(destroyedOn.load(), ranOn.load())
+      << "the task was destroyed off the worker thread";
+  EXPECT_NE(destroyedOn.load(), std::this_thread::get_id())
+      << "the task was destroyed on the thread that called add()";
 }
 
 } // end anonymous namespace


### PR DESCRIPTION
Summary:
Graft of D115945725 (authored by Gang Zhao) to shermes/stable.
Upstream this was facebook/hermes PR #2133. The `Pull Request
resolved:` line is deliberately not carried over, so this graft
is not linked back to that PR.

Grafted cleanly with no conflicts.
`lib/Support/SerialExecutor.cpp` is now byte-identical to
`xplat/static_h`.

This fixes three things:

1. A race in the finalizer executor. The task is supposed to
destroy HostObjects once the refCount of the shared_ptr to it is
1, but the source task still held a copy, so the object was not
destroyed on the finalizer thread. The task is now moved into the
queue rather than copied, using `llvh::unique_function` so the
source is always emptied. `std::function` makes no such
guarantee: libc++ copies small inlined callables on move.

2. A deadlock when destroying a dequeued task while the lock is
held. A task destructor may call `add()` again, so the task is now
destroyed before re-acquiring the lock.

3. `~SerialExecutor` sets `threadState_` to `Terminating` and then
waits for the worker to drain the queue. A task still running at
that point may enqueue more work. `add()` mishandled that and
could spawn a second worker, overwriting `tid_` out from under the
join and resetting `threadState_` so the drain loop never saw
Terminating. `add()` now treats Terminating like Initialized, and
a new `workerThreadId_` lets it assert that a teardown-time
enqueue comes from the worker thread itself.

Item 3 was previously split out as D116089505. That diff has since
been folded into D115945725 upstream, so it is not grafted
separately.

Differential Revision: D117917440


