### PR TITLE
proposal: copy native state for structured clone

### DIFF
--- a/API/hermes/hermes.cpp
+++ b/API/hermes/hermes.cpp
@@ -307,9 +307,10 @@ class HermesRuntimeImpl final : public HermesRuntime,
         runtime_(*rt_),
         vmExperimentFlags_(runtimeConfig.getVMExperimentFlags()),
         finalizerExecutor_(
-            0,
-            std::chrono::milliseconds::max(),
-            finalizerThreadRunner(runtimeConfig)),
+            std::make_shared<::hermes::SerialExecutor>(
+                0,
+                std::chrono::milliseconds::max(),
+                finalizerThreadRunner(runtimeConfig))),
         mutatorScope{runtime_} {
 #ifdef HERMES_ENABLE_DEBUGGER
     compileFlags_.debug = true;
@@ -399,7 +400,7 @@ class HermesRuntimeImpl final : public HermesRuntime,
     }
 
     // Release the VM runtime. This needs to happen before the
-    // finalizerExecutor_ is destroyed so that the VM runtime has a chance to
+    // finalizerExecutor_ is released so that the VM runtime has a chance to
     // queue all clean-up tasks.
     rt_.reset();
   }
@@ -973,7 +974,7 @@ class HermesRuntimeImpl final : public HermesRuntime,
         : rt_(rt), ho_(ho) {}
 
     ~JsiProxy() {
-      rt_.finalizerExecutor_.add(
+      rt_.finalizerExecutor_->add(
           [ho = std::move(ho_)]() mutable { ho.reset(); });
     }
 
@@ -1137,28 +1138,37 @@ class HermesRuntimeImpl final : public HermesRuntime,
 
     static void finalize(void *context) {
       auto *hfc = reinterpret_cast<HFContext *>(context);
-      hfc->hermesRuntimeImpl.finalizerExecutor_.add([hfc]() { delete hfc; });
+      hfc->hermesRuntimeImpl.finalizerExecutor_->add([hfc]() { delete hfc; });
     }
 
     jsi::HostFunctionType hostFunction;
     HermesRuntimeImpl &hermesRuntimeImpl;
   };
 
-  /// Holds the jsi::NativeState shared pointer and the HermesRuntimeImpl.
-  /// This is passed in as the NativeState context to store the NativeState
-  /// object. The static finalize method will be passed in as function pointer
-  /// to the VM.
+  /// Holds the jsi::NativeState shared pointer. It is owned by a shared_ptr
+  /// that is in turn owned by the vm::NativeState cell, so that the structured
+  /// clone algorithm can hand the very same context to a vm::NativeState in
+  /// another runtime. See makeNativeStateContext for how it is released.
   struct NativeStateContext {
     std::shared_ptr<jsi::NativeState> state;
-    HermesRuntimeImpl &runtime;
-
-    /// Called when the VM tries to
-    /// finalize the NativeState object.
-    static void finalize(vm::GC &, vm::NativeState *ns) {
-      auto *context = reinterpret_cast<NativeStateContext *>(ns->context());
-      context->runtime.finalizerExecutor_.add([context]() { delete context; });
-    }
   };
+
+  /// \return a shared reference to a new NativeStateContext holding \p state.
+  /// The context is destroyed on this runtime's finalizer executor rather than
+  /// on the thread that drops the last reference, because destroying the
+  /// jsi::NativeState can run arbitrary user code. The deleter keeps the
+  /// executor alive, so the context stays destructible after this runtime is
+  /// gone.
+  std::shared_ptr<void> makeNativeStateContext(
+      std::shared_ptr<jsi::NativeState> state) {
+    return std::shared_ptr<void>(
+        new NativeStateContext{std::move(state)},
+        [executor = finalizerExecutor_](void *context) {
+          executor->add([context]() {
+            delete static_cast<NativeStateContext *>(context);
+          });
+        });
+  }
 
   // A ManagedChunkedList element that indicates whether it's occupied based on
   // a refcount.
