### PR TITLE
Graft "[SH] Implement Worker error handling" to shermes/stable

### DIFF
--- a/API/hermes/extensions/11-Worker.js
+++ b/API/hermes/extensions/11-Worker.js
@@ -7,10 +7,13 @@
 
 // Worker extension setup function.
 // Receives native helper functions and installs Worker globally.
-extensions.Worker = function(nativeInit) {
+extensions.Worker = function(nativeInit, nativeTerminate) {
     class Worker {
         constructor(script) {
             nativeInit(this, script);
+        }
+        terminate() {
+            return nativeTerminate.call(this);
         }
     }
 

--- a/API/hermes/extensions/11-Worker.js
+++ b/API/hermes/extensions/11-Worker.js
@@ -7,13 +7,16 @@
 
 // Worker extension setup function.
 // Receives native helper functions and installs Worker globally.
-extensions.Worker = function(nativeInit, nativeTerminate) {
+extensions.Worker = function(nativeInit, nativeTerminate, nativePostMessage) {
     class Worker {
         constructor(script) {
             nativeInit(this, script);
         }
         terminate() {
             return nativeTerminate.call(this);
+        }
+        postMessage(...args) {
+            return nativePostMessage.call(this, ...args);
         }
     }
 

--- a/API/hermes/extensions/11-Worker.js
+++ b/API/hermes/extensions/11-Worker.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Worker extension setup function.
+// Receives native helper functions and installs Worker globally.
+extensions.Worker = function(nativeInit) {
+    class Worker {
+        constructor(script) {
+            nativeInit(this, script);
+        }
+    }
+
+    globalThis.Worker = Worker;
+};

--- a/API/hermes/extensions/CMakeLists.txt
+++ b/API/hermes/extensions/CMakeLists.txt
@@ -92,6 +92,7 @@ set(EXTENSIONS_CPP_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/JSIUtils.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/Dummy.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/TextEncoder.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/Worker.cpp
 )
 
 # Append contrib sources if enabled (set by contrib/CMakeLists.txt).

--- a/API/hermes/extensions/Extensions.cpp
+++ b/API/hermes/extensions/Extensions.cpp
@@ -15,6 +15,7 @@
 #include "contrib/ContribExtensions.h"
 #endif
 
+#include "Worker.h"
 #include "jsi/jsi.h"
 
 namespace facebook {
@@ -27,6 +28,11 @@ void installExtensions(jsi::Runtime &rt, jsi::Object extensions) {
   // Delegate to each extension's install function.
   installTextEncoder(rt, extensions);
   installDummy(rt, extensions);
+
+#ifdef JSI_UNSTABLE
+  // Workers rely on features in JSI_UNSTABLE currently.
+  installWorker(rt, extensions);
+#endif
 
 #if HERMES_ENABLE_CONTRIB_EXTENSIONS
   // Install community-contributed extensions.

--- a/API/hermes/extensions/Worker.cpp
+++ b/API/hermes/extensions/Worker.cpp
@@ -13,6 +13,7 @@
 #include "llvh/Support/Compiler.h"
 
 #include <condition_variable>
+#include <deque>
 #include <mutex>
 #include <thread>
 
@@ -20,6 +21,7 @@ namespace facebook {
 namespace hermes {
 namespace {
 
+using Message = std::shared_ptr<jsi::Serialized>;
 /// Stores some resources shared between a specific Worker and the main
 /// thread/event loop thread. Everything in this struct is guarded by the state
 /// mutex;
@@ -31,6 +33,8 @@ struct WorkerState {
   std::condition_variable toWorkerCondition{};
   /// Once true, worker will be terminated at the earliest convenience.
   bool terminated{false};
+  /// Messages to Worker from the parent runtime.
+  std::deque<Message> toWorkerQueue;
 };
 
 /// Worker-specific Native state, used to mark an Object as a Worker instance.
@@ -74,6 +78,31 @@ inline bool isWorkerInstance(jsi::Runtime &rt, const jsi::Value &self) {
       self.asObject(rt).hasNativeState<WorkerNativeState>(rt);
 }
 
+/// Retrieves the \p handlerName property on \p object if it exists as a
+/// Callable. Otherwise, return undefined.
+jsi::Value getHandler(
+    jsi::Runtime &rt,
+    const jsi::Object &obj,
+    const jsi::PropNameID &handlerName) {
+  auto handlerRes = obj.getProperty(rt, handlerName);
+  if (!handlerRes.isObject() || !handlerRes.asObject(rt).isFunction(rt)) {
+    return jsi::Value::undefined();
+  }
+  return handlerRes;
+}
+
+/// Deserializes the serialized \p message into the provided \p runtime. Then,
+/// call the \p handler with the deserialized value as the argument.
+void processMessageWithHandler(
+    jsi::Runtime &rt,
+    Message &&message,
+    const jsi::Function &handler) {
+  auto serializationInterface = jsi::castInterface<jsi::ISerialization>(&rt);
+  assert(serializationInterface && "ISerialization is not supported");
+  jsi::Value deserialized = serializationInterface->deserialize(message);
+  handler.call(rt, deserialized);
+}
+
 /// Acquires the \p workerState.mutex and resources in \p workerState to
 /// indicate the Worker is terminated. Request the \p workerRuntime to stop
 /// execution. If \p notifyWorker is called, then also notifies the worker to
@@ -99,6 +128,11 @@ void setTerminationState(
   auto *hermesInterface = jsi::castInterface<IHermes>(&workerRuntime);
   assert(hermesInterface && "IHermes is not supported");
   hermesInterface->asyncTriggerTimeout();
+
+  // Once terminated, no messages will be processed by the Worker. Discard
+  // queue.
+  workerState->toWorkerQueue.clear();
+
   if (notifyWorker) {
     workerState->toWorkerCondition.notify_all();
   }
@@ -126,12 +160,44 @@ void WorkerNativeState::startWorkerThread(std::string script) {
 
       // While the Worker isn't terminated, it is allowed to run the event loop.
       while (!workerState->terminated) {
-        // Wait until it is time to wake up. The possible scenario:
         // 1. Worker thread went to sleep, and another thread has terminated
-        // the worker. Worker should wake up and terminate.
-        // 2. [to be implemented] Worker thread went to sleep, then another
-        // thread posted a message. Wake up to process the message.
-        workerState->toWorkerCondition.wait(lock);
+        // the worker. Worker should wake up and terminate. The message queue is
+        // cleared when `terminate` is called. Thus, we also need to check the
+        // `terminated` flag to make sure the thread doesn't immediately go back
+        // to sleep.
+        // 2. Worker thread went to sleep, then another thread posted a message.
+        // Wake up to process the message.
+        workerState->toWorkerCondition.wait(lock, [workerState] {
+          return workerState->terminated || !workerState->toWorkerQueue.empty();
+        });
+        // If the Worker thread woke up because the Worker was terminated,
+        // then break out of the event loop.
+        if (workerState->terminated) {
+          break;
+        }
+
+        // Otherwise, process the next message on the queue, which is guaranteed
+        // to exist.
+        Message message = std::move(workerState->toWorkerQueue.front());
+        workerState->toWorkerQueue.pop_front();
+        lock.unlock();
+
+        // Everything from now on can be processed without the lock as it
+        // doesn't rely on any shared resources between threads.
+        auto workerGlobal = workerRuntime->global();
+        jsi::Value onMessage = getHandler(
+            *workerRuntime,
+            workerGlobal,
+            jsi::PropNameID::forAscii(*workerRuntime, "onmessage"));
+        if (LLVM_LIKELY(!onMessage.isUndefined())) {
+          auto onMessageFunc =
+              onMessage.asObject(*workerRuntime).asFunction(*workerRuntime);
+          processMessageWithHandler(
+              *workerRuntime, std::move(message), onMessageFunc);
+        }
+
+        // Lock again for the next tick.
+        lock.lock();
       }
     } catch (const jsi::JSIException &) {
       // Script failed. End worker thread.
@@ -196,6 +262,56 @@ jsi::Value terminateWorker(
   return jsi::Value::undefined();
 }
 
+/// This implements the `postMessage` method of the Worker object that sends a
+/// message to the Worker. The arguments in \p args must be provided in the
+/// following order:
+/// 1. A serializable message
+/// 2. [not implemented yet] An optional array of transferable arguments
+jsi::Value postMessageToWorker(
+    jsi::Runtime &rt,
+    const jsi::Value &self,
+    const jsi::Value *args,
+    size_t count) {
+  if (LLVM_UNLIKELY(!isWorkerInstance(rt, self))) {
+    throwTypeError(rt, "'this' object should be a Worker.");
+  }
+  if (LLVM_UNLIKELY(count == 0)) {
+    throwTypeError(rt, "Must provide a message to post to Worker.");
+  }
+
+  // This is safe because the isWorkerInstance check above checks that a
+  // WorkerNativeState is attached.
+  auto workerNs = self.asObject(rt).getNativeState<WorkerNativeState>(rt);
+  auto workerState = workerNs->workerState;
+  {
+    std::lock_guard<std::mutex> lock(workerState->stateMutex);
+    if (workerState->terminated) {
+      // Worker is terminated, just return and don't try to serialize.
+      return jsi::Value::undefined();
+    }
+  }
+  // Serialize outside the lock because serialization can run some JS
+  // and try to acquire the lock as a side effect.
+  auto *serializationInterface = jsi::castInterface<jsi::ISerialization>(&rt);
+  assert(serializationInterface && "ISerialization not supported");
+  auto serialized = serializationInterface->serialize(args[0]);
+
+  {
+    // Accessing Worker's shared state. Acquire the lock.
+    std::lock_guard<std::mutex> lock(workerState->stateMutex);
+    // We need to perform the termination check again since there is a chance
+    // the Worker was terminated while serialization.
+    if (workerState->terminated) {
+      return jsi::Value::undefined();
+    }
+
+    workerState->toWorkerQueue.push_back(std::move(serialized));
+    // Notify the Worker to wake up and process this message.
+    workerState->toWorkerCondition.notify_all();
+  }
+  return jsi::Value::undefined();
+}
+
 } // namespace
 
 void installWorker(jsi::Runtime &rt, jsi::Object &extensions) {
@@ -208,7 +324,10 @@ void installWorker(jsi::Runtime &rt, jsi::Object &extensions) {
   jsi::Function terminateWorkerFunc = jsi::Function::createFromHostFunction(
       rt, jsi::PropNameID::forAscii(rt, "terminateWorker"), 0, terminateWorker);
 
-  setup.call(rt, initWorker, terminateWorkerFunc);
+  jsi::Function postMessageFunc = jsi::Function::createFromHostFunction(
+      rt, jsi::PropNameID::forAscii(rt, "postMessage"), 1, postMessageToWorker);
+
+  setup.call(rt, initWorker, terminateWorkerFunc, postMessageFunc);
 }
 
 } // namespace hermes

--- a/API/hermes/extensions/Worker.cpp
+++ b/API/hermes/extensions/Worker.cpp
@@ -330,6 +330,28 @@ void installPostMessageFromWorker(
   workerRuntime.global().setProperty(workerRuntime, "postMessage", onMessage);
 }
 
+/// Install the 'close` global function on the \p workerRuntime. The close
+/// function will acquire the mutex \p workerState.stateMutex, set the
+/// termination flag, and clear all messages.
+void installCloseFromWorker(
+    jsi::Runtime &workerRuntime,
+    const std::shared_ptr<WorkerState> &workerState) {
+  // Native Function that handles the `close` calls from inside the Worker to
+  // terminate the Worker.
+  auto closeFromWorker = [workerState = workerState](
+                             jsi::Runtime &runtime,
+                             const jsi::Value &,
+                             const jsi::Value *args,
+                             size_t) {
+    setTerminationState(workerState, runtime, false);
+    return jsi::Value::undefined();
+  };
+  auto closePropId = jsi::PropNameID::forAscii(workerRuntime, "close");
+  jsi::Function close = jsi::Function::createFromHostFunction(
+      workerRuntime, closePropId, 0, closeFromWorker);
+  workerRuntime.global().setProperty(workerRuntime, closePropId, close);
+}
+
 WorkerNativeState::~WorkerNativeState() {
   setTerminationState(workerState, *workerRuntime, true);
   // If the Worker thread is still active, wait for it to finish.
@@ -432,6 +454,7 @@ jsi::Value initializeWorker(
 
   // Install the event-processing handlers onto the Worker runtime
   installPostMessageFromWorker(*workerRuntime, workerState);
+  installCloseFromWorker(*workerRuntime, workerState);
 
   auto workerNativeState = std::make_shared<WorkerNativeState>(
       workerState, std::move(workerRuntime));

--- a/API/hermes/extensions/Worker.cpp
+++ b/API/hermes/extensions/Worker.cpp
@@ -28,6 +28,7 @@ using Message = std::
 /// thread/event loop thread. Everything in this struct is guarded by the state
 /// mutex;
 struct WorkerState {
+  WorkerState(jsi::Runtime &parentRuntime) : parentRuntime(parentRuntime) {}
   /// Mutex to guard all the resources in this WorkerState
   std::mutex stateMutex{};
   /// Used to put the Worker thread to sleep when there's nothing to do in the
@@ -37,6 +38,12 @@ struct WorkerState {
   bool terminated{false};
   /// Messages to Worker from the parent runtime.
   std::deque<Message> toWorkerQueue;
+  /// Parent runtime that created this Worker. Used to register Workers
+  /// for the event loop.
+  jsi::Runtime &parentRuntime;
+  /// The ID assigned when the Worker was registered with the integrator
+  /// event-loop.
+  uint64_t id;
 };
 
 /// Worker-specific Native state, used to mark an Object as a Worker instance.
@@ -153,6 +160,15 @@ void setTerminationState(
   // queue.
   workerState->toWorkerQueue.clear();
 
+  auto *setEventLoopControlInterface =
+      jsi::castInterface<ISetEventLoopControl>(&workerState->parentRuntime);
+  assert(
+      setEventLoopControlInterface && "ISetEventLoopControl is not supported");
+  auto *eventLoopControl = setEventLoopControlInterface->getEventLoopControl();
+  if (LLVM_LIKELY(eventLoopControl)) {
+    eventLoopControl->unregisterTaskQueueSource(workerState->id);
+  }
+
   if (notifyWorker) {
     workerState->toWorkerCondition.notify_all();
   }
@@ -256,10 +272,19 @@ jsi::Value initializeWorker(
   auto self = args[0].asObject(rt);
   auto *api = jsi::castInterface<IHermesRootAPI>(makeHermesRootAPI());
   auto workerRuntime = api->makeHermesRuntime(::hermes::vm::RuntimeConfig());
-  auto workerState = std::make_shared<WorkerState>();
+  auto workerState = std::make_shared<WorkerState>(rt);
   auto workerNativeState = std::make_shared<WorkerNativeState>(
       workerState, std::move(workerRuntime));
   self.setNativeState(rt, workerNativeState);
+
+  auto *setEventLoopControlInterface =
+      jsi::castInterface<ISetEventLoopControl>(&workerState->parentRuntime);
+  assert(
+      setEventLoopControlInterface && "ISetEventLoopControl is not supported");
+  auto *eventLoopControl = setEventLoopControlInterface->getEventLoopControl();
+  if (LLVM_LIKELY(eventLoopControl)) {
+    workerState->id = eventLoopControl->registerTaskQueueSource();
+  }
 
   // Start the worker thread
   std::string script = args[1].asString(rt).utf8(rt);

--- a/API/hermes/extensions/Worker.cpp
+++ b/API/hermes/extensions/Worker.cpp
@@ -11,6 +11,7 @@
 #include "hermes/Public/RuntimeConfig.h"
 #include "hermes/hermes.h"
 #include "llvh/Support/Compiler.h"
+#include "llvh/Support/ErrorHandling.h"
 
 #include <condition_variable>
 #include <deque>
@@ -21,7 +22,8 @@ namespace facebook {
 namespace hermes {
 namespace {
 
-using Message = std::shared_ptr<jsi::Serialized>;
+using Message = std::
+    variant<std::shared_ptr<jsi::Serialized>, std::unique_ptr<jsi::Serialized>>;
 /// Stores some resources shared between a specific Worker and the main
 /// thread/event loop thread. Everything in this struct is guarded by the state
 /// mutex;
@@ -99,8 +101,26 @@ void processMessageWithHandler(
     const jsi::Function &handler) {
   auto serializationInterface = jsi::castInterface<jsi::ISerialization>(&rt);
   assert(serializationInterface && "ISerialization is not supported");
-  jsi::Value deserialized = serializationInterface->deserialize(message);
-  handler.call(rt, deserialized);
+  if (auto serializedNoTransfer =
+          std::get_if<std::shared_ptr<jsi::Serialized>>(&message)) {
+    jsi::Value deserialized =
+        serializationInterface->deserialize(*serializedNoTransfer);
+    handler.call(rt, deserialized);
+  } else if (
+      auto serializedWithTransfer =
+          std::get_if<std::unique_ptr<jsi::Serialized>>(&message)) {
+    jsi::Array deserialized = serializationInterface->deserializeWithTransfer(
+        *serializedWithTransfer);
+
+    // 'deserializeWithTransfer' must return the deserialized message at the
+    // index 0 of the return JS Array. Thus, the size must not be 0.
+    assert(
+        deserialized.size(rt) != 0 &&
+        "deserializeWithTransfer must contain the message in the array");
+    handler.call(rt, deserialized.getValueAtIndex(rt, 0));
+  } else {
+    llvm_unreachable("Unknown serialization type encountered");
+  }
 }
 
 /// Acquires the \p workerState.mutex and resources in \p workerState to
@@ -266,7 +286,7 @@ jsi::Value terminateWorker(
 /// message to the Worker. The arguments in \p args must be provided in the
 /// following order:
 /// 1. A serializable message
-/// 2. [not implemented yet] An optional array of transferable arguments
+/// 2. An optional array of transferable arguments
 jsi::Value postMessageToWorker(
     jsi::Runtime &rt,
     const jsi::Value &self,
@@ -294,7 +314,20 @@ jsi::Value postMessageToWorker(
   // and try to acquire the lock as a side effect.
   auto *serializationInterface = jsi::castInterface<jsi::ISerialization>(&rt);
   assert(serializationInterface && "ISerialization not supported");
-  auto serialized = serializationInterface->serialize(args[0]);
+  Message serialized;
+  const jsi::Value &message = args[0];
+  if (count == 1) {
+    serialized = serializationInterface->serialize(message);
+  } else {
+    // Check the 'transfers' argument is an Array
+    const jsi::Value &transfers = args[1];
+    if (LLVM_UNLIKELY(
+            !transfers.isObject() || !transfers.asObject(rt).isArray(rt))) {
+      throw jsi::JSError(rt, "Must provide an Array of transferable arguments");
+    }
+    serialized = serializationInterface->serializeWithTransfer(
+        message, transfers.asObject(rt).asArray(rt));
+  }
 
   {
     // Accessing Worker's shared state. Acquire the lock.

--- a/API/hermes/extensions/Worker.cpp
+++ b/API/hermes/extensions/Worker.cpp
@@ -8,7 +8,11 @@
 #ifdef JSI_UNSTABLE
 #include "Worker.h"
 #include "Intrinsics.h"
+#include "hermes/Public/RuntimeConfig.h"
+#include "hermes/hermes.h"
 #include "llvh/Support/Compiler.h"
+
+#include <thread>
 
 namespace facebook {
 namespace hermes {
@@ -23,8 +27,62 @@ namespace {
 /// its execution and the thread will be joined.
 class WorkerNativeState : public jsi::NativeState {
  public:
-  WorkerNativeState() = default;
+  WorkerNativeState(std::unique_ptr<jsi::Runtime> workerRuntime)
+      : workerRuntime(std::move(workerRuntime)) {};
+  ~WorkerNativeState();
+
+  /// Start and assign the Worker a new thread to run \p script using the Worker
+  /// runtime.
+  void startWorkerThread(std::string script);
+
+  /// Worker runtime. Created when the Worker is created and used to execute all
+  /// JS for the Worker.
+  std::unique_ptr<jsi::Runtime> workerRuntime;
+
+ private:
+  /// Worker thread used to run all JS execution and event loop processing in
+  /// the worker. When the Worker is terminated, the thread is joined.
+  std::thread workerThread_;
 };
+
+/// Request the \p workerRuntime to stop execution. May be called multiple
+/// times.
+void setTerminationState(jsi::Runtime &workerRuntime) {
+  // Request the Worker runtime to terminate the execution at a convenient
+  // time. The timeout exception thrown doesn't matter because the Worker
+  // will be terminated.
+  auto *hermesInterface = jsi::castInterface<IHermes>(&workerRuntime);
+  assert(hermesInterface && "IHermes is not supported");
+  hermesInterface->asyncTriggerTimeout();
+}
+
+WorkerNativeState::~WorkerNativeState() {
+  setTerminationState(*workerRuntime);
+  // If the Worker thread is still active, wait for it to finish.
+  if (workerThread_.joinable()) {
+    workerThread_.join();
+  }
+}
+
+void WorkerNativeState::startWorkerThread(std::string script) {
+  // workerRuntime will outlive this lambda scope because we explicitly join
+  // the worker thread in the WorkerNativeState destructor. Thus, it is safe
+  // to capture the workerRuntime here.
+  workerThread_ = std::thread(
+      [scriptCopy = std::move(script), workerRuntime = workerRuntime.get()]() {
+        try {
+          workerRuntime->evaluateJavaScript(
+              std::make_unique<jsi::StringBuffer>(std::move(scriptCopy)), "");
+        } catch (const jsi::JSIException &) {
+          // Script failed. End worker thread.
+          // This is different from HTML behavior, where Worker report these
+          // error events, and an 'onerror' handler can be attached to the
+          // Worker to handle the event in the main thread. However, that event
+          // handling is not implemented yet.
+          return;
+        }
+      });
+}
 
 /// Called by the JS constructor in `11-Worker.js` to mark the first argument.
 /// The arguments in \p args must be provided in the following order:
@@ -49,8 +107,15 @@ jsi::Value initializeWorker(
   // This is provided by the `11-Worker.js` script, so it should always be an
   // Object.
   auto self = args[0].asObject(rt);
-  self.setNativeState(rt, std::make_shared<WorkerNativeState>());
+  auto *api = jsi::castInterface<IHermesRootAPI>(makeHermesRootAPI());
+  auto workerRuntime = api->makeHermesRuntime(::hermes::vm::RuntimeConfig());
+  auto workerNativeState =
+      std::make_shared<WorkerNativeState>(std::move(workerRuntime));
+  self.setNativeState(rt, workerNativeState);
 
+  // Start the worker thread
+  std::string script = args[1].asString(rt).utf8(rt);
+  workerNativeState->startWorkerThread(std::move(script));
   return jsi::Value::undefined();
 }
 

--- a/API/hermes/extensions/Worker.cpp
+++ b/API/hermes/extensions/Worker.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifdef JSI_UNSTABLE
+#include "Worker.h"
+#include "Intrinsics.h"
+#include "llvh/Support/Compiler.h"
+
+namespace facebook {
+namespace hermes {
+namespace {
+
+/// Worker-specific Native state, used to mark an Object as a Worker instance.
+/// These Worker instances are modeled after HTML WebWorkers.
+/// Workers will create a new Hermes Runtime and a new thread upon creation to
+/// execute the user-provided Javascript code. It also communicates with the
+/// parent runtime through message queues, which are guarded by a mutex. Upon
+/// Worker termination (via GC or terminate/close calls), the Worker will quit
+/// its execution and the thread will be joined.
+class WorkerNativeState : public jsi::NativeState {
+ public:
+  WorkerNativeState() = default;
+};
+
+/// Called by the JS constructor in `11-Worker.js` to mark the first argument.
+/// The arguments in \p args must be provided in the following order:
+/// 1. the object to be marked as Worker
+/// 2. the script to be executed by the Worker
+jsi::Value initializeWorker(
+    jsi::Runtime &rt,
+    const jsi::Value &,
+    const jsi::Value *args,
+    size_t count) {
+  // This is only called by the Worker extension script in `11-Worker.js`, so we
+  // can guarantee that the argument count is 2.
+  assert(count == 2);
+
+  // Verify the user-provided script argument
+  if (LLVM_UNLIKELY(!args[1].isString())) {
+    throwTypeError(
+        rt, "Must provide the source code as a String for the Worker to run");
+  }
+
+  // Mark the self object as a Worker
+  // This is provided by the `11-Worker.js` script, so it should always be an
+  // Object.
+  auto self = args[0].asObject(rt);
+  self.setNativeState(rt, std::make_shared<WorkerNativeState>());
+
+  return jsi::Value::undefined();
+}
+
+} // namespace
+
+void installWorker(jsi::Runtime &rt, jsi::Object &extensions) {
+  // Set up function specified in `11-Worker.js`.
+  jsi::Function setup = extensions.getPropertyAsFunction(rt, "Worker");
+
+  jsi::Function initWorker = jsi::Function::createFromHostFunction(
+      rt, jsi::PropNameID::forAscii(rt, "initWorker"), 2, initializeWorker);
+
+  setup.call(rt, initWorker);
+}
+
+} // namespace hermes
+} // namespace facebook
+#endif

--- a/API/hermes/extensions/Worker.cpp
+++ b/API/hermes/extensions/Worker.cpp
@@ -12,11 +12,26 @@
 #include "hermes/hermes.h"
 #include "llvh/Support/Compiler.h"
 
+#include <condition_variable>
+#include <mutex>
 #include <thread>
 
 namespace facebook {
 namespace hermes {
 namespace {
+
+/// Stores some resources shared between a specific Worker and the main
+/// thread/event loop thread. Everything in this struct is guarded by the state
+/// mutex;
+struct WorkerState {
+  /// Mutex to guard all the resources in this WorkerState
+  std::mutex stateMutex{};
+  /// Used to put the Worker thread to sleep when there's nothing to do in the
+  /// Worker event loop, and signals the thread should wake up for processing.
+  std::condition_variable toWorkerCondition{};
+  /// Once true, worker will be terminated at the earliest convenience.
+  bool terminated{false};
+};
 
 /// Worker-specific Native state, used to mark an Object as a Worker instance.
 /// These Worker instances are modeled after HTML WebWorkers.
@@ -27,13 +42,21 @@ namespace {
 /// its execution and the thread will be joined.
 class WorkerNativeState : public jsi::NativeState {
  public:
-  WorkerNativeState(std::unique_ptr<jsi::Runtime> workerRuntime)
-      : workerRuntime(std::move(workerRuntime)) {};
+  WorkerNativeState(
+      std::shared_ptr<WorkerState> workerState,
+      std::unique_ptr<jsi::Runtime> workerRuntime)
+      : workerState(std::move(workerState)),
+        workerRuntime(std::move(workerRuntime)) {}
   ~WorkerNativeState();
 
   /// Start and assign the Worker a new thread to run \p script using the Worker
   /// runtime.
   void startWorkerThread(std::string script);
+
+  /// State specific to the Worker. This has shared ownership between the
+  /// Worker Native State, the Worker thread, and event-loop task (which can run
+  /// after the Worker has been GC'd).
+  std::shared_ptr<WorkerState> workerState;
 
   /// Worker runtime. Created when the Worker is created and used to execute all
   /// JS for the Worker.
@@ -45,19 +68,44 @@ class WorkerNativeState : public jsi::NativeState {
   std::thread workerThread_;
 };
 
-/// Request the \p workerRuntime to stop execution. May be called multiple
-/// times.
-void setTerminationState(jsi::Runtime &workerRuntime) {
+/// Returns true if \p is a Worker instance, false otherwise.
+inline bool isWorkerInstance(jsi::Runtime &rt, const jsi::Value &self) {
+  return self.isObject() &&
+      self.asObject(rt).hasNativeState<WorkerNativeState>(rt);
+}
+
+/// Acquires the \p workerState.mutex and resources in \p workerState to
+/// indicate the Worker is terminated. Request the \p workerRuntime to stop
+/// execution. If \p notifyWorker is called, then also notifies the worker to
+/// wake up. May be called by the Worker thread or main thread/event loop
+/// thread, and may be called multiple times.
+void setTerminationState(
+    const std::shared_ptr<WorkerState> &workerState,
+    jsi::Runtime &workerRuntime,
+    bool notifyWorker) {
+  std::lock_guard<std::mutex> lock(workerState->stateMutex);
+  if (workerState->terminated) {
+    // Already terminated. Just return.
+    return;
+  }
+
+  // Set the terminated flag. In the Worker's event-loop, it will check for
+  // this flag and exit the event-loop.
+  workerState->terminated = true;
+
   // Request the Worker runtime to terminate the execution at a convenient
   // time. The timeout exception thrown doesn't matter because the Worker
   // will be terminated.
   auto *hermesInterface = jsi::castInterface<IHermes>(&workerRuntime);
   assert(hermesInterface && "IHermes is not supported");
   hermesInterface->asyncTriggerTimeout();
+  if (notifyWorker) {
+    workerState->toWorkerCondition.notify_all();
+  }
 }
 
 WorkerNativeState::~WorkerNativeState() {
-  setTerminationState(*workerRuntime);
+  setTerminationState(workerState, *workerRuntime, true);
   // If the Worker thread is still active, wait for it to finish.
   if (workerThread_.joinable()) {
     workerThread_.join();
@@ -68,20 +116,33 @@ void WorkerNativeState::startWorkerThread(std::string script) {
   // workerRuntime will outlive this lambda scope because we explicitly join
   // the worker thread in the WorkerNativeState destructor. Thus, it is safe
   // to capture the workerRuntime here.
-  workerThread_ = std::thread(
-      [scriptCopy = std::move(script), workerRuntime = workerRuntime.get()]() {
-        try {
-          workerRuntime->evaluateJavaScript(
-              std::make_unique<jsi::StringBuffer>(std::move(scriptCopy)), "");
-        } catch (const jsi::JSIException &) {
-          // Script failed. End worker thread.
-          // This is different from HTML behavior, where Worker report these
-          // error events, and an 'onerror' handler can be attached to the
-          // Worker to handle the event in the main thread. However, that event
-          // handling is not implemented yet.
-          return;
-        }
-      });
+  workerThread_ = std::thread([scriptCopy = std::move(script),
+                               workerRuntime = workerRuntime.get(),
+                               workerState = workerState]() {
+    try {
+      workerRuntime->evaluateJavaScript(
+          std::make_unique<jsi::StringBuffer>(std::move(scriptCopy)), "");
+      std::unique_lock<std::mutex> lock(workerState->stateMutex);
+
+      // While the Worker isn't terminated, it is allowed to run the event loop.
+      while (!workerState->terminated) {
+        // Wait until it is time to wake up. The possible scenario:
+        // 1. Worker thread went to sleep, and another thread has terminated
+        // the worker. Worker should wake up and terminate.
+        // 2. [to be implemented] Worker thread went to sleep, then another
+        // thread posted a message. Wake up to process the message.
+        workerState->toWorkerCondition.wait(lock);
+      }
+    } catch (const jsi::JSIException &) {
+      // Script failed. End worker thread.
+      // This is different from HTML behavior, where Worker report these
+      // error events, and an 'onerror' handler can be attached to the
+      // Worker to handle the event. However, that event handling is not
+      // implemented yet.
+      setTerminationState(workerState, *workerRuntime, false);
+      return;
+    }
+  });
 }
 
 /// Called by the JS constructor in `11-Worker.js` to mark the first argument.
@@ -109,13 +170,29 @@ jsi::Value initializeWorker(
   auto self = args[0].asObject(rt);
   auto *api = jsi::castInterface<IHermesRootAPI>(makeHermesRootAPI());
   auto workerRuntime = api->makeHermesRuntime(::hermes::vm::RuntimeConfig());
-  auto workerNativeState =
-      std::make_shared<WorkerNativeState>(std::move(workerRuntime));
+  auto workerState = std::make_shared<WorkerState>();
+  auto workerNativeState = std::make_shared<WorkerNativeState>(
+      workerState, std::move(workerRuntime));
   self.setNativeState(rt, workerNativeState);
 
   // Start the worker thread
   std::string script = args[1].asString(rt).utf8(rt);
   workerNativeState->startWorkerThread(std::move(script));
+  return jsi::Value::undefined();
+}
+/// This implements the `terminate` method of the Worker object, which takes in
+/// no arguments. This method marks the Worker as terminated, requests the
+/// Worker to stop execution, and clears all messages.
+jsi::Value terminateWorker(
+    jsi::Runtime &rt,
+    const jsi::Value &self,
+    const jsi::Value *args,
+    size_t count) {
+  if (LLVM_UNLIKELY(!isWorkerInstance(rt, self))) {
+    throwTypeError(rt, "'this' object must be a Worker");
+  }
+  auto worker = self.asObject(rt).getNativeState<WorkerNativeState>(rt);
+  setTerminationState(worker->workerState, *worker->workerRuntime, true);
   return jsi::Value::undefined();
 }
 
@@ -128,7 +205,10 @@ void installWorker(jsi::Runtime &rt, jsi::Object &extensions) {
   jsi::Function initWorker = jsi::Function::createFromHostFunction(
       rt, jsi::PropNameID::forAscii(rt, "initWorker"), 2, initializeWorker);
 
-  setup.call(rt, initWorker);
+  jsi::Function terminateWorkerFunc = jsi::Function::createFromHostFunction(
+      rt, jsi::PropNameID::forAscii(rt, "terminateWorker"), 0, terminateWorker);
+
+  setup.call(rt, initWorker, terminateWorkerFunc);
 }
 
 } // namespace hermes

--- a/API/hermes/extensions/Worker.cpp
+++ b/API/hermes/extensions/Worker.cpp
@@ -28,7 +28,10 @@ using Message = std::
 /// thread/event loop thread. Everything in this struct is guarded by the state
 /// mutex;
 struct WorkerState {
-  WorkerState(jsi::Runtime &parentRuntime) : parentRuntime(parentRuntime) {}
+  WorkerState(jsi::Runtime &parentRuntime, const jsi::Object &workerObject)
+      : weakWorker(
+            std::make_unique<jsi::WeakObject>(parentRuntime, workerObject)),
+        parentRuntime(parentRuntime) {}
   /// Mutex to guard all the resources in this WorkerState
   std::mutex stateMutex{};
   /// Used to put the Worker thread to sleep when there's nothing to do in the
@@ -38,6 +41,14 @@ struct WorkerState {
   bool terminated{false};
   /// Messages to Worker from the parent runtime.
   std::deque<Message> toWorkerQueue;
+  /// Messages from the Worker to the parent runtime.
+  std::deque<Message> fromWorkerQueue;
+  /// A WeakRef of the JS Worker Object. This is used by the event loop to
+  /// process messages from the Worker. We use a WeakRef here because a Worker
+  /// can be terminated but previous tasks may still be scheduled, which
+  /// shouldn't prevent clean up of the Worker if it is ready for GC. Upon
+  /// termination, this will be reset.
+  std::unique_ptr<jsi::WeakObject> weakWorker;
   /// Parent runtime that created this Worker. Used to register Workers
   /// for the event loop.
   jsi::Runtime &parentRuntime;
@@ -159,6 +170,9 @@ void setTerminationState(
   // Once terminated, no messages will be processed by the Worker. Discard
   // queue.
   workerState->toWorkerQueue.clear();
+  workerState->fromWorkerQueue.clear();
+
+  workerState->weakWorker.reset();
 
   auto *setEventLoopControlInterface =
       jsi::castInterface<ISetEventLoopControl>(&workerState->parentRuntime);
@@ -172,6 +186,148 @@ void setTerminationState(
   if (notifyWorker) {
     workerState->toWorkerCondition.notify_all();
   }
+}
+
+/// Scheduled as a task on the integrator's event loop to process a single
+/// message sent from the Worker via `postMessage`. Dequeues the message from
+/// the shared `fromWorkerQueue`, resolves the Worker's `onmessage` handler,
+/// and process the message using the handler.
+/// This may be called while the Worker is terminating itself in the Worker
+/// thread. In this case, there is no guarantee that the next message will be
+/// processed by this function call.
+void processMessageFromWorker(const std::shared_ptr<WorkerState> &workerState) {
+  std::unique_lock<std::mutex> stateLock(workerState->stateMutex);
+  if (workerState->terminated) {
+    // By the time this task is running, the Worker has been terminated, so
+    // no message should be processed.
+    return;
+  }
+  // There must be a message to be processed, otherwise this task wouldn't
+  // have been scheduled.
+  assert(
+      !workerState->fromWorkerQueue.empty() &&
+      "Processing non-existent message");
+  Message serialized = std::move(workerState->fromWorkerQueue.front());
+  workerState->fromWorkerQueue.pop_front();
+
+  // weakWorker is safe to dereference because it is only reset when the Worker
+  // is terminated. However, we currently hold the worker state lock and checked
+  // the worker is not terminated.
+  auto worker = workerState->weakWorker->lock(workerState->parentRuntime);
+  if (LLVM_UNLIKELY(worker.isUndefined())) {
+    /// The Worker object is not valid anymore, no message processing will be
+    /// done.
+    return;
+  }
+  auto workerObj = worker.asObject(workerState->parentRuntime);
+
+  // At this point, we've checked for termination and obtained the message.
+  // We don't care if the Worker is terminated from the Worker thread while
+  // the event is being processed. The actual event processing needs to
+  // happen outside the lock because it can run JS.
+  stateLock.unlock();
+
+  auto onMessageRes = getHandler(
+      workerState->parentRuntime,
+      workerObj,
+      jsi::PropNameID::forAscii(workerState->parentRuntime, "onmessage"));
+  if (LLVM_UNLIKELY(onMessageRes.isUndefined())) {
+    return;
+  }
+  auto onMessageHandler = onMessageRes.asObject(workerState->parentRuntime)
+                              .asFunction(workerState->parentRuntime);
+  processMessageWithHandler(
+      workerState->parentRuntime, std::move(serialized), onMessageHandler);
+}
+
+/// Install the 'postMessage` global function on the \p workerRuntime. The
+/// 'postMessage' function will serialize the provided message and transfer
+/// values, and queue the message in \p workerState.fromWorkerQueue. It will
+/// also schedule a task using the ISetEventLoop functionality of \p
+/// workerState.parentRuntime
+void installPostMessageFromWorker(
+    jsi::Runtime &workerRuntime,
+    const std::shared_ptr<WorkerState> &workerState) {
+  // Native Function that handles the `postMessage` calls from Worker to send
+  // message to the event loop.
+  auto postMessageFromWorker = [workerState = workerState](
+                                   jsi::Runtime &runtime,
+                                   const jsi::Value &,
+                                   const jsi::Value *args,
+                                   size_t count) {
+    if (LLVM_UNLIKELY(count == 0)) {
+      throwTypeError(runtime, "Must provide a message to postMessage");
+    }
+    auto *setEventLoopControlInterface =
+        jsi::castInterface<ISetEventLoopControl>(&workerState->parentRuntime);
+    assert(
+        setEventLoopControlInterface &&
+        "ISetEventLoopControl is not supported");
+    auto *eventLoopControl =
+        setEventLoopControlInterface->getEventLoopControl();
+
+    // No integrator-provided way for the Worker to schedule a task for message
+    // processing, so this message will get lost anyway. Just return.
+    if (LLVM_UNLIKELY(!eventLoopControl)) {
+      return jsi::Value::undefined();
+    }
+
+    {
+      std::lock_guard<std::mutex> lock(workerState->stateMutex);
+      if (workerState->terminated) {
+        // Worker is terminated, just return and don't try to serialize.
+        return jsi::Value::undefined();
+      }
+    }
+    // Serialization happens outside the lock because  serialization can run
+    // some JS and try to acquire the lock as a side effect.
+
+    auto serializationInterface =
+        jsi::castInterface<jsi::ISerialization>(&runtime);
+    assert(serializationInterface && "ISerialization is not supported");
+
+    Message serialized;
+    const jsi::Value &message = args[0];
+    if (count == 1) {
+      serialized = serializationInterface->serialize(message);
+    } else {
+      // Check the 'transfers' argument is an Array
+      const jsi::Value &transfers = args[1];
+      if (LLVM_UNLIKELY(
+              !transfers.isObject() ||
+              !transfers.asObject(runtime).isArray(runtime))) {
+        throwTypeError(
+            runtime, "Must provide an Array of transferable arguments");
+      }
+      serialized = serializationInterface->serializeWithTransfer(
+          message, transfers.asObject(runtime).asArray(runtime));
+    }
+
+    {
+      // Lock again to access the shared worker state.
+      std::lock_guard<std::mutex> lock(workerState->stateMutex);
+      // We need to perform the termination check again since there is a chance
+      // the Worker was terminated while serialization.
+      if (workerState->terminated) {
+        return jsi::Value::undefined();
+      }
+
+      workerState->fromWorkerQueue.push_back(std::move(serialized));
+    }
+
+    // Schedule a task for the event-loop to check the message we just queued
+    eventLoopControl->scheduleTask([workerState = workerState]() {
+      processMessageFromWorker(workerState);
+    });
+    return jsi::Value::undefined();
+  };
+
+  jsi::Function onMessage = jsi::Function::createFromHostFunction(
+      workerRuntime,
+      jsi::PropNameID::forAscii(workerRuntime, "postMessage"),
+      1,
+      postMessageFromWorker);
+  workerRuntime.global().setProperty(workerRuntime, "postMessage", onMessage);
 }
 
 WorkerNativeState::~WorkerNativeState() {
@@ -272,7 +428,11 @@ jsi::Value initializeWorker(
   auto self = args[0].asObject(rt);
   auto *api = jsi::castInterface<IHermesRootAPI>(makeHermesRootAPI());
   auto workerRuntime = api->makeHermesRuntime(::hermes::vm::RuntimeConfig());
-  auto workerState = std::make_shared<WorkerState>(rt);
+  auto workerState = std::make_shared<WorkerState>(rt, self);
+
+  // Install the event-processing handlers onto the Worker runtime
+  installPostMessageFromWorker(*workerRuntime, workerState);
+
   auto workerNativeState = std::make_shared<WorkerNativeState>(
       workerState, std::move(workerRuntime));
   self.setNativeState(rt, workerNativeState);

--- a/API/hermes/extensions/Worker.cpp
+++ b/API/hermes/extensions/Worker.cpp
@@ -18,6 +18,8 @@
 #include <mutex>
 #include <thread>
 
+#include "hermes/Platform/Logging.h"
+
 namespace facebook {
 namespace hermes {
 namespace {
@@ -43,6 +45,8 @@ struct WorkerState {
   std::deque<Message> toWorkerQueue;
   /// Messages from the Worker to the parent runtime.
   std::deque<Message> fromWorkerQueue;
+  /// Errors encountered by the Worker thread
+  std::deque<Message> workerErrorQueue;
   /// A WeakRef of the JS Worker Object. This is used by the event loop to
   /// process messages from the Worker. We use a WeakRef here because a Worker
   /// can be terminated but previous tasks may still be scheduled, which
@@ -171,6 +175,7 @@ void setTerminationState(
   // queue.
   workerState->toWorkerQueue.clear();
   workerState->fromWorkerQueue.clear();
+  workerState->workerErrorQueue.clear();
 
   workerState->weakWorker.reset();
 
@@ -352,6 +357,88 @@ void installCloseFromWorker(
   workerRuntime.global().setProperty(workerRuntime, closePropId, close);
 }
 
+/// A helper function called from the Worker thread to post \p error encountered
+/// by the Worker runtime, and schedule an error processign task. This will
+/// acquire the \p workerState.mutex to add the message.
+void postError(
+    jsi::Runtime &runtime,
+    const jsi::Value &error,
+    const std::shared_ptr<WorkerState> &workerState) {
+  auto errorHandlingTask = [workerState = workerState]() {
+    std::unique_lock<std::mutex> stateLock(workerState->stateMutex);
+    if (workerState->terminated) {
+      // By the time this task is running, the Worker has been terminated, so
+      // error handling shouldn't matter
+      return;
+    }
+    // There must be an error to be processed, otherwise this task wouldn't
+    // have been scheduled.
+    assert(
+        !workerState->workerErrorQueue.empty() &&
+        "Processing non-existent error");
+    Message serialized = std::move(workerState->workerErrorQueue.front());
+    workerState->workerErrorQueue.pop_front();
+    auto worker = workerState->weakWorker->lock(workerState->parentRuntime);
+    if (LLVM_UNLIKELY(worker.isUndefined())) {
+      /// The Worker object is not valid anymore, no message processing will be
+      /// done.
+      return;
+    }
+    auto workerObj = worker.asObject(workerState->parentRuntime);
+    stateLock.unlock();
+
+    auto onErrorRes = getHandler(
+        workerState->parentRuntime,
+        workerObj,
+        jsi::PropNameID::forAscii(workerState->parentRuntime, "onerror"));
+    if (LLVM_UNLIKELY(onErrorRes.isUndefined())) {
+      return;
+    }
+    auto onErrorHandler = onErrorRes.asObject(workerState->parentRuntime)
+                              .asFunction(workerState->parentRuntime);
+    processMessageWithHandler(
+        workerState->parentRuntime, std::move(serialized), onErrorHandler);
+  };
+
+  auto *setEventLoopControlInterface =
+      jsi::castInterface<ISetEventLoopControl>(&workerState->parentRuntime);
+  assert(
+      setEventLoopControlInterface && "ISetEventLoopControl is not supported");
+  auto *eventLoopControl = setEventLoopControlInterface->getEventLoopControl();
+
+  // No integrator-provided way for the Worker to schedule a task to process the
+  // error, so this message will get lost anyway. Just return.
+  if (LLVM_UNLIKELY(!eventLoopControl)) {
+    return;
+  }
+
+  auto serializationInterface =
+      jsi::castInterface<jsi::ISerialization>(&runtime);
+  assert(serializationInterface && "ISerialization is not supported");
+  std::shared_ptr<jsi::Serialized> serialized;
+
+  try {
+    serialized = serializationInterface->serialize(error);
+  } catch (const jsi::JSError &error) {
+    /// If we encounter an error while serializing the original JSError, then
+    /// give up
+    ::hermes::hermesLog("HermesWorker", "Failed to serialize Worker error.");
+    return;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(workerState->stateMutex);
+    if (workerState->terminated) {
+      // Worker was terminated after the Error has been serialized, don't post
+      // the message.
+      return;
+    }
+    workerState->workerErrorQueue.push_back(std::move(serialized));
+  }
+
+  eventLoopControl->scheduleTask(errorHandlingTask);
+}
+
 WorkerNativeState::~WorkerNativeState() {
   setTerminationState(workerState, *workerRuntime, true);
   // If the Worker thread is still active, wait for it to finish.
@@ -370,57 +457,64 @@ void WorkerNativeState::startWorkerThread(std::string script) {
     try {
       workerRuntime->evaluateJavaScript(
           std::make_unique<jsi::StringBuffer>(std::move(scriptCopy)), "");
-      std::unique_lock<std::mutex> lock(workerState->stateMutex);
+    } catch (const jsi::JSError &scriptError) {
+      postError(*workerRuntime, scriptError.value(), workerState);
+    } catch (const jsi::JSINativeException &) {
+      /// evaluateJavaScript can also throw JSINativeException, which isn't
+      /// serializable. In this case, just terminate the Worker.
+      ::hermes::hermesLog(
+          "HermesWorker",
+          "Encountered JSINativeException while running Worker script.");
+      setTerminationState(workerState, *workerRuntime, false);
+      return;
+    }
 
-      // While the Worker isn't terminated, it is allowed to run the event loop.
-      while (!workerState->terminated) {
-        // 1. Worker thread went to sleep, and another thread has terminated
-        // the worker. Worker should wake up and terminate. The message queue is
-        // cleared when `terminate` is called. Thus, we also need to check the
-        // `terminated` flag to make sure the thread doesn't immediately go back
-        // to sleep.
-        // 2. Worker thread went to sleep, then another thread posted a message.
-        // Wake up to process the message.
-        workerState->toWorkerCondition.wait(lock, [workerState] {
-          return workerState->terminated || !workerState->toWorkerQueue.empty();
-        });
-        // If the Worker thread woke up because the Worker was terminated,
-        // then break out of the event loop.
-        if (workerState->terminated) {
-          break;
-        }
+    std::unique_lock<std::mutex> lock(workerState->stateMutex);
+    // While the Worker isn't terminated, it is allowed to run the event loop.
+    while (!workerState->terminated) {
+      // 1. Worker thread went to sleep, and another thread has terminated
+      // the worker. Worker should wake up and terminate. The message queue is
+      // cleared when `terminate` is called. Thus, we also need to check the
+      // `terminated` flag to make sure the thread doesn't immediately go back
+      // to sleep.
+      // 2. Worker thread went to sleep, then another thread posted a message.
+      // Wake up to process the message.
+      workerState->toWorkerCondition.wait(lock, [workerState] {
+        return workerState->terminated || !workerState->toWorkerQueue.empty();
+      });
+      // If the Worker thread woke up because the Worker was terminated,
+      // then break out of the event loop.
+      if (workerState->terminated) {
+        break;
+      }
 
-        // Otherwise, process the next message on the queue, which is guaranteed
-        // to exist.
-        Message message = std::move(workerState->toWorkerQueue.front());
-        workerState->toWorkerQueue.pop_front();
-        lock.unlock();
+      // Otherwise, process the next message on the queue, which is guaranteed
+      // to exist.
+      Message message = std::move(workerState->toWorkerQueue.front());
+      workerState->toWorkerQueue.pop_front();
+      lock.unlock();
 
-        // Everything from now on can be processed without the lock as it
-        // doesn't rely on any shared resources between threads.
-        auto workerGlobal = workerRuntime->global();
-        jsi::Value onMessage = getHandler(
-            *workerRuntime,
-            workerGlobal,
-            jsi::PropNameID::forAscii(*workerRuntime, "onmessage"));
-        if (LLVM_LIKELY(!onMessage.isUndefined())) {
+      // Everything from now on can be processed without the lock as it doesn't
+      // rely on any shared resources between threads.
+      auto workerGlobal = workerRuntime->global();
+      jsi::Value onMessage = getHandler(
+          *workerRuntime,
+          workerGlobal,
+          jsi::PropNameID::forAscii(*workerRuntime, "onmessage"));
+      if (LLVM_LIKELY(!onMessage.isUndefined())) {
+        try {
           auto onMessageFunc =
               onMessage.asObject(*workerRuntime).asFunction(*workerRuntime);
           processMessageWithHandler(
               *workerRuntime, std::move(message), onMessageFunc);
+        } catch (const jsi::JSError &error) {
+          // Error processing the message, post the error for the parent to
+          // handle.
+          postError(*workerRuntime, error.value(), workerState);
         }
-
-        // Lock again for the next tick.
-        lock.lock();
       }
-    } catch (const jsi::JSIException &) {
-      // Script failed. End worker thread.
-      // This is different from HTML behavior, where Worker report these
-      // error events, and an 'onerror' handler can be attached to the
-      // Worker to handle the event. However, that event handling is not
-      // implemented yet.
-      setTerminationState(workerState, *workerRuntime, false);
-      return;
+      // Lock again for the next tick.
+      lock.lock();
     }
   });
 }

--- a/API/hermes/extensions/Worker.h
+++ b/API/hermes/extensions/Worker.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#ifdef JSI_UNSTABLE
+#ifndef HERMES_EXTENSIONS_WORKER_H
+#define HERMES_EXTENSIONS_WORKER_H
+
+#include <jsi/jsi.h>
+
+namespace facebook {
+namespace hermes {
+
+/// Install the Worker constructor on the global object.
+/// \param runtime The JSI runtime to install into.
+/// \param extensions The precompiled extensions object containing setup
+///   functions.
+void installWorker(jsi::Runtime &rt, jsi::Object &extensions);
+
+} // namespace hermes
+} // namespace facebook
+
+#endif // HERMES_EXTENSIONS_WORKER_H
+#endif // JSI_UNSTABLE

--- a/API/hermes/hermes.cpp
+++ b/API/hermes/hermes.cpp
@@ -3408,6 +3408,10 @@ std::unique_ptr<jsi::ThreadSafeRuntime> makeThreadSafeHermesRuntime(
   hermesRt.setDebugger(std::make_unique<debugger::Debugger>());
 #endif
 
+#if HERMES_ENABLE_CORE_EXTENSIONS
+  loadAndInstallExtensions(hermesRt);
+#endif
+
   return ret;
 }
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -863,6 +863,7 @@ if(HERMES_ENABLE_TEST_SUITE)
     unicode_lite=${HERMES_UNICODE_LITE}
     core_extensions_enabled=${HERMES_ENABLE_CORE_EXTENSIONS}
     contrib_extensions_enabled=${HERMES_ENABLE_CONTRIB_EXTENSIONS}
+    jsi_unstable=${JSI_UNSTABLE}
     qemu_run_prefix=${QEMU_RUN_PREFIX}
     )
 

--- a/include/hermes/Runtime/Libhermes.h
+++ b/include/hermes/Runtime/Libhermes.h
@@ -51,6 +51,7 @@ const char libhermes[] =
 "function ArrayBuffer() {}"
 "function DataView() {}"
 "function TextEncoder() {}"
+"function Worker() {}"
 #define TYPED_ARRAY(name, type) \
   "function " #name "Array() {}"
 #include "hermes/VM/TypedArrays.def"

--- a/lib/ConsoleHost/ConsoleHost.cpp
+++ b/lib/ConsoleHost/ConsoleHost.cpp
@@ -28,6 +28,8 @@
 
 #include "jsi/jsi.h"
 
+#include <queue>
+
 namespace hermes {
 
 ConsoleHostContext::ConsoleHostContext(vm::Runtime &runtime) {
@@ -620,6 +622,76 @@ auto maybeCatchException(const F &f) -> decltype(f()) {
 #endif
 }
 
+#ifdef JSI_UNSTABLE
+// Simple EventLoopControl that just adds the tasks to a queue when
+// `scheduleTask` is called and tracks the number of sources. When the queue
+// is empty, users can also wait for new tasks to be added.
+class EventLoopControl final : public facebook::hermes::IEventLoopControl {
+  void scheduleTask(const std::function<void()> &callback) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    tasks_.push(callback);
+    cv_.notify_all();
+  }
+
+  uint64_t registerTaskQueueSource() override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    sourceCount_++;
+    sources_.insert(sourceCount_);
+    return sourceCount_;
+  }
+
+  void unregisterTaskQueueSource(uint64_t sourceId) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    sources_.erase(sourceId);
+    if (sources_.empty()) {
+      cv_.notify_all();
+    }
+  }
+
+ public:
+  ~EventLoopControl() = default;
+  /// Drain all tasks from the queue, blocking until there are no more tasks
+  /// and no more active sources that could schedule new tasks.
+  void drainTasks() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    while (true) {
+      if (!tasks_.empty()) {
+        // There are tasks to run. Grab the next one and run it.
+        auto task = tasks_.front();
+        tasks_.pop();
+        lock.unlock();
+        // Run the task outside the lock. Otherwise, the running task may
+        // also try to queue more tasks, causing a deadlock.
+        task();
+        lock.lock();
+      } else if (!sources_.empty()) {
+        // No tasks to run, but there are still active sources that may
+        // schedule tasks. Sleep until woken by `scheduleTask` or
+        // `decrementTaskQueueSource`
+        cv_.wait(lock);
+      } else {
+        // No tasks and no sources at this point, exit the event loop.
+        break;
+      }
+    }
+  }
+
+ private:
+  // Callbacks are added to the queue from the Worker thread and removed from
+  // the main thread. Guard with a mutex.
+  std::mutex mutex_{};
+  // Used to wake up the event-loop if it is waiting for a new task or if all
+  // task sources have disappeared.
+  std::condition_variable cv_;
+  // All schedules tasks.
+  std::queue<std::function<void()>> tasks_{};
+  // Counter of total number of sources. Incremented when register is called.
+  uint64_t sourceCount_{0};
+  // The set of active sources
+  llvh::DenseSet<uint64_t> sources_{};
+};
+#endif
+
 bool executeHBCBytecodeImpl(
     std::shared_ptr<hbc::BCProvider> &&bytecode,
     const ExecuteOptions &options,
@@ -631,6 +703,12 @@ bool executeHBCBytecodeImpl(
   }
 
   std::unique_ptr<vm::StatSamplingThread> statSampler;
+
+#ifdef JSI_UNSTABLE
+  // Declared before hermesRuntime so it outlives the runtime. The runtime's
+  // finalizerExecutor_ may call into the EventLoopControl during destruction.
+  EventLoopControl eventLoopControl{};
+#endif
 
   // Create HermesRuntime (JSI wrapper) - this installs JSI extensions like
   // TextEncoder. We then extract the underlying vm::Runtime for low-level
@@ -675,6 +753,13 @@ bool executeHBCBytecodeImpl(
                     "include memory instrumentation\n";
 #endif
   }
+
+#ifdef JSI_UNSTABLE
+  auto *setEventLoopInterface =
+      facebook::jsi::castInterface<facebook::hermes::ISetEventLoopControl>(
+          hermesRuntime.get());
+  setEventLoopInterface->setEventLoopControl(&eventLoopControl);
+#endif
 
   vm::GCScope scope(*runtime);
   ConsoleHostContext ctx{*runtime};
@@ -761,6 +846,11 @@ bool executeHBCBytecodeImpl(
       microtask::performCheckpoint(*runtime);
     }
   }
+
+#ifdef JSI_UNSTABLE
+  // Run all tasks queued in the event loop.
+  eventLoopControl.drainTasks();
+#endif
 
 #if HERMESVM_SAMPLING_PROFILER_AVAILABLE
   if (options.sampleProfiling != ExecuteOptions::SampleProfilingMode::None) {

--- a/lib/VM/SerializedValue.cpp
+++ b/lib/VM/SerializedValue.cpp
@@ -2235,18 +2235,21 @@ CallResult<PseudoHandle<JSArray>> deserializeWithTransfer(
   // targetRealm, memory).
   // Deserialize the main serialized value, which is located at the front of
   // serialized.content
+
+  // 5. Return { [[Deserialized]]: deserialized, [[TransferredValues]]:
+  // transferredValues }.
+  struct : Locals {
+    PinnedValue<> deserialized;
+    PinnedValue<JSArray> result;
+  } lv;
+  LocalsRAII lraii(runtime, &lv);
+
   const uint8_t *start = serialized.content.data();
   auto valRes = deserializeImpl(runtime, serialized, start, memoryMap);
   if (LLVM_UNLIKELY(valRes == ExecutionStatus::EXCEPTION)) {
     return ExecutionStatus::EXCEPTION;
   }
-
-  // 5. Return { [[Deserialized]]: deserialized, [[TransferredValues]]:
-  // transferredValues }.
-  struct : Locals {
-    PinnedValue<JSArray> result;
-  } lv;
-  LocalsRAII lraii(runtime, &lv);
+  lv.deserialized = *valRes;
 
   auto transferLen = transferredIds.size();
   auto arrayLen = transferLen + 1;
@@ -2266,7 +2269,7 @@ CallResult<PseudoHandle<JSArray>> deserializeWithTransfer(
       *lv.result,
       runtime,
       0,
-      SmallHermesValue::encodeHermesValue(*valRes, runtime));
+      SmallHermesValue::encodeHermesValue(*lv.deserialized, runtime));
 
   // At this point, all objects are deserialized and the result Array is
   // allocated. No other allocation needs to happen.

--- a/test/Sema/flow/array-literal-infer.js
+++ b/test/Sema/flow/array-literal-infer.js
@@ -95,57 +95,58 @@ var strArr: (number | string)[] = ["a", "b", "c", ...numArr];
 // CHECK-NEXT:        Decl %d.34 'ArrayBuffer' UndeclaredGlobalProperty
 // CHECK-NEXT:        Decl %d.35 'DataView' UndeclaredGlobalProperty
 // CHECK-NEXT:        Decl %d.36 'TextEncoder' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.37 'Uint8Array' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.38 'Int8Array' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.39 'Uint8ClampedArray' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.40 'Uint16Array' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.41 'Int16Array' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.42 'Uint32Array' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.43 'Int32Array' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.44 'Float32Array' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.45 'Float64Array' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.46 'BigUint64Array' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.47 'BigInt64Array' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.48 'print' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.49 'eval' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.50 'parseInt' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.51 'parseFloat' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.52 'isNaN' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.53 'isFinite' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.54 'escape' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.55 'unescape' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.56 'decodeURI' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.57 'decodeURIComponent' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.58 'encodeURI' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.59 'encodeURIComponent' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.60 'gc' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.37 'Worker' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.38 'Uint8Array' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.39 'Int8Array' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.40 'Uint8ClampedArray' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.41 'Uint16Array' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.42 'Int16Array' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.43 'Uint32Array' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.44 'Int32Array' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.45 'Float32Array' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.46 'Float64Array' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.47 'BigUint64Array' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.48 'BigInt64Array' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.49 'print' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.50 'eval' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.51 'parseInt' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.52 'parseFloat' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.53 'isNaN' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.54 'isFinite' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.55 'escape' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.56 'unescape' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.57 'decodeURI' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.58 'decodeURIComponent' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.59 'encodeURI' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.60 'encodeURIComponent' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.61 'gc' UndeclaredGlobalProperty
 // CHECK-NEXT:    Func strict
 // CHECK-NEXT:        Scope %s.2
-// CHECK-NEXT:            Decl %d.61 'exports' Parameter : any
-// CHECK-NEXT:            Decl %d.62 'arguments' Var Arguments
+// CHECK-NEXT:            Decl %d.62 'exports' Parameter : any
+// CHECK-NEXT:            Decl %d.63 'arguments' Var Arguments
 // CHECK-NEXT:        Func strict
 // CHECK-NEXT:            Scope %s.3
-// CHECK-NEXT:                Decl %d.63 'unionArr' Var : %array.10
-// CHECK-NEXT:                Decl %d.64 'annotatedArr' Var : %array.10
-// CHECK-NEXT:                Decl %d.65 'Base' Class : %class_constructor.4
-// CHECK-NEXT:                Decl %d.66 'Derived' Class : %class_constructor.8
-// CHECK-NEXT:                Decl %d.67 'baseArr' Var : %array.11
-// CHECK-NEXT:                Decl %d.68 'numArr' Var : %array.12
-// CHECK-NEXT:                Decl %d.69 'strArr' Var : %array.14
-// CHECK-NEXT:                Decl %d.70 'arguments' Var Arguments
+// CHECK-NEXT:                Decl %d.64 'unionArr' Var : %array.10
+// CHECK-NEXT:                Decl %d.65 'annotatedArr' Var : %array.10
+// CHECK-NEXT:                Decl %d.66 'Base' Class : %class_constructor.4
+// CHECK-NEXT:                Decl %d.67 'Derived' Class : %class_constructor.8
+// CHECK-NEXT:                Decl %d.68 'baseArr' Var : %array.11
+// CHECK-NEXT:                Decl %d.69 'numArr' Var : %array.12
+// CHECK-NEXT:                Decl %d.70 'strArr' Var : %array.14
+// CHECK-NEXT:                Decl %d.71 'arguments' Var Arguments
 // CHECK-NEXT:                Scope %s.4
 // CHECK-NEXT:                Scope %s.5
 // CHECK-NEXT:            Func strict
 // CHECK-NEXT:                Scope %s.6
 // CHECK-NEXT:            Func strict
 // CHECK-NEXT:                Scope %s.7
-// CHECK-NEXT:                    Decl %d.71 'arguments' Var Arguments
+// CHECK-NEXT:                    Decl %d.72 'arguments' Var Arguments
 
 // CHECK:Program Scope %s.1
 // CHECK-NEXT:    ExpressionStatement
 // CHECK-NEXT:        CallExpression : any
 // CHECK-NEXT:            FunctionExpression : %untyped_function.1
-// CHECK-NEXT:                Id 'exports' [D:E:%d.61 'exports']
+// CHECK-NEXT:                Id 'exports' [D:E:%d.62 'exports']
 // CHECK-NEXT:                BlockStatement
 // CHECK-NEXT:                    ExpressionStatement
 // CHECK-NEXT:                        CallExpression : any
@@ -157,23 +158,23 @@ var strArr: (number | string)[] = ["a", "b", "c", ...numArr];
 // CHECK-NEXT:                                                NumericLiteral : number
 // CHECK-NEXT:                                                StringLiteral : string
 // CHECK-NEXT:                                                Id 'undefined' [D:E:%d.26 'undefined'] : void
-// CHECK-NEXT:                                            Id 'unionArr' [D:E:%d.63 'unionArr']
+// CHECK-NEXT:                                            Id 'unionArr' [D:E:%d.64 'unionArr']
 // CHECK-NEXT:                                    VariableDeclaration
 // CHECK-NEXT:                                        VariableDeclarator
 // CHECK-NEXT:                                            ArrayExpression : %array.10
 // CHECK-NEXT:                                                NumericLiteral : number
 // CHECK-NEXT:                                                StringLiteral : string
-// CHECK-NEXT:                                            Id 'annotatedArr' [D:E:%d.64 'annotatedArr']
+// CHECK-NEXT:                                            Id 'annotatedArr' [D:E:%d.65 'annotatedArr']
 // CHECK-NEXT:                                    ExpressionStatement
 // CHECK-NEXT:                                        AssignmentExpression : %array.10
-// CHECK-NEXT:                                            Id 'annotatedArr' [D:E:%d.64 'annotatedArr'] : %array.10
-// CHECK-NEXT:                                            Id 'unionArr' [D:E:%d.63 'unionArr'] : %array.10
+// CHECK-NEXT:                                            Id 'annotatedArr' [D:E:%d.65 'annotatedArr'] : %array.10
+// CHECK-NEXT:                                            Id 'unionArr' [D:E:%d.64 'unionArr'] : %array.10
 // CHECK-NEXT:                                    ClassDeclaration Scope %s.4
-// CHECK-NEXT:                                        Id 'Base' [D:E:%d.65 'Base']
+// CHECK-NEXT:                                        Id 'Base' [D:E:%d.66 'Base']
 // CHECK-NEXT:                                        ClassBody
 // CHECK-NEXT:                                    ClassDeclaration Scope %s.5
-// CHECK-NEXT:                                        Id 'Derived' [D:E:%d.66 'Derived']
-// CHECK-NEXT:                                        Id 'Base' [D:E:%d.65 'Base'] : %class_constructor.4
+// CHECK-NEXT:                                        Id 'Derived' [D:E:%d.67 'Derived']
+// CHECK-NEXT:                                        Id 'Base' [D:E:%d.66 'Base'] : %class_constructor.4
 // CHECK-NEXT:                                        ClassBody
 // CHECK-NEXT:                                            MethodDefinition : %function.6
 // CHECK-NEXT:                                                Id 'constructor'
@@ -186,17 +187,17 @@ var strArr: (number | string)[] = ["a", "b", "c", ...numArr];
 // CHECK-NEXT:                                        VariableDeclarator
 // CHECK-NEXT:                                            ArrayExpression : %array.11
 // CHECK-NEXT:                                                NewExpression : %class.2
-// CHECK-NEXT:                                                    Id 'Base' [D:E:%d.65 'Base'] : %class_constructor.4
+// CHECK-NEXT:                                                    Id 'Base' [D:E:%d.66 'Base'] : %class_constructor.4
 // CHECK-NEXT:                                                NewExpression : %class.5
-// CHECK-NEXT:                                                    Id 'Derived' [D:E:%d.66 'Derived'] : %class_constructor.8
-// CHECK-NEXT:                                            Id 'baseArr' [D:E:%d.67 'baseArr']
+// CHECK-NEXT:                                                    Id 'Derived' [D:E:%d.67 'Derived'] : %class_constructor.8
+// CHECK-NEXT:                                            Id 'baseArr' [D:E:%d.68 'baseArr']
 // CHECK-NEXT:                                    VariableDeclaration
 // CHECK-NEXT:                                        VariableDeclarator
 // CHECK-NEXT:                                            ArrayExpression : %array.12
 // CHECK-NEXT:                                                NumericLiteral : number
 // CHECK-NEXT:                                                NumericLiteral : number
 // CHECK-NEXT:                                                NumericLiteral : number
-// CHECK-NEXT:                                            Id 'numArr' [D:E:%d.68 'numArr']
+// CHECK-NEXT:                                            Id 'numArr' [D:E:%d.69 'numArr']
 // CHECK-NEXT:                                    VariableDeclaration
 // CHECK-NEXT:                                        VariableDeclarator
 // CHECK-NEXT:                                            ArrayExpression : %array.14
@@ -204,6 +205,6 @@ var strArr: (number | string)[] = ["a", "b", "c", ...numArr];
 // CHECK-NEXT:                                                StringLiteral : string
 // CHECK-NEXT:                                                StringLiteral : string
 // CHECK-NEXT:                                                SpreadElement
-// CHECK-NEXT:                                                    Id 'numArr' [D:E:%d.68 'numArr'] : %array.12
-// CHECK-NEXT:                                            Id 'strArr' [D:E:%d.69 'strArr']
+// CHECK-NEXT:                                                    Id 'numArr' [D:E:%d.69 'numArr'] : %array.12
+// CHECK-NEXT:                                            Id 'strArr' [D:E:%d.70 'strArr']
 // CHECK-NEXT:            ObjectExpression : %object.15

--- a/test/Sema/flow/xmod-builtins.js
+++ b/test/Sema/flow/xmod-builtins.js
@@ -86,61 +86,62 @@
 // CHECK-NEXT:        Decl %d.34 'ArrayBuffer' UndeclaredGlobalProperty
 // CHECK-NEXT:        Decl %d.35 'DataView' UndeclaredGlobalProperty
 // CHECK-NEXT:        Decl %d.36 'TextEncoder' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.37 'Uint8Array' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.38 'Int8Array' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.39 'Uint8ClampedArray' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.40 'Uint16Array' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.41 'Int16Array' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.42 'Uint32Array' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.43 'Int32Array' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.44 'Float32Array' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.45 'Float64Array' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.46 'BigUint64Array' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.47 'BigInt64Array' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.48 'print' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.49 'eval' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.50 'parseInt' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.51 'parseFloat' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.52 'isNaN' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.53 'isFinite' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.54 'escape' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.55 'unescape' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.56 'decodeURI' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.57 'decodeURIComponent' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.58 'encodeURI' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.59 'encodeURIComponent' UndeclaredGlobalProperty
-// CHECK-NEXT:        Decl %d.60 'gc' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.37 'Worker' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.38 'Uint8Array' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.39 'Int8Array' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.40 'Uint8ClampedArray' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.41 'Uint16Array' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.42 'Int16Array' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.43 'Uint32Array' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.44 'Int32Array' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.45 'Float32Array' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.46 'Float64Array' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.47 'BigUint64Array' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.48 'BigInt64Array' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.49 'print' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.50 'eval' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.51 'parseInt' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.52 'parseFloat' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.53 'isNaN' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.54 'isFinite' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.55 'escape' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.56 'unescape' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.57 'decodeURI' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.58 'decodeURIComponent' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.59 'encodeURI' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.60 'encodeURIComponent' UndeclaredGlobalProperty
+// CHECK-NEXT:        Decl %d.61 'gc' UndeclaredGlobalProperty
 // CHECK-NEXT:    Func strict
 // CHECK-NEXT:        Scope %s.2
-// CHECK-NEXT:            Decl %d.61 'exports' Parameter : any
-// CHECK-NEXT:            Decl %d.62 'arguments' Var Arguments
+// CHECK-NEXT:            Decl %d.62 'exports' Parameter : any
+// CHECK-NEXT:            Decl %d.63 'arguments' Var Arguments
 // CHECK-NEXT:        Func strict
 // CHECK-NEXT:            Scope %s.3
-// CHECK-NEXT:                Decl %d.63 'arguments' Var Arguments
+// CHECK-NEXT:                Decl %d.64 'arguments' Var Arguments
 // CHECK-NEXT:            Func strict
 // CHECK-NEXT:                Scope %s.4
-// CHECK-NEXT:                    Decl %d.64 'global' Parameter : any
-// CHECK-NEXT:                    Decl %d.65 'require' Parameter : any
-// CHECK-NEXT:                    Decl %d.66 's' Parameter : string
-// CHECK-NEXT:                    Decl %d.67 'arguments' Var Arguments
+// CHECK-NEXT:                    Decl %d.65 'global' Parameter : any
+// CHECK-NEXT:                    Decl %d.66 'require' Parameter : any
+// CHECK-NEXT:                    Decl %d.67 's' Parameter : string
+// CHECK-NEXT:                    Decl %d.68 'arguments' Var Arguments
 // CHECK-NEXT:            Func strict
 // CHECK-NEXT:                Scope %s.5
-// CHECK-NEXT:                    Decl %d.68 'global' Parameter : any
-// CHECK-NEXT:                    Decl %d.69 'require' Parameter : any
-// CHECK-NEXT:                    Decl %d.70 'n' Var : number
-// CHECK-NEXT:                    Decl %d.71 'arguments' Var Arguments
+// CHECK-NEXT:                    Decl %d.69 'global' Parameter : any
+// CHECK-NEXT:                    Decl %d.70 'require' Parameter : any
+// CHECK-NEXT:                    Decl %d.71 'n' Var : number
+// CHECK-NEXT:                    Decl %d.72 'arguments' Var Arguments
 // CHECK-NEXT:            Func strict
 // CHECK-NEXT:                Scope %s.6
-// CHECK-NEXT:                    Decl %d.72 'global' Parameter : any
-// CHECK-NEXT:                    Decl %d.73 'require' Parameter : any
-// CHECK-NEXT:                    Decl %d.74 'n2' Var : number
-// CHECK-NEXT:                    Decl %d.75 'arguments' Var Arguments
+// CHECK-NEXT:                    Decl %d.73 'global' Parameter : any
+// CHECK-NEXT:                    Decl %d.74 'require' Parameter : any
+// CHECK-NEXT:                    Decl %d.75 'n2' Var : number
+// CHECK-NEXT:                    Decl %d.76 'arguments' Var Arguments
 
 // CHECK:Program Scope %s.1
 // CHECK-NEXT:    ExpressionStatement
 // CHECK-NEXT:        CallExpression : any
 // CHECK-NEXT:            FunctionExpression : %untyped_function.1
-// CHECK-NEXT:                Id 'exports' [D:E:%d.61 'exports']
+// CHECK-NEXT:                Id 'exports' [D:E:%d.62 'exports']
 // CHECK-NEXT:                BlockStatement
 // CHECK-NEXT:                    ExpressionStatement
 // CHECK-NEXT:                        FunctionExpression : %untyped_function.1
@@ -152,9 +153,9 @@
 // CHECK-NEXT:                                            Id 'moduleFactory'
 // CHECK-NEXT:                                        NumericLiteral : number
 // CHECK-NEXT:                                        FunctionExpression : %function.2
-// CHECK-NEXT:                                            Id 'global' [D:E:%d.64 'global']
-// CHECK-NEXT:                                            Id 'require' [D:E:%d.65 'require']
-// CHECK-NEXT:                                            Id 's' [D:E:%d.66 's']
+// CHECK-NEXT:                                            Id 'global' [D:E:%d.65 'global']
+// CHECK-NEXT:                                            Id 'require' [D:E:%d.66 'require']
+// CHECK-NEXT:                                            Id 's' [D:E:%d.67 's']
 // CHECK-NEXT:                                            BlockStatement
 // CHECK-NEXT:                                                ReturnStatement
 // CHECK-NEXT:                                                    ImplicitCheckedCast : number
@@ -163,7 +164,7 @@
 // CHECK-NEXT:                                                            BinOp +
 // CHECK-NEXT:                                                            MemberExpression : any
 // CHECK-NEXT:                                                                AsExpression : any
-// CHECK-NEXT:                                                                    Id 's' [D:E:%d.66 's'] : string
+// CHECK-NEXT:                                                                    Id 's' [D:E:%d.67 's'] : string
 // CHECK-NEXT:                                                                    AnyTypeAnnotation
 // CHECK-NEXT:                                                                Id 'length'
 // CHECK-NEXT:                                ExpressionStatement
@@ -173,20 +174,20 @@
 // CHECK-NEXT:                                            Id 'moduleFactory'
 // CHECK-NEXT:                                        NumericLiteral : number
 // CHECK-NEXT:                                        FunctionExpression : %function.3
-// CHECK-NEXT:                                            Id 'global' [D:E:%d.68 'global']
-// CHECK-NEXT:                                            Id 'require' [D:E:%d.69 'require']
+// CHECK-NEXT:                                            Id 'global' [D:E:%d.69 'global']
+// CHECK-NEXT:                                            Id 'require' [D:E:%d.70 'require']
 // CHECK-NEXT:                                            BlockStatement
 // CHECK-NEXT:                                                VariableDeclaration
 // CHECK-NEXT:                                                    VariableDeclarator
 // CHECK-NEXT:                                                        NumericLiteral : number
-// CHECK-NEXT:                                                        Id 'n' [D:E:%d.70 'n']
+// CHECK-NEXT:                                                        Id 'n' [D:E:%d.71 'n']
 // CHECK-NEXT:                                                ExpressionStatement
 // CHECK-NEXT:                                                    CallExpression : void
 // CHECK-NEXT:                                                        MemberExpression : any
 // CHECK-NEXT:                                                            SHBuiltin
 // CHECK-NEXT:                                                            Id 'export'
 // CHECK-NEXT:                                                        StringLiteral : string
-// CHECK-NEXT:                                                        Id 'n' [D:E:%d.70 'n'] : number
+// CHECK-NEXT:                                                        Id 'n' [D:E:%d.71 'n'] : number
 // CHECK-NEXT:                                                ReturnStatement
 // CHECK-NEXT:                                                    NumericLiteral : number
 // CHECK-NEXT:                                ExpressionStatement
@@ -196,8 +197,8 @@
 // CHECK-NEXT:                                            Id 'moduleFactory'
 // CHECK-NEXT:                                        NumericLiteral : number
 // CHECK-NEXT:                                        FunctionExpression : %function.3
-// CHECK-NEXT:                                            Id 'global' [D:E:%d.72 'global']
-// CHECK-NEXT:                                            Id 'require' [D:E:%d.73 'require']
+// CHECK-NEXT:                                            Id 'global' [D:E:%d.73 'global']
+// CHECK-NEXT:                                            Id 'require' [D:E:%d.74 'require']
 // CHECK-NEXT:                                            BlockStatement
 // CHECK-NEXT:                                                VariableDeclaration
 // CHECK-NEXT:                                                    VariableDeclarator
@@ -216,7 +217,7 @@
 // CHECK-NEXT:                                                                    Id 'length'
 // CHECK-NEXT:                                                                BinOp +
 // CHECK-NEXT:                                                                NumericLiteral : number
-// CHECK-NEXT:                                                        Id 'n2' [D:E:%d.74 'n2']
+// CHECK-NEXT:                                                        Id 'n2' [D:E:%d.75 'n2']
 // CHECK-NEXT:                                                ReturnStatement
 // CHECK-NEXT:                                                    NumericLiteral : number
 // CHECK-NEXT:            ObjectExpression : %object.4

--- a/test/hermes/worker/lit.local.cfg
+++ b/test/hermes/worker/lit.local.cfg
@@ -1,0 +1,3 @@
+# Worker tests are excluded when JSI_UNSTABLE=OFF
+if "jsi_unstable" not in config.available_features:
+    config.unsupported = True

--- a/test/hermes/worker/worker-basic.js
+++ b/test/hermes/worker/worker-basic.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+// RUN: %shermes -exec -Wx,-gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+
+// Test that a Worker can be created and runs its script.
+// The worker sends a message back to confirm it executed.
+
+var worker = new Worker(`
+  postMessage("hello from worker");
+`);
+
+worker.onmessage = function(msg) {
+  print(msg);
+  worker.terminate();
+}
+
+// CHECK: hello from worker

--- a/test/hermes/worker/worker-close.js
+++ b/test/hermes/worker/worker-close.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/// RUN: %hermes -gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+// RUN: %shermes -exec -Wx,-gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+
+// Test that calling close() inside a Worker stops processing future messages.
+var worker = new Worker(`
+  onmessage = function(msg) {
+    if (msg == "close") {
+      // Close the Worker.
+      close();
+    } else {
+      postMessage("should not be sent");
+    }
+  }
+`);
+
+worker.onmessage = function(msg) {
+  print(msg);
+}
+
+// Send a message to the Worker that will trigger it to close it.
+worker.postMessage("close");
+print("sent 'close' to worker");
+// CHECK: sent 'close' to worker
+
+// Send another message that should not be processed by the Worker.
+worker.postMessage("lost message");
+// CHECK-NOT: should not be sent

--- a/test/hermes/worker/worker-error-type-propagation.js
+++ b/test/hermes/worker/worker-error-type-propagation.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+// RUN: %shermes -exec -Wx,-gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+
+// Test that different error types and non-Error thrown values are correctly
+// propagated to onerror.
+
+var worker = new Worker(`
+  onmessage = function(msg) {
+    if (msg == 0) {
+      throw new RangeError("out of range");
+    } else if (msg == 1) {
+      throw "a string error";
+    } else if (msg == 2) {
+      close();
+    }
+  }
+`);
+
+var step = 0;
+
+worker.onerror = function(err) {
+  step++;
+  if (step == 1) {
+    // RangeError
+    print("step 1: " + err.message);
+    worker.postMessage(1);
+  } else if (step == 2) {
+    // String throw
+    print("step 2: " + err);
+    worker.postMessage("2");
+  }
+}
+
+worker.postMessage(step);
+
+// CHECK: step 1: out of range
+// CHECK-NEXT: step 2: a string error

--- a/test/hermes/worker/worker-local-scope.js
+++ b/test/hermes/worker/worker-local-scope.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -gc-sanitize-handles=1 %s
+// RUN: %shermes -exec -Wx,-gc-sanitize-handles=1 %s
+
+// Test that a Worker created inside a local scope (function) is properly
+// cleaned up by the engine when the variable goes out of scope. The worker
+// sends multiple messages to the main thread. After the function returns,
+// the only reference to the Worker is through the onmessage closure.
+
+function createLocalWorker() {
+  var worker = new Worker(`
+    postMessage("local msg 1");
+    postMessage("local msg 2");
+    postMessage("local msg 3");
+  `);
+
+  var received = 0;
+  worker.onmessage = function(msg) {
+    print(msg);
+  }
+}
+
+createLocalWorker();
+gc();

--- a/test/hermes/worker/worker-multiple-messages.js
+++ b/test/hermes/worker/worker-multiple-messages.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+// RUN: %shermes -exec -Wx,-gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+
+// Test that multiple messages can be sent to a Worker sequentially and
+// the worker processes them in order.
+
+var worker = new Worker(`
+  var count = 0;
+  onmessage = function(msg) {
+    count++;
+    postMessage("msg " + count + ": " + msg);
+  }
+`);
+
+var received = 0;
+worker.onmessage = function(msg) {
+  received++;
+  print(msg);
+  if (received === 3) {
+    worker.terminate();
+  }
+}
+
+worker.postMessage("a");
+worker.postMessage("b");
+worker.postMessage("c");
+
+// CHECK: msg 1: a
+// CHECK-NEXT: msg 2: b
+// CHECK-NEXT: msg 3: c

--- a/test/hermes/worker/worker-onerror-basic.js
+++ b/test/hermes/worker/worker-onerror-basic.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+// RUN: %shermes -exec -Wx,-gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+
+// Test that worker.onerror is called when the worker's onmessage handler
+// throws an error, and that the error value is correctly propagated.
+
+var worker = new Worker(`
+  onmessage = function(msg) {
+    throw new Error("something went wrong");
+  }
+`);
+
+worker.onerror = function(err) {
+  print(err.message);
+  worker.terminate();
+}
+
+worker.postMessage("trigger");
+
+// CHECK: something went wrong

--- a/test/hermes/worker/worker-onerror-continue.js
+++ b/test/hermes/worker/worker-onerror-continue.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+// RUN: %shermes -exec -Wx,-gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+
+// Test that the worker event loop continues after an error in onmessage.
+// The worker should be able to process subsequent messages after throwing.
+
+var worker = new Worker(`
+  onmessage = function(msg) {
+    if (msg === "throw") {
+      throw new Error("handled error");
+    }
+    postMessage("processed: " + msg);
+  }
+`);
+
+var errorCount = 0;
+var messageCount = 0;
+
+worker.onerror = function(err) {
+  errorCount++;
+  print("error " + errorCount + ": " + err.message);
+  // Send another message after the error to verify the worker is still alive.
+  worker.postMessage("after-error");
+}
+
+worker.onmessage = function(msg) {
+  messageCount++;
+  print("message " + messageCount + ": " + msg);
+  worker.terminate();
+}
+
+worker.postMessage("throw");
+
+// CHECK: error 1: handled error
+// CHECK-NEXT: message 1: processed: after-error

--- a/test/hermes/worker/worker-onerror-multiple.js
+++ b/test/hermes/worker/worker-onerror-multiple.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+// RUN: %shermes -exec -Wx,-gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+
+// Test that multiple errors from a worker are all dispatched to onerror.
+
+var worker = new Worker(`
+  onmessage = function(msg) {
+    if (msg === "ok") {
+      postMessage("done");
+      return;
+    }
+    throw new Error("error: " + msg);
+  }
+`);
+
+var errorCount = 0;
+
+worker.onerror = function(err) {
+  errorCount++;
+  print("onerror " + errorCount + ": " + err.message);
+  if (errorCount < 3) {
+    // Send another message that will throw.
+    worker.postMessage("fail" + (errorCount + 1));
+  } else {
+    // After 3 errors, send a message that succeeds.
+    worker.postMessage("ok");
+  }
+}
+
+worker.onmessage = function(msg) {
+  print(msg);
+  print("total errors: " + errorCount);
+  worker.terminate();
+}
+
+worker.postMessage("fail1");
+
+// CHECK: onerror 1: error: fail1
+// CHECK-NEXT: onerror 2: error: fail2
+// CHECK-NEXT: onerror 3: error: fail3
+// CHECK-NEXT: done
+// CHECK-NEXT: total errors: 3

--- a/test/hermes/worker/worker-onerror-not-set.js
+++ b/test/hermes/worker/worker-onerror-not-set.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+// RUN: %shermes -exec -Wx,-gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+
+// Test that when onerror is not set, errors are silently discarded and the
+// worker event loop continues processing subsequent messages.
+
+var worker = new Worker(`
+  onmessage = function(msg) {
+    if (msg === "throw") {
+      throw new Error("ignored error");
+    }
+    postMessage("got: " + msg);
+  }
+`);
+
+// Intentionally do NOT set worker.onerror.
+
+worker.onmessage = function(msg) {
+  print(msg);
+  worker.terminate();
+}
+
+// First message throws, but onerror is not set so error is discarded.
+worker.postMessage("throw");
+// Second message should still be processed.
+worker.postMessage("hello");
+
+// CHECK-NOT: ignored error
+// CHECK: got: hello

--- a/test/hermes/worker/worker-onerror-script-error.js
+++ b/test/hermes/worker/worker-onerror-script-error.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+// RUN: %shermes -exec -Wx,-gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+
+// Test that worker.onerror is called when the worker script throws during
+// initial evaluation (before the event loop starts).
+
+var worker = new Worker(`
+  throw new Error("init failed");
+`);
+
+worker.onerror = function(err) {
+  print("script error: " + err.message);
+  worker.terminate();
+}
+
+// CHECK: script error: init failed

--- a/test/hermes/worker/worker-ping-pong.js
+++ b/test/hermes/worker/worker-ping-pong.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+// RUN: %shermes -exec -Wx,-gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+
+var worker = new Worker(`
+  onmessage = function(msg) {
+    if (msg == "ping") {
+      postMessage("pong");
+    } else if (msg == "salt") {
+      postMessage("pepper");
+    }
+  }
+`);
+
+worker.onmessage = function(msg) {
+  if (msg == "pong") {
+    print("received pong");
+    worker.postMessage("salt");
+  } else if (msg == "pepper") {
+    print("received pepper");
+    worker.terminate();
+  }
+}
+worker.postMessage("ping");
+
+// CHECK: received pong
+// CHECK: received pepper

--- a/test/hermes/worker/worker-postmessage.js
+++ b/test/hermes/worker/worker-postmessage.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+// RUN: %shermes -exec -Wx,-gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+
+// Test that postMessage from main to worker works and the worker can
+// echo the message back.
+
+var worker = new Worker(`
+  onmessage = function(msg) {
+    postMessage("echo: " + msg);
+  }
+`);
+
+worker.onmessage = function(msg) {
+  print(msg);
+  worker.terminate();
+}
+worker.postMessage("test message");
+
+// CHECK: echo: test message

--- a/test/hermes/worker/worker-structured-data.js
+++ b/test/hermes/worker/worker-structured-data.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+// RUN: %shermes -exec -Wx,-gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+
+// Test that structured data (objects, arrays, numbers) can be sent
+// between the main thread and the worker via postMessage.
+
+var worker = new Worker(`
+  onmessage = function(msg) {
+    postMessage({
+      name: msg.name,
+      items: msg.items,
+      count: msg.items.length,
+    });
+  }
+`);
+
+worker.onmessage = function(msg) {
+  print("name: " + msg.name);
+  print("count: " + msg.count);
+  print("items: " + msg.items.join(", "));
+  worker.terminate();
+}
+worker.postMessage({name: "test", items: [1, 2, 3]});
+
+// CHECK: name: test
+// CHECK-NEXT: count: 3
+// CHECK-NEXT: items: 1, 2, 3

--- a/test/hermes/worker/worker-terminate.js
+++ b/test/hermes/worker/worker-terminate.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+// RUN: %shermes -exec -Wx,-gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+
+// Test that terminate stops the worker and no further messages are processed.
+
+var worker = new Worker(`
+  onmessage = function(msg) {
+    postMessage("received: " + msg);
+  }
+`);
+
+var messageCount = 0;
+worker.onmessage = function(msg) {
+  messageCount++;
+  print(msg);
+  // Terminate after the first message.
+  worker.terminate();
+  // This message should not be processed since the worker is terminated.
+  worker.postMessage("second");
+}
+worker.postMessage("first");
+
+// CHECK: received: first
+// CHECK-NOT: received: second

--- a/test/hermes/worker/worker-transfer-basic.js
+++ b/test/hermes/worker/worker-transfer-basic.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+// RUN: %shermes -exec -Wx,-gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+
+// Test that an ArrayBuffer can be transferred from the main thread to
+// a Worker. After transfer, the original ArrayBuffer should be neutered
+// (byteLength becomes 0).
+
+var ab = new ArrayBuffer(4);
+var view = new Uint8Array(ab);
+view[0] = 10;
+view[1] = 20;
+view[2] = 30;
+view[3] = 40;
+
+print("before transfer: " + ab.byteLength);
+// CHECK: before transfer: 4
+
+var worker = new Worker(`
+  onmessage = function(msg) {
+    var view = msg;
+    postMessage("length: " + msg.byteLength);
+    postMessage("values: " + view[0] + "," + view[1] + "," + view[2] + "," + view[3]);
+  }
+`);
+
+var received = 0;
+worker.onmessage = function(msg) {
+  received++;
+  print(msg);
+  if (received === 2) {
+    worker.terminate();
+  }
+}
+worker.postMessage(view, [ab]);
+
+print("after transfer: " + ab.byteLength);
+// CHECK-NEXT: after transfer: 0
+// CHECK: length: 4
+// CHECK-NEXT: values: 10,20,30,40

--- a/test/hermes/worker/worker-transfer-from-worker.js
+++ b/test/hermes/worker/worker-transfer-from-worker.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+// RUN: %shermes -exec -Wx,-gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+
+// Test that a Worker can transfer an ArrayBuffer back to the main thread
+// via postMessage with transfers.
+
+var worker = new Worker(`
+  onmessage = function(msg) {
+    var ab = new ArrayBuffer(3);
+    var view = new Uint8Array(ab);
+    view[0] = 100;
+    view[1] = 200;
+    view[2] = msg;
+    postMessage(view, [ab]);
+  }
+`);
+
+worker.onmessage = function(msg) {
+  var view = msg;
+  print("byteLength: " + msg.byteLength);
+  print("values: " + view[0] + "," + view[1] + "," + view[2]);
+  worker.terminate();
+}
+worker.postMessage(42);
+
+// CHECK: byteLength: 3
+// CHECK-NEXT: values: 100,200,42

--- a/test/hermes/worker/worker-transfer-multiple.js
+++ b/test/hermes/worker/worker-transfer-multiple.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+// RUN: %shermes -exec -Wx,-gc-sanitize-handles=1 %s | %FileCheck %s --match-full-lines
+
+// Test transferring multiple ArrayBuffers in a single postMessage call.
+
+var ab1 = new ArrayBuffer(2);
+var ab2 = new ArrayBuffer(3);
+var v1 = new Uint8Array(ab1);
+v1.set([1, 2]);
+var v2 = new Uint8Array(ab2);
+v2.set([3, 4, 5]);
+
+var worker = new Worker(`
+  onmessage = function(msg) {
+    var v1 = msg.v1;
+    var v2 = msg.v2;
+    postMessage("buf1: " + Array.prototype.join.call(v1, ","));
+    postMessage("buf2: " + Array.prototype.join.call(v2, ","));
+  }
+`);
+
+var received = 0;
+worker.onmessage = function(msg) {
+  received++;
+  print(msg);
+  if (received === 2) {
+    worker.terminate();
+  }
+}
+worker.postMessage({v1: v1, v2: v2}, [ab1, ab2]);
+
+print("ab1 detached: " + (ab1.byteLength === 0));
+print("ab2 detached: " + (ab2.byteLength === 0));
+
+// CHECK: ab1 detached: true
+// CHECK-NEXT: ab2 detached: true
+// CHECK: buf1: 1,2
+// CHECK-NEXT: buf2: 3,4,5

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -128,6 +128,9 @@ if isTrue(lit_config.params.get("core_extensions_enabled")):
 if isTrue(lit_config.params.get("contrib_extensions_enabled")):
   config.available_features.add("contrib_extensions")
 
+if isTrue(lit_config.params.get("jsi_unstable")):
+  config.available_features.add("jsi_unstable")
+
 # Note
 # 1. substitutions are applied in order.
 #    %hermesc must appear before %hermes, or else %hermes will substitute *inside* %hermesc

--- a/tools/shermes/ConsoleBindings.cpp
+++ b/tools/shermes/ConsoleBindings.cpp
@@ -9,9 +9,15 @@
 #include "hermes/hermes.h"
 #include "jsi/jsi.h"
 
+#include "llvh/ADT/DenseSet.h"
+
 #include <chrono>
+#include <condition_variable>
 #include <cstdio>
 #include <cstring>
+#include <functional>
+#include <mutex>
+#include <queue>
 #include <thread>
 #include <vector>
 
@@ -48,6 +54,76 @@ class VectorMutableBuffer : public facebook::jsi::MutableBuffer {
 
 } // namespace
 
+#ifdef JSI_UNSTABLE
+  // Simple EventLoopControl that just adds the tasks to a queue when
+// `scheduleTask` is called and tracks the number of sources. When the queue
+// is empty, users can also wait for new tasks to be added.
+class EventLoopControl final : public facebook::hermes::IEventLoopControl {
+  void scheduleTask(const std::function<void()> &callback) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    tasks_.push(callback);
+    cv_.notify_all();
+  }
+
+  uint64_t registerTaskQueueSource() override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    sourceCount_++;
+    sources_.insert(sourceCount_);
+    return sourceCount_;
+  }
+
+  void unregisterTaskQueueSource(uint64_t sourceId) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    sources_.erase(sourceId);
+    if (sources_.empty()) {
+      cv_.notify_all();
+    }
+  }
+
+ public:
+  ~EventLoopControl() = default;
+  /// Drain all tasks from the queue, blocking until there are no more tasks
+  /// and no more active sources that could schedule new tasks.
+  void drainTasks() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    while (true) {
+      if (!tasks_.empty()) {
+        // There are tasks to run. Grab the next one and run it.
+        auto task = tasks_.front();
+        tasks_.pop();
+        lock.unlock();
+        // Run the task outside the lock. Otherwise, the running task may
+        // also try to queue more tasks, causing a deadlock.
+        task();
+        lock.lock();
+      } else if (!sources_.empty()) {
+        // No tasks to run, but there are still active sources that may
+        // schedule tasks. Sleep until woken by `scheduleTask` or
+        // `decrementTaskQueueSource`
+        cv_.wait(lock);
+      } else {
+        // No tasks and no sources at this point, exit the event loop.
+        break;
+      }
+    }
+  }
+
+ private:
+  // Callbacks are added to the queue from the Worker thread and removed from
+  // the main thread. Guard with a mutex.
+  std::mutex mutex_{};
+  // Used to wake up the event-loop if it is waiting for a new task or if all
+  // task sources have disappeared.
+  std::condition_variable cv_;
+  // All schedules tasks.
+  std::queue<std::function<void()>> tasks_{};
+  // Counter of total number of sources. Incremented when register is called.
+  uint64_t sourceCount_{0};
+  // The set of active sources
+  llvh::DenseSet<uint64_t> sources_{};
+};
+#endif
+
 /// Object that contains console state that needs to be preserved between
 /// init_console_bindings and run_event_loop.
 struct SHConsoleContext {
@@ -59,6 +135,11 @@ struct SHConsoleContext {
   int scriptArgc;
   const char *const *scriptArgv;
 
+#ifdef JSI_UNSTABLE
+  EventLoopControl eventLoopControl{};
+  facebook::hermes::HermesRuntime *hermesRuntime{nullptr};
+#endif
+
   SHConsoleContext(
       facebook::jsi::Object &&helpers,
       int scriptArgc,
@@ -66,6 +147,17 @@ struct SHConsoleContext {
       : helpers(std::move(helpers)),
         scriptArgc(scriptArgc),
         scriptArgv(scriptArgv) {}
+
+  ~SHConsoleContext() {
+#ifdef JSI_UNSTABLE
+    if (hermesRuntime) {
+      auto *iface =
+          facebook::jsi::castInterface<facebook::hermes::ISetEventLoopControl>(
+              hermesRuntime);
+      iface->setEventLoopControl(nullptr);
+    }
+#endif
+  }
 };
 
 /// Init harness symbols used in the test262 testsuite:
@@ -289,6 +381,13 @@ extern "C" SHERMES_EXPORT SHConsoleContext *init_console_bindings(
 
   initHermesCLIBindings(hrt, consoleContext.get());
 
+#ifdef JSI_UNSTABLE
+  consoleContext->hermesRuntime = &hrt;
+  auto *setEventLoopInterface =
+      jsi::castInterface<facebook::hermes::ISetEventLoopControl>(&hrt);
+  setEventLoopInterface->setEventLoopControl(&consoleContext->eventLoopControl);
+#endif
+
   jsi::Object &helpers = consoleContext->helpers;
 
   jsi::Function runMacroTask = helpers.getPropertyAsFunction(hrt, "run");
@@ -357,6 +456,11 @@ extern "C" SHERMES_EXPORT bool run_event_loop(
       runMacroTask.call(hrt, curTimeMs);
       hrt.drainMicrotasks();
     }
+
+#ifdef JSI_UNSTABLE
+    // Run all tasks queued in the event loop.
+    consoleContext->eventLoopControl.drainTasks();
+#endif
   } catch (jsi::JSError &e) {
     // Handle JS exceptions here.
     fprintf(stderr, "JS Exception: %s\n", e.what());

--- a/unittests/API/APITest.cpp
+++ b/unittests/API/APITest.cpp
@@ -2893,6 +2893,27 @@ var worker = new Worker(`while(true) {}`); worker;
 
   // Terminate the worker
   terminate.callWithThis(*rt, worker);
+
+  code = R"(
+var worker = new Worker(`
+  onmessage = function(msg) {
+    print(msg);
+  }
+`);
+worker;
+)";
+  worker = eval(code).asObject(*rt);
+
+  auto postMessage = worker.getPropertyAsFunction(*rt, "postMessage");
+  // postMessage on non-Worker object
+  EXPECT_THROW(postMessage.callWithThis(*rt, nonWorkerObject, 1), JSError);
+  // postMessage with no message
+  EXPECT_THROW(postMessage.callWithThis(*rt, worker), JSError);
+
+  // Post a message, then terminate worker
+  postMessage.callWithThis(*rt, worker, "hello!");
+  terminate = worker.getPropertyAsFunction(*rt, "terminate");
+  terminate.callWithThis(*rt, worker);
 }
 
 INSTANTIATE_TEST_CASE_P(

--- a/unittests/API/APITest.cpp
+++ b/unittests/API/APITest.cpp
@@ -2880,10 +2880,19 @@ TEST_P(HermesWorkerTest, WebWorkerBasic) {
 
   EXPECT_THROW(eval("new Worker(123);"), JSError);
 
+  // Create a simple worker that just loops forever
   auto code = R"(
-var worker = new Worker(`"foobar"`);
+var worker = new Worker(`while(true) {}`); worker;
 )";
-  eval(code);
+  auto worker = eval(code).asObject(*rt);
+
+  auto terminate = worker.getPropertyAsFunction(*rt, "terminate");
+  // Terminate on a non-Worker object should throw.
+  Object nonWorkerObject(*rt);
+  EXPECT_THROW(terminate.callWithThis(*rt, nonWorkerObject), JSError);
+
+  // Terminate the worker
+  terminate.callWithThis(*rt, worker);
 }
 
 INSTANTIATE_TEST_CASE_P(

--- a/unittests/API/APITest.cpp
+++ b/unittests/API/APITest.cpp
@@ -2868,10 +2868,35 @@ TEST_P(HermesSerializationTest, SerializeWithTransferThrows) {
       serializationInterface->serializeWithTransfer(val, transferArr), JSError);
 }
 
+class HermesWorkerTest : public HermesRuntimeTest {
+ public:
+  HermesWorkerTest() : HermesRuntimeTest() {}
+};
+
+#if HERMES_ENABLE_CORE_EXTENSIONS
+TEST_P(HermesWorkerTest, WebWorkerBasic) {
+  auto workerGlobal = rt->global().getProperty(*rt, "Worker");
+  EXPECT_TRUE(!workerGlobal.isUndefined());
+
+  EXPECT_THROW(eval("new Worker(123);"), JSError);
+
+  auto code = R"(
+var worker = new Worker(`"foobar"`);
+)";
+  eval(code);
+}
+
+INSTANTIATE_TEST_CASE_P(
+    Runtimes,
+    HermesWorkerTest,
+    ::testing::ValuesIn(runtimeGenerators()));
+#endif
+
 INSTANTIATE_TEST_CASE_P(
     Runtimes,
     HermesSerializationTest,
     ::testing::ValuesIn(runtimeGenerators()));
+
 #endif
 
 INSTANTIATE_TEST_CASE_P(

--- a/unittests/API/APITest.cpp
+++ b/unittests/API/APITest.cpp
@@ -2900,6 +2900,9 @@ var worker = new Worker(`
     print(msg);
   }
 `);
+var nontransferable= ["non-transferable"];
+var ab = new ArrayBuffer(8);
+var transfers = [ab];
 worker;
 )";
   worker = eval(code).asObject(*rt);
@@ -2912,6 +2915,30 @@ worker;
 
   // Post a message, then terminate worker
   postMessage.callWithThis(*rt, worker, "hello!");
+  // Post a message with transfer, but transfers is not an Array
+  EXPECT_THROW(
+      postMessage.callWithThis(*rt, worker, "hello!", "not an array"), JSError);
+
+  // Post a message with transfer, but don't the transfers array contains
+  // non-transferable arguments
+  auto nontransferable = rt->global().getProperty(*rt, "nontransferable");
+  EXPECT_THROW(
+      postMessage.callWithThis(*rt, worker, "hello!", nontransferable),
+      JSError);
+
+  // Send an ArrayBuffer as message without transfer
+  auto abVal = rt->global().getProperty(*rt, "ab");
+  postMessage.callWithThis(*rt, worker, abVal);
+  // Make sure the original array buffer is not detached
+  auto ab = abVal.asObject(*rt).getArrayBuffer(*rt);
+  EXPECT_FALSE(ab.getProperty(*rt, "detached").asBool());
+
+  // Post a message with transfer
+  auto transfers = rt->global().getProperty(*rt, "transfers");
+  postMessage.callWithThis(*rt, worker, "hello!", transfers);
+  // Make sure the original array buffer is detached.
+  EXPECT_TRUE(ab.getProperty(*rt, "detached").asBool());
+
   terminate = worker.getPropertyAsFunction(*rt, "terminate");
   terminate.callWithThis(*rt, worker);
 }

--- a/unittests/API/CMakeLists.txt
+++ b/unittests/API/CMakeLists.txt
@@ -53,6 +53,13 @@ set(LLVM_ENABLE_RTTI ON)
 
 add_hermes_unittest(APITests ${APITestsSources})
 
+# Pass core extensions flag to C++ code.
+if(HERMES_ENABLE_CORE_EXTENSIONS)
+  target_compile_definitions(APITests PRIVATE HERMES_ENABLE_CORE_EXTENSIONS=1)
+else()
+  target_compile_definitions(APITests PRIVATE HERMES_ENABLE_CORE_EXTENSIONS=0)
+endif()
+
 target_link_libraries(APITests
   compileJS
   traceInterpreter

--- a/utils/testsuite/skiplist.json
+++ b/utils/testsuite/skiplist.json
@@ -3346,7 +3346,19 @@
         "mjsunit/regress/regress-crbug-1406774.js",
         "mjsunit/regress/regress-crbug-1412487.js",
         "mjsunit/regress/regress-crbug-1421198.js",
-        "mjsunit/regress/regress-v8-12219.js"
+        "mjsunit/regress/regress-v8-12219.js",
+        "mjsunit/regress/regress-v8-12219.js",
+        "mjsunit/regress/regress-crbug-503578.js",
+        "mjsunit/regress/regress-crbug-503968.js",
+        "mjsunit/regress/regress-crbug-503991.js",
+        "mjsunit/regress/regress-crbug-504136.js",
+        "mjsunit/regress/regress-crbug-505778.js",
+        "mjsunit/regress/regress-crbug-511880.js",
+        "mjsunit/regress/regress-crbug-518747.js",
+        "mjsunit/regress/regress-crbug-514081.js",
+        "mjsunit/regress/regress-crbug-522496.js",
+        "mjsunit/regress/regress-4271.js",
+        "mjsunit/regress/regress-4279.js"
       ],
       "comment": "Uses Worker, not supported."
     },


### PR DESCRIPTION
Summary:
Graft of D94992345 (authored by Chi Tsai) to shermes/stable.
Grafted `b455b9658d98` from `xplat/static_h` to
`xplat/shermes/stable`; applied with no conflicts.

Add support for attaching an `onerror` handler onto the Worker. When
the Worker encounters errors, it will send the error as a message to
the main thread. The main thread's event-loop then process the message
using the `onerror` handler.

Note that encountering an error within the Worker does not necessarily
mean the Worker will no longer be able to do future worke. For example,
if an error occurred during the initial script execution, the Worker
may still receives messages in its event-loop. Similarly, if an error
occurs while processing a message, it can still process the next
message.

Differential Revision: D118200645
