### PR TITLE
OSS-Fuzz: Fix fuzzing build errors

### DIFF
--- a/tools/fuzzers/libfuzzer/CMakeLists.txt
+++ b/tools/fuzzers/libfuzzer/CMakeLists.txt
@@ -18,5 +18,6 @@ if(HERMES_ENABLE_LIBFUZZER)
     target_link_libraries(fuzzer-jsi-entry
       PRIVATE
         hermesapi
+        hermesvm_a
     )
 endif()

--- a/tools/fuzzers/libfuzzer/fuzzer-jsi-entry.cpp
+++ b/tools/fuzzers/libfuzzer/fuzzer-jsi-entry.cpp
@@ -29,7 +29,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   // for validity (for performance purposes).
   // Discard inputs that would be interpreted as bytecode to avoid reporting
   // those as errors.
-  if (HermesRuntime::isHermesBytecode(data, size)) {
+  if (facebook::jsi::castInterface<facebook::hermes::IHermesRootAPI>(
+          facebook::hermes::makeHermesRootAPI())
+          ->isHermesBytecode(data, size)) {
     return 0;
   }
 


### PR DESCRIPTION
This PR fixes the fuzzer and build to accommodate the API changes which causes the OSS-Fuzz build for project hermes failing.