### PR TITLE
fix(deps): bump ws in tools/hcdp to patch GHSA-58qx-3vcg-4xpx / GHSA-96hv-2xvq-fx4p

### DIFF
--- a/tools/hcdp/package-lock.json
+++ b/tools/hcdp/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "chrome-launcher": "^0.15.2",
         "chromium-edge-launcher": "^0.2.0",
-        "ws": "^8.16.0"
+        "ws": "^8.21.3"
       }
     },
     "node_modules/@types/node": {
@@ -259,9 +259,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/tools/hcdp/package.json
+++ b/tools/hcdp/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "Hermes CDP",
   "dependencies": {
-    "ws": "^8.16.0",
     "chrome-launcher": "^0.15.2",
-    "chromium-edge-launcher": "^0.2.0"
+    "chromium-edge-launcher": "^0.2.0",
+    "ws": "^8.21.3"
   }
 }


### PR DESCRIPTION
Automated dependency bump to address two disclosed CVEs in `ws`, a runtime dependency of the `tools/hcdp` (Hermes Chrome DevTools Protocol bridge) helper.

- **Advisory:** [GHSA-58qx-3vcg-4xpx](https://github.com/advisories/GHSA-58qx-3vcg-4xpx) (uninitialized memory disclosure)
- **Advisory:** [GHSA-96hv-2xvq-fx4p](https://github.com/advisories/GHSA-96hv-2xvq-fx4p) (memory exhaustion DoS via tiny fragments/chunks)
- **Severity:** high / moderate
- **Package:** `ws` `8.18.3` → `8.21.3` (latest 8.x; OSV-verified clean at target, fixes land at 8.20.1 and 8.21.0 respectively)

`tools/hcdp/package.json`'s declared range was bumped from `^8.16.0` to `^8.21.3` to match (npm rewrote it automatically via `--package-lock-only`); no other packages changed in the lockfile.

Detected by [osv-scanner](https://google.github.io/osv-scanner/). No code changes outside the manifest/lockfile.

---
Filed by [Aeon](https://github.com/aeonfun/aeon).