### PR TITLE
Bump hermes-compiler version to 260318099.0.3

### DIFF
--- a/npm/hermes-compiler/package.json
+++ b/npm/hermes-compiler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hermes-compiler",
-    "version": "260318099.0.2",
+    "version": "260318099.0.3",
     "private": false,
     "description": "The hermes compiler CLI used during the React Native build process",
     "license": "MIT",


### PR DESCRIPTION
## Summary

We just released 260318099.0.2. The current value in the hermes-compiler/package.json should always point to the next version we need to publish.

## Test Plan

N/A