### PR TITLE
[260318099.0.0-stable] pick: Implement `tryGetMutableBuffer` API

### DIFF
--- a/API/hermes/hermes.cpp
+++ b/API/hermes/hermes.cpp
@@ -896,6 +896,9 @@ class HermesRuntimeImpl final : public HermesRuntime,
       void (*deleter)(const void *data)) override;
   const void *getRuntimeDataImpl(const jsi::UUID &uuid) override;
 
+  std::shared_ptr<jsi::MutableBuffer> tryGetMutableBuffer(
+      const jsi::ArrayBuffer &arrayBuffer) override;
+
   bool strictEquals(const jsi::Symbol &a, const jsi::Symbol &b) const override;
   bool strictEquals(const jsi::BigInt &a, const jsi::BigInt &b) const override;
   bool strictEquals(const jsi::String &a, const jsi::String &b) const override;
@@ -3176,6 +3179,24 @@ void HermesRuntimeImpl::setRuntimeDataImpl(
 const void *HermesRuntimeImpl::getRuntimeDataImpl(const jsi::UUID &uuid) {
   auto entry = dataMap_.lookup(uuid);
   return entry.first;
+}
+
+std::shared_ptr<jsi::MutableBuffer> HermesRuntimeImpl::tryGetMutableBuffer(
+    const jsi::ArrayBuffer &arrayBuffer) {
+  auto abHandle = arrayBufferHandle(arrayBuffer);
+  if (LLVM_UNLIKELY(!abHandle->attached())) {
+    return nullptr;
+  }
+  if (LLVM_UNLIKELY(!abHandle->external())) {
+    return nullptr;
+  }
+
+  // External ArrayBuffers are created using the `createArrayBuffer` API with a
+  // shared pointer of a MutableBuffer. We pass in that shared pointer as the
+  // context when creating a JSArrayBuffer, thus we can assume the type of the
+  // context here.
+  return std::static_pointer_cast<jsi::MutableBuffer>(
+      vm::JSArrayBuffer::getExternalDataContext(runtime_, abHandle));
 }
 
 bool HermesRuntimeImpl::strictEquals(const jsi::Symbol &a, const jsi::Symbol &b)

--- a/unittests/API/APITest.cpp
+++ b/unittests/API/APITest.cpp
@@ -1722,6 +1722,43 @@ TEST_P(HermesRuntimeTest, FinalizableHostFunctionConstructorTest) {
   // throw TypeError
   EXPECT_THROW(eval("new HostFunc(false)"), JSError);
 }
+TEST_P(HermesRuntimeTest, TryGetMutableBuffer) {
+  auto arrayBuffer =
+      eval("new ArrayBuffer(8);").getObject(*rt).getArrayBuffer(*rt);
+  EXPECT_EQ(arrayBuffer.tryGetMutableBuffer(*rt), nullptr);
+
+  struct TestBuffer : MutableBuffer {
+    size_t size() const override {
+      return sizeof(arr);
+    }
+    uint8_t *data() override {
+      return reinterpret_cast<uint8_t *>(arr.data());
+    }
+
+    std::array<uint8_t, 3> arr;
+  };
+  auto buf = std::make_shared<TestBuffer>();
+  for (uint32_t i = 0; i < buf->arr.size(); i++) {
+    buf->arr[i] = i;
+  }
+  arrayBuffer = ArrayBuffer(*rt, buf);
+
+  auto mutableBuffer = arrayBuffer.tryGetMutableBuffer(*rt);
+  auto *mutableBufferData = mutableBuffer->data();
+  EXPECT_EQ(mutableBuffer->size(), 3);
+  EXPECT_EQ(mutableBufferData[0], 0);
+  EXPECT_EQ(mutableBufferData[1], 1);
+  EXPECT_EQ(mutableBufferData[2], 2);
+
+  // Modifying the returned MutableBuffer data also modifies the ArrayBuffer
+  // data.
+  mutableBufferData[1] = 100;
+  auto *arrayBufferData = arrayBuffer.data(*rt);
+  EXPECT_EQ(arrayBufferData[0], 0);
+  EXPECT_EQ(arrayBufferData[1], 100);
+  EXPECT_EQ(arrayBufferData[2], 2);
+}
+
 
 #ifdef JSI_UNSTABLE
 class HermesSerializationTest : public HermesRuntimeTest {


### PR DESCRIPTION
## Summary

Requesting a pick for #1988 (based on merged commit: https://github.com/facebook/hermes/commit/9a50bd0f36415ccbdeedc44eccb1bb45a0d41e90)

`ArrayBuffer::tryGetMutableBuffer` is implemented on `250829098.0.0-stable` and it shipped in `hermes-v250829098.0.11`, React Native has been using it since 0.86.0. 

The problem is that `260318099` branch diverged before that commit and never received it, so React Native 0.88.0-rc.0 (which moved to `hermes-v260318099.0.2`) regressed.

The failure is silent. JSI still declares the method and the default `Runtime::tryGetMutableBuffer` returns `nullptr`, so nothing fails to compile and no error is raised — callers just fall back to copying.

React Native calls that API in `ReactCommon/react/bridging/ArrayBuffer.h`and `JavaTurboModule.cpp`, so TurboModule `ArrayBuffer` arguments on Android now take an allocation plus a full copy on every crossing.

This was found by `expo-modules-core`'s Android instrumentation tests, which assert zero-copy sharing and five of them began failing on 0.88.0-rc.0 (https://github.com/expo/expo/pull/49910).

Everything the override needs is already present on this branch (`JSArrayBuffer::setExternalDataBlock`, `getExternalDataContext`, `external()`, plus the JSI declaration and base implementation), so only the `hermes.cpp` change is required.

## Test Plan

- The picked commit's own unit test (`HermesRuntimeTest.TryGetMutableBuffer` in `unittests/API/APITest.cpp`) is included, with its body unchanged. It needed re-anchoring: upstream it applies after `TEST_P(HermesRuntimeTest, ArrayPush)`, which this branch doesn't have (also part of #1988), so it now sits at the end of the `HermesRuntimeTest` block, before `#ifdef JSI_UNSTABLE`.
- Verified the regression on device against RN 0.88.0-rc.0 (Android arm64 emulator, `makeHermesRuntime`): an ArrayBuffer created via `Runtime::createArrayBuffer(std::shared_ptr<MutableBuffer>)` is genuinely external — the JS-visible `data()` pointer is identical to the native `MutableBuffer::data()`, and native writes are visible through it — while `tryGetMutableBuffer` returns `nullptr` through both `ArrayBuffer::tryGetMutableBuffer(rt)` and `Runtime::tryGetMutableBuffer(ab)`.