@@ -1398,9 +1408,12 @@ class HermesRuntimeImpl final : public HermesRuntime,
   /// Executor used to finalize NativeState, HostFunction, and HostObjects on
   /// a background thread so that GC collection is not blocked by potentially
   /// expensive clean-up work. The destructor explicitly calls rt_.reset()
-  /// before this member is destroyed to ensure all clean-up tasks are queued
-  /// before the executor drains and joins.
-  ::hermes::SerialExecutor finalizerExecutor_;
+  /// before this member is released to ensure all clean-up tasks are queued
+  /// before the executor drains and joins. It is held by shared_ptr because a
+  /// NativeState copied into another runtime by the structured clone algorithm
+  /// keeps releasing its jsi::NativeState on this executor, and so may outlive
+  /// this runtime.
+  std::shared_ptr<::hermes::SerialExecutor> finalizerExecutor_;
 
   /// Provided by the integrator for the Runtime to schedule a task. This is
   /// called whenever the Hermes Runtime wants to run a task, but should not
@@ -2669,12 +2682,12 @@ void HermesRuntimeImpl::setNativeState(
   } else if (h->isHostObject()) {
     throw jsi::JSINativeException("native state unsupported on HostObject");
   }
-  // Allocate a NativeStateBox on the C++ heap and use it as context of
-  // NativeState. The box also carries a reference to the runtime so the
-  // Release callback can queue destruction to the finalizer thread.
-  auto *nativeStateCtx = new NativeStateContext{std::move(state), *this};
-  lv.ns = vm::NativeState::create(
-      runtime_, nativeStateCtx, NativeStateContext::finalize);
+  // Allocate a NativeStateContext on the C++ heap and use it as the shared
+  // context of the NativeState. Sharing it means the structured clone
+  // algorithm can attach the same jsi::NativeState to a copy of this object,
+  // in this or in another runtime.
+  lv.ns = vm::NativeState::createShared(
+      runtime_, makeNativeStateContext(std::move(state)));
   auto res = vm::JSObject::defineOwnProperty(
       h,
       runtime_,
@@ -2710,7 +2723,8 @@ std::shared_ptr<jsi::NativeState> HermesRuntimeImpl::getNativeState(
   vm::NativeState *ns = vm::vmcast<vm::NativeState>(
       vm::JSObject::getNamedSlotValueUnsafe(*h, runtime_, desc)
           .getObject(runtime_));
-  return reinterpret_cast<NativeStateContext *>(ns->context())->state;
+  assert(ns->isShared() && "NativeState was not created by setNativeState");
+  return static_cast<NativeStateContext *>(ns->getSharedContext().get())->state;
 }
 
 void HermesRuntimeImpl::setExternalMemoryPressure(

--- a/API/hermes_abi/hermes_vtable.cpp
+++ b/API/hermes_abi/hermes_vtable.cpp
@@ -1213,8 +1213,8 @@ HermesABINativeState *get_native_state(
   vm::NativeState *ns = vm::vmcast<vm::NativeState>(
       vm::JSObject::getNamedSlotValueUnsafe(*h, runtime, desc)
           .getObject(runtime));
-  assert(ns->context() && "State cannot be null.");
-  return static_cast<HermesABINativeState *>(ns->context());
+  assert(ns->isShared() && "NativeState was not created by set_native_state");
+  return static_cast<HermesABINativeState *>(ns->getSharedContext().get());
 }
 
 HermesABIVoidOrError set_native_state(
@@ -1232,14 +1232,17 @@ HermesABIVoidOrError set_native_state(
   } lv;
   vm::LocalsRAII lraii(runtime, &lv);
 
-  auto finalize = [](vm::GC &, vm::NativeState *ns) {
-    auto *self = static_cast<HermesABINativeState *>(ns->context());
+  auto release = [](void *context) {
+    auto *self = static_cast<HermesABINativeState *>(context);
     self->vtable->release(self);
   };
   // Note that creating the vm::NativeState here takes ownership of abiState, so
   // if the below steps fail, abiState will simply be freed when the
-  // vm::NativeState is garbage collected.
-  lv.ns = vm::NativeState::create(runtime, abiState, finalize);
+  // vm::NativeState is garbage collected. The context is shared so that the
+  // structured clone algorithm can attach the same native state to a copy of
+  // this object.
+  lv.ns = vm::NativeState::createShared(
+      runtime, std::shared_ptr<void>(abiState, release));
 
   auto h = toHandle(obj);
   if (h->isProxyObject()) {

--- a/include/hermes/VM/NativeState.h
+++ b/include/hermes/VM/NativeState.h
@@ -11,6 +11,8 @@
 #include "hermes/VM/GCCell.h"
 #include "hermes/VM/Metadata.h"
 
+#include <memory>
+
 namespace hermes {
 namespace vm {
 
@@ -43,6 +45,29 @@ class NativeState final : public GCCell {
   static NativeState *
   create(Runtime &runtime, void *context, FinalizeNativeStatePtr finalizePtr);
 
+  /// Create a new NativeState on the JS heap which shares ownership of \p
+  /// context with every other holder of that shared pointer. Unlike a
+  /// NativeState created by create(), such a NativeState can be duplicated
+  /// into another Runtime, because the duplicate shares ownership of the same
+  /// native data. This is used by the structured clone algorithm, see
+  /// SerializedValue.h.
+  static NativeState *createShared(
+      Runtime &runtime,
+      std::shared_ptr<void> context);
+
+  /// \return true if this NativeState was created by createShared, and its
+  /// context can therefore be shared with another NativeState.
+  bool isShared() const {
+    return finalizePtr_ == _finalizeSharedImpl;
+  }
+
+  /// \return the shared context owned by this NativeState.
+  /// \pre isShared() must be true.
+  const std::shared_ptr<void> &getSharedContext() const {
+    assert(isShared() && "NativeState does not own a shared context");
+    return *static_cast<const std::shared_ptr<void> *>(context_);
+  }
+
   void *context() {
     return context_;
   }
@@ -52,6 +77,10 @@ class NativeState final : public GCCell {
 
  private:
   static void _finalizeImpl(GCCell *cell, GC &gc);
+
+  /// Finalizer for a NativeState created by createShared. It doubles as the tag
+  /// that identifies such a NativeState, see isShared().
+  static void _finalizeSharedImpl(GC &gc, NativeState *ns);
 
   void *context_;
   FinalizeNativeStatePtr finalizePtr_;

--- a/include/hermes/VM/SerializedValue.h
+++ b/include/hermes/VM/SerializedValue.h
@@ -48,6 +48,16 @@ class SerializedValue {
   /// block.
   std::vector<std::pair<uint8_t *, std::shared_ptr<void>>> externalBuffers;
 
+  /// For JS objects carrying a shareable NativeState, store a strong reference
+  /// to the native data. Each serialized object record refers to an entry here
+  /// by index, and every deserialization attaches a NativeState sharing the
+  /// same entry. This keeps the native data alive for as long as this
+  /// SerializedValue, independently of the runtime it was serialized from.
+  /// Note that a NativeState that is not shareable, i.e. one created by
+  /// NativeState::create rather than NativeState::createShared, cannot be
+  /// copied into another runtime and is silently dropped.
+  std::vector<std::shared_ptr<void>> nativeStates;
+
   /// Describes the type of JS value for some serialized content. The special
   /// Reference type is used to point at a JS value serialized at some other
   /// location.

--- a/lib/VM/NativeState.cpp
+++ b/lib/VM/NativeState.cpp
@@ -32,6 +32,18 @@ NativeState *NativeState::create(
       context, finalizePtr);
 }
 
+/* static */
+NativeState *NativeState::createShared(
+    Runtime &runtime,
+    std::shared_ptr<void> context) {
+  auto *box = new std::shared_ptr<void>(std::move(context));
+  return create(runtime, box, _finalizeSharedImpl);
+}
+
+void NativeState::_finalizeSharedImpl(GC &, NativeState *ns) {
+  delete static_cast<std::shared_ptr<void> *>(ns->context());
+}
+
 void NativeState::_finalizeImpl(GCCell *cell, GC &gc) {
   auto *self = vmcast<NativeState>(cell);
   self->finalizePtr_(gc, self);

--- a/lib/VM/SerializedValue.cpp
+++ b/lib/VM/SerializedValue.cpp
@@ -1384,6 +1384,103 @@ CallResult<PseudoHandle<JSTypedArrayBase>> deserializeTypedArray(
   return createPseudoHandle(*lv.self);
 }
 
+/// Sentinel stored in place of an index into SerializedValue::nativeStates to
+/// mean that the serialized object carries no native state.
+constexpr uint32_t kNoNativeState = UINT32_MAX;
+
+/// \return a strong reference to the native data attached to \p selfObject, or
+/// nullptr if the object has no native state, or if its native state is not
+/// shareable and therefore cannot be copied into another Runtime.
+std::shared_ptr<void> getSharedNativeState(
+    Runtime &runtime,
+    Handle<JSObject> selfObject) {
+  // Proxy and HostObject cannot carry native state.
+  if (selfObject->isProxyObject() || selfObject->isHostObject()) {
+    return nullptr;
+  }
+  NamedPropertyDescriptor desc;
+  if (!JSObject::getOwnNamedDescriptor(
+          selfObject,
+          runtime,
+          Predefined::getSymbolID(Predefined::InternalPropertyNativeState),
+          desc)) {
+    return nullptr;
+  }
+  NoAllocScope noAlloc(runtime);
+  auto *ns = vmcast<NativeState>(
+      JSObject::getNamedSlotValueUnsafe(*selfObject, runtime, desc)
+          .getObject(runtime));
+  if (!ns->isShared()) {
+    return nullptr;
+  }
+  return ns->getSharedContext();
+}
+
+/// Serialize the native state attached to \p selfObject at the end of \p
+/// serialized with the format (has native state, index into
+/// SerializedValue::nativeStates). The index is only written when the object
+/// does carry a shareable native state.
+void serializeNativeState(
+    Runtime &runtime,
+    SerializedValue &serialized,
+    Handle<JSObject> selfObject) {
+  std::shared_ptr<void> nativeState = getSharedNativeState(runtime, selfObject);
+  if (!nativeState) {
+    serialized.content.push_back(0);
+    return;
+  }
+  serialized.content.push_back(1);
+  appendValueToBuffer<uint32_t>(
+      serialized.content, (uint32_t)serialized.nativeStates.size());
+  serialized.nativeStates.push_back(std::move(nativeState));
+}
+
+/// Deserialize the native state record pointed to by \p content and update
+/// \p content to point past it.
+/// \return the index into SerializedValue::nativeStates of the native state to
+/// attach, or kNoNativeState if the record carries none.
+uint32_t deserializeNativeStateIndex(const uint8_t *&content) {
+  if (!*content++) {
+    return kNoNativeState;
+  }
+  return deserializeUInt32(content);
+}
+
+/// Attach the native state at index \p idx of \p serialized to \p selfObject,
+/// sharing ownership of the native data with every other object deserialized
+/// from the same record. Does nothing if \p idx is kNoNativeState.
+ExecutionStatus attachNativeState(
+    Runtime &runtime,
+    const SerializedValue &serialized,
+    uint32_t idx,
+    Handle<JSObject> selfObject) {
+  if (idx == kNoNativeState) {
+    return ExecutionStatus::RETURNED;
+  }
+  assert(idx < serialized.nativeStates.size() && "Invalid native state index");
+
+  struct : Locals {
+    PinnedValue<NativeState> ns;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
+  lv.ns = NativeState::createShared(runtime, serialized.nativeStates[idx]);
+
+  auto res = JSObject::defineOwnProperty(
+      selfObject,
+      runtime,
+      Predefined::getSymbolID(Predefined::InternalPropertyNativeState),
+      DefinePropertyFlags::getDefaultNewPropertyFlags(),
+      lv.ns,
+      PropOpFlags().plusInternalForce());
+  if (LLVM_UNLIKELY(res == ExecutionStatus::EXCEPTION)) {
+    return ExecutionStatus::EXCEPTION;
+  }
+  if (LLVM_UNLIKELY(!*res)) {
+    return runtime.raiseError("Failed to deserialize native state");
+  }
+  return ExecutionStatus::RETURNED;
+}
+
 /// If \p value has not been serialized before, append its serialized Record
 /// onto the content buffer of \p serialized, adding any information
 /// necessary in its string and offset buffer as well. Store an entry in \p
@@ -1463,7 +1560,7 @@ ExecutionStatus serializeImpl(
   }
 
   // All object types will be serialized with the following format:
-  // (type tag, object ID, content).
+  // (type tag, object ID, native state, content).
   // Find the offset that points to the start of the serialized object, where
   // the type tag will be serialized. Assign the object an ID, which other
   // records can use to reference this object.
@@ -1476,6 +1573,10 @@ ExecutionStatus serializeImpl(
 
   // Add an object ID -> typeTagOffset entry in the offset array.
   offsets.push_back(typeTagOffset);
+
+  // The native state field sits at a fixed position in every object record, so
+  // that deserialization can read it before dispatching on the type tag.
+  serializeNativeState(runtime, serialized, selfObjHandle);
 
   // 6. Let serialized be an uninitialized value.
   if (auto *jsBool = dyn_vmcast<JSBoolean>(*value)) {
@@ -1742,6 +1843,7 @@ CallResult<HermesValue> deserializeImpl(
   } lv;
   LocalsRAII lraii{runtime, &lv};
   uint32_t id = deserializeUInt32(curr);
+  uint32_t nativeStateIdx = deserializeNativeStateIndex(curr);
 
   if (typeTag == SerializedValue::Type::Boolean) {
     // 6. Otherwise, if serialized.[[Type]] is "Boolean", then set value to a
@@ -1889,6 +1991,18 @@ CallResult<HermesValue> deserializeImpl(
   // later.
   memoryMap[id] = &runtime.serializationValues_.add(
       *lv.self, getUInt32Hash(runtime.gcStableHashHermesValue(*lv.self)));
+
+  // Attach the native state, if the source object had one, before the
+  // properties are deserialized, so that it is in place for the whole graph.
+  if (LLVM_UNLIKELY(
+          attachNativeState(
+              runtime,
+              serialized,
+              nativeStateIdx,
+              Handle<JSObject>::vmcast(&lv.self)) ==
+          ExecutionStatus::EXCEPTION)) {
+    return ExecutionStatus::EXCEPTION;
+  }
 
   // 24. If deep is true, then:
   if (deep) {
@@ -2061,6 +2175,10 @@ ExecutionStatus serializeTransferList(
         : SerializedValue::Type::ArrayBufferInternal;
     serialized.content.push_back(getUInt8FromSerializedType(type));
     appendValueToBuffer<uint32_t>(serialized.content, id);
+    // Transfer records use the same (type tag, object ID, native state,
+    // content) layout as the object records written by serializeImpl.
+    serializeNativeState(
+        runtime, serialized, Handle<JSObject>::vmcast(&lv.arrayBuffer));
     //    2-3: Handled in the helper.
     serializeArrayBufferForTransfer(runtime, serialized, lv.arrayBuffer);
     //  3. Perform ? DetachArrayBuffer(transferable).
@@ -2079,12 +2197,16 @@ ExecutionStatus serializeTransferList(
 /// serialized. Returns a list of IDs of the objects that are successfully
 /// transferred.
 /// Implements Step 2, 3 of StructuredDeserializeWithTransfer
-std::vector<uint32_t> deserializeTransferList(
+CallResult<std::vector<uint32_t>> deserializeTransferList(
     Runtime &runtime,
     SerializedValue &serialized,
     DeserializationValueDenseMap &memoryMap) {
   // 2. Let transferredValues be a new empty List.
   std::vector<uint32_t> transferredIds;
+  struct : Locals {
+    PinnedValue<JSArrayBuffer> arrayBuffer;
+  } lv;
+  LocalsRAII lraii{runtime, &lv};
   // 3. For each transferDataHolder of
   // serializeWithTransferResult.[[TransferDataHolders]]:
   // Transferred values are assigned serialization id first, so they must start
@@ -2102,13 +2224,25 @@ std::vector<uint32_t> deserializeTransferList(
     assert(
         deserializedId == i &&
         "ID in serialized record does not match the record being deserialized.");
-    auto res = deserializeArrayBufferForTransfer(
+    uint32_t nativeStateIdx = deserializeNativeStateIndex(curr);
+    lv.arrayBuffer = deserializeArrayBufferForTransfer(
         runtime, serialized, curr, isInternalBuffer);
+
+    if (LLVM_UNLIKELY(
+            attachNativeState(
+                runtime,
+                serialized,
+                nativeStateIdx,
+                Handle<JSObject>::vmcast(&lv.arrayBuffer)) ==
+            ExecutionStatus::EXCEPTION)) {
+      return ExecutionStatus::EXCEPTION;
+    }
 
     // 3-4. Resizeable ArrayBuffer and Platform objects: Unsupported
     // 5. Set memory[transferDataHolder] to value.
     auto *valuePtr = &runtime.serializationValues_.add(
-        res.getHermesValue(), runtime.gcStableHashJSObject(res.get()));
+        lv.arrayBuffer.getHermesValue(),
+        runtime.gcStableHashJSObject(*lv.arrayBuffer));
     memoryMap[i] = valuePtr;
 
     // 6. Append value to transferredValues.
@@ -2227,8 +2361,12 @@ CallResult<PseudoHandle<JSArray>> deserializeWithTransfer(
     cleanUpAfterDeserializeWithTransfer(serialized, memoryMap);
   });
   // 2-3: Handled in the helper.
-  std::vector<uint32_t> transferredIds =
+  auto transferListRes =
       deserializeTransferList(runtime, serialized, memoryMap);
+  if (LLVM_UNLIKELY(transferListRes == ExecutionStatus::EXCEPTION)) {
+    return ExecutionStatus::EXCEPTION;
+  }
+  std::vector<uint32_t> transferredIds = std::move(*transferListRes);
 
   // 4. Let deserialized be ?
   // StructuredDeserialize(serializeWithTransferResult.[[Serialized]],

--- a/unittests/API/APITest.cpp
+++ b/unittests/API/APITest.cpp
@@ -3269,6 +3269,172 @@ TEST_P(HermesSerializationTest, SerializeWithTransferThrows) {
       serializationInterface->serializeWithTransfer(val, transferArr), JSError);
 }
 
+namespace {
+/// NativeState subclass used by the structured clone tests below. It counts its
+/// own destructions so a test can tell when the last owner released it. The
+/// counter is atomic because a NativeState is destroyed on the finalizer
+/// thread.
+class SerializationState : public NativeState {
+ public:
+  SerializationState(int value, std::atomic<int> *dtors)
+      : value(value), dtors(dtors) {}
+  ~SerializationState() override {
+    if (dtors)
+      ++*dtors;
+  }
+
+  int value;
+  std::atomic<int> *dtors;
+};
+
+/// Wait for \p dtors to reach \p expected, or give up after two seconds.
+void waitForSerializationStateDtors(std::atomic<int> &dtors, int expected) {
+  for (int i = 0; i < 200; ++i) {
+    if (dtors.load() == expected)
+      return;
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+}
+} // namespace
+
+TEST_P(HermesSerializationTest, SerializeNativeState) {
+  // An object without native state must not gain one.
+  auto plain = deserializeAsObject(evalAndSerialize("({a: 1})"));
+  EXPECT_FALSE(plain.hasNativeState<SerializationState>(*rt));
+
+  auto state = std::make_shared<SerializationState>(42, nullptr);
+  auto obj = eval("({a: 1})").getObject(*rt);
+  obj.setNativeState(*rt, state);
+  auto serialized = serializationInterface->serialize(Value(*rt, obj));
+
+  // The copy shares the very same jsi::NativeState instance.
+  auto copy = deserializeAsObject(serialized);
+  ASSERT_TRUE(copy.hasNativeState<SerializationState>(*rt));
+  EXPECT_EQ(copy.getNativeState<SerializationState>(*rt).get(), state.get());
+  EXPECT_EQ(copy.getProperty(*rt, "a").getNumber(), 1);
+
+  // The original object keeps its native state.
+  EXPECT_EQ(obj.getNativeState<SerializationState>(*rt).get(), state.get());
+
+  // A Serialized object can be deserialized many times, including into another
+  // runtime. Every copy shares the same instance.
+  auto copyInRt2 =
+      serializationInterface2->deserialize(serialized).getObject(*rt2);
+  ASSERT_TRUE(copyInRt2.hasNativeState<SerializationState>(*rt2));
+  EXPECT_EQ(
+      copyInRt2.getNativeState<SerializationState>(*rt2).get(), state.get());
+}
+
+TEST_P(HermesSerializationTest, SerializeNestedNativeState) {
+  auto outerState = std::make_shared<SerializationState>(1, nullptr);
+  auto innerState = std::make_shared<SerializationState>(2, nullptr);
+
+  auto outer = eval("({inner: {}, alias: null})").getObject(*rt);
+  auto inner = outer.getPropertyAsObject(*rt, "inner");
+  // The same inner object is reachable twice, so it is serialized once and
+  // referenced the second time.
+  outer.setProperty(*rt, "alias", inner);
+  outer.setNativeState(*rt, outerState);
+  inner.setNativeState(*rt, innerState);
+
+  auto copy =
+      deserializeAsObject(serializationInterface->serialize(Value(*rt, outer)));
+  EXPECT_EQ(
+      copy.getNativeState<SerializationState>(*rt).get(), outerState.get());
+
+  auto innerCopy = copy.getPropertyAsObject(*rt, "inner");
+  EXPECT_EQ(
+      innerCopy.getNativeState<SerializationState>(*rt).get(),
+      innerState.get());
+
+  // The reference record must produce the same object, native state included.
+  auto aliasCopy = copy.getPropertyAsObject(*rt, "alias");
+  EXPECT_TRUE(Object::strictEquals(*rt, innerCopy, aliasCopy));
+}
+
+TEST_P(HermesSerializationTest, SerializeNativeStateOnExoticObjects) {
+  // Native state is carried by every serializable object type, not only plain
+  // objects, because it lives at a fixed position of every object record.
+  const char *sources[] = {
+      "[1, 2, 3]",
+      "new Map([[1, 2]])",
+      "new Set([1])",
+      "new Date(0)",
+      "new Int8Array([1, 2])",
+      "new Error('boom')",
+      "new Number(7)",
+  };
+  for (const char *source : sources) {
+    auto state = std::make_shared<SerializationState>(0, nullptr);
+    auto obj = eval(source).getObject(*rt);
+    obj.setNativeState(*rt, state);
+
+    auto copy =
+        serializationInterface2
+            ->deserialize(serializationInterface->serialize(Value(*rt, obj)))
+            .getObject(*rt2);
+    ASSERT_TRUE(copy.hasNativeState<SerializationState>(*rt2)) << source;
+    EXPECT_EQ(copy.getNativeState<SerializationState>(*rt2).get(), state.get())
+        << source;
+  }
+}
+
+TEST_P(HermesSerializationTest, SerializeNativeStateWithTransfer) {
+  auto messageState = std::make_shared<SerializationState>(1, nullptr);
+  auto bufferState = std::make_shared<SerializationState>(2, nullptr);
+
+  auto message = eval("var ab = new ArrayBuffer(8); ({m: 1})").getObject(*rt);
+  message.setNativeState(*rt, messageState);
+
+  auto buffer = rt->global().getPropertyAsObject(*rt, "ab");
+  buffer.setNativeState(*rt, bufferState);
+  Array transfers = Array::createWithElements(*rt, Value(*rt, buffer));
+
+  auto serialized = serializationInterface->serializeWithTransfer(
+      Value(*rt, message), transfers);
+  auto deserialized =
+      serializationInterface2->deserializeWithTransfer(serialized);
+
+  ASSERT_EQ(deserialized.length(*rt2), 2);
+  auto messageCopy = deserialized.getValueAtIndex(*rt2, 0).asObject(*rt2);
+  ASSERT_TRUE(messageCopy.hasNativeState<SerializationState>(*rt2));
+  EXPECT_EQ(
+      messageCopy.getNativeState<SerializationState>(*rt2).get(),
+      messageState.get());
+
+  // A transferred ArrayBuffer carries its native state too.
+  auto bufferCopy = deserialized.getValueAtIndex(*rt2, 1).asObject(*rt2);
+  ASSERT_TRUE(bufferCopy.hasNativeState<SerializationState>(*rt2));
+  EXPECT_EQ(
+      bufferCopy.getNativeState<SerializationState>(*rt2).get(),
+      bufferState.get());
+}
+
+TEST_P(HermesSerializationTest, SerializedNativeStateOutlivesSourceObject) {
+  // Destructors run on the finalizer thread, so use an atomic.
+  std::atomic<int> dtors = 0;
+  {
+    std::shared_ptr<Serialized> serialized;
+    {
+      auto obj = eval("({})").getObject(*rt);
+      obj.setNativeState(*rt, std::make_shared<SerializationState>(42, &dtors));
+      serialized = serializationInterface->serialize(Value(*rt, obj));
+    }
+    // The source object is now unreachable, but the Serialized object still
+    // owns the native state, so it must not have been destroyed.
+    eval("gc()");
+    EXPECT_EQ(0, dtors.load());
+
+    auto copy = deserializeAsObject(serialized);
+    ASSERT_TRUE(copy.hasNativeState<SerializationState>(*rt));
+    EXPECT_EQ(copy.getNativeState<SerializationState>(*rt)->value, 42);
+  }
+  // Nothing holds the native state any more.
+  eval("gc()");
+  waitForSerializationStateDtors(dtors, 1);
+  EXPECT_EQ(1, dtors.load());
+}
+
 class HermesWorkerTest : public HermesRuntimeTest {
  public:
   HermesWorkerTest() : HermesRuntimeTest() {}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `main`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/HEAD/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.

  Note: We kindly request that pull requests address more than just a single typo.
  While we sincerely appreciate your attention to detail, we would be most grateful
  if typo fixes were batched together to include several corrections. This helps our
  maintainers focus on substantive contributions to the codebase. Thank you for your
  understanding and cooperation!
-->

## Summary

I was experimenting with `jsi::Serialized` and noticed that the structured clone algorithm underneath didn't copy a `jsi::NativeState` tied to cloned object. `jsi::NativeState` is extensively used for React Native libraries and `jsi::Serialized` not supporting it is, in my opinion, a serious hindrance to the `jsi::Serialized` adoption.

The code in this PR is an AI generated PoC to see how extensive would the changes be.

Does support for `jsi::NativeState` in `jsi::Serialized` and structured clone align with your idea of how it should be implemented?

## Test Plan

New unit tests.
